### PR TITLE
refactor(terminal): add Ghostty VT render state bridge

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -58,6 +58,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 24       | 7    | 2026-06-19   |
 | [Terminal DOM Rendering](patterns/terminal-dom-rendering.md)                                         | terminal           | 3        | 0    | 2026-06-19   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
+| [Terminal Render-State Driver Contract](patterns/terminal-render-state-driver-contract.md)           | terminal           | 1        | 0    | 2026-06-19   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 85       | 25   | 2026-06-08   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 51       | 24   | 2026-06-18   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |

--- a/docs/reviews/patterns/terminal-render-state-driver-contract.md
+++ b/docs/reviews/patterns/terminal-render-state-driver-contract.md
@@ -1,0 +1,31 @@
+---
+id: terminal-render-state-driver-contract
+category: terminal
+created: 2026-06-19
+last_updated: 2026-06-19
+ref_count: 0
+---
+
+# Terminal Render-State Driver Contract
+
+## Summary
+
+Future native terminal render-state drivers (e.g. a libghostty-vt bridge) receive
+PTY bytes through a `writeBytes` callback and report side effects such as OSC-7
+cwd changes via an `effects` object. Because the adapter that wraps these drivers
+uses a stack-scoped guard (`activeInput`) that is cleared as soon as `writeBytes`
+returns, any effect callback that fires asynchronously after the call completes
+will be silently dropped. The driver interface contract must therefore be
+documented explicitly: effect callbacks must be invoked synchronously inside the
+`writeBytes` call.
+
+## Findings
+
+### 1. writeBytes JSDoc omits synchronous-effects calling contract
+
+- **Source:** github-claude | PR #558 round 1 | 2026-06-19
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts` L15-22
+- **Finding:** `GhosttyVtRenderStateDriver.writeBytes` docs told native implementors to keep OSC effects inside the driver boundary but did not state that `effects` callbacks (e.g. `onCwdChange`) must fire synchronously before `writeBytes` returns. The wrapping `GhosttyVtByteParserAdapter` clears `activeInput` immediately after the call, so an asynchronous native callback would silently drop cwd events.
+- **Fix:** Added a paragraph to the `writeBytes` JSDoc stating that `effects` callbacks must be invoked synchronously within the call, because the adapter path clears active input after `writeBytes` and drops asynchronously dispatched events.
+- **Commit:** same commit as this entry

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
@@ -1,0 +1,148 @@
+// cspell:ignore ghostty libghostty
+import { describe, expect, test, vi } from 'vitest'
+import type { GhosttyByteParserAdapterInput } from './ghosttyParserEngine'
+import { createGhosttyParserEngine } from './ghosttyParserEngine'
+import {
+  createGhosttyVtRenderStateByteParserAdapter,
+  type GhosttyVtRenderStateDriver,
+} from './ghosttyVtRenderStateDriver'
+import type { GhosttyVtRenderSnapshot } from './ghosttyVtRenderSnapshot'
+
+const createInput = (
+  bytes: Uint8Array,
+  emitEvent = vi.fn()
+): GhosttyByteParserAdapterInput => ({
+  bytes,
+  decodedText: 'decoded fallback',
+  output: {
+    offsetStart: 13,
+    byteLen: bytes.length,
+    phase: 'live',
+  },
+  emitEvent,
+})
+
+describe('ghosttyVtRenderStateDriver', () => {
+  test('bridges driver-owned render state into replace snapshot output', () => {
+    const writeBytes = vi.fn()
+
+    const readSnapshot = vi.fn(() => ({
+      rows: ['prompt', 'output'],
+      cursor: {
+        rowIndex: 1,
+        columnOffset: 3,
+      },
+    }))
+
+    const adapter = createGhosttyVtRenderStateByteParserAdapter(() => ({
+      writeBytes,
+      readSnapshot,
+    }))
+
+    const bytes = new Uint8Array([0x70, 0x74, 0x79])
+
+    expect(adapter.parseBytes(createInput(bytes))).toEqual({
+      visibleText: 'prompt\noutput',
+      displayDelta: {
+        operations: [
+          {
+            type: 'replace',
+            text: 'prompt\noutput',
+            cursorOffset: 10,
+          },
+        ],
+      },
+    })
+    expect(writeBytes).toHaveBeenCalledWith(bytes)
+    expect(readSnapshot).toHaveBeenCalledOnce()
+  })
+
+  test('can be injected behind the Ghostty parser engine byte path', () => {
+    const writeBytes = vi.fn()
+
+    const byteParserAdapter = createGhosttyVtRenderStateByteParserAdapter(
+      (): GhosttyVtRenderStateDriver => ({
+        writeBytes,
+        readSnapshot: () => ({
+          rows: ['vt prompt'],
+          cursor: {
+            rowIndex: 0,
+            columnOffset: 2,
+          },
+        }),
+      })
+    )
+
+    const parserEngine = createGhosttyParserEngine({ byteParserAdapter })
+    const bytes = new Uint8Array([0xff, 0xfe])
+
+    expect(
+      parserEngine.parseInput({
+        inputMode: 'bytes',
+        bytes,
+        text: 'lossy fallback',
+        output: null,
+      })
+    ).toEqual({
+      visibleText: 'vt prompt',
+      displayDelta: {
+        operations: [
+          {
+            type: 'replace',
+            text: 'vt prompt',
+            cursorOffset: 2,
+          },
+        ],
+      },
+    })
+    expect(writeBytes).toHaveBeenCalledWith(bytes)
+  })
+
+  test('keeps cwd effects on the parser event path', () => {
+    const adapter = createGhosttyVtRenderStateByteParserAdapter((effects) => ({
+      writeBytes: (): void => {
+        effects.onCwdChange('file://localhost/tmp/render-state')
+      },
+      readSnapshot: (): GhosttyVtRenderSnapshot => ({
+        rows: ['rendered'],
+      }),
+    }))
+
+    const emitEvent = vi.fn()
+
+    adapter.parseBytes(createInput(new Uint8Array([0x1b]), emitEvent))
+
+    expect(emitEvent).toHaveBeenCalledWith({
+      type: 'cwd',
+      source: 'osc7',
+      uri: 'file://localhost/tmp/render-state',
+      output: {
+        offsetStart: 13,
+        byteLen: 1,
+        phase: 'live',
+      },
+    })
+  })
+
+  test('forwards lifecycle to the render-state driver', () => {
+    const reset = vi.fn()
+    const dispose = vi.fn()
+
+    const adapter = createGhosttyVtRenderStateByteParserAdapter(() => ({
+      writeBytes: vi.fn(),
+      readSnapshot: (): GhosttyVtRenderSnapshot => ({
+        rows: [],
+      }),
+      reset,
+      dispose,
+    }))
+
+    adapter.reset?.()
+    adapter.dispose?.()
+    adapter.dispose?.()
+    adapter.reset?.()
+
+    expect(reset).toHaveBeenCalledOnce()
+    expect(dispose).toHaveBeenCalledOnce()
+  })
+})

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
@@ -18,6 +18,11 @@ export interface GhosttyVtRenderStateDriver {
    *
    * A native libghostty-vt bridge should keep cursor, scrollback, attributes,
    * and OSC effects inside this driver boundary.
+   *
+   * Any `effects` callbacks, such as `effects.onCwdChange`, must be invoked
+   * synchronously before `writeBytes` returns, because the adapter path clears
+   * active input immediately after the call and will drop asynchronously
+   * dispatched events.
    */
   writeBytes: (bytes: Uint8Array) => void
   readSnapshot: () => GhosttyVtRenderSnapshot

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
@@ -1,0 +1,61 @@
+// cspell:ignore ghostty libghostty
+import type { GhosttyByteParserAdapter } from './ghosttyParserEngine'
+import {
+  createGhosttyVtByteParserAdapter,
+  type GhosttyVtParserDriver,
+  type GhosttyVtParserDriverFactory,
+  type GhosttyVtParserEffects,
+} from './ghosttyVtByteParserAdapter'
+import {
+  createGhosttyVtRenderSnapshotOutput,
+  type GhosttyVtRenderSnapshot,
+} from './ghosttyVtRenderSnapshot'
+import type { TerminalParserEngineOutput } from './terminalParserEngine'
+
+export interface GhosttyVtRenderStateDriver {
+  /**
+   * Consume raw PTY bytes and update driver-owned terminal/render state.
+   *
+   * A native libghostty-vt bridge should keep cursor, scrollback, attributes,
+   * and OSC effects inside this driver boundary.
+   */
+  writeBytes: (bytes: Uint8Array) => void
+  readSnapshot: () => GhosttyVtRenderSnapshot
+  reset?: () => void
+  dispose?: () => void
+}
+
+export type GhosttyVtRenderStateDriverFactory = (
+  effects: GhosttyVtParserEffects
+) => GhosttyVtRenderStateDriver
+
+export const createGhosttyVtRenderStateParserDriverFactory =
+  (
+    createRenderStateDriver: GhosttyVtRenderStateDriverFactory
+  ): GhosttyVtParserDriverFactory =>
+  (effects): GhosttyVtParserDriver => {
+    const renderStateDriver = createRenderStateDriver(effects)
+
+    return {
+      writeBytes: (bytes): TerminalParserEngineOutput => {
+        renderStateDriver.writeBytes(bytes)
+
+        return createGhosttyVtRenderSnapshotOutput(
+          renderStateDriver.readSnapshot()
+        )
+      },
+      reset: (): void => {
+        renderStateDriver.reset?.()
+      },
+      dispose: (): void => {
+        renderStateDriver.dispose?.()
+      },
+    }
+  }
+
+export const createGhosttyVtRenderStateByteParserAdapter = (
+  createRenderStateDriver: GhosttyVtRenderStateDriverFactory
+): GhosttyByteParserAdapter =>
+  createGhosttyVtByteParserAdapter(
+    createGhosttyVtRenderStateParserDriverFactory(createRenderStateDriver)
+  )


### PR DESCRIPTION
## Summary
- Add a dependency-free `GhosttyVtRenderStateDriver` bridge that adapts driver-owned VT rows/cursor state into the existing Ghostty byte parser adapter.
- Convert render-state snapshots through `createGhosttyVtRenderSnapshotOutput(...)`, so bytes flow into the driver and renderer output stays on the generic `displayDelta.replace` contract.
- Cover injection through `createGhosttyParserEngine`, OSC7/cwd effect routing, and lifecycle forwarding with mocked driver tests.

## Why
The previous slices proved byte-preserving PTY events, parser-engine byte input, a swappable Ghostty byte adapter, VT driver lifecycle, replace display deltas, and cursor offsets. This slice adds the first real bridge shape between a future native/libghostty-vt render-state owner and the existing app-level parser/renderer contracts without adding a native dependency yet.

## Verification
- `npx vitest run src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts src/features/terminal/components/TerminalPane/ghosttyVtByteParserAdapter.test.ts src/features/terminal/components/TerminalPane/ghosttyParserEngine.test.ts src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.test.ts`
- `npm run type-check`
- `npm run lint`
- `npm run format:check`
- `npm run test:e2e:ghostty`
- Pre-push `npm run test`: 302 files, 3899 passed, 3 skipped

## Manual testing
No manual smoke is required for this slice. It is a dependency-free bridge seam with mocked driver coverage; runtime Ghostty behavior is unchanged until a real VT/render-state driver is wired.


Refs VIM-172