### PR TITLE
feat(sessions): add explicit pane placements

### DIFF
--- a/crates/backend/src/terminal/workspace_layout.rs
+++ b/crates/backend/src/terminal/workspace_layout.rs
@@ -88,10 +88,21 @@ pub struct WorkspaceSession {
     pub id: String,
     pub project_id: String,
     pub layout: String,
+    #[serde(default)]
+    pub placements: Vec<PanePlacement>,
     pub working_directory: String,
     pub active: bool,
     pub open: bool,
     pub panes: Vec<WorkspacePane>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(test, derive(ts_rs::TS))]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(test, ts(export))]
+pub struct PanePlacement {
+    pub pane_id: String,
+    pub slot_id: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -188,6 +199,30 @@ fn custom_layout_capacity(
 
 fn layout_capacity(layout: &str, custom_pane_layouts: &[PaneLayoutDefinition]) -> Option<usize> {
     builtin_layout_capacity(layout).or_else(|| custom_layout_capacity(custom_pane_layouts, layout))
+}
+
+fn builtin_layout_slot_ids(layout: &str) -> Option<Vec<String>> {
+    builtin_layout_capacity(layout).map(|capacity| {
+        (0..capacity)
+            .map(|index| format!("slot:p{index}"))
+            .collect()
+    })
+}
+
+fn custom_layout_slot_ids(
+    custom_pane_layouts: &[PaneLayoutDefinition],
+    layout: &str,
+) -> Option<Vec<String>> {
+    custom_pane_layouts
+        .iter()
+        .find(|definition| definition.id == layout)
+        .map(|definition| definition.add_order.clone())
+}
+
+fn layout_slot_ids(layout: &str, custom_pane_layouts: &[PaneLayoutDefinition]) -> Vec<String> {
+    builtin_layout_slot_ids(layout)
+        .or_else(|| custom_layout_slot_ids(custom_pane_layouts, layout))
+        .unwrap_or_else(|| vec!["slot:p0".to_string()])
 }
 
 fn layout_for_count(n: usize) -> &'static str {
@@ -384,6 +419,72 @@ fn pane_active(pane: &WorkspacePane) -> bool {
     }
 }
 
+fn pane_id(pane: &WorkspacePane) -> &str {
+    match pane {
+        WorkspacePane::Shell(s) => &s.pane_id,
+        WorkspacePane::Browser(b) => &b.pane_id,
+    }
+}
+
+fn repair_placements(
+    raw_placements: &[serde_json::Value],
+    panes: &[WorkspacePane],
+    layout: &str,
+    custom_pane_layouts: &[PaneLayoutDefinition],
+) -> Vec<PanePlacement> {
+    let pane_ids: std::collections::HashSet<String> =
+        panes.iter().map(|pane| pane_id(pane).to_string()).collect();
+    let slot_order = layout_slot_ids(layout, custom_pane_layouts);
+    let slot_ids: std::collections::HashSet<String> = slot_order.iter().cloned().collect();
+    let mut used_pane_ids = std::collections::HashSet::new();
+    let mut used_slot_ids = std::collections::HashSet::new();
+    let mut placements = Vec::new();
+
+    for raw in raw_placements {
+        let Some(pane_id) = str_field(raw, "paneId").filter(|id| pane_ids.contains(id)) else {
+            continue;
+        };
+        let Some(slot_id) =
+            str_field(raw, "slotId").filter(|id| id.starts_with("slot:") && slot_ids.contains(id))
+        else {
+            continue;
+        };
+        if used_pane_ids.contains(&pane_id) || used_slot_ids.contains(&slot_id) {
+            continue;
+        }
+
+        used_pane_ids.insert(pane_id.clone());
+        used_slot_ids.insert(slot_id.clone());
+        placements.push(PanePlacement { pane_id, slot_id });
+    }
+
+    let mut available_slot_ids = slot_order
+        .into_iter()
+        .filter(|slot_id| !used_slot_ids.contains(slot_id))
+        .collect::<Vec<_>>()
+        .into_iter();
+
+    for pane in panes {
+        let pane_id = pane_id(pane);
+        if used_pane_ids.contains(pane_id) {
+            continue;
+        }
+
+        let Some(slot_id) = available_slot_ids.next() else {
+            break;
+        };
+
+        used_pane_ids.insert(pane_id.to_string());
+        used_slot_ids.insert(slot_id.clone());
+        placements.push(PanePlacement {
+            pane_id: pane_id.to_string(),
+            slot_id,
+        });
+    }
+
+    placements
+}
+
 /// Lenient decode + repair (spec §2.2). Reads each field tolerantly from
 /// `raw` (never hard-fails on missing/wrong-typed values), then repairs into
 /// the strict model. `active_project_id` / `active_cwd` supply the defaults
@@ -472,6 +573,12 @@ pub fn repair_workspace_layout(
         if layout_capacity(&layout, &custom_pane_layouts).unwrap_or(1) < panes.len() {
             layout = layout_for_count(panes.len()).to_string();
         }
+        let raw_placements = rs
+            .get("placements")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        let placements = repair_placements(&raw_placements, &panes, &layout, &custom_pane_layouts);
 
         // At most one active session in the loop (first active:true wins).
         // `open` is independent: it records Active-section membership, so many
@@ -491,6 +598,7 @@ pub fn repair_workspace_layout(
             id,
             project_id,
             layout,
+            placements,
             working_directory,
             active,
             open,
@@ -821,6 +929,16 @@ mod tests {
                 id: "s1".into(),
                 project_id: "p".into(),
                 layout: "vsplit".into(),
+                placements: vec![
+                    PanePlacement {
+                        pane_id: "p0".into(),
+                        slot_id: "slot:p0".into(),
+                    },
+                    PanePlacement {
+                        pane_id: "p1".into(),
+                        slot_id: "slot:p1".into(),
+                    },
+                ],
                 working_directory: "/w".into(),
                 active: true,
                 open: true,
@@ -857,6 +975,7 @@ mod tests {
         assert!(json.contains("\"historyIndex\":0"), "json: {json}");
         assert!(json.contains("\"kind\":\"shell\""), "json: {json}");
         assert!(json.contains("\"kind\":\"browser\""), "json: {json}");
+        assert!(json.contains("\"slotId\":\"slot:p1\""), "json: {json}");
         assert!(json.contains("\"open\":true"), "json: {json}");
         let back: WorkspaceLayoutStore = serde_json::from_str(&json).unwrap();
         assert_eq!(back, store);
@@ -1025,6 +1144,67 @@ mod tests {
 
         assert_eq!(store.sessions[0].layout, "custom:grid2x2");
         assert_eq!(store.sessions[0].panes.len(), 4);
+    }
+
+    #[test]
+    fn repairs_placements_against_layout_slots_and_pane_ids() {
+        let custom_layout = json!({
+            "schemaVersion": 1,
+            "id": "custom:main-side",
+            "title": "Main side",
+            "source": "workspace",
+            "tracks": {
+                "columns": [{ "id": "main", "units": 16 }, { "id": "side", "units": 8 }],
+                "rows": [{ "id": "top", "units": 12 }, { "id": "bottom", "units": 12 }]
+            },
+            "slots": [
+                { "id": "slot:main", "rect": { "col": 0, "row": 0, "colSpan": 1, "rowSpan": 2 }},
+                { "id": "slot:side-top", "rect": { "col": 1, "row": 0, "colSpan": 1, "rowSpan": 1 }},
+                { "id": "slot:side-bottom", "rect": { "col": 1, "row": 1, "colSpan": 1, "rowSpan": 1 }}
+            ],
+            "addOrder": ["slot:main", "slot:side-top", "slot:side-bottom"]
+        });
+        let store = repair_workspace_layout(
+            json!({
+              "version": 1,
+              "customPaneLayouts": [custom_layout],
+              "sessions": [{
+                "id": "s",
+                "projectId": "p",
+                "layout": "custom:main-side",
+                "workingDirectory": "/",
+                "active": true,
+                "open": true,
+                "placements": [
+                    { "paneId": "p1", "slotId": "slot:side-top" },
+                    { "paneId": "missing", "slotId": "slot:main" },
+                    { "paneId": "p0", "slotId": "slot:side-top" },
+                    { "paneId": "p2", "slotId": "slot:missing" }
+                ],
+                "panes": browser_panes_json(3)
+              }]
+            }),
+            "proj",
+            "/",
+        );
+
+        assert_eq!(
+            store.sessions[0].placements,
+            vec![
+                PanePlacement {
+                    pane_id: "p1".into(),
+                    slot_id: "slot:side-top".into(),
+                },
+                PanePlacement {
+                    pane_id: "p0".into(),
+                    slot_id: "slot:main".into(),
+                },
+                PanePlacement {
+                    pane_id: "p2".into(),
+                    slot_id: "slot:side-bottom".into(),
+                },
+            ]
+        );
     }
 
     #[test]
@@ -1282,6 +1462,10 @@ mod tests {
                 id: "s".into(),
                 project_id: "proj".into(),
                 layout: "single".into(),
+                placements: vec![PanePlacement {
+                    pane_id: "p0".into(),
+                    slot_id: "slot:p0".into(),
+                }],
                 working_directory: "/".into(),
                 active: true,
                 open: true,
@@ -1319,6 +1503,10 @@ mod tests {
                     id: "s".into(),
                     project_id: "proj".into(),
                     layout: "single".into(),
+                    placements: vec![PanePlacement {
+                        pane_id: "p0".into(),
+                        slot_id: "slot:p0".into(),
+                    }],
                     working_directory: "/".into(),
                     active: true,
                     open: true,
@@ -1363,6 +1551,10 @@ mod tests {
                 id: "s".into(),
                 project_id: "proj".into(),
                 layout: "single".into(),
+                placements: vec![PanePlacement {
+                    pane_id: "p0".into(),
+                    slot_id: "slot:p0".into(),
+                }],
                 working_directory: "/".into(),
                 active: true,
                 open: true,
@@ -1420,6 +1612,10 @@ mod tests {
                 id: "s".into(),
                 project_id: "proj".into(),
                 layout: "single".into(),
+                placements: vec![PanePlacement {
+                    pane_id: "p0".into(),
+                    slot_id: "slot:p0".into(),
+                }],
                 working_directory: "/".into(),
                 active: true,
                 open: true,

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -107,3 +107,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Shared Controller Segmentation](patterns/shared-controller-segmentation.md)                         | react-patterns     | 2        | 0    | 2026-06-18   |
 | [Vite HMR Static Dependencies](patterns/vite-hmr-static-deps.md)                                     | code-quality       | 3        | 2    | 2026-06-18   |
 | [Custom Pane Layout Preservation](patterns/custom-pane-layout-preservation.md)                       | correctness        | 1        | 0    | 2026-06-19   |
+| [Pane Slot Identity](patterns/pane-slot-identity.md)                                                 | correctness        | 2        | 0    | 2026-06-19   |

--- a/docs/reviews/patterns/pane-slot-identity.md
+++ b/docs/reviews/patterns/pane-slot-identity.md
@@ -26,11 +26,11 @@ pass the `slotId` through every layer that needs to act on a specific cell.
 - **Severity:** LOW
 - **File:** `src/features/terminal/components/SplitView/SplitView.tsx` L291-340
 - **Finding:** The `visiblePaneAssignments.map(({ pane, slotId }, i)` callback used
-the array index `i` for the focus tooltip (`Focus pane ${i + 1}`) and the shortcut
-hint (`Mod+${i + 1}`). With explicit placements, `panes[0]` can occupy a later
-visual slot, so the label/hint no longer matched the pane's grid position.
+  the array index `i` for the focus tooltip (`Focus pane ${i + 1}`) and the shortcut
+  hint (`Mod+${i + 1}`). With explicit placements, `panes[0]` can occupy a later
+  visual slot, so the label/hint no longer matched the pane's grid position.
 - **Fix:** Replaced both `i + 1` uses with `slotIndex + 1`, where
-`slotIndex = layout.definition.addOrder.indexOf(slotId)`.
+  `slotIndex = layout.definition.addOrder.indexOf(slotId)`.
 - **Commit:** same commit as this entry
 
 ### 2. Pass the clicked empty slot into pane creation
@@ -39,11 +39,11 @@ visual slot, so the label/hint no longer matched the pane's grid position.
 - **Severity:** P2 / MEDIUM
 - **File:** `src/features/terminal/components/SplitView/SplitView.tsx` L403-403
 - **Finding:** Each rendered empty slot knew its `slotId`, but `EmptySlot` was not
-passed the value and `onAddPane` had no slot parameter. `applyAddPane` then let
-`normalizePanePlacements` assign the new pane to the first empty slot in
-`addOrder`, so clicking a later empty hole could create the pane elsewhere.
+  passed the value and `onAddPane` had no slot parameter. `applyAddPane` then let
+  `normalizePanePlacements` assign the new pane to the first empty slot in
+  `addOrder`, so clicking a later empty hole could create the pane elsewhere.
 - **Fix:** Added `slotId` to `EmptySlotProps`, passed it from `SplitView` to
-`EmptySlot`, threaded it through `onAddPane` / `useSessionManager.addPane`, and
-updated `applyAddPane` to record a `{paneId, slotId}` placement when a slot id is
-provided.
+  `EmptySlot`, threaded it through `onAddPane` / `useSessionManager.addPane`, and
+  updated `applyAddPane` to record a `{paneId, slotId}` placement when a slot id is
+  provided.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/pane-slot-identity.md
+++ b/docs/reviews/patterns/pane-slot-identity.md
@@ -1,0 +1,49 @@
+---
+id: pane-slot-identity
+category: correctness
+created: 2026-06-19
+last_updated: 2026-06-19
+ref_count: 0
+---
+
+# Pane Slot Identity
+
+## Summary
+
+`SplitView` renders panes inside a CSS grid whose cells are addressed by explicit
+`slot:<id>` identifiers. The visual position of a pane is determined by its slot,
+not by its index in `session.panes[]`. Code that derives user-visible labels,
+keyboard-shortcut hints, or callback arguments from the array index (or that drops
+the slot id while threading an action through the component tree) will misalign
+what the user sees with what the UI claims. Always use the resolved `slotIndex` or
+pass the `slotId` through every layer that needs to act on a specific cell.
+
+## Findings
+
+### 1. SplitView tooltip/shortcut hint uses pane-array index, not slot position
+
+- **Source:** github-claude | PR #555 round 1 | 2026-06-19
+- **Severity:** LOW
+- **File:** `src/features/terminal/components/SplitView/SplitView.tsx` L291-340
+- **Finding:** The `visiblePaneAssignments.map(({ pane, slotId }, i)` callback used
+the array index `i` for the focus tooltip (`Focus pane ${i + 1}`) and the shortcut
+hint (`Mod+${i + 1}`). With explicit placements, `panes[0]` can occupy a later
+visual slot, so the label/hint no longer matched the pane's grid position.
+- **Fix:** Replaced both `i + 1` uses with `slotIndex + 1`, where
+`slotIndex = layout.definition.addOrder.indexOf(slotId)`.
+- **Commit:** same commit as this entry
+
+### 2. Pass the clicked empty slot into pane creation
+
+- **Source:** github-codex-connector (P2 / MEDIUM) | PR #555 round 1 | 2026-06-19
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/terminal/components/SplitView/SplitView.tsx` L403-403
+- **Finding:** Each rendered empty slot knew its `slotId`, but `EmptySlot` was not
+passed the value and `onAddPane` had no slot parameter. `applyAddPane` then let
+`normalizePanePlacements` assign the new pane to the first empty slot in
+`addOrder`, so clicking a later empty hole could create the pane elsewhere.
+- **Fix:** Added `slotId` to `EmptySlotProps`, passed it from `SplitView` to
+`EmptySlot`, threaded it through `onAddPane` / `useSessionManager.addPane`, and
+updated `applyAddPane` to record a `{paneId, slotId}` placement when a slot id is
+provided.
+- **Commit:** same commit as this entry

--- a/electron/workspace-layout-controller.test.ts
+++ b/electron/workspace-layout-controller.test.ts
@@ -38,6 +38,10 @@ const sampleShape = (): PersistedWorkspaceShape => ({
       id: 's1',
       projectId: 'proj-1',
       layout: 'vsplit',
+      placements: [
+        { paneId: 'p0', slotId: 'slot:p0' },
+        { paneId: 'p1', slotId: 'slot:p1' },
+      ],
       workingDirectory: '/repo',
       active: true,
       open: true,
@@ -66,6 +70,10 @@ const sampleStore = (): PersistedWorkspaceLayoutStore => ({
       id: 's1',
       projectId: 'proj-1',
       layout: 'vsplit',
+      placements: [
+        { paneId: 'p0', slotId: 'slot:p0' },
+        { paneId: 'p1', slotId: 'slot:p1' },
+      ],
       workingDirectory: '/repo',
       active: true,
       open: true,

--- a/electron/workspace-layout-controller.ts
+++ b/electron/workspace-layout-controller.ts
@@ -14,6 +14,7 @@ import {
 import type {
   IpcMainLike,
   LoadWorkspaceForRestoreRequest,
+  PersistedPanePlacement,
   PersistedTab,
   PersistedWorkspaceLayoutStore,
   PersistedWorkspacePane,
@@ -71,6 +72,7 @@ const storeToShape = (
     id: session.id,
     projectId: session.projectId,
     layout: session.layout,
+    placements: session.placements,
     workingDirectory: session.workingDirectory,
     active: session.active,
     open: session.open,
@@ -88,6 +90,13 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 
 const isNullableString = (value: unknown): value is string | null =>
   value === null || typeof value === 'string'
+
+const isPersistedPanePlacement = (
+  placement: unknown
+): placement is PersistedPanePlacement =>
+  isRecord(placement) &&
+  typeof placement.paneId === 'string' &&
+  typeof placement.slotId === 'string'
 
 const isLoadWorkspaceForRestoreRequest = (
   request: unknown
@@ -139,6 +148,9 @@ const isPersistedWorkspaceSessionShape = (
     typeof session.id === 'string' &&
     typeof session.projectId === 'string' &&
     typeof session.layout === 'string' &&
+    (session.placements === undefined ||
+      (Array.isArray(session.placements) &&
+        session.placements.every(isPersistedPanePlacement))) &&
     typeof session.workingDirectory === 'string' &&
     typeof session.active === 'boolean' &&
     typeof session.open === 'boolean' &&
@@ -161,7 +173,10 @@ const normalizeWorkspaceShape = (
   dto: PersistedWorkspaceShape
 ): PersistedWorkspaceShape => ({
   customPaneLayouts: dto.customPaneLayouts ?? [],
-  sessions: dto.sessions,
+  sessions: dto.sessions.map((session) => ({
+    ...session,
+    placements: session.placements ?? [],
+  })),
 })
 
 const cloneTabs = (tabs: PersistedTab[]): PersistedTab[] =>

--- a/electron/workspace-layout-roundtrip.test.ts
+++ b/electron/workspace-layout-roundtrip.test.ts
@@ -89,6 +89,7 @@ const roundTripShape = (): PersistedWorkspaceShape => ({
       id: 'ws-browser',
       projectId: 'proj-1',
       layout: 'single',
+      placements: [{ paneId: 'p0', slotId: 'slot:p0' }],
       workingDirectory: '/repo',
       active: true,
       open: true,
@@ -97,7 +98,11 @@ const roundTripShape = (): PersistedWorkspaceShape => ({
     {
       id: 'ws-mixed',
       projectId: 'proj-1',
-      layout: 'vsplit',
+      layout: 'custom:main-side-stack',
+      placements: [
+        { paneId: 'p0', slotId: 'slot:main' },
+        { paneId: 'p1', slotId: 'slot:side-top' },
+      ],
       workingDirectory: '/repo',
       active: false,
       open: true,

--- a/electron/workspace-layout-types.ts
+++ b/electron/workspace-layout-types.ts
@@ -43,6 +43,11 @@ export interface PersistedBrowserPane {
 
 export type PersistedWorkspacePane = PersistedShellPane | PersistedBrowserPane
 
+export interface PersistedPanePlacement {
+  paneId: string
+  slotId: string
+}
+
 export interface PersistedTrackSpec {
   readonly id: string
   readonly units: number
@@ -79,6 +84,7 @@ export interface PersistedWorkspaceSession {
   id: string
   projectId: string
   layout: string
+  placements: PersistedPanePlacement[]
   workingDirectory: string
   active: boolean
   open: boolean
@@ -119,6 +125,7 @@ export interface PersistedWorkspaceSessionShape {
   id: string
   projectId: string
   layout: string
+  placements?: PersistedPanePlacement[]
   workingDirectory: string
   active: boolean
   open: boolean

--- a/electron/workspace-layout-writer.test.ts
+++ b/electron/workspace-layout-writer.test.ts
@@ -15,6 +15,10 @@ const shape = (): PersistedWorkspaceShape => ({
       id: 's1',
       projectId: 'proj-1',
       layout: 'vsplit',
+      placements: [
+        { paneId: 'p0', slotId: 'slot:p0' },
+        { paneId: 'p1', slotId: 'slot:p1' },
+      ],
       workingDirectory: '/repo',
       active: true,
       open: true,
@@ -81,6 +85,10 @@ describe('WorkspaceLayoutWriter', () => {
           id: 's1',
           projectId: 'proj-1',
           layout: 'vsplit',
+          placements: [
+            { paneId: 'p0', slotId: 'slot:p0' },
+            { paneId: 'p1', slotId: 'slot:p1' },
+          ],
           workingDirectory: '/repo',
           active: true,
           open: true,

--- a/electron/workspace-layout-writer.ts
+++ b/electron/workspace-layout-writer.ts
@@ -165,6 +165,7 @@ export class WorkspaceLayoutWriter
         id: session.id,
         projectId: session.projectId,
         layout: session.layout,
+        placements: session.placements ?? [],
         workingDirectory: session.workingDirectory,
         active: session.active,
         open: session.open,

--- a/src/features/sessions/hooks/usePushWorkspaceGrouping.test.ts
+++ b/src/features/sessions/hooks/usePushWorkspaceGrouping.test.ts
@@ -105,6 +105,10 @@ describe('buildWorkspaceShape', () => {
           id: 's1',
           projectId: 'proj-1',
           layout: 'vsplit',
+          placements: [
+            { paneId: 'p0', slotId: 'slot:p0' },
+            { paneId: 'p1', slotId: 'slot:p1' },
+          ],
           workingDirectory: '/repo',
           active: true,
           open: true,
@@ -137,6 +141,22 @@ describe('buildWorkspaceShape', () => {
       buildWorkspaceShape([makeSession()], 's1', [customLayout])
         .customPaneLayouts
     ).toEqual([customLayout])
+  })
+
+  test('preserves explicit custom-slot placements when they match the layout', () => {
+    expect(
+      buildWorkspaceShape(
+        [
+          makeSession({
+            layout: 'custom:test',
+            panes: [shellPane()],
+            placements: [{ paneId: 'p0', slotId: 'slot:main' }],
+          }),
+        ],
+        's1',
+        [customLayout]
+      ).sessions[0].placements
+    ).toEqual([{ paneId: 'p0', slotId: 'slot:main' }])
   })
 })
 

--- a/src/features/sessions/hooks/usePushWorkspaceGrouping.ts
+++ b/src/features/sessions/hooks/usePushWorkspaceGrouping.ts
@@ -24,8 +24,12 @@ import {
   type PersistedWorkspaceShape,
   type PersistedWorkspacePaneShape,
 } from '../workspaceLayoutBridge'
-import type { PaneLayoutDefinition } from '../../terminal/layout-registry'
+import {
+  PaneLayoutRegistry,
+  type PaneLayoutDefinition,
+} from '../../terminal/layout-registry'
 import { isShellPane } from '../utils/paneKind'
+import { normalizePanePlacements } from '../utils/panePlacements'
 import { isOpenSession } from '../utils/sessionStatus'
 import type { Session } from '../types'
 
@@ -55,37 +59,50 @@ export const buildWorkspaceShape = (
   sessions: readonly Session[],
   activeSessionId: string | null,
   customPaneLayouts: readonly PaneLayoutDefinition[] = []
-): PersistedWorkspaceShape => ({
-  customPaneLayouts,
-  sessions: sessions.map((session) => ({
-    id: session.id,
-    projectId: session.projectId,
-    layout: session.layout,
-    workingDirectory: session.workingDirectory,
-    active: session.id === activeSessionId,
-    open: isOpenSession(session),
-    panes: session.panes.map(
-      (pane, paneIndex): PersistedWorkspacePaneShape =>
-        isShellPane(pane)
-          ? {
-              kind: 'shell',
-              paneId: pane.id,
-              paneIndex,
-              active: pane.active,
-              ptyId: pane.ptyId,
-              cwd: pane.cwd,
-              agentType: pane.agentType,
-              agentSessionId: null,
-            }
-          : {
-              kind: 'browser',
-              paneId: pane.id,
-              paneIndex,
-              active: pane.active,
-            }
-    ),
-  })),
-})
+): PersistedWorkspaceShape => {
+  const layoutRegistry = new PaneLayoutRegistry(customPaneLayouts)
+
+  return {
+    customPaneLayouts,
+    sessions: sessions.map((session) => {
+      const layout = layoutRegistry.getFallbackLayout(session.layout)
+
+      return {
+        id: session.id,
+        projectId: session.projectId,
+        layout: session.layout,
+        placements: normalizePanePlacements(
+          session.panes,
+          layout,
+          session.placements
+        ),
+        workingDirectory: session.workingDirectory,
+        active: session.id === activeSessionId,
+        open: isOpenSession(session),
+        panes: session.panes.map(
+          (pane, paneIndex): PersistedWorkspacePaneShape =>
+            isShellPane(pane)
+              ? {
+                  kind: 'shell',
+                  paneId: pane.id,
+                  paneIndex,
+                  active: pane.active,
+                  ptyId: pane.ptyId,
+                  cwd: pane.cwd,
+                  agentType: pane.agentType,
+                  agentSessionId: null,
+                }
+              : {
+                  kind: 'browser',
+                  paneId: pane.id,
+                  paneIndex,
+                  active: pane.active,
+                }
+        ),
+      }
+    }),
+  }
+}
 
 // Signature of the structural half (everything except cwd/agentType drift), so
 // a `cd` or agent-detection update debounces instead of pushing eagerly.
@@ -96,6 +113,7 @@ const structuralSignature = (shape: PersistedWorkspaceShape): string =>
       id: session.id,
       projectId: session.projectId,
       layout: session.layout,
+      placements: session.placements,
       workingDirectory: session.workingDirectory,
       active: session.active,
       open: session.open,

--- a/src/features/sessions/hooks/useSessionManager.ts
+++ b/src/features/sessions/hooks/useSessionManager.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from 'react'
 import { flushSync } from 'react-dom'
 import type {
+  LayoutSlotId,
   Pane,
   PaneKind,
   PaneLayoutId,
@@ -86,7 +87,7 @@ export interface SessionManager {
   ) => void
   setSessionLayout: (sessionId: string, layoutId: PaneLayoutId) => void
   setSessionActivePane: (sessionId: string, paneId: string) => void
-  addPane: (sessionId: string, kind?: PaneKind) => void
+  addPane: (sessionId: string, kind?: PaneKind, slotId?: LayoutSlotId) => void
   removePane: (sessionId: string, paneId: string) => void
   /**
    * Restart an Exited session in the same cwd. Idempotent on the kill side:
@@ -1234,7 +1235,11 @@ export const useSessionManager = (
   )
 
   const addPane = useCallback(
-    (sessionId: string, kind: PaneKind = 'shell'): void => {
+    (
+      sessionId: string,
+      kind: PaneKind = 'shell',
+      slotId?: LayoutSlotId
+    ): void => {
       if (pendingPaneOps.current.has(sessionId)) {
         log.warn(
           `addPane: another pane op in flight for ${sessionId}; ignoring`
@@ -1294,7 +1299,14 @@ export const useSessionManager = (
               const capacity = target
                 ? layoutRegistry.capacityFor(target.layout)
                 : 0
-              const update = applyAddPane(prev, sessionId, newPane, capacity)
+
+              const update = applyAddPane(
+                prev,
+                sessionId,
+                newPane,
+                capacity,
+                slotId
+              )
               appended = update.appended
 
               return update.sessions
@@ -1377,7 +1389,14 @@ export const useSessionManager = (
               const capacity = target
                 ? layoutRegistry.capacityFor(target.layout)
                 : 0
-              const update = applyAddPane(prev, sessionId, newPane, capacity)
+
+              const update = applyAddPane(
+                prev,
+                sessionId,
+                newPane,
+                capacity,
+                slotId
+              )
               appended = update.appended
 
               return update.sessions

--- a/src/features/sessions/types/index.ts
+++ b/src/features/sessions/types/index.ts
@@ -21,6 +21,13 @@ export type CustomPaneLayoutId = `custom:${string}`
 
 export type PaneLayoutId = LayoutId | CustomPaneLayoutId
 
+export type LayoutSlotId = `slot:${string}`
+
+export interface PanePlacement {
+  paneId: string
+  slotId: LayoutSlotId
+}
+
 export type PaneKind = 'shell' | 'browser'
 
 export interface Pane {
@@ -121,6 +128,12 @@ export interface Session {
   agentType: 'claude-code' | 'codex' | 'kimi' | 'aider' | 'generic'
   /** Per-session canvas layout. Builtin ids or validated workspace custom ids. */
   layout: PaneLayoutId
+  /**
+   * Optional explicit pane-to-layout-slot mapping. Older sessions and PTY-only
+   * restores omit this; render/persistence derive a compatible mapping from
+   * `panes[]` order and the layout's `addOrder`.
+   */
+  placements?: PanePlacement[]
   /** Session-scoped collapse state for the right agent activity panel.
    *  Shared by every pane so switching pane within a session never
    *  jumps the bar. UI-only: hydrated from localStorage by session id

--- a/src/features/sessions/utils/groupSessionsFromInfos.test.ts
+++ b/src/features/sessions/utils/groupSessionsFromInfos.test.ts
@@ -138,6 +138,13 @@ describe('groupSessionsFromInfos', () => {
       'p3',
     ])
 
+    expect(restored.placements).toEqual([
+      { paneId: 'p0', slotId: 'slot:p0' },
+      { paneId: 'p1', slotId: 'slot:p1' },
+      { paneId: 'p2', slotId: 'slot:p2' },
+      { paneId: 'p3', slotId: 'slot:p3' },
+    ])
+
     expect(restored.panes.map((pane) => pane.agentType)).toEqual([
       'claude-code',
       'codex',
@@ -566,6 +573,34 @@ describe('reconstructWorkspace', () => {
     expect(s.layout).toBe('vsplit')
   })
 
+  test('preserves valid store placements and fills invalid or missing entries', () => {
+    const store = storeOf([
+      storeSession({
+        id: 'ws-placements',
+        layout: 'quad',
+        placements: [
+          { paneId: 'p2', slotId: 'slot:p1' },
+          { paneId: 'missing', slotId: 'slot:p0' },
+          { paneId: 'p0', slotId: 'slot:p1' },
+          { paneId: 'p1', slotId: 'slot:missing' },
+        ],
+        panes: [
+          browserShape({ paneId: 'p0', paneIndex: 0, active: true }),
+          browserShape({ paneId: 'p1', paneIndex: 1, active: false }),
+          browserShape({ paneId: 'p2', paneIndex: 2, active: false }),
+        ],
+      }),
+    ])
+
+    const sessions = reconstructWorkspace(store, [], null)
+
+    expect(sessions[0].placements).toEqual([
+      { paneId: 'p2', slotId: 'slot:p1' },
+      { paneId: 'p0', slotId: 'slot:p0' },
+      { paneId: 'p1', slotId: 'slot:p2' },
+    ])
+  })
+
   test('preserves a persisted custom layout when its definition is present', () => {
     const store = storeOf(
       [
@@ -600,6 +635,9 @@ describe('reconstructWorkspace', () => {
 
     expect(sessions).toHaveLength(1)
     expect(sessions[0].layout).toBe('single')
+    expect(sessions[0].placements).toEqual([
+      { paneId: 'p0', slotId: 'slot:p0' },
+    ])
   })
 
   test('reload shape restores browser-only and mixed browser sessions together', () => {

--- a/src/features/sessions/utils/groupSessionsFromInfos.ts
+++ b/src/features/sessions/utils/groupSessionsFromInfos.ts
@@ -27,6 +27,7 @@ import type {
   PersistedShellPaneShape,
 } from '../workspaceLayoutBridge'
 import { readActivityPanelCollapsed } from './activityPanelCollapsedStore'
+import { normalizePanePlacements } from './panePlacements'
 import { sessionFromInfo } from './sessionFromInfo'
 import { deriveShellSessionStatus } from './sessionStatus'
 import { tabName } from './tabName'
@@ -117,7 +118,8 @@ const buildGroupedSession = (
   workspaceId: string,
   layout: PaneLayoutId,
   entries: GroupedEntry[],
-  fallbackIndex: number
+  fallbackIndex: number,
+  registry: PaneLayoutRegistry
 ): Session => {
   // Stable ordering by paneIndex; ties broken by first-seen order.
   const ordered = [...entries].sort(
@@ -168,6 +170,11 @@ const buildGroupedSession = (
     workingDirectory: workspaceDirectory,
     agentType: activePane.agentType,
     layout,
+    placements: normalizePanePlacements(
+      panes,
+      registry.getFallbackLayout(layout),
+      undefined
+    ),
     activityPanelCollapsed: readActivityPanelCollapsed(workspaceId),
     panes,
     createdAt: now,
@@ -249,7 +256,13 @@ export const groupSessionsFromInfos = (
       return sessionFromInfo(bucket.entries[0], index)
     }
 
-    return buildGroupedSession(bucket.id, bucket.layout, bucket.entries, index)
+    return buildGroupedSession(
+      bucket.id,
+      bucket.layout,
+      bucket.entries,
+      index,
+      registry
+    )
   })
 }
 
@@ -375,6 +388,7 @@ const buildStoreSession = (
   }))
   const activePane = panes.find((pane) => pane.active) ?? panes[0]
   const now = new Date().toISOString()
+  const layout = toLayoutId(shape.layout, registry)
 
   return {
     id: shape.id,
@@ -384,7 +398,12 @@ const buildStoreSession = (
     status: deriveShellSessionStatus(panes),
     workingDirectory: shape.workingDirectory,
     agentType: activePane.agentType,
-    layout: toLayoutId(shape.layout, registry),
+    layout,
+    placements: normalizePanePlacements(
+      panes,
+      registry.getFallbackLayout(layout),
+      shape.placements
+    ),
     activityPanelCollapsed: readActivityPanelCollapsed(shape.id),
     panes,
     createdAt: now,

--- a/src/features/sessions/utils/paneLifecycle.test.ts
+++ b/src/features/sessions/utils/paneLifecycle.test.ts
@@ -256,13 +256,7 @@ describe('applyAddPane', () => {
   })
 
   test('records a placement for the requested slot when slotId is provided', () => {
-    const result = applyAddPane(
-      [mockSession()],
-      's0',
-      newPane,
-      2,
-      'slot:right'
-    )
+    const result = applyAddPane([mockSession()], 's0', newPane, 2, 'slot:right')
 
     expect(result.appended).toBe(true)
     expect(result.sessions[0].placements).toContainEqual({

--- a/src/features/sessions/utils/paneLifecycle.test.ts
+++ b/src/features/sessions/utils/paneLifecycle.test.ts
@@ -308,6 +308,35 @@ describe('applyRemovePane', () => {
     expect(result.newActivePtyId).toBeUndefined()
   })
 
+  test('drops removed pane placement and reflows against the next layout', () => {
+    const result = applyRemovePane(
+      [
+        mockSession({
+          layout: 'quad',
+          placements: [
+            { paneId: 'p0', slotId: 'slot:p3' },
+            { paneId: 'p1', slotId: 'slot:p0' },
+            { paneId: 'p2', slotId: 'slot:p1' },
+          ],
+          panes: [
+            mockPane({ id: 'p0', ptyId: 'pty-0', active: true }),
+            mockPane({ id: 'p1', ptyId: 'pty-1', active: false }),
+            mockPane({ id: 'p2', ptyId: 'pty-2', active: false }),
+          ],
+        }),
+      ],
+      's0',
+      'p1',
+      'quad'
+    )
+
+    expect(result.sessions[0].layout).toBe('vsplit')
+    expect(result.sessions[0].placements).toEqual([
+      { paneId: 'p2', slotId: 'slot:p1' },
+      { paneId: 'p0', slotId: 'slot:p0' },
+    ])
+  })
+
   test('closing in quad shrinks to threeRight', () => {
     const result = applyRemovePane(
       [

--- a/src/features/sessions/utils/paneLifecycle.test.ts
+++ b/src/features/sessions/utils/paneLifecycle.test.ts
@@ -254,6 +254,22 @@ describe('applyAddPane', () => {
 
     expect(result.sessions[1]).toBe(untouched)
   })
+
+  test('records a placement for the requested slot when slotId is provided', () => {
+    const result = applyAddPane(
+      [mockSession()],
+      's0',
+      newPane,
+      2,
+      'slot:right'
+    )
+
+    expect(result.appended).toBe(true)
+    expect(result.sessions[0].placements).toContainEqual({
+      paneId: 'p1',
+      slotId: 'slot:right',
+    })
+  })
 })
 
 describe('applyRemovePane', () => {

--- a/src/features/sessions/utils/paneLifecycle.ts
+++ b/src/features/sessions/utils/paneLifecycle.ts
@@ -6,6 +6,7 @@ import {
 } from '../../terminal/layout-registry/layoutRegistry'
 import { deriveShellSessionStatus } from './sessionStatus'
 import { isShellPane } from './paneKind'
+import { normalizePanePlacements } from './panePlacements'
 
 export { autoShrinkLayoutFor } from '../../terminal/layout-registry/layoutRegistry'
 
@@ -130,10 +131,21 @@ export const applyRemovePane = (
 
   const activePane = panes.find((pane) => pane.active)
 
+  const layout = autoShrinkLayoutFor(
+    panes.length,
+    currentLayoutId,
+    layoutRegistry
+  )
+
   const updated: Session = {
     ...session,
     panes,
-    layout: autoShrinkLayoutFor(panes.length, currentLayoutId, layoutRegistry),
+    layout,
+    placements: normalizePanePlacements(
+      panes,
+      layoutRegistry.getFallbackLayout(layout),
+      session.placements?.filter((placement) => placement.paneId !== paneId)
+    ),
     status: deriveShellSessionStatus(panes),
     agentType: activePane?.agentType ?? session.agentType,
   }

--- a/src/features/sessions/utils/paneLifecycle.ts
+++ b/src/features/sessions/utils/paneLifecycle.ts
@@ -1,4 +1,10 @@
-import type { Pane, PaneLayoutId, Session } from '../types'
+import type {
+  LayoutSlotId,
+  Pane,
+  PaneLayoutId,
+  PanePlacement,
+  Session,
+} from '../types'
 import {
   BUILTIN_PANE_LAYOUT_REGISTRY,
   autoShrinkLayoutFor,
@@ -51,7 +57,8 @@ export const applyAddPane = (
   sessions: Session[],
   sessionId: string,
   newPane: Pane,
-  capacity: number
+  capacity: number,
+  slotId?: LayoutSlotId
 ): ApplyAddPaneResult => {
   const sessionIndex = sessions.findIndex((session) => session.id === sessionId)
   if (sessionIndex === -1) {
@@ -74,9 +81,19 @@ export const applyAddPane = (
     { ...newPane, active: true },
   ]
 
+  const placements: PanePlacement[] | undefined = slotId
+    ? [
+        ...(session.placements?.filter(
+          (placement) => placement.slotId !== slotId
+        ) ?? []),
+        { paneId: newPane.id, slotId },
+      ]
+    : session.placements
+
   const updated: Session = {
     ...session,
     panes,
+    placements,
     status: deriveShellSessionStatus(panes),
     agentType: newPane.agentType,
   }

--- a/src/features/sessions/utils/panePlacements.test.ts
+++ b/src/features/sessions/utils/panePlacements.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'vitest'
+import type { Pane } from '../types'
+import { LAYOUTS } from '../../terminal/layout-registry'
+import { normalizePanePlacements, resolvePanePlacement } from './panePlacements'
+
+const pane = (id: string): Pane => ({
+  id,
+  ptyId: `pty-${id}`,
+  cwd: '/repo',
+  agentType: 'generic',
+  status: 'running',
+  active: id === 'p0',
+})
+
+describe('normalizePanePlacements', () => {
+  test('derives placements from pane order and layout addOrder when absent', () => {
+    expect(
+      normalizePanePlacements(
+        [pane('p0'), pane('p1')],
+        LAYOUTS.vsplit,
+        undefined
+      )
+    ).toEqual([
+      { paneId: 'p0', slotId: 'slot:p0' },
+      { paneId: 'p1', slotId: 'slot:p1' },
+    ])
+  })
+
+  test('preserves valid explicit placements and fills missing panes', () => {
+    expect(
+      normalizePanePlacements(
+        [pane('p0'), pane('p1'), pane('p2')],
+        LAYOUTS.quad,
+        [
+          { paneId: 'p2', slotId: 'slot:p1' },
+          { paneId: 'missing', slotId: 'slot:p0' },
+          { paneId: 'p1', slotId: 'slot:missing' },
+          { paneId: 'p0', slotId: 'slot:p1' },
+        ]
+      )
+    ).toEqual([
+      { paneId: 'p2', slotId: 'slot:p1' },
+      { paneId: 'p0', slotId: 'slot:p0' },
+      { paneId: 'p1', slotId: 'slot:p2' },
+    ])
+  })
+
+  test('omits panes when the layout has no remaining slots', () => {
+    expect(
+      normalizePanePlacements(
+        [pane('p0'), pane('p1')],
+        LAYOUTS.single,
+        undefined
+      )
+    ).toEqual([{ paneId: 'p0', slotId: 'slot:p0' }])
+  })
+})
+
+describe('resolvePanePlacement', () => {
+  test('returns assignments in pane order and empty slots in layout order', () => {
+    const resolution = resolvePanePlacement(
+      [pane('p0'), pane('p1')],
+      LAYOUTS.quad,
+      [
+        { paneId: 'p1', slotId: 'slot:p3' },
+        { paneId: 'p0', slotId: 'slot:p1' },
+      ]
+    )
+
+    expect(
+      resolution.assignments.map(({ pane: assignedPane, slotId }) => ({
+        paneId: assignedPane.id,
+        slotId,
+      }))
+    ).toEqual([
+      { paneId: 'p0', slotId: 'slot:p1' },
+      { paneId: 'p1', slotId: 'slot:p3' },
+    ])
+    expect(resolution.emptySlotIds).toEqual(['slot:p0', 'slot:p2'])
+  })
+})

--- a/src/features/sessions/utils/panePlacements.ts
+++ b/src/features/sessions/utils/panePlacements.ts
@@ -1,0 +1,98 @@
+import type { LayoutShape } from '../../terminal/layout-registry'
+import type { LayoutSlotId, Pane, PanePlacement } from '../types'
+
+export interface PaneSlotAssignment {
+  readonly pane: Pane
+  readonly slotId: LayoutSlotId
+}
+
+export interface PanePlacementResolution {
+  readonly assignments: readonly PaneSlotAssignment[]
+  readonly placements: readonly PanePlacement[]
+  readonly emptySlotIds: readonly LayoutSlotId[]
+}
+
+const uniquePaneIds = (panes: readonly Pane[]): ReadonlySet<string> =>
+  new Set(panes.map((pane) => pane.id))
+
+const validLayoutSlotIds = (layout: LayoutShape): ReadonlySet<LayoutSlotId> =>
+  new Set(layout.definition.addOrder)
+
+export const normalizePanePlacements = (
+  panes: readonly Pane[],
+  layout: LayoutShape,
+  placements: readonly PanePlacement[] | undefined
+): PanePlacement[] => {
+  const paneIds = uniquePaneIds(panes)
+  const slotIds = validLayoutSlotIds(layout)
+  const usedPaneIds = new Set<string>()
+  const usedSlotIds = new Set<LayoutSlotId>()
+  const normalized: PanePlacement[] = []
+
+  for (const placement of placements ?? []) {
+    if (
+      !paneIds.has(placement.paneId) ||
+      !slotIds.has(placement.slotId) ||
+      usedPaneIds.has(placement.paneId) ||
+      usedSlotIds.has(placement.slotId)
+    ) {
+      continue
+    }
+
+    usedPaneIds.add(placement.paneId)
+    usedSlotIds.add(placement.slotId)
+    normalized.push({
+      paneId: placement.paneId,
+      slotId: placement.slotId,
+    })
+  }
+
+  const availableSlotIds = layout.definition.addOrder.filter(
+    (slotId) => !usedSlotIds.has(slotId)
+  )
+
+  for (const pane of panes) {
+    if (usedPaneIds.has(pane.id)) {
+      continue
+    }
+
+    const slotId = availableSlotIds.shift()
+    if (!slotId) {
+      break
+    }
+
+    usedPaneIds.add(pane.id)
+    usedSlotIds.add(slotId)
+    normalized.push({ paneId: pane.id, slotId })
+  }
+
+  return normalized
+}
+
+export const resolvePanePlacement = (
+  panes: readonly Pane[],
+  layout: LayoutShape,
+  placements: readonly PanePlacement[] | undefined
+): PanePlacementResolution => {
+  const normalized = normalizePanePlacements(panes, layout, placements)
+
+  const slotByPaneId = new Map(
+    normalized.map((placement) => [placement.paneId, placement.slotId])
+  )
+
+  const occupiedSlotIds = new Set(
+    normalized.map((placement) => placement.slotId)
+  )
+
+  return {
+    assignments: panes.flatMap((pane) => {
+      const slotId = slotByPaneId.get(pane.id)
+
+      return slotId ? [{ pane, slotId }] : []
+    }),
+    placements: normalized,
+    emptySlotIds: layout.definition.addOrder.filter(
+      (slotId) => !occupiedSlotIds.has(slotId)
+    ),
+  }
+}

--- a/src/features/sessions/workspaceLayoutBridge.ts
+++ b/src/features/sessions/workspaceLayoutBridge.ts
@@ -6,6 +6,7 @@
 // pane existence + shell fields, never browser tab/history (main owns those).
 
 import type { PaneLayoutDefinition } from '../terminal/layout-registry'
+import type { PanePlacement } from './types'
 
 export interface PersistedShellPaneShape {
   kind: 'shell'
@@ -33,6 +34,7 @@ export interface PersistedWorkspaceSessionShape {
   id: string
   projectId: string
   layout: string
+  placements?: readonly PanePlacement[]
   workingDirectory: string
   active: boolean
   open: boolean

--- a/src/features/terminal/components/SplitView/EmptySlot.test.tsx
+++ b/src/features/terminal/components/SplitView/EmptySlot.test.tsx
@@ -5,7 +5,7 @@ import { EmptySlot } from './EmptySlot'
 
 describe('EmptySlot', () => {
   test('renders shell and browser add pane buttons', () => {
-    render(<EmptySlot sessionId="s1" onAddPane={vi.fn()} />)
+    render(<EmptySlot sessionId="s1" slotId="slot:test" onAddPane={vi.fn()} />)
 
     expect(
       screen.getByRole('button', { name: 'add shell pane' })
@@ -16,27 +16,31 @@ describe('EmptySlot', () => {
     ).toBeInTheDocument()
   })
 
-  test('clicking add shell pane calls onAddPane with shell kind', async () => {
+  test('clicking add shell pane calls onAddPane with shell kind and slot id', async () => {
     const user = userEvent.setup()
     const onAddPane = vi.fn()
 
-    render(<EmptySlot sessionId="s1" onAddPane={onAddPane} />)
+    render(
+      <EmptySlot sessionId="s1" slotId="slot:test" onAddPane={onAddPane} />
+    )
 
     await user.click(screen.getByRole('button', { name: 'add shell pane' }))
 
     expect(onAddPane).toHaveBeenCalledOnce()
-    expect(onAddPane).toHaveBeenCalledWith('s1', 'shell')
+    expect(onAddPane).toHaveBeenCalledWith('s1', 'shell', 'slot:test')
   })
 
-  test('clicking add browser pane calls onAddPane with browser kind', async () => {
+  test('clicking add browser pane calls onAddPane with browser kind and slot id', async () => {
     const user = userEvent.setup()
     const onAddPane = vi.fn()
 
-    render(<EmptySlot sessionId="s1" onAddPane={onAddPane} />)
+    render(
+      <EmptySlot sessionId="s1" slotId="slot:test" onAddPane={onAddPane} />
+    )
 
     await user.click(screen.getByRole('button', { name: 'add browser pane' }))
 
     expect(onAddPane).toHaveBeenCalledOnce()
-    expect(onAddPane).toHaveBeenCalledWith('s1', 'browser')
+    expect(onAddPane).toHaveBeenCalledWith('s1', 'browser', 'slot:test')
   })
 })

--- a/src/features/terminal/components/SplitView/EmptySlot.tsx
+++ b/src/features/terminal/components/SplitView/EmptySlot.tsx
@@ -1,13 +1,15 @@
 import { useCallback, type ReactElement } from 'react'
-import type { PaneKind } from '../../../sessions/types'
+import type { LayoutSlotId, PaneKind } from '../../../sessions/types'
 
 export interface EmptySlotProps {
   sessionId: string
-  onAddPane: (sessionId: string, kind?: PaneKind) => void
+  slotId: LayoutSlotId
+  onAddPane: (sessionId: string, kind?: PaneKind, slotId?: LayoutSlotId) => void
 }
 
 export const EmptySlot = ({
   sessionId,
+  slotId,
   onAddPane,
 }: EmptySlotProps): ReactElement => {
   // Round 13, Claude LOW: dropped the previous `event.stopPropagation()`.
@@ -17,12 +19,12 @@ export const EmptySlot = ({
   // place to gate it; the empty slot's button shouldn't silently
   // suppress unknown future handlers.
   const handleShellClick = useCallback((): void => {
-    onAddPane(sessionId, 'shell')
-  }, [onAddPane, sessionId])
+    onAddPane(sessionId, 'shell', slotId)
+  }, [onAddPane, sessionId, slotId])
 
   const handleBrowserClick = useCallback((): void => {
-    onAddPane(sessionId, 'browser')
-  }, [onAddPane, sessionId])
+    onAddPane(sessionId, 'browser', slotId)
+  }, [onAddPane, sessionId, slotId])
 
   return (
     <div className="flex h-full w-full items-center justify-center rounded-lg border border-dashed border-outline-variant/35 bg-surface-container/35">

--- a/src/features/terminal/components/SplitView/SplitView.test.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.test.tsx
@@ -471,6 +471,25 @@ describe('SplitView - multi-pane layouts', () => {
     expect(slots[3]).toHaveStyle({ gridArea: 'p3' })
   })
 
+  test('explicit placements choose grid areas independently of pane order', () => {
+    const session = {
+      ...makeSession('quad', 2),
+      placements: [
+        { paneId: 'p0', slotId: 'slot:p3' },
+        { paneId: 'p1', slotId: 'slot:p0' },
+      ],
+    } satisfies Session
+
+    render(<SplitView session={session} service={makeMockService()} isActive />)
+
+    const slots = screen.getAllByTestId('split-view-slot')
+
+    expect(slots[0]).toHaveAttribute('data-pane-id', 'p0')
+    expect(slots[0]).toHaveStyle({ gridArea: 'p3' })
+    expect(slots[1]).toHaveAttribute('data-pane-id', 'p1')
+    expect(slots[1]).toHaveStyle({ gridArea: 'p0' })
+  })
+
   test('focus marker follows pane.active and inactive panes are dimmed', () => {
     render(
       <SplitView

--- a/src/features/terminal/components/SplitView/SplitView.test.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.test.tsx
@@ -646,7 +646,7 @@ describe('SplitView - under-capacity', () => {
     ).not.toBeInTheDocument()
   })
 
-  test('clicking empty slot add button calls onAddPane with session id', async () => {
+  test('clicking empty slot add button calls onAddPane with session id and empty slot', async () => {
     const user = userEvent.setup()
     const onAddPane = vi.fn()
 
@@ -662,7 +662,7 @@ describe('SplitView - under-capacity', () => {
     await user.click(screen.getByRole('button', { name: 'add shell pane' }))
 
     expect(onAddPane).toHaveBeenCalledOnce()
-    expect(onAddPane).toHaveBeenCalledWith('sess-fix', 'shell')
+    expect(onAddPane).toHaveBeenCalledWith('sess-fix', 'shell', 'slot:p1')
   })
 })
 

--- a/src/features/terminal/components/SplitView/SplitView.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.tsx
@@ -58,7 +58,11 @@ export interface SplitViewProps {
     browserUrl: string
   ) => void
   onRequestFocus?: () => void
-  onAddPane?: (sessionId: string, kind?: Pane['kind'], slotId?: LayoutSlotId) => void
+  onAddPane?: (
+    sessionId: string,
+    kind?: Pane['kind'],
+    slotId?: LayoutSlotId
+  ) => void
   onClosePane?: (sessionId: string, paneId: string) => void
   /** Toggle a pane's ephemeral burner terminal (VIM-53). */
   onBurner?: (target: BurnerTarget) => void

--- a/src/features/terminal/components/SplitView/SplitView.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.tsx
@@ -58,7 +58,7 @@ export interface SplitViewProps {
     browserUrl: string
   ) => void
   onRequestFocus?: () => void
-  onAddPane?: (sessionId: string, kind?: Pane['kind']) => void
+  onAddPane?: (sessionId: string, kind?: Pane['kind'], slotId?: LayoutSlotId) => void
   onClosePane?: (sessionId: string, paneId: string) => void
   /** Toggle a pane's ephemeral burner terminal (VIM-53). */
   onBurner?: (target: BurnerTarget) => void
@@ -288,7 +288,7 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
         >
           {/* eslint-disable-next-line react/jsx-boolean-value -- framer-motion: `initial={false}` skips the entry animation for children already mounted. Omitting `initial` reverts to the default (animate on mount) — semantically distinct. */}
           <AnimatePresence initial={false}>
-            {visiblePaneAssignments.map(({ pane, slotId }, i) => {
+            {visiblePaneAssignments.map(({ pane, slotId }) => {
               const isBrowserPane = !isShellPane(pane)
               const mode = isBrowserPane ? 'browser' : paneMode(pane)
               const slotIndex = layout.definition.addOrder.indexOf(slotId)
@@ -336,8 +336,8 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
                   nothing to hint at, and overlaying an active
                   terminal with a popover would interfere. */}
                   <Tooltip
-                    content={`Focus pane ${i + 1}`}
-                    shortcut={['Mod', String(i + 1)]}
+                    content={`Focus pane ${slotIndex + 1}`}
+                    shortcut={['Mod', String(slotIndex + 1)]}
                     disabled={pane.active}
                     placement="top"
                   >
@@ -412,7 +412,11 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
                       className="relative min-h-0 min-w-0"
                       style={{ gridArea: gridAreaForSlotId(slotId) }}
                     >
-                      <EmptySlot sessionId={session.id} onAddPane={onAddPane} />
+                      <EmptySlot
+                        sessionId={session.id}
+                        slotId={slotId}
+                        onAddPane={onAddPane}
+                      />
                     </motion.div>
                   )
                 })

--- a/src/features/terminal/components/SplitView/SplitView.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.tsx
@@ -10,8 +10,14 @@ import {
   type ReactElement,
 } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
-import type { Pane, PaneLayoutId, Session } from '../../../sessions/types'
+import type {
+  LayoutSlotId,
+  Pane,
+  PaneLayoutId,
+  Session,
+} from '../../../sessions/types'
 import { isShellPane } from '../../../sessions/utils/paneKind'
+import { resolvePanePlacement } from '../../../sessions/utils/panePlacements'
 import { BrowserPane, focusBrowserPane } from '../../../browser'
 import type { NotifyPaneReady } from '../../hooks/useTerminal'
 import type { BurnerTarget } from '../../hooks/useBurnerTerminals'
@@ -244,26 +250,21 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
 
     const visiblePanes = selectVisiblePanes(session.panes, layout.capacity)
 
-    const emptySlotIndices =
-      session.panes.length < layout.capacity
-        ? Array.from(
-            { length: layout.capacity - session.panes.length },
-            (_, index) => session.panes.length + index
-          )
-        : []
+    const { assignments: visiblePaneAssignments, emptySlotIds } =
+      resolvePanePlacement(visiblePanes, layout, session.placements)
 
     const gridTemplateAreas = grid.areas
       .map((row) => `"${row.join(' ')}"`)
       .join(' ')
 
-    const gridAreaForSlotIndex = (slotIndex: number): string => {
-      if (slotIndex < 0 || slotIndex >= layout.definition.addOrder.length) {
+    const gridAreaForSlotId = (slotId: LayoutSlotId): string => {
+      if (!layout.definition.addOrder.includes(slotId)) {
         throw new Error(
-          `Slot index ${slotIndex} is out of bounds for layout ${layout.definition.id}`
+          `Slot ${slotId} is unknown for layout ${layout.definition.id}`
         )
       }
 
-      return gridAreaNameForSlotId(layout.definition.addOrder[slotIndex])
+      return gridAreaNameForSlotId(slotId)
     }
 
     return (
@@ -287,9 +288,10 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
         >
           {/* eslint-disable-next-line react/jsx-boolean-value -- framer-motion: `initial={false}` skips the entry animation for children already mounted. Omitting `initial` reverts to the default (animate on mount) — semantically distinct. */}
           <AnimatePresence initial={false}>
-            {visiblePanes.map((pane, i) => {
+            {visiblePaneAssignments.map(({ pane, slotId }, i) => {
               const isBrowserPane = !isShellPane(pane)
               const mode = isBrowserPane ? 'browser' : paneMode(pane)
+              const slotIndex = layout.definition.addOrder.indexOf(slotId)
 
               const closeHandler =
                 onClosePane && canClosePane(session) ? onClosePane : undefined
@@ -319,8 +321,10 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
                   data-pty-id={pane.ptyId}
                   data-mode={mode}
                   data-cwd={pane.cwd}
+                  data-slot-id={slotId}
+                  data-slot-index={slotIndex}
                   className="relative min-h-0 min-w-0"
-                  style={{ gridArea: gridAreaForSlotIndex(i) }}
+                  style={{ gridArea: gridAreaForSlotId(slotId) }}
                 >
                   {/* Inner Tooltip wrapper. The motion.div above carries
                   the click handler + grid placement; this inner Tooltip
@@ -392,21 +396,26 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
               )
             })}
             {onAddPane
-              ? emptySlotIndices.map((slotIndex) => (
-                  <motion.div
-                    key={`empty-${slotIndex}`}
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: 1 }}
-                    exit={{ opacity: 0 }}
-                    transition={SLOT_FADE_TRANSITION}
-                    data-testid="split-view-empty-slot"
-                    data-slot-index={slotIndex}
-                    className="relative min-h-0 min-w-0"
-                    style={{ gridArea: gridAreaForSlotIndex(slotIndex) }}
-                  >
-                    <EmptySlot sessionId={session.id} onAddPane={onAddPane} />
-                  </motion.div>
-                ))
+              ? emptySlotIds.map((slotId) => {
+                  const slotIndex = layout.definition.addOrder.indexOf(slotId)
+
+                  return (
+                    <motion.div
+                      key={`empty-${slotId}`}
+                      initial={{ opacity: 0 }}
+                      animate={{ opacity: 1 }}
+                      exit={{ opacity: 0 }}
+                      transition={SLOT_FADE_TRANSITION}
+                      data-testid="split-view-empty-slot"
+                      data-slot-id={slotId}
+                      data-slot-index={slotIndex}
+                      className="relative min-h-0 min-w-0"
+                      style={{ gridArea: gridAreaForSlotId(slotId) }}
+                    >
+                      <EmptySlot sessionId={session.id} onAddPane={onAddPane} />
+                    </motion.div>
+                  )
+                })
               : null}
           </AnimatePresence>
           {isActive && hasSize ? (

--- a/src/features/terminal/layout-registry/layoutDefinition.ts
+++ b/src/features/terminal/layout-registry/layoutDefinition.ts
@@ -1,6 +1,7 @@
 import type {
   CustomPaneLayoutId,
   LayoutId,
+  LayoutSlotId,
   PaneKind,
   PaneLayoutId,
 } from '../../sessions/types'
@@ -9,9 +10,7 @@ import type { LayoutRatios } from './ratioModel'
 
 export type BuiltinPaneLayoutId = LayoutId
 
-export type { CustomPaneLayoutId, PaneLayoutId }
-
-export type LayoutSlotId = `slot:${string}`
+export type { CustomPaneLayoutId, LayoutSlotId, PaneLayoutId }
 
 export type PaneLayoutSource = 'builtin' | 'workspace'
 

--- a/src/features/workspace/components/TerminalZone.test.tsx
+++ b/src/features/workspace/components/TerminalZone.test.tsx
@@ -846,7 +846,7 @@ describe('TerminalZone', () => {
     await user.click(screen.getByRole('button', { name: 'add shell pane' }))
 
     expect(addPane).toHaveBeenCalledOnce()
-    expect(addPane).toHaveBeenCalledWith('s1', 'shell')
+    expect(addPane).toHaveBeenCalledWith('s1', 'shell', 'slot:p1')
   })
 
   test('clicking a pane close control forwards removePane with both ids', async () => {

--- a/src/features/workspace/components/TerminalZone.tsx
+++ b/src/features/workspace/components/TerminalZone.tsx
@@ -6,7 +6,7 @@ import {
   type PointerEvent,
   type ReactElement,
 } from 'react'
-import type { PaneKind, Session } from '../../sessions/types'
+import type { LayoutSlotId, PaneKind, Session } from '../../sessions/types'
 import type { ITerminalService } from '../../terminal/services/terminalService'
 import type { BurnerTarget } from '../../terminal/hooks/useBurnerTerminals'
 import type { PaneLayoutRegistry } from '../../terminal/layout-registry'
@@ -56,7 +56,7 @@ export interface TerminalZoneProps {
     paneId: string,
     browserUrl: string
   ) => void
-  addPane: (sessionId: string, kind?: PaneKind) => void
+  addPane: (sessionId: string, kind?: PaneKind, slotId?: LayoutSlotId) => void
   removePane: (sessionId: string, paneId: string) => void
   isZoneFocused?: boolean
   onContainerFocus?: () => void


### PR DESCRIPTION
## Summary
- Add explicit pane-to-layout-slot placements to the session/domain model.
- Preserve current pane-index/addOrder behavior as the backward-compatible fallback.
- Thread placements through SplitView rendering, restore, Electron DTOs, and the Rust durable workspace-layout store.

## Validation
- npm run test -- src/features/sessions/utils/panePlacements.test.ts src/features/sessions/hooks/usePushWorkspaceGrouping.test.ts src/features/sessions/utils/groupSessionsFromInfos.test.ts src/features/sessions/utils/paneLifecycle.test.ts src/features/terminal/components/SplitView/SplitView.test.tsx electron/workspace-layout-controller.test.ts electron/workspace-layout-writer.test.ts electron/workspace-layout-roundtrip.test.ts
- cargo test --manifest-path crates/backend/Cargo.toml terminal::workspace_layout
- npm run type-check
- npm run lint
- git diff --check

Manual testing is not required for this PR because it adds the placement data compatibility layer and keeps the current UI behavior covered by automated tests.