### PR TITLE
feat(settings): add sidebar subsection tree

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -57,7 +57,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 71       | 31   | 2026-06-16   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 93       | 26   | 2026-06-16   |
-| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 75       | 27   | 2026-06-19   |
+| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 76       | 28   | 2026-06-19   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 67       | 22   | 2026-06-14   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)                                       | backend            | 2        | 1    | 2026-05-20   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -54,7 +54,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 1        | 0    | 2026-06-09   |
-| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 71       | 31   | 2026-06-16   |
+| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 72       | 32   | 2026-06-19   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 93       | 26   | 2026-06-16   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 76       | 28   | 2026-06-19   |

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -693,3 +693,12 @@ handlers must not trap focus without implementing the promised behavior.
 - **Finding:** For contextual queries such as `appearance fonts`, the settings sidebar still renders the Appearance section as a clickable `role="option"` because it is in `filteredSections`, but the navigable `results` array contains only the matching target rows. With no explicit selection, `activeSearchResultKey` was `null`, so `SettingsSidebar` fell back to `aria-activedescendant` for the active Appearance section while `handleConfirmSearchResult` would confirm `searchResults[0]` (a target). Keyboard/screen-reader users were told one option was active but a different one was activated on Enter.
 - **Fix:** In `SettingsDialog`, default `activeSearchResultKey` to `searchResults[0].key` when the query is non-empty and no explicit selection exists, so the announced active descendant always matches the result that Enter confirms. Preserved the empty-query no-op behavior fixed in #74.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 76. Invalid aria-expanded on role="option" for expandable settings sections
