### PR TITLE
refactor(terminal): add Ghostty snapshot cursor output

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -56,7 +56,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 1        | 0    | 2026-06-09   |
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 65       | 32   | 2026-06-18   |
 | [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 24       | 7    | 2026-06-19   |
-| [Terminal DOM Rendering](patterns/terminal-dom-rendering.md)                                         | terminal           | 2        | 0    | 2026-06-18   |
+| [Terminal DOM Rendering](patterns/terminal-dom-rendering.md)                                         | terminal           | 3        | 0    | 2026-06-19   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 85       | 25   | 2026-06-08   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 51       | 24   | 2026-06-18   |

--- a/docs/reviews/patterns/terminal-dom-rendering.md
+++ b/docs/reviews/patterns/terminal-dom-rendering.md
@@ -2,7 +2,7 @@
 id: terminal-dom-rendering
 category: terminal
 created: 2026-06-18
-last_updated: 2026-06-18
+last_updated: 2026-06-19
 ref_count: 0
 ---
 
@@ -30,4 +30,13 @@ The terminal renderer translates a buffered text/runs model into DOM rows for di
 - **File:** `src/features/terminal/components/TerminalPane/terminalTextSurface.ts` L479
 - **Finding:** `measureCharacterWidth` appended a probe span, forced `getBoundingClientRect()`, and removed the span on every `fit()` call. During continuous pane/window resize this repeated a synchronous layout read for a font metric that is stable for the surface lifetime.
 - **Fix:** Added a nullable `cachedCharacterWidth` instance field. `measureCharacterWidth` returns the cached value after the first successful measurement; the cache is not invalidated because `TERMINAL_FONT_FAMILY` and `TERMINAL_FONT_SIZE` are constants for the surface.
+- **Commit:** same commit as this entry
+
+### 3. Translate snapshot columns to text offsets
+
+- **Source:** github-codex-connector | PR #553 round 1 | 2026-06-19
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.ts` L35
+- **Finding:** When a VT snapshot row contains wide or combining characters before the cursor, the snapshot helper treated the parser's terminal-cell column as a raw UTF-16 string offset by clamping against `row.length` and returning that value directly, which placed the cursor inside wide characters or between combining marks.
+- **Fix:** Reused `TerminalDisplayBuffer`'s cell-width mapping by exporting `findTextOffsetForCellColumn` and consuming it in `readSnapshotCursorOffset`; the helper advances through zero-width combining marks so the cursor offset lands after the complete grapheme cluster. Added unit tests for wide characters and combining marks.
 - **Commit:** same commit as this entry

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
@@ -16,6 +16,7 @@ import {
   ghosttyTerminalRenderer,
   type GhosttyTerminalOptions,
 } from './ghosttyInstance'
+import { createGhosttyVtRenderSnapshotOutput } from './ghosttyVtRenderSnapshot'
 import { GHOSTTY_TERMINAL_CAPABILITIES } from './terminalRendererCapabilities'
 
 const setElementSize = (
@@ -197,6 +198,52 @@ describe('ghosttyInstance', () => {
     })
 
     expect(created.viewportReader.readVisibleText()).toBe('screen snapshot two')
+  })
+
+  test('renders the cursor from parser display snapshot coordinates', () => {
+    const parser: TerminalParser = {
+      onEvent: (): TerminalDisposable => ({ dispose: vi.fn() }),
+    }
+
+    const parserEngine: TerminalParserEngine = {
+      inputMode: 'bytes',
+      capabilities: ghosttyTerminalRenderer.capabilities,
+      parser,
+      parseText: (text): TerminalParserEngineOutput => ({
+        visibleText: text,
+      }),
+      parseInput: (input): TerminalParserEngineOutput => ({
+        visibleText: input.text,
+      }),
+      parseOutput: (): TerminalParserEngineOutput =>
+        createGhosttyVtRenderSnapshotOutput({
+          rows: ['prompt', 'output'],
+          cursor: {
+            rowIndex: 1,
+            columnOffset: 2,
+          },
+        }),
+    }
+
+    const created = createTrackedGhosttyTerminal({
+      createParserEngine: () => parserEngine,
+    })
+
+    created.output.writeOutput({
+      text: 'snapshot',
+      offsetStart: 0,
+      byteLen: 8,
+      phase: 'live',
+    })
+
+    const cursor = created.terminal.element?.querySelector(
+      '[data-terminal-cursor="true"]'
+    )
+
+    expect(created.viewportReader.readVisibleText()).toBe('prompt\noutput')
+    expect(cursor?.parentElement?.textContent).toBe('output')
+    expect(cursor?.previousSibling?.textContent).toBe('ou')
+    expect(cursor?.nextSibling?.textContent).toBe('tput')
   })
 
   test('disposes the parser engine once through terminal disposal', () => {

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.test.ts
@@ -69,4 +69,40 @@ describe('ghosttyVtRenderSnapshot', () => {
       cursorOffset: 'prompt'.length,
     })
   })
+
+  test('maps wide characters to a single terminal cell without splitting', () => {
+    const row = 'a漢'
+
+    expect(
+      createGhosttyVtRenderSnapshotOutput({
+        rows: [row],
+        cursor: {
+          rowIndex: 0,
+          columnOffset: 2,
+        },
+      }).displayDelta?.operations[0]
+    ).toEqual({
+      type: 'replace',
+      text: row,
+      cursorOffset: 1,
+    })
+  })
+
+  test('advances through combining marks at the cell boundary', () => {
+    const row = 'e\u0301' // e + combining acute
+
+    expect(
+      createGhosttyVtRenderSnapshotOutput({
+        rows: [row],
+        cursor: {
+          rowIndex: 0,
+          columnOffset: 1,
+        },
+      }).displayDelta?.operations[0]
+    ).toEqual({
+      type: 'replace',
+      text: row,
+      cursorOffset: row.length,
+    })
+  })
 })

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.test.ts
@@ -1,0 +1,72 @@
+// cspell:ignore ghostty
+import { describe, expect, test } from 'vitest'
+import { createGhosttyVtRenderSnapshotOutput } from './ghosttyVtRenderSnapshot'
+
+describe('ghosttyVtRenderSnapshot', () => {
+  test('converts a VT screen snapshot into a replace display delta', () => {
+    expect(
+      createGhosttyVtRenderSnapshotOutput({
+        rows: ['prompt', 'output'],
+        cursor: {
+          rowIndex: 0,
+          columnOffset: 2,
+        },
+      })
+    ).toEqual({
+      visibleText: 'prompt\noutput',
+      displayDelta: {
+        operations: [
+          {
+            type: 'replace',
+            text: 'prompt\noutput',
+            cursorOffset: 2,
+          },
+        ],
+      },
+    })
+  })
+
+  test('converts later-row cursor coordinates into a text offset', () => {
+    expect(
+      createGhosttyVtRenderSnapshotOutput({
+        rows: ['one', 'two', 'three'],
+        cursor: {
+          rowIndex: 2,
+          columnOffset: 2,
+        },
+      }).displayDelta?.operations[0]
+    ).toEqual({
+      type: 'replace',
+      text: 'one\ntwo\nthree',
+      cursorOffset: 'one\ntwo\nth'.length,
+    })
+  })
+
+  test('clamps cursor coordinates to the snapshot bounds', () => {
+    expect(
+      createGhosttyVtRenderSnapshotOutput({
+        rows: ['one', 'two'],
+        cursor: {
+          rowIndex: 99,
+          columnOffset: 99,
+        },
+      }).displayDelta?.operations[0]
+    ).toEqual({
+      type: 'replace',
+      text: 'one\ntwo',
+      cursorOffset: 'one\ntwo'.length,
+    })
+  })
+
+  test('uses the snapshot end when no cursor is supplied', () => {
+    expect(
+      createGhosttyVtRenderSnapshotOutput({
+        rows: ['prompt'],
+      }).displayDelta?.operations[0]
+    ).toEqual({
+      type: 'replace',
+      text: 'prompt',
+      cursorOffset: 'prompt'.length,
+    })
+  })
+})

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.ts
@@ -34,7 +34,7 @@ const readSnapshotCursorOffset = (
 
   const precedingRowsLength = snapshot.rows
     .slice(0, rowIndex)
-    .reduce((length, row) => length + row.length + 1, 0)
+    .reduce((length, previousRow) => length + previousRow.length + 1, 0)
 
   return precedingRowsLength + rowTextOffset
 }

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.ts
@@ -1,0 +1,63 @@
+// cspell:ignore ghostty
+import type { TerminalParserEngineOutput } from './terminalParserEngine'
+
+export interface GhosttyVtRenderSnapshotCursor {
+  readonly rowIndex: number
+  readonly columnOffset: number
+}
+
+export interface GhosttyVtRenderSnapshot {
+  readonly rows: readonly string[]
+  readonly cursor?: GhosttyVtRenderSnapshotCursor
+}
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(Math.max(value, min), max)
+
+const readSnapshotText = (snapshot: GhosttyVtRenderSnapshot): string =>
+  snapshot.rows.join('\n')
+
+const readSnapshotCursorOffset = (
+  snapshot: GhosttyVtRenderSnapshot,
+  text: string
+): number => {
+  const cursor = snapshot.cursor
+
+  if (!cursor || snapshot.rows.length === 0) {
+    return text.length
+  }
+
+  const rowIndex = clamp(cursor.rowIndex, 0, snapshot.rows.length - 1)
+
+  const columnOffset = clamp(
+    cursor.columnOffset,
+    0,
+    snapshot.rows[rowIndex]?.length ?? 0
+  )
+
+  const precedingRowsLength = snapshot.rows
+    .slice(0, rowIndex)
+    .reduce((length, row) => length + row.length + 1, 0)
+
+  return precedingRowsLength + columnOffset
+}
+
+export const createGhosttyVtRenderSnapshotOutput = (
+  snapshot: GhosttyVtRenderSnapshot
+): TerminalParserEngineOutput => {
+  const text = readSnapshotText(snapshot)
+  const cursorOffset = readSnapshotCursorOffset(snapshot, text)
+
+  return {
+    visibleText: text,
+    displayDelta: {
+      operations: [
+        {
+          type: 'replace',
+          text,
+          cursorOffset,
+        },
+      ],
+    },
+  }
+}

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.ts
@@ -1,4 +1,5 @@
 // cspell:ignore ghostty
+import { findTextOffsetForCellColumn } from './terminalDisplayBuffer'
 import type { TerminalParserEngineOutput } from './terminalParserEngine'
 
 export interface GhosttyVtRenderSnapshotCursor {
@@ -28,18 +29,14 @@ const readSnapshotCursorOffset = (
   }
 
   const rowIndex = clamp(cursor.rowIndex, 0, snapshot.rows.length - 1)
-
-  const columnOffset = clamp(
-    cursor.columnOffset,
-    0,
-    snapshot.rows[rowIndex]?.length ?? 0
-  )
+  const row = snapshot.rows[rowIndex] ?? ''
+  const rowTextOffset = findTextOffsetForCellColumn(row, cursor.columnOffset)
 
   const precedingRowsLength = snapshot.rows
     .slice(0, rowIndex)
     .reduce((length, row) => length + row.length + 1, 0)
 
-  return precedingRowsLength + columnOffset
+  return precedingRowsLength + rowTextOffset
 }
 
 export const createGhosttyVtRenderSnapshotOutput = (

--- a/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.test.ts
@@ -44,6 +44,23 @@ describe('TerminalDisplayBuffer', () => {
     expect(buffer.readVisibleText()).toBe('snapshot two')
   })
 
+  test('applies replace display delta cursor offsets', () => {
+    const buffer = new TerminalDisplayBuffer()
+
+    buffer.applyDelta({
+      operations: [
+        {
+          type: 'replace',
+          text: 'prompt\noutput',
+          cursorOffset: 'prompt\nou'.length,
+        },
+      ],
+    })
+
+    expect(buffer.readVisibleText()).toBe('prompt\noutput')
+    expect(buffer.readCursorOffset()).toBe('prompt\nou'.length)
+  })
+
   test('applies empty replace display deltas as a clear operation', () => {
     const buffer = new TerminalDisplayBuffer()
 

--- a/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
+++ b/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
@@ -46,6 +46,7 @@ export type TerminalDisplayDeltaOperation =
   | {
       readonly type: 'replace'
       readonly text: string
+      readonly cursorOffset?: number
     }
 
 export interface TerminalDisplayDelta {
@@ -1502,9 +1503,19 @@ export class TerminalDisplayBuffer {
     this.state = createEmptyState()
   }
 
-  replace(data: string): void {
+  replace(data: string, cursorOffset?: number): void {
     this.clear()
     this.write(data)
+
+    if (cursorOffset !== undefined) {
+      const cursor = Math.min(Math.max(cursorOffset, 0), this.state.text.length)
+
+      this.state = {
+        ...this.state,
+        cursor,
+        cursorRow: readCursorRow(this.state.text, cursor),
+      }
+    }
   }
 
   write(data: string): void {
@@ -1521,7 +1532,7 @@ export class TerminalDisplayBuffer {
   applyDelta(delta: TerminalDisplayDelta): void {
     delta.operations.forEach((operation) => {
       if (operation.type === 'replace') {
-        this.replace(operation.text)
+        this.replace(operation.text, operation.cursorOffset)
 
         return
       }

--- a/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
+++ b/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
@@ -463,6 +463,26 @@ const findOffsetForCellColumn = (
   return lineEnd
 }
 
+export const findTextOffsetForCellColumn = (
+  text: string,
+  targetColumn: number
+): number => {
+  const offset = findOffsetForCellColumn(text, 0, text.length, targetColumn)
+  let cursor = offset
+
+  while (cursor < text.length) {
+    const codePoint = text.codePointAt(cursor) ?? 0
+
+    if (!isCombiningCodePoint(codePoint)) {
+      break
+    }
+
+    cursor += codePoint > 0xffff ? 2 : 1
+  }
+
+  return cursor
+}
+
 const findOffsetForChaColumn = (
   text: string,
   lineStart: number,


### PR DESCRIPTION
## Summary
- Add a dependency-free Ghostty VT render snapshot helper that turns driver-owned screen rows and cursor coordinates into `displayDelta.replace` output.
- Let replace display deltas carry an explicit cursor offset so snapshot renders do not always put the cursor at the end.
- Cover the Ghostty renderer path with an injected parser engine snapshot test.

## Why
A real VT parser owns screen text and cursor state. This keeps that ownership inside the Ghostty adapter boundary and exposes generic renderer deltas to the app without adding a native/libghostty dependency yet.

## Verification
- `npx vitest run src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.test.ts src/features/terminal/components/TerminalPane/terminalDisplayBuffer.test.ts src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts src/features/terminal/components/TerminalPane/ghosttyVtByteParserAdapter.test.ts`
- `npm run type-check`
- `npm run lint`
- `npm run format:check`
- `npm run test:e2e:ghostty`
- Pre-push `npm run test`

## Manual testing
No manual smoke is required for this slice. It only extends the renderer contract and injected-engine coverage; runtime Ghostty behavior is unchanged until a real VT/render-state driver is wired.


Refs VIM-169