### PR TITLE
refactor(terminal): expose Ghostty VT driver option

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -58,7 +58,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 24       | 7    | 2026-06-19   |
 | [Terminal DOM Rendering](patterns/terminal-dom-rendering.md)                                         | terminal           | 3        | 0    | 2026-06-19   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
-| [Terminal Render-State Driver Contract](patterns/terminal-render-state-driver-contract.md)           | terminal           | 1        | 0    | 2026-06-19   |
+| [Terminal Render-State Driver Contract](patterns/terminal-render-state-driver-contract.md)           | terminal           | 2        | 0    | 2026-06-19   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 85       | 25   | 2026-06-08   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 51       | 24   | 2026-06-18   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -58,7 +58,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 24       | 7    | 2026-06-19   |
 | [Terminal DOM Rendering](patterns/terminal-dom-rendering.md)                                         | terminal           | 3        | 0    | 2026-06-19   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
-| [Terminal Render-State Driver Contract](patterns/terminal-render-state-driver-contract.md)           | terminal           | 2        | 0    | 2026-06-19   |
+| [Terminal Render-State Driver Contract](patterns/terminal-render-state-driver-contract.md)           | terminal           | 3        | 1    | 2026-06-19   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 85       | 25   | 2026-06-08   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 51       | 24   | 2026-06-18   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
@@ -67,7 +67,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Command Injection](patterns/command-injection.md)                                                   | security           | 7        | 3    | 2026-05-02   |
 | [Policy Judge Hygiene](patterns/policy-judge-hygiene.md)                                             | security           | 15       | 2    | 2026-04-20   |
 | [Fail-Closed Hooks](patterns/fail-closed-hooks.md)                                                   | security           | 3        | 1    | 2026-04-20   |
-| [Preflight Checks](patterns/preflight-checks.md)                                                     | error-handling     | 3        | 0    | 2026-05-31   |
+| [Preflight Checks](patterns/preflight-checks.md)                                                     | error-handling     | 4        | 1    | 2026-06-19   |
 | [CSP Configuration](patterns/csp-configuration.md)                                                   | security           | 8        | 5    | 2026-05-16   |
 | [Network Request Hardening](patterns/network-request-hardening.md)                                   | security           | 1        | 1    | 2026-06-08   |
 | [PTY Session Management](patterns/pty-session-management.md)                                         | backend            | 9        | 3    | 2026-06-13   |

--- a/docs/reviews/patterns/preflight-checks.md
+++ b/docs/reviews/patterns/preflight-checks.md
@@ -2,8 +2,8 @@
 id: preflight-checks
 category: error-handling
 created: 2026-04-20
-last_updated: 2026-05-31
-ref_count: 0
+last_updated: 2026-06-19
+ref_count: 1
 ---
 
 # Preflight Checks
@@ -47,4 +47,13 @@ When adding / removing / refactoring preflight checks:
 - **File:** `scripts/qa-runner/watch.mjs`
 - **Finding:** `computeState()` enumerated negative states (missing, pending, fail) to block on Claude check status, but `skipping` and `cancel` buckets bypassed the gate. An old clean Claude comment could still let the PR reach `GOOD_SHAPE` and auto-merge without a fresh review.
 - **Fix:** Replaced negative-state enumeration with a single positive gate `claudeReady = claudeCheck?.bucket === 'pass'`; block on `!claudeReady` so any non-pass state (including skipped/cancelled) waits.
