### PR TITLE
refactor(terminal): add display delta output contract

### DIFF
--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
@@ -135,6 +135,70 @@ describe('ghosttyInstance', () => {
     expect(created.viewportReader.readVisibleText()).toBe('parsed:from-engine')
   })
 
+  test('applies parser display replace deltas without appending snapshots', () => {
+    const parser: TerminalParser = {
+      onEvent: (): TerminalDisposable => ({ dispose: vi.fn() }),
+    }
+
+    const parseOutput = vi
+      .fn<(chunk: TerminalOutputChunk) => TerminalParserEngineOutput>()
+      .mockReturnValueOnce({
+        visibleText: 'screen snapshot one',
+        displayDelta: {
+          operations: [
+            {
+              type: 'replace',
+              text: 'screen snapshot one',
+            },
+          ],
+        },
+      })
+      .mockReturnValueOnce({
+        visibleText: 'screen snapshot two',
+        displayDelta: {
+          operations: [
+            {
+              type: 'replace',
+              text: 'screen snapshot two',
+            },
+          ],
+        },
+      })
+
+    const parserEngine: TerminalParserEngine = {
+      inputMode: 'bytes',
+      capabilities: ghosttyTerminalRenderer.capabilities,
+      parser,
+      parseText: (text): TerminalParserEngineOutput => ({
+        visibleText: text,
+      }),
+      parseInput: (input): TerminalParserEngineOutput => ({
+        visibleText: input.text,
+      }),
+      parseOutput,
+    }
+
+    const created = createTrackedGhosttyTerminal({
+      createParserEngine: () => parserEngine,
+    })
+
+    created.output.writeOutput({
+      text: 'first',
+      offsetStart: 0,
+      byteLen: 5,
+      phase: 'live',
+    })
+
+    created.output.writeOutput({
+      text: 'second',
+      offsetStart: 5,
+      byteLen: 6,
+      phase: 'live',
+    })
+
+    expect(created.viewportReader.readVisibleText()).toBe('screen snapshot two')
+  })
+
   test('disposes the parser engine once through terminal disposal', () => {
     const parser: TerminalParser = {
       onEvent: (): TerminalDisposable => ({ dispose: vi.fn() }),

--- a/src/features/terminal/components/TerminalPane/ghosttyVtByteParserAdapter.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtByteParserAdapter.test.ts
@@ -68,6 +68,34 @@ describe('ghosttyVtByteParserAdapter', () => {
     })
   })
 
+  test('passes VT render deltas back to the parser engine caller', () => {
+    const adapter = createGhosttyVtByteParserAdapter(() => ({
+      writeBytes: (): TerminalParserEngineOutput => ({
+        visibleText: 'screen snapshot two',
+        displayDelta: {
+          operations: [
+            {
+              type: 'replace',
+              text: 'screen snapshot two',
+            },
+          ],
+        },
+      }),
+    }))
+
+    expect(adapter.parseBytes(createInput(new Uint8Array([0x67])))).toEqual({
+      visibleText: 'screen snapshot two',
+      displayDelta: {
+        operations: [
+          {
+            type: 'replace',
+            text: 'screen snapshot two',
+          },
+        ],
+      },
+    })
+  })
+
   test('ignores VT cwd effects fired outside an active byte write', () => {
     const capturedEffects: {
       onCwdChange?: GhosttyVtParserEffects['onCwdChange']

--- a/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.test.ts
@@ -30,6 +30,32 @@ describe('TerminalDisplayBuffer', () => {
     expect(buffer.readVisibleText()).toBe('hello\nworld')
   })
 
+  test('applies append and replace display delta operations', () => {
+    const buffer = new TerminalDisplayBuffer()
+
+    buffer.applyDelta({
+      operations: [{ type: 'append', text: 'snapshot one' }],
+    })
+
+    buffer.applyDelta({
+      operations: [{ type: 'replace', text: 'snapshot two' }],
+    })
+
+    expect(buffer.readVisibleText()).toBe('snapshot two')
+  })
+
+  test('applies empty replace display deltas as a clear operation', () => {
+    const buffer = new TerminalDisplayBuffer()
+
+    buffer.write('old snapshot')
+    buffer.applyDelta({
+      operations: [{ type: 'replace', text: '' }],
+    })
+
+    expect(buffer.readVisibleText()).toBe('')
+    expect(buffer.readCursorOffset()).toBe(0)
+  })
+
   test('rewrites the current line when carriage return output arrives', () => {
     const buffer = new TerminalDisplayBuffer()
 

--- a/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
+++ b/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
@@ -38,6 +38,20 @@ export interface TerminalDisplayRun {
   readonly style: TerminalDisplayStyle
 }
 
+export type TerminalDisplayDeltaOperation =
+  | {
+      readonly type: 'append'
+      readonly text: string
+    }
+  | {
+      readonly type: 'replace'
+      readonly text: string
+    }
+
+export interface TerminalDisplayDelta {
+  readonly operations: readonly TerminalDisplayDeltaOperation[]
+}
+
 interface DisplayState {
   readonly text: string
   readonly cursor: number
@@ -1488,6 +1502,11 @@ export class TerminalDisplayBuffer {
     this.state = createEmptyState()
   }
 
+  replace(data: string): void {
+    this.clear()
+    this.write(data)
+  }
+
   write(data: string): void {
     if (data.length === 0) {
       return
@@ -1497,6 +1516,18 @@ export class TerminalDisplayBuffer {
       applyDisplayData(this.state, data, this.columns),
       this.maxScrollbackLines
     )
+  }
+
+  applyDelta(delta: TerminalDisplayDelta): void {
+    delta.operations.forEach((operation) => {
+      if (operation.type === 'replace') {
+        this.replace(operation.text)
+
+        return
+      }
+
+      this.write(operation.text)
+    })
   }
 
   readText(): string {

--- a/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
+++ b/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
@@ -11,10 +11,12 @@ import {
   TerminalOutputPayloadRouter,
   type TerminalOutputPayloadSelection,
 } from './terminalOutputPayload'
+import type { TerminalDisplayDelta } from './terminalDisplayBuffer'
 
 export interface TerminalParserEngineOutput {
   readonly visibleText: string
   readonly displayText?: string
+  readonly displayDelta?: TerminalDisplayDelta
 }
 
 export type TerminalParserEngineInputMode = TerminalOutputInputMode

--- a/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
+++ b/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
@@ -8,6 +8,7 @@ import type {
 } from '../../types'
 import {
   TerminalDisplayBuffer,
+  type TerminalDisplayDelta,
   type TerminalDisplayRun,
   type TerminalDisplayStyle,
 } from './terminalDisplayBuffer'
@@ -41,6 +42,7 @@ export interface TerminalTextSurfaceOptions {
 export interface TerminalTextSurfaceOutput {
   readonly visibleText: string
   readonly displayText?: string
+  readonly displayDelta?: TerminalDisplayDelta
 }
 
 const createDisposable = (dispose: () => void): TerminalDisposable => ({
@@ -262,6 +264,14 @@ export class TerminalTextSurface implements TerminalSurface {
     callback?: () => void
   ): void {
     if (this.disposed) {
+      callback?.()
+
+      return
+    }
+
+    if (output.displayDelta) {
+      this.outputBuffer.applyDelta(output.displayDelta)
+      this.renderOutput()
       callback?.()
 
       return


### PR DESCRIPTION
## Summary
- Add a parser-output `displayDelta` contract for renderer display operations.
- Teach `TerminalDisplayBuffer` and `TerminalTextSurface` to apply append/replace display deltas before falling back to existing append-only text output.
- Cover the Ghostty VT bridge and Ghostty renderer path so repeated screen snapshots replace stale text instead of appending ghosted snapshots.

## Why
A real Ghostty/libghostty VT driver owns terminal screen state. The previous output contract only supported append-style text, which would make a driver either diff state internally or risk duplicating whole-screen snapshots per PTY chunk. This PR adds the minimal renderer contract needed for a driver to publish replacement snapshots safely while keeping the existing text path unchanged.

## Verification
- `npx vitest run src/features/terminal/components/TerminalPane/terminalDisplayBuffer.test.ts src/features/terminal/components/TerminalPane/ghosttyVtByteParserAdapter.test.ts src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts`
- `npm run type-check`
- `npm run lint`
- `npm run format:check`
- `npm run test:e2e:ghostty`
- Pre-push `npm run test` — 300 files, 3887 passed, 3 skipped

## Manual testing
No manual smoke is required for this slice. It is a dependency-free renderer contract step; the current Ghostty visual behavior should stay unchanged until a real VT/render-state driver emits deltas.


Refs VIM-163