### PR TITLE
refactor(command-palette): use Dialog shell

### DIFF
--- a/src/features/command-palette/CommandPalette.tsx
+++ b/src/features/command-palette/CommandPalette.tsx
@@ -1,5 +1,5 @@
-import { AnimatePresence, motion } from 'framer-motion'
 import type { ReactElement } from 'react'
+import { Dialog } from '@/components/Dialog'
 import { CommandInput } from './components/CommandInput'
 import { CommandResults } from './components/CommandResults'
 import { CommandFooter } from './components/CommandFooter'
@@ -27,6 +27,8 @@ const getActiveDescendantId = (
   return activeCommand ? `command-${activeCommand.id}` : undefined
 }
 
+const DIALOG_CLOSE_ON_ESCAPE = false
+
 export const CommandPalette = ({
   state,
   filteredResults,
@@ -35,62 +37,37 @@ export const CommandPalette = ({
   setQuery,
   selectIndex,
 }: CommandPaletteProps): ReactElement | null => (
-  <AnimatePresence>
-    {state.isOpen && (
-      <div
-        role="dialog"
-        aria-modal="true"
-        aria-label="Command palette"
-        className="fixed inset-0 z-[100] flex items-start justify-center pt-[15vh]"
-      >
-        {/* Backdrop */}
-        <motion.div
-          data-testid="command-palette-backdrop"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          transition={{ duration: 0.15 }}
-          className="absolute inset-0 backdrop-blur-sm bg-surface-container-lowest/40"
-          onClick={close}
-        />
+  <Dialog
+    open={state.isOpen}
+    onOpenChange={(open): void => {
+      if (!open) {
+        close()
+      }
+    }}
+    placement="top"
+    size="lg"
+    closeOnEscape={DIALOG_CLOSE_ON_ESCAPE}
+    aria-label="Command palette"
+    backdropTestId="command-palette-backdrop"
+  >
+    <CommandInput
+      value={state.query}
+      onChange={setQuery}
+      activeDescendantId={getActiveDescendantId(
+        clampedSelectedIndex,
+        filteredResults
+      )}
+    />
 
-        {/* Panel */}
-        <motion.div
-          initial={{ scale: 0.96, opacity: 0, y: -8 }}
-          animate={{ scale: 1, opacity: 1, y: 0 }}
-          exit={{ scale: 0.96, opacity: 0, y: -8 }}
-          transition={{
-            type: 'spring',
-            stiffness: 400,
-            damping: 30,
-          }}
-          className="relative w-full max-w-2xl mx-4 bg-surface-container/90 glass-panel rounded-2xl border border-outline-variant/30 shadow-2xl overflow-hidden flex flex-col h-fit"
-        >
-          {/* Input section */}
-          <CommandInput
-            value={state.query}
-            onChange={setQuery}
-            activeDescendantId={getActiveDescendantId(
-              clampedSelectedIndex,
-              filteredResults
-            )}
-          />
+    <div className="h-px bg-surface-container-low/30" />
 
-          {/* Divider */}
-          <div className="h-px bg-surface-container-low/30" />
+    <CommandResults
+      filteredResults={filteredResults}
+      selectedIndex={clampedSelectedIndex}
+      onSelect={selectIndex}
+    />
 
-          {/* Results */}
-          <CommandResults
-            filteredResults={filteredResults}
-            selectedIndex={clampedSelectedIndex}
-            onSelect={selectIndex}
-          />
-
-          {/* Footer */}
-          <div className="h-px bg-surface-container-low/30" />
-          <CommandFooter />
-        </motion.div>
-      </div>
-    )}
-  </AnimatePresence>
+    <div className="h-px bg-surface-container-low/30" />
+    <CommandFooter />
+  </Dialog>
 )


### PR DESCRIPTION
## Summary

- migrates `CommandPalette` from its feature-local modal wrapper to the shared `Dialog` primitive
- preserves palette-specific input, results, selected-index, and active-descendant behavior
- keeps Escape ownership in `useCommandPalette` by disabling Dialog-level Escape close for this consumer

## Why

`Dialog` now owns the viewport overlay, backdrop, panel motion/chrome, focus trap, and aria-modal shell. The command palette should only own command-palette state and rendering.

## Stack

Base: `refactor/dialog-component`
Head: `refactor/vim-116-command-palette-dialog`
Depends on: #548 and #554

## Validation

- `npx vitest run src/features/command-palette/CommandPalette.test.tsx src/components/Dialog.test.tsx`
- `npx eslint src/features/command-palette/CommandPalette.tsx src/features/command-palette/CommandPalette.test.tsx src/components/Dialog.tsx src/components/Dialog.test.tsx`
- `npm run generate:bindings:if-missing && npm run type-check:generated`
- `npm run lint`
- `npx prettier --check src/features/command-palette/CommandPalette.tsx src/features/command-palette/CommandPalette.test.tsx`
- `git diff --check`