+- **Commit:** same commit as this entry
+
+### 4. Reject byteOnly parser engine mode without an explicit byte adapter
+
+- **Source:** github-codex-connector | PR #559 round 1 | 2026-06-19
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/ghosttyParserEngine.ts` L71-L84
+- **Finding:** `GhosttyParserEngineOptions` exported `byteOnly`, but when `byteOnly` was used without an explicit `byteParserAdapter`, the default adapter decoded bytes and re-entered `parseText`, which now throws. The invalid combination was accepted at construction and failed later with a misleading text-input error.
+- **Fix:** Added a constructor assertion that throws immediately when `byteOnly` is enabled without a `byteParserAdapter`, turning the latent misconfiguration into a fail-fast error at engine creation.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/terminal-render-state-driver-contract.md
+++ b/docs/reviews/patterns/terminal-render-state-driver-contract.md
@@ -3,7 +3,7 @@ id: terminal-render-state-driver-contract
 category: terminal
 created: 2026-06-19
 last_updated: 2026-06-19
-ref_count: 0
+ref_count: 1
 ---
 
 # Terminal Render-State Driver Contract
@@ -37,4 +37,13 @@ documented explicitly: effect callbacks must be invoked synchronously inside the
 - **File:** `src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts` L78
 - **Finding:** `createGhosttyVtRenderStateParserEngine` wrapped the render-state driver in the generic Ghostty parser engine, which falls back to the text parser and resets the byte adapter when a chunk arrives without `bytesBase64`. During restore, `useTerminal` synthesizes replay chunks as text, so the VT driver was reset before later byte chunks arrived; subsequent replace snapshots were generated from driver state that never saw the replayed bytes.
 - **Fix:** Added a `byteOnly` option to `GhosttyParserEngineOptions` and enabled it for VT render-state engines. Text-mode input now throws instead of falling back to the text parser, keeping the driver byte-only until restore supplies byte-preserving replay data.
+- **Commit:** same commit as this entry
+
+### 3. Bypass byte-only parser for direct terminal status writes
+
+- **Source:** github-codex-connector | PR #559 round 1 | 2026-06-19
+- **Severity:** HIGH
+- **File:** `src/features/terminal/components/TerminalPane/ghosttyInstance.ts` L58-L62
+- **Finding:** `GhosttyTerminalModel` wired `TerminalTextSurface.transformOutput` to `parserEngine.parseText` for every raw `terminal.write` call. With a VT render-state driver, the parser engine is configured as `byteOnly`, so `parseText` throws on synthetic status strings such as PTY exit/error messages instead of rendering them.
+- **Fix:** Added an `acceptsTextInput` flag to `TerminalParserEngine` and set it to `false` for byte-only Ghostty engines. `GhosttyTerminalModel.transformOutput` now returns plain `{ visibleText: data }` when the engine does not accept text input, bypassing the byte-only parser for direct terminal status writes.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/terminal-render-state-driver-contract.md
+++ b/docs/reviews/patterns/terminal-render-state-driver-contract.md
@@ -29,3 +29,12 @@ documented explicitly: effect callbacks must be invoked synchronously inside the
 - **Finding:** `GhosttyVtRenderStateDriver.writeBytes` docs told native implementors to keep OSC effects inside the driver boundary but did not state that `effects` callbacks (e.g. `onCwdChange`) must fire synchronously before `writeBytes` returns. The wrapping `GhosttyVtByteParserAdapter` clears `activeInput` immediately after the call, so an asynchronous native callback would silently drop cwd events.
 - **Fix:** Added a paragraph to the `writeBytes` JSDoc stating that `effects` callbacks must be invoked synchronously within the call, because the adapter path clears active input after `writeBytes` and drops asynchronously dispatched events.
 - **Commit:** same commit as this entry
+
+### 2. Render-state parser engine inherits Ghostty text fallback
+
+- **Source:** github-codex-connector | PR #559 round 1 | 2026-06-19
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts` L78
+- **Finding:** `createGhosttyVtRenderStateParserEngine` wrapped the render-state driver in the generic Ghostty parser engine, which falls back to the text parser and resets the byte adapter when a chunk arrives without `bytesBase64`. During restore, `useTerminal` synthesizes replay chunks as text, so the VT driver was reset before later byte chunks arrived; subsequent replace snapshots were generated from driver state that never saw the replayed bytes.
+- **Fix:** Added a `byteOnly` option to `GhosttyParserEngineOptions` and enabled it for VT render-state engines. Text-mode input now throws instead of falling back to the text parser, keeping the driver byte-only until restore supplies byte-preserving replay data.
+- **Commit:** same commit as this entry

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
@@ -178,6 +178,21 @@ describe('ghosttyInstance', () => {
     expect(cursor?.previousSibling?.textContent).toBe('rendered')
   })
 