+
+- **Source:** github-codex-connector | PR #549 round 1 | 2026-06-19
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/settings/components/SettingsSidebar.tsx` L212
+- **Finding:** The PR added `aria-expanded` to section buttons that also carry `role="option"`. `aria-expanded` is not a supported attribute on `option` elements, so assistive technology may ignore the expanded state and screen-reader users get no reliable expand/collapse signal for the new subsection navigation.
+- **Fix:** Removed the invalid `aria-expanded` attribute from the `role="option"` section button as the minimal localized fix. The visual chevron rotation still communicates state to sighted users; a fuller migration to valid `tree`/`treeitem` semantics is left for future refactor.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -2,8 +2,8 @@
 id: testing-gaps
 category: testing
 created: 2026-04-09
-last_updated: 2026-06-16
-ref_count: 31
+last_updated: 2026-06-19
+ref_count: 32
 ---
 
 # Testing Gaps
@@ -700,4 +700,13 @@ filesystem scope restrictions).
 - **File:** `docs/superpowers/plans/2026-06-15-keybinding-engine-pr1.md`
 - **Finding:** Task 3's `catalog.test.ts` checks descriptor invariants per entry but never asserts that `detectConflicts(resolveBindings({}, isMac, superKey), superKey)` returns `[]`. A future catalog addition that reuses a default `(super, code)` would produce a permanently non-empty `conflicts` array in `useKeybindings` before the user changes anything.
 - **Fix:** Added a `default catalog is conflict-free for both platforms` test to Task 5's `resolve.test.ts` plan, importing `detectConflicts` and asserting zero conflicts for both `isMac` values.
+- **Commit:** same commit as this entry
+
+### 68. New subsection navigation branch lacks parallel aria-activedescendant regression test
+
+- **Source:** github-codex-connector | PR #549 round 2 | 2026-06-19
+- **Severity:** MEDIUM
+- **File:** `src/features/settings/components/SettingsSidebar.tsx` L74-83, `src/features/settings/components/SettingsSidebar.test.tsx`
+- **Finding:** The PR introduced a new `activeSubsection` path in `fallbackActiveResultId` that routes the combobox's `aria-activedescendant` to `settings-search-result-subsection-${id}` when subsection tree mode is active. Existing tests covered subsection rendering, click handling, and selected/current state, but none asserted the combobox attribute itself — the actual screen-reader focus signal. A future refactor to the ternary or subsection id helper could silently break AT focus announcements for the new subsection UI.
+- **Fix:** Added a focused `SettingsSidebar.test.tsx` case that renders subsection tree mode with `activeTargetId={SETTINGS_TARGET_IDS.appearanceUiFont}` and asserts the combobox `aria-activedescendant` equals `settings-search-result-subsection-appearance-fonts`.
 - **Commit:** same commit as this entry

--- a/src/features/settings/SettingsDialog.test.tsx
+++ b/src/features/settings/SettingsDialog.test.tsx
@@ -147,6 +147,33 @@ describe('SettingsDialog', () => {
     scrollIntoView.mockRestore()
   })
 
+  test('navigates subsection clicks to the first matching settings row', async () => {
+    const user = userEvent.setup()
+
+    const scrollIntoView = vi
+      .spyOn(Element.prototype, 'scrollIntoView')
+      .mockImplementation(() => undefined)
+    render(<SettingsDialog open onClose={vi.fn()} />)
+
+    await user.click(screen.getByRole('option', { name: 'Fonts' }))
+
+    const target = screen.getByTestId(
+      `settings-target-${SETTINGS_TARGET_IDS.appearanceUiFont}`
+    )
+
+    await waitFor(() => {
+      expect(target).toHaveFocus()
+    })
+
+    expect(
+      screen.getByRole('option', { name: 'Fonts', current: 'location' })
+    ).toHaveAttribute('aria-selected', 'true')
+    expect(target).toHaveAttribute('data-settings-target-active', 'true')
+    expect(scrollIntoView).toHaveBeenCalled()
+
+    scrollIntoView.mockRestore()
+  })
+
   test('clears search from the search field button', async () => {
     const user = userEvent.setup()
     render(<SettingsDialog open onClose={vi.fn()} />)

--- a/src/features/settings/SettingsDialog.tsx
+++ b/src/features/settings/SettingsDialog.tsx
@@ -4,10 +4,15 @@ import type {
   SettingsDialogProps,
   SettingsSearchNavigationDirection,
   SettingsSectionId,
+  SettingsSubsection,
   SettingsTarget,
   SettingsTargetId,
 } from './types'
-import { SETTINGS_SECTIONS, SETTINGS_TARGETS } from './sections'
+import {
+  SETTINGS_SECTIONS,
+  SETTINGS_SUBSECTIONS,
+  SETTINGS_TARGETS,
+} from './sections'
 import {
   searchSettings,
   settingsSectionResultKey,
@@ -170,6 +175,18 @@ export const SettingsDialog = ({
       },
       'focus-target'
     )
+  }
+
+  const handlePickSubsection = (subsection: SettingsSubsection): void => {
+    const target = SETTINGS_TARGETS.find(
+      (candidate) => candidate.id === subsection.targetId
+    )
+
+    if (target === undefined) {
+      return
+    }
+
+    handlePickTarget(target)
   }
 
   const handleNavigateSearchResult = (
@@ -356,11 +373,13 @@ export const SettingsDialog = ({
               <SettingsSidebar
                 sections={filtered}
                 targets={targetMatches}
+                subsections={SETTINGS_SUBSECTIONS}
                 active={section}
                 activeTargetId={activeTargetId}
                 activeSearchResultKey={activeSearchResultKey}
                 onPick={handlePickSection}
                 onPickTarget={handlePickTarget}
+                onPickSubsection={handlePickSubsection}
                 onClearQuery={handleClearQuery}
                 onNavigateSearchResult={handleNavigateSearchResult}
                 onConfirmSearchResult={handleConfirmSearchResult}

--- a/src/features/settings/components/SettingsSidebar.test.tsx
+++ b/src/features/settings/components/SettingsSidebar.test.tsx
@@ -4,6 +4,7 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {
   SETTINGS_SECTIONS,
+  SETTINGS_SUBSECTIONS,
   SETTINGS_TARGET_IDS,
   SETTINGS_TARGETS,
 } from '../sections'
@@ -11,6 +12,10 @@ import { SettingsSidebar } from './SettingsSidebar'
 
 const redactTarget = SETTINGS_TARGETS.find(
   (target) => target.id === SETTINGS_TARGET_IDS.generalRedactPrivateValues
+)!
+
+const fontsSubsection = SETTINGS_SUBSECTIONS.find(
+  (subsection) => subsection.id === 'appearance-fonts'
 )!
 
 const StatefulSidebar = (): ReactElement => {
@@ -122,6 +127,83 @@ describe('SettingsSidebar', () => {
     SETTINGS_SECTIONS.forEach((s) => {
       expect(screen.getByRole('option', { name: s.label })).toBeInTheDocument()
     })
+  })
+
+  test('renders subsections under the active expanded section', () => {
+    render(
+      <SettingsSidebar {...baseProps} subsections={SETTINGS_SUBSECTIONS} />
+    )
+
+    expect(screen.getByRole('option', { name: 'Theme' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('option', { name: 'Interface' })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Fonts' })).toBeInTheDocument()
+  })
+
+  test('collapses and expands subsection rows from the section option', async () => {
+    const user = userEvent.setup()
+    render(
+      <SettingsSidebar {...baseProps} subsections={SETTINGS_SUBSECTIONS} />
+    )
+
+    await user.click(screen.getByRole('option', { name: 'Appearance' }))
+
+    expect(screen.queryByRole('option', { name: 'Fonts' })).toBeNull()
+
+    await user.click(screen.getByRole('option', { name: 'Appearance' }))
+
+    expect(screen.getByRole('option', { name: 'Fonts' })).toBeInTheDocument()
+  })
+
+  test('calls onPickSubsection when a subsection is clicked', async () => {
+    const user = userEvent.setup()
+    const onPickSubsection = vi.fn()
+    render(
+      <SettingsSidebar
+        {...baseProps}
+        subsections={SETTINGS_SUBSECTIONS}
+        onPickSubsection={onPickSubsection}
+      />
+    )
+
+    await user.click(screen.getByRole('option', { name: 'Fonts' }))
+
+    expect(onPickSubsection).toHaveBeenCalledWith(fontsSubsection)
+  })
+
+  test('marks the active subsection with aria-current and aria-selected', () => {
+    render(
+      <SettingsSidebar
+        {...baseProps}
+        subsections={SETTINGS_SUBSECTIONS}
+        activeTargetId={SETTINGS_TARGET_IDS.appearanceUiFont}
+      />
+    )
+
+    expect(
+      screen.getByRole('option', { name: 'Fonts', current: 'location' })
+    ).toHaveAttribute('aria-selected', 'true')
+  })
+
+  test('keeps search target rows instead of subsection rows while searching', () => {
+    render(
+      <SettingsSidebar
+        {...baseProps}
+        sections={SETTINGS_SECTIONS.filter(
+          (section) => section.id === 'general'
+        )}
+        targets={[redactTarget]}
+        subsections={SETTINGS_SUBSECTIONS}
+        active="general"
+        query="redact"
+      />
+    )
+
+    expect(
+      screen.getByRole('option', { name: 'Redact Private Values' })
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: 'Privacy' })).toBeNull()
   })
 
   test('forwards query changes', async () => {

--- a/src/features/settings/components/SettingsSidebar.test.tsx
+++ b/src/features/settings/components/SettingsSidebar.test.tsx
@@ -91,6 +91,23 @@ describe('SettingsSidebar', () => {
     )
   })
 
+  test('points aria-activedescendant at the active subsection result', () => {
+    render(
+      <SettingsSidebar
+        {...baseProps}
+        subsections={SETTINGS_SUBSECTIONS}
+        activeTargetId={SETTINGS_TARGET_IDS.appearanceUiFont}
+      />
+    )
+
+    expect(
+      screen.getByRole('combobox', { name: 'Search settings' })
+    ).toHaveAttribute(
+      'aria-activedescendant',
+      'settings-search-result-subsection-appearance-fonts'
+    )
+  })
+
   test('uses the selected search result key for aria-activedescendant', () => {
     render(
       <SettingsSidebar

--- a/src/features/settings/components/SettingsSidebar.tsx
+++ b/src/features/settings/components/SettingsSidebar.tsx
@@ -212,7 +212,6 @@ export const SettingsSidebar = ({
                 role="option"
                 aria-selected={isActive}
                 aria-current={isActive ? 'page' : undefined}
-                aria-expanded={hasTreeChildren ? isExpanded : undefined}
                 onClick={() => handlePickSection(s.id, sectionSubsections)}
                 className={`relative flex w-full items-center gap-2 rounded-md border-none px-2.5 py-1.5 text-left font-body text-[13px] transition-colors ${
                   isActive

--- a/src/features/settings/components/SettingsSidebar.tsx
+++ b/src/features/settings/components/SettingsSidebar.tsx
@@ -1,9 +1,17 @@
-import { useRef, type KeyboardEvent, type ReactElement } from 'react'
+import {
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type ReactElement,
+} from 'react'
 import { Tooltip } from '@/components/Tooltip'
 import type {
   SettingsSearchNavigationDirection,
   SettingsSectionId,
   SettingsSidebarProps,
+  SettingsSubsection,
+  SettingsSubsectionId,
   SettingsTargetId,
 } from '../types'
 import { resultKeyToAriaId } from '../search'
@@ -17,14 +25,19 @@ const sectionResultId = (id: SettingsSectionId): string =>
 const targetResultId = (id: SettingsTargetId): string =>
   `settings-search-result-target-${id}`
 
+const subsectionResultId = (id: SettingsSubsectionId): string =>
+  `settings-search-result-subsection-${id}`
+
 export const SettingsSidebar = ({
   sections,
   targets = [],
+  subsections = [],
   active,
   activeTargetId = null,
   activeSearchResultKey = null,
   onPick,
   onPickTarget = (): void => undefined,
+  onPickSubsection = (): void => undefined,
   onClearQuery = (): void => undefined,
   onNavigateSearchResult = (): void => undefined,
   onConfirmSearchResult = (): void => undefined,
@@ -33,13 +46,41 @@ export const SettingsSidebar = ({
 }: SettingsSidebarProps): ReactElement => {
   const searchInputRef = useRef<HTMLInputElement>(null)
 
+  const [expandedSectionIds, setExpandedSectionIds] = useState<
+    Set<SettingsSectionId>
+  >(() => new Set([active]))
+  const searchActive = query.trim() !== ''
+  const treeActive = subsections.length > 0 && !searchActive
+
+  useEffect(() => {
+    setExpandedSectionIds((current) => {
+      if (current.has(active)) {
+        return current
+      }
+
+      return new Set([...current, active])
+    })
+  }, [active])
+
+  const activeSubsection =
+    activeTargetId === null
+      ? undefined
+      : subsections.find(
+          (subsection) =>
+            subsection.section === active &&
+            subsection.targetIds.includes(activeTargetId)
+        )
+
   const fallbackActiveResultId =
     activeTargetId !== null &&
+    !treeActive &&
     targets.some((target) => target.id === activeTargetId)
       ? targetResultId(activeTargetId)
-      : sections.some((section) => section.id === active)
-        ? sectionResultId(active)
-        : undefined
+      : activeSubsection !== undefined
+        ? subsectionResultId(activeSubsection.id)
+        : sections.some((section) => section.id === active)
+          ? sectionResultId(active)
+          : undefined
 
   const activeResultId =
     activeSearchResultKey === null
@@ -51,6 +92,27 @@ export const SettingsSidebar = ({
   const handleClearQuery = (): void => {
     onClearQuery()
     searchInputRef.current?.focus()
+  }
+
+  const handlePickSection = (
+    id: SettingsSectionId,
+    sectionSubsections: SettingsSubsection[]
+  ): void => {
+    onPick(id)
+
+    if (treeActive && sectionSubsections.length > 0) {
+      setExpandedSectionIds((current) => {
+        const next = new Set(current)
+
+        if (id === active && next.has(id)) {
+          next.delete(id)
+        } else {
+          next.add(id)
+        }
+
+        return next
+      })
+    }
   }
 
   const handleNavigate = (
@@ -135,6 +197,13 @@ export const SettingsSidebar = ({
             (target) => target.section === s.id
           )
 
+          const sectionSubsections = treeActive
+            ? subsections.filter((subsection) => subsection.section === s.id)
+            : []
+          const isExpanded = searchActive || expandedSectionIds.has(s.id)
+          const hasTreeChildren = sectionSubsections.length > 0
+          const shouldShowTargets = !treeActive && sectionTargets.length > 0
+
           return (
             <div key={s.id} className="mb-px">
               <button
@@ -143,7 +212,8 @@ export const SettingsSidebar = ({
                 role="option"
                 aria-selected={isActive}
                 aria-current={isActive ? 'page' : undefined}
-                onClick={() => onPick(s.id)}
+                aria-expanded={hasTreeChildren ? isExpanded : undefined}
+                onClick={() => handlePickSection(s.id, sectionSubsections)}
                 className={`relative flex w-full items-center gap-2 rounded-md border-none px-2.5 py-1.5 text-left font-body text-[13px] transition-colors ${
                   isActive
                     ? 'bg-primary-container/10 text-primary'
@@ -156,16 +226,57 @@ export const SettingsSidebar = ({
                 <Icon
                   name="chevron_right"
                   size={13}
-                  className={
+                  className={`transition-transform ${
                     isActive
                       ? 'text-primary-container'
                       : 'text-on-surface-muted'
-                  }
+                  } ${hasTreeChildren && isExpanded ? 'rotate-90' : ''}`}
                 />
                 {s.label}
               </button>
 
-              {sectionTargets.length > 0 && (
+              {treeActive && hasTreeChildren && isExpanded && (
+                <div className="mt-0.5 mb-1 space-y-px pl-5">
+                  {sectionSubsections.map((subsection) => {
+                    const isSubsectionActive =
+                      activeSubsection?.id === subsection.id
+
+                    return (
+                      <button
+                        id={subsectionResultId(subsection.id)}
+                        key={subsection.id}
+                        type="button"
+                        role="option"
+                        aria-selected={isSubsectionActive}
+                        aria-current={
+                          isSubsectionActive ? 'location' : undefined
+                        }
+                        onClick={() => onPickSubsection(subsection)}
+                        className={`flex w-full items-center gap-1.5 rounded-md border-none px-2 py-1.5 text-left font-body text-[12px] transition-colors ${
+                          isSubsectionActive
+                            ? 'bg-primary-container/[0.08] text-primary'
+                            : 'bg-transparent text-on-surface-muted hover:bg-on-surface/[0.03] hover:text-on-surface-variant'
+                        }`}
+                      >
+                        <Icon
+                          name="subdirectory_arrow_right"
+                          size={12}
+                          className={
+                            isSubsectionActive
+                              ? 'text-primary-container'
+                              : 'text-on-surface-muted'
+                          }
+                        />
+                        <span className="min-w-0 truncate">
+                          {subsection.label}
+                        </span>
+                      </button>
+                    )
+                  })}
+                </div>
+              )}
+
+              {shouldShowTargets && (
                 <div className="mt-0.5 mb-1 space-y-px pl-5">
                   {sectionTargets.map((target) => {
                     const isTargetActive = target.id === activeTargetId

--- a/src/features/settings/index.test.ts
+++ b/src/features/settings/index.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_ALIASES,
   KEYMAP_GROUPS,
   SETTINGS_SECTIONS,
+  SETTINGS_SUBSECTIONS,
   SettingsDialog,
   VIM_KEYMAP_GROUPS,
   useSettingsDialog,
@@ -20,6 +21,7 @@ describe('settings feature barrel', () => {
 
   test('exports section and scheme constants', () => {
     expect(SETTINGS_SECTIONS.length).toBeGreaterThan(0)
+    expect(SETTINGS_SUBSECTIONS.length).toBeGreaterThan(0)
     expect(BUILTIN_SCHEMES.length).toBeGreaterThan(0)
     expect(KEYMAP_GROUPS.length).toBeGreaterThan(0)
     expect(VIM_KEYMAP_GROUPS.length).toBeGreaterThan(0)

--- a/src/features/settings/index.ts
+++ b/src/features/settings/index.ts
@@ -7,11 +7,13 @@ export {
   DEFAULT_ALIASES,
   KEYMAP_GROUPS,
   SETTINGS_TARGET_IDS,
+  SETTINGS_SUBSECTIONS,
   SETTINGS_TARGETS,
   SETTINGS_SECTIONS,
   VIM_KEYMAP_GROUPS,
   keymapCommandTargetId,
   keymapStaticTargetId,
+  settingsSubsectionId,
 } from './sections'
 
 export type {
@@ -28,6 +30,8 @@ export type {
   SettingsSection,
   SettingsSectionId,
   SettingsSidebarProps,
+  SettingsSubsection,
+  SettingsSubsectionId,
   SettingsTarget,
   SettingsTargetId,
 } from './types'

--- a/src/features/settings/sections.test.ts
+++ b/src/features/settings/sections.test.ts
@@ -4,10 +4,12 @@ import {
   DEFAULT_ALIASES,
   KEYMAP_GROUPS,
   SETTINGS_TARGET_IDS,
+  SETTINGS_SUBSECTIONS,
   SETTINGS_TARGETS,
   SETTINGS_SECTIONS,
   VIM_KEYMAP_GROUPS,
   keymapCommandTargetId,
+  settingsSubsectionId,
 } from './sections'
 
 describe('SETTINGS_SECTIONS', () => {
@@ -64,6 +66,37 @@ describe('SETTINGS_TARGETS', () => {
           id: keymapCommandTargetId('palette-leader'),
           section: 'keymap',
           label: 'Command palette leader',
+        }),
+      ])
+    )
+  })
+})
+
+describe('SETTINGS_SUBSECTIONS', () => {
+  test('derives unique subsection ids from section and label', () => {
+    const ids = SETTINGS_SUBSECTIONS.map((subsection) => subsection.id)
+
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(settingsSubsectionId('appearance', 'Fonts')).toBe('appearance-fonts')
+  })
+
+  test('contains subsection target groups in source order', () => {
+    expect(SETTINGS_SUBSECTIONS).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'appearance-fonts',
+          section: 'appearance',
+          label: 'Fonts',
+          targetId: SETTINGS_TARGET_IDS.appearanceUiFont,
+          targetIds: [
+            SETTINGS_TARGET_IDS.appearanceUiFont,
+            SETTINGS_TARGET_IDS.appearanceMonoFont,
+          ],
+        }),
+        expect.objectContaining({
+          id: 'keymap-global',
+          section: 'keymap',
+          label: 'Global',
         }),
       ])
     )

--- a/src/features/settings/sections.ts
+++ b/src/features/settings/sections.ts
@@ -3,6 +3,8 @@ import type {
   AppearanceScheme,
   KeymapGroup,
   SettingsSection,
+  SettingsSubsection,
+  SettingsSubsectionId,
   SettingsTarget,
   SettingsTargetId,
 } from './types'
@@ -47,6 +49,19 @@ export const keymapCommandTargetId = (id: CommandId): SettingsTargetId =>
 
 export const keymapStaticTargetId = (id: string): SettingsTargetId =>
   `keymap-static-${id}`
+
+const slugifySubsection = (label: string): string =>
+  label
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+
+export const settingsSubsectionId = (
+  section: SettingsSection['id'],
+  label: string
+): SettingsSubsectionId => `${section}-${slugifySubsection(label)}`
 
 /* eslint-disable vimeflow/no-hardcoded-colors -- literal preview swatches for the
    appearance scheme picker (AppearancePane): each entry intentionally shows that
@@ -350,6 +365,32 @@ export const SETTINGS_TARGETS: SettingsTarget[] = [
     subsection: 'Aliases',
   },
 ]
+
+export const SETTINGS_SUBSECTIONS: SettingsSubsection[] =
+  SETTINGS_TARGETS.reduce<SettingsSubsection[]>((subsections, target) => {
+    if (target.subsection === undefined) {
+      return subsections
+    }
+
+    const id = settingsSubsectionId(target.section, target.subsection)
+    const existing = subsections.find((subsection) => subsection.id === id)
+
+    if (existing !== undefined) {
+      existing.targetIds.push(target.id)
+
+      return subsections
+    }
+
+    subsections.push({
+      id,
+      section: target.section,
+      label: target.subsection,
+      targetId: target.id,
+      targetIds: [target.id],
+    })
+
+    return subsections
+  }, [])
 
 export const DEFAULT_ALIASES: AgentAlias[] = [
   {

--- a/src/features/settings/types.ts
+++ b/src/features/settings/types.ts
@@ -33,6 +33,16 @@ export interface SettingsTarget {
   subsection?: string
 }
 
+export type SettingsSubsectionId = string
+
+export interface SettingsSubsection {
+  id: SettingsSubsectionId
+  section: SettingsSectionId
+  label: string
+  targetId: SettingsTargetId
+  targetIds: SettingsTargetId[]
+}
+
 export type SettingsSearchNavigationDirection = 'next' | 'previous'
 
 export interface SettingsDialogProps {
@@ -43,11 +53,13 @@ export interface SettingsDialogProps {
 export interface SettingsSidebarProps {
   sections: SettingsSection[]
   targets?: SettingsTarget[]
+  subsections?: SettingsSubsection[]
   active: SettingsSectionId
   activeTargetId?: SettingsTargetId | null
   activeSearchResultKey?: string | null
   onPick: (id: SettingsSectionId) => void
   onPickTarget?: (target: SettingsTarget) => void
+  onPickSubsection?: (subsection: SettingsSubsection) => void
   onClearQuery?: () => void
   onNavigateSearchResult?: (
     direction: SettingsSearchNavigationDirection


### PR DESCRIPTION
## Summary

- Derive sidebar subsections from the existing settings target metadata.
- Render expanded category subsections in the Settings sidebar when search is idle.
- Reuse the existing target navigation path so selecting a subsection opens the owning pane and focuses the first setting row in that group.

Refs VIM-106

## Validation

- `npm test -- --run`
- `npm run lint`
- `npm run type-check:generated`
- `npm run format:check`
- `git diff --check`