+  test('renders direct terminal status writes when the VT render-state driver is byte-only', () => {
+    const created = createTrackedGhosttyTerminal({
+      createVtRenderStateDriver: (): GhosttyVtRenderStateDriver => ({
+        writeBytes: vi.fn(),
+        readSnapshot: () => ({ rows: ['vt prompt'] }),
+      }),
+    })
+
+    created.terminal.write('process exited with code 0')
+
+    expect(created.viewportReader.readVisibleText()).toBe(
+      'process exited with code 0'
+    )
+  })
+
   test('prefers an injected parser engine over a VT render-state driver option', () => {
     const parser: TerminalParser = {
       onEvent: (): TerminalDisposable => ({ dispose: vi.fn() }),

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
@@ -16,6 +16,7 @@ import {
   ghosttyTerminalRenderer,
   type GhosttyTerminalOptions,
 } from './ghosttyInstance'
+import type { GhosttyVtRenderStateDriver } from './ghosttyVtRenderStateDriver'
 import { createGhosttyVtRenderSnapshotOutput } from './ghosttyVtRenderSnapshot'
 import { GHOSTTY_TERMINAL_CAPABILITIES } from './terminalRendererCapabilities'
 
@@ -134,6 +135,93 @@ describe('ghosttyInstance', () => {
     expect(createParserEngine).toHaveBeenCalledOnce()
     expect(parseOutput).toHaveBeenCalledWith(chunk)
     expect(created.viewportReader.readVisibleText()).toBe('parsed:from-engine')
+  })
+
+  test('wires a VT render-state driver option through the Ghostty byte parser path', () => {
+    const writeBytes = vi.fn()
+
+    const readSnapshot = vi.fn(() => ({
+      rows: ['vt prompt', 'rendered output'],
+      cursor: {
+        rowIndex: 1,
+        columnOffset: 8,
+      },
+    }))
+
+    const created = createTrackedGhosttyTerminal({
+      createVtRenderStateDriver: (): GhosttyVtRenderStateDriver => ({
+        writeBytes,
+        readSnapshot,
+      }),
+    })
+
+    const bytes = new Uint8Array([0xff, 0xfe])
+
+    created.output.writeOutput({
+      text: 'lossy fallback',
+      bytesBase64: encodeBase64(bytes),
+      offsetStart: 17,
+      byteLen: bytes.length,
+      phase: 'live',
+    })
+
+    const cursor = created.terminal.element?.querySelector(
+      '[data-terminal-cursor="true"]'
+    )
+
+    expect(writeBytes).toHaveBeenCalledWith(bytes)
+    expect(readSnapshot).toHaveBeenCalledOnce()
+    expect(created.viewportReader.readVisibleText()).toBe(
+      'vt prompt\nrendered output'
+    )
+    expect(cursor?.parentElement?.textContent).toBe('rendered output')
+    expect(cursor?.previousSibling?.textContent).toBe('rendered')
+  })
+
+  test('prefers an injected parser engine over a VT render-state driver option', () => {
+    const parser: TerminalParser = {
+      onEvent: (): TerminalDisposable => ({ dispose: vi.fn() }),
+    }
+
+    const createVtRenderStateDriver = vi.fn(
+      (): GhosttyVtRenderStateDriver => ({
+        writeBytes: vi.fn(),
+        readSnapshot: () => ({ rows: ['from-vt'] }),
+      })
+    )
+
+    const createParserEngine = vi.fn(
+      (): TerminalParserEngine => ({
+        inputMode: 'bytes',
+        capabilities: ghosttyTerminalRenderer.capabilities,
+        parser,
+        parseText: (text): TerminalParserEngineOutput => ({
+          visibleText: text,
+        }),
+        parseInput: (input): TerminalParserEngineOutput => ({
+          visibleText: input.text,
+        }),
+        parseOutput: (): TerminalParserEngineOutput => ({
+          visibleText: 'from-parser-engine',
+        }),
+      })
+    )
+
+    const created = createTrackedGhosttyTerminal({
+      createParserEngine,
+      createVtRenderStateDriver,
+    })
+
+    created.output.writeOutput({
+      text: 'input',
+      offsetStart: 0,
+      byteLen: 5,
+      phase: 'live',
+    })
+
+    expect(created.viewportReader.readVisibleText()).toBe('from-parser-engine')
+    expect(createParserEngine).toHaveBeenCalledOnce()
+    expect(createVtRenderStateDriver).not.toHaveBeenCalled()
   })
 
   test('applies parser display replace deltas without appending snapshots', () => {

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.ts
@@ -16,11 +16,32 @@ import {
   TerminalTextSurface,
   type TerminalTextSurfaceOutput,
 } from './terminalTextSurface'
+import {
+  createGhosttyVtRenderStateParserEngine,
+  type GhosttyVtRenderStateDriverFactory,
+} from './ghosttyVtRenderStateDriver'
 
 export { GHOSTTY_TERMINAL_RENDERER_ID } from './ghosttyRendererMetadata'
 
 export interface GhosttyTerminalOptions {
   readonly createParserEngine?: () => TerminalParserEngine
+  readonly createVtRenderStateDriver?: GhosttyVtRenderStateDriverFactory
+}
+
+const createParserEngineForGhosttyTerminal = (
+  options: GhosttyTerminalOptions
+): TerminalParserEngine => {
+  if (options.createParserEngine) {
+    return options.createParserEngine()
+  }
+
+  if (options.createVtRenderStateDriver) {
+    return createGhosttyVtRenderStateParserEngine(
+      options.createVtRenderStateDriver
+    )
+  }
+
+  return createGhosttyParserEngine()
 }
 
 class GhosttyTerminalModel {
@@ -31,8 +52,7 @@ class GhosttyTerminalModel {
   readonly parser: TerminalParser
 
   constructor(options: GhosttyTerminalOptions = {}) {
-    this.parserEngine =
-      options.createParserEngine?.() ?? createGhosttyParserEngine()
+    this.parserEngine = createParserEngineForGhosttyTerminal(options)
     this.parser = this.parserEngine.parser
 
     this.terminal = new TerminalTextSurface({

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.ts
@@ -58,7 +58,9 @@ class GhosttyTerminalModel {
     this.terminal = new TerminalTextSurface({
       rendererId: GHOSTTY_TERMINAL_RENDERER_ID,
       transformOutput: (data): TerminalTextSurfaceOutput =>
-        this.parserEngine.parseText(data, null),
+        this.parserEngine.acceptsTextInput === false
+          ? { visibleText: data }
+          : this.parserEngine.parseText(data, null),
     })
 
     const originalTerminalDispose = this.terminal.dispose.bind(this.terminal)

--- a/src/features/terminal/components/TerminalPane/ghosttyParserEngine.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyParserEngine.test.ts
@@ -59,6 +59,12 @@ describe('ghosttyParserEngine', () => {
     expect(engine.capabilities).toBe(GHOSTTY_TERMINAL_CAPABILITIES)
   })
 
+  test('rejects byteOnly mode without an explicit byte parser adapter', () => {
+    expect(() => createGhosttyParserEngine({ byteOnly: true })).toThrow(
+      'byteOnly mode requires a byteParserAdapter'
+    )
+  })
+
   test('parses visible output from bytes before text fallback', () => {
     const engine = createGhosttyParserEngine()
 

--- a/src/features/terminal/components/TerminalPane/ghosttyParserEngine.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyParserEngine.ts
@@ -64,6 +64,7 @@ export class GhosttyControlSequenceParserEngine
   implements GhosttyParserEngine
 {
   readonly id: typeof GHOSTTY_PARSER_ENGINE_ID = GHOSTTY_PARSER_ENGINE_ID
+  readonly acceptsTextInput: boolean
   private readonly byteParserAdapter: GhosttyByteParserAdapter
   private readonly byteOnly: boolean
   private isDisposed = false
@@ -76,6 +77,14 @@ export class GhosttyControlSequenceParserEngine
     })
 
     this.byteOnly = options.byteOnly ?? false
+    this.acceptsTextInput = !this.byteOnly
+
+    if (this.byteOnly && !options.byteParserAdapter) {
+      throw new Error(
+        'Ghostty parser engine byteOnly mode requires a byteParserAdapter'
+      )
+    }
+
     this.byteParserAdapter =
       options.byteParserAdapter ??
       new ControlSequenceGhosttyByteParserAdapter((text, output) =>

--- a/src/features/terminal/components/TerminalPane/ghosttyParserEngine.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyParserEngine.ts
@@ -30,6 +30,7 @@ export interface GhosttyByteParserAdapter {
 
 export interface GhosttyParserEngineOptions {
   readonly byteParserAdapter?: GhosttyByteParserAdapter
+  readonly byteOnly?: boolean
 }
 
 export interface GhosttyParserEngine extends TerminalParserEngine {
@@ -64,6 +65,7 @@ export class GhosttyControlSequenceParserEngine
 {
   readonly id: typeof GHOSTTY_PARSER_ENGINE_ID = GHOSTTY_PARSER_ENGINE_ID
   private readonly byteParserAdapter: GhosttyByteParserAdapter
+  private readonly byteOnly: boolean
   private isDisposed = false
 
   constructor(options: GhosttyParserEngineOptions = {}) {
@@ -73,11 +75,25 @@ export class GhosttyControlSequenceParserEngine
       preserveSgrStyles: true,
     })
 
+    this.byteOnly = options.byteOnly ?? false
     this.byteParserAdapter =
       options.byteParserAdapter ??
       new ControlSequenceGhosttyByteParserAdapter((text, output) =>
         this.parseText(text, output)
       )
+  }
+
+  parseText(
+    text: string,
+    output: TerminalParserOutputContext | null
+  ): TerminalParserEngineOutput {
+    if (this.byteOnly) {
+      throw new Error(
+        'Ghostty VT render-state parser engine does not accept text input; use byte output chunks'
+      )
+    }
+
+    return super.parseText(text, output)
   }
 
   parseInput(input: TerminalParserEngineInput): TerminalParserEngineOutput {
@@ -90,6 +106,12 @@ export class GhosttyControlSequenceParserEngine
           this.emitParserEvent(event)
         },
       })
+    }
+
+    if (this.byteOnly) {
+      throw new Error(
+        'Ghostty VT render-state parser engine does not accept text input; use byte output chunks'
+      )
     }
 
     this.byteParserAdapter.reset?.()

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
@@ -4,6 +4,7 @@ import type { GhosttyByteParserAdapterInput } from './ghosttyParserEngine'
 import { createGhosttyParserEngine } from './ghosttyParserEngine'
 import {
   createGhosttyVtRenderStateByteParserAdapter,
+  createGhosttyVtRenderStateParserEngine,
   type GhosttyVtRenderStateDriver,
 } from './ghosttyVtRenderStateDriver'
 import type { GhosttyVtRenderSnapshot } from './ghosttyVtRenderSnapshot'
@@ -144,5 +145,33 @@ describe('ghosttyVtRenderStateDriver', () => {
 
     expect(reset).toHaveBeenCalledOnce()
     expect(dispose).toHaveBeenCalledOnce()
+  })
+
+  test('rejects text input instead of falling back to the text parser', () => {
+    const writeBytes = vi.fn()
+    const reset = vi.fn()
+
+    const engine = createGhosttyVtRenderStateParserEngine(
+      (): GhosttyVtRenderStateDriver => ({
+        writeBytes,
+        readSnapshot: () => ({
+          rows: ['vt text path'],
+          cursor: { rowIndex: 0, columnOffset: 4 },
+        }),
+        reset,
+      })
+    )
+
+    expect(() =>
+      engine.parseInput({
+        inputMode: 'text',
+        text: 'hello',
+        output: null,
+      })
+    ).toThrow(
+      'Ghostty VT render-state parser engine does not accept text input; use byte output chunks'
+    )
+    expect(writeBytes).not.toHaveBeenCalled()
+    expect(reset).not.toHaveBeenCalled()
   })
 })

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
@@ -73,6 +73,7 @@ export const createGhosttyVtRenderStateParserEngine = (
   createRenderStateDriver: GhosttyVtRenderStateDriverFactory
 ): GhosttyParserEngine =>
   createGhosttyParserEngine({
+    byteOnly: true,
     byteParserAdapter: createGhosttyVtRenderStateByteParserAdapter(
       createRenderStateDriver
     ),

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
@@ -1,5 +1,9 @@
 // cspell:ignore ghostty libghostty
-import type { GhosttyByteParserAdapter } from './ghosttyParserEngine'
+import {
+  createGhosttyParserEngine,
+  type GhosttyByteParserAdapter,
+  type GhosttyParserEngine,
+} from './ghosttyParserEngine'
 import {
   createGhosttyVtByteParserAdapter,
   type GhosttyVtParserDriver,
@@ -64,3 +68,12 @@ export const createGhosttyVtRenderStateByteParserAdapter = (
   createGhosttyVtByteParserAdapter(
     createGhosttyVtRenderStateParserDriverFactory(createRenderStateDriver)
   )
+
+export const createGhosttyVtRenderStateParserEngine = (
+  createRenderStateDriver: GhosttyVtRenderStateDriverFactory
+): GhosttyParserEngine =>
+  createGhosttyParserEngine({
+    byteParserAdapter: createGhosttyVtRenderStateByteParserAdapter(
+      createRenderStateDriver
+    ),
+  })

--- a/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
+++ b/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
@@ -33,6 +33,7 @@ export interface TerminalParserEngineOptions {
 
 export interface TerminalParserEngine {
   readonly inputMode: TerminalParserEngineInputMode
+  readonly acceptsTextInput?: boolean
   readonly capabilities: TerminalRendererCapabilities
   readonly parser: TerminalParser
   parseText: (
@@ -59,6 +60,7 @@ class EngineTerminalControlSequenceParser extends TerminalControlSequenceParser 
 }
 
 export class TerminalControlSequenceParserEngine implements TerminalParserEngine {
+  readonly acceptsTextInput: boolean = true
   readonly capabilities: TerminalRendererCapabilities
   readonly parser: TerminalControlSequenceParser
   private readonly emittableParser: EngineTerminalControlSequenceParser


### PR DESCRIPTION
## Summary
- Add `createGhosttyVtRenderStateParserEngine(...)` so a render-state driver factory can be turned into a Ghostty parser engine without hand-wiring byte adapters.
- Add `createVtRenderStateDriver` to `GhosttyTerminalOptions`, while keeping `createParserEngine` precedence and the default control-sequence parser unchanged.
- Cover raw byte flow into the supplied VT driver, snapshot rendering through the terminal option, cursor placement, and option precedence.

## Why
The previous slice added the dependency-free VT render-state bridge, but callers still had to remember how to assemble the parser engine and byte adapter. This moves that plumbing into the Ghostty terminal boundary so a future native/libghostty-vt driver can be injected as a single driver factory.

## Verification
- `npx vitest run src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts src/features/terminal/components/TerminalPane/ghosttyParserEngine.test.ts src/features/terminal/components/TerminalPane/ghosttyVtByteParserAdapter.test.ts src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.test.ts`
- `npm run type-check`
- `npm run lint`
- `npm run format:check`
- `npm run test:e2e:ghostty`
- Pre-push `npm run test`: 302 files, 3901 passed, 3 skipped

## Manual testing
No manual smoke is required for this slice. It exposes an injection option and keeps default runtime Ghostty behavior unchanged until a real VT/render-state driver is wired.


Refs VIM-173