### PR TITLE
fix(agent): move bridge runtime into app data

### DIFF
--- a/crates/backend/src/agent/README.md
+++ b/crates/backend/src/agent/README.md
@@ -97,7 +97,7 @@ Constructs the right adapter for a detected agent type. Returns `Arc<dyn AgentAd
 
 - `AgentType::ClaudeCode` → `ClaudeCodeAdapter` (`pid`/`pty_start` discarded)
 - `AgentType::Codex` → `CodexAdapter::new(pid, pty_start)`
-- everything else → `NoOpAdapter::new(t)` (returns errors from `parse_status` / `validate_transcript` / `tail_transcript`; `status_source` returns a `.vimeflow/sessions/{sid}/status.json` placeholder; `pid`/`pty_start` discarded)
+- everything else → `NoOpAdapter::new(t, app_data_dir)` (returns errors from `parse_status` / `validate_transcript` / `tail_transcript`; `status_source` returns an app-data bridge status placeholder; `pid`/`pty_start` discarded)
 
 > **Resolved 2026-05-05** by [`docs/superpowers/specs/2026-05-05-codex-adapter-trait-simplification-design.md`](../../../docs/superpowers/specs/2026-05-05-codex-adapter-trait-simplification-design.md) (issue [#156](https://github.com/winoooops/vimeflow/issues/156)): `BindContext` is now private to `codex/`, the old bind error type is deleted, the trait method is `status_source(cwd, sid) -> Result<_, String>`, and codex's cold-start retry lives inside `CodexAdapter::status_source` via the `retry_locator` helper.
 
@@ -137,6 +137,7 @@ impl BackendState {
             self.agents.clone(),
             self.transcripts.clone(),
             self.events.clone(),
+            self.app_data_dir.clone(),
             session_id,
         )
         .await
@@ -184,15 +185,15 @@ Each method is a "provider hook" — every concrete adapter implements all five.
 
 ### `ClaudeCodeAdapter`
 
-Stateless struct (zero fields). Each hook delegates to a sibling module under `claude_code/`:
+Stateless adapter for parsing and tailing. The status locator carries the app-data root; each hook delegates to a sibling module under `claude_code/`:
 
 ```rust
 impl AgentAdapter for ClaudeCodeAdapter {
     fn agent_type(&self) -> AgentType { AgentType::ClaudeCode }
-    fn status_source(&self, cwd, sid) -> Result<StatusSource, String> {
+    fn status_source(&self, app_data_dir, cwd, sid) -> Result<StatusSource, String> {
         Ok(StatusSource {
-            path: cwd.join(".vimeflow/sessions").join(sid).join("status.json"),
-            trust_root: cwd.to_path_buf(),
+            path: crate::terminal::bridge::session_status_file(app_data_dir, cwd, sid),
+            trust_root: app_data_dir.to_path_buf(),
         })
     }
     fn parse_status(&self, sid, raw) -> Result<ParsedStatus, String> {
@@ -215,11 +216,12 @@ The Claude-Code-specific submodules under `adapter/claude_code/`:
 
 ### `NoOpAdapter`
 
-Fallback for `AgentType::Aider` / `Generic` until real adapters ship. One field, one constructor:
+Fallback for `AgentType::Aider` / `Generic` until real adapters ship:
 
 ```rust
 pub(crate) struct NoOpAdapter {
     agent_type: AgentType,
+    app_data_dir: PathBuf,
 }
 
 impl AgentAdapter for NoOpAdapter {
@@ -228,8 +230,8 @@ impl AgentAdapter for NoOpAdapter {
         // Same path Claude uses → watcher's create_dir_all + watch
         // matches today's silent-no-op UX for unsupported agents.
         Ok(StatusSource {
-            path: cwd.join(".vimeflow/sessions").join(sid).join("status.json"),
-            trust_root: cwd.to_path_buf(),
+            path: crate::terminal::bridge::session_status_file(&self.app_data_dir, cwd, sid),
+            trust_root: self.app_data_dir.clone(),
         })
     }
     fn parse_status(&self, _, _) -> Result<ParsedStatus, String>  { Err("…no status decoder".into()) }
@@ -240,7 +242,7 @@ impl AgentAdapter for NoOpAdapter {
 }
 ```
 
-**Why this exists:** if `for_attach` returned `Err` for unsupported variants, the frontend's exit-collapse path (gated on `watcherStartedRef.current`) would never run after an unsupported agent session exits — the panel would stay in `isActive: true` indefinitely. `NoOpAdapter` returns the standard `.vimeflow/sessions/{sid}/status.json` path so the watcher starts successfully (no events ever fire because unsupported agents do not write that file), `watcherStartedRef.current` flips to `true`, and exit-collapse runs naturally. Codex no longer uses this path; it has a real adapter.
+**Why this exists:** if `for_attach` returned `Err` for unsupported variants, the frontend's exit-collapse path (gated on `watcherStartedRef.current`) would never run after an unsupported agent session exits — the panel would stay in `isActive: true` indefinitely. `NoOpAdapter` returns the standard app-data bridge status path so the watcher starts successfully (no events ever fire because unsupported agents do not write that file), `watcherStartedRef.current` flips to `true`, and exit-collapse runs naturally. Codex no longer uses this path; it has a real adapter.
 
 ---
 

--- a/crates/backend/src/agent/adapter/README.md
+++ b/crates/backend/src/agent/adapter/README.md
@@ -16,8 +16,8 @@ and the backend pushes a uniform stream of events:
 - `agent-cwd` — workspace cwd transitions reported by the agent
 - `test-run` — structured test-runner snapshots (cargo, vitest, …)
 
-The frontend never needs to know that Claude Code writes JSON to
-`.vimeflow/sessions/<sid>/status.json` while Codex writes JSONL to
+The frontend never needs to know that Claude Code writes JSON to a
+Vimeflow-owned app-data bridge status file while Codex writes JSONL to
 `~/.codex/sessions/<yyyy>/<mm>/<dd>/rollout-*.jsonl` and indexes its sessions
 through `~/.codex/state.sqlite` + `~/.codex/logs.sqlite`.
 

--- a/crates/backend/src/agent/adapter/attach.rs
+++ b/crates/backend/src/agent/adapter/attach.rs
@@ -70,6 +70,13 @@ pub(crate) struct AttachContext {
     /// via [`crate::agent::config::AgentSpec::provider_home`]; adding a
     /// new provider home only touches that registry, not this struct.
     pub(crate) provider_home: Option<PathBuf>,
+    /// Explicit provider-home override used by hermetic E2E helpers.
+    /// When set, it takes precedence over both the registry-resolved
+    /// `provider_home` and any agent-specific environment variable
+    /// (`KIMI_CODE_HOME`) so tests can seed fixtures under a temporary
+    /// directory without mutating the process-wide environment across
+    /// an await.
+    pub(crate) provider_home_override: Option<PathBuf>,
     /// Filesystem path to `/proc`. `Some(/proc)` on Linux; `None` on
     /// platforms where `/proc` doesn't exist (macOS, Windows). Codex's
     /// `/proc`-based fast-paths (`resume_thread_id_from_proc`,
@@ -159,6 +166,7 @@ mod tests {
             agent_type: AgentType::ClaudeCode,
             app_data_dir: PathBuf::from("/home/u/.config/vimeflow"),
             provider_home: Some(PathBuf::from("/home/u/.claude")),
+            provider_home_override: None,
             proc_root: Some(PathBuf::from("/proc")),
         };
 
@@ -191,6 +199,7 @@ mod tests {
             agent_type: AgentType::Codex,
             app_data_dir: PathBuf::from("/tmp/vimeflow-data"),
             provider_home: Some(PathBuf::from(".codex")),
+            provider_home_override: None,
             proc_root: None,
         };
 
@@ -217,6 +226,7 @@ mod tests {
             agent_type: AgentType::Codex,
             app_data_dir: PathBuf::from("/tmp/vimeflow-data"),
             provider_home: None,
+            provider_home_override: None,
             proc_root: None,
         };
         // If AgentType lost Copy, this would consume attach.agent_type.

--- a/crates/backend/src/agent/adapter/attach.rs
+++ b/crates/backend/src/agent/adapter/attach.rs
@@ -61,6 +61,9 @@ pub(crate) struct AttachContext {
     pub(crate) pty_start: SystemTime,
     /// Which CLI agent is attached.
     pub(crate) agent_type: AgentType,
+    /// Vimeflow-owned app data directory. Runtime bridge/status files live
+    /// under this root instead of the user's project tree.
+    pub(crate) app_data_dir: PathBuf,
     /// Home directory for the attached agent (e.g. `~/.codex` for Codex,
     /// `~/.claude` for ClaudeCode). `None` when the active agent has no
     /// canonical home (Aider / Generic today). Resolved at attach time
@@ -154,6 +157,7 @@ mod tests {
             agent_pid: 200,
             pty_start: SystemTime::UNIX_EPOCH,
             agent_type: AgentType::ClaudeCode,
+            app_data_dir: PathBuf::from("/home/u/.config/vimeflow"),
             provider_home: Some(PathBuf::from("/home/u/.claude")),
             proc_root: Some(PathBuf::from("/proc")),
         };
@@ -165,6 +169,10 @@ mod tests {
         assert_ne!(attach.shell_pid, attach.agent_pid);
         assert_eq!(attach.pty_start, SystemTime::UNIX_EPOCH);
         assert_eq!(attach.agent_type, AgentType::ClaudeCode);
+        assert_eq!(
+            attach.app_data_dir,
+            PathBuf::from("/home/u/.config/vimeflow")
+        );
         assert_eq!(attach.provider_home, Some(PathBuf::from("/home/u/.claude")));
         assert_eq!(attach.proc_root, Some(PathBuf::from("/proc")));
     }
@@ -181,6 +189,7 @@ mod tests {
             agent_pid: 2,
             pty_start: SystemTime::UNIX_EPOCH,
             agent_type: AgentType::Codex,
+            app_data_dir: PathBuf::from("/tmp/vimeflow-data"),
             provider_home: Some(PathBuf::from(".codex")),
             proc_root: None,
         };
@@ -188,6 +197,7 @@ mod tests {
         let cloned = original.clone();
         assert_eq!(cloned.session_id, original.session_id);
         assert_eq!(cloned.agent_pid, original.agent_pid);
+        assert_eq!(cloned.app_data_dir, original.app_data_dir);
         assert_eq!(cloned.provider_home, original.provider_home);
         assert_eq!(cloned.proc_root, original.proc_root);
     }
@@ -205,6 +215,7 @@ mod tests {
             agent_pid: 2,
             pty_start: SystemTime::UNIX_EPOCH,
             agent_type: AgentType::Codex,
+            app_data_dir: PathBuf::from("/tmp/vimeflow-data"),
             provider_home: None,
             proc_root: None,
         };

--- a/crates/backend/src/agent/adapter/base/watcher_runtime.rs
+++ b/crates/backend/src/agent/adapter/base/watcher_runtime.rs
@@ -482,8 +482,7 @@ impl AgentWatcherState {
                     // debug-asserts the match so a future
                     // contributor accidentally passing the wrong
                     // session's guard fails fast in debug builds.
-                    removed_transcript =
-                        ts.stop_with_held_gate(&session_id, &_gate_guard);
+                    removed_transcript = ts.stop_with_held_gate(&session_id, &_gate_guard);
                 }
                 // Always clear: either the new handle owns the entry
                 // (claim transferred) or we just tore it down — either
@@ -585,7 +584,7 @@ impl AgentWatcherState {
     /// because both sides come from the same stub state — they match
     /// each other, not the production state. Threading the real
     /// state is the only structural fix.
-    #[cfg(test)]
+    #[cfg(any(test, feature = "e2e-test"))]
     pub(crate) fn insert_agent_type_for_test(
         &self,
         transcript_state: TranscriptState,
@@ -961,11 +960,7 @@ pub(crate) fn start_watching(
                 }
             }
             Err(e) => {
-                log::warn!(
-                    "Failed to parse statusline for session {}: {}",
-                    sid,
-                    e
-                );
+                log::warn!("Failed to parse statusline for session {}: {}", sid, e);
                 (TxOutcome::ParseError, None)
             }
         };
@@ -1326,12 +1321,9 @@ pub(crate) fn start_watching(
     })
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "e2e-test"))]
 impl WatcherHandle {
-    pub(crate) fn new_for_test(
-        transcript_state: TranscriptState,
-        session_id: String,
-    ) -> Self {
+    pub(crate) fn new_for_test(transcript_state: TranscriptState, session_id: String) -> Self {
         // `agent_type` defaults to `ClaudeCode`. Tests that care about
         // the agent type pass the real value through
         // `AgentWatcherState::insert(sid, handle, agent_type)`, which
@@ -1373,6 +1365,7 @@ impl WatcherHandle {
     /// Without this seam, tests can't exercise the ownership-transfer
     /// decision independently of running the full inline-init / notify
     /// code path.
+    #[cfg(test)]
     pub(crate) fn set_claimed_for_test(&mut self, v: bool) {
         self.claimed_transcript
             .store(v, std::sync::atomic::Ordering::Release);
@@ -1654,7 +1647,15 @@ mod tests {
         let sink = Arc::new(FakeEventSink::new());
 
         let status = transcript_state
-            .start_or_replace(adapter, sink, sid.clone(), transcript_path, None, None, None)
+            .start_or_replace(
+                adapter,
+                sink,
+                sid.clone(),
+                transcript_path,
+                None,
+                None,
+                None,
+            )
             .expect("failed to start transcript watcher");
         assert_eq!(status, TranscriptStartStatus::Started);
 

--- a/crates/backend/src/agent/adapter/bindings.rs
+++ b/crates/backend/src/agent/adapter/bindings.rs
@@ -118,7 +118,11 @@ impl AgentBindings {
                 // structural fix (PR #261 cycle 11 F31) shares one
                 // `CompositeLocator`; B'' (this step) then consumes the
                 // streamer view directly in `start_or_replace`.
-                let codex_home = ctx.provider_home.clone().unwrap_or_else(default_codex_home);
+                let codex_home = ctx
+                    .provider_home_override
+                    .clone()
+                    .or_else(|| ctx.provider_home.clone())
+                    .unwrap_or_else(default_codex_home);
                 // `ctx.proc_root` carries `Some("/proc")` on Linux,
                 // `None` on non-Linux, and `Some(tempdir)` in test
                 // harnesses that inject a fake `/proc`. Pass the
@@ -161,13 +165,21 @@ impl AgentBindings {
             }
             AgentType::Kimi => {
                 // kimi-code's locator reads `<kimi_home>/session_index.jsonl`
-                // to resolve the attach cwd to a `wire.jsonl`. `$KIMI_CODE_HOME`
-                // is authoritative (kimi-code reads it to override its home);
-                // then the typed `provider_home`; then `default_kimi_home`.
-                let kimi_home = std::env::var_os("KIMI_CODE_HOME")
-                    // Ignore an empty `$KIMI_CODE_HOME` so it doesn't root at "" (matches `default_kimi_home`).
-                    .filter(|v| !v.is_empty())
-                    .map(PathBuf::from)
+                // to resolve the attach cwd to a `wire.jsonl`. An explicit
+                // hermetic override (E2E helpers) wins over `$KIMI_CODE_HOME`
+                // and the registry-resolved `provider_home`; otherwise
+                // `$KIMI_CODE_HOME` stays authoritative to match kimi-code's
+                // own home resolution, then `provider_home`, then
+                // `default_kimi_home`.
+                let kimi_home = ctx
+                    .provider_home_override
+                    .clone()
+                    .or_else(|| {
+                        std::env::var_os("KIMI_CODE_HOME")
+                            // Ignore an empty `$KIMI_CODE_HOME` so it doesn't root at "" (matches `default_kimi_home`).
+                            .filter(|v| !v.is_empty())
+                            .map(PathBuf::from)
+                    })
                     .or_else(|| ctx.provider_home.clone())
                     .unwrap_or_else(default_kimi_home);
                 super::kimi::kdbg(&format!(
@@ -242,6 +254,7 @@ mod tests {
             agent_type: AgentType::ClaudeCode,
             app_data_dir: PathBuf::from("/tmp/vimeflow-data"),
             provider_home: Some(PathBuf::from("/home/u/.claude")),
+            provider_home_override: None,
             proc_root: None,
         }
     }
@@ -256,6 +269,7 @@ mod tests {
             agent_type: AgentType::Codex,
             app_data_dir: PathBuf::from("/tmp/vimeflow-data"),
             provider_home: home,
+            provider_home_override: None,
             proc_root: None,
         }
     }
@@ -270,6 +284,7 @@ mod tests {
             agent_type: AgentType::Kimi,
             app_data_dir: PathBuf::from("/tmp/vimeflow-data"),
             provider_home: home,
+            provider_home_override: None,
             proc_root: None,
         }
     }
@@ -284,6 +299,7 @@ mod tests {
             agent_type: AgentType::Aider,
             app_data_dir: PathBuf::from("/tmp/vimeflow-data"),
             provider_home: None,
+            provider_home_override: None,
             proc_root: None,
         }
     }

--- a/crates/backend/src/agent/adapter/bindings.rs
+++ b/crates/backend/src/agent/adapter/bindings.rs
@@ -88,7 +88,7 @@ impl AgentBindings {
                 let adapter: Arc<ClaudeCodeAdapter> = Arc::new(ClaudeCodeAdapter);
                 Ok(Self {
                     agent_type: ctx.agent_type,
-                    locator: Arc::new(ClaudeStatusFileLocator),
+                    locator: Arc::new(ClaudeStatusFileLocator::new(ctx.app_data_dir.clone())),
                     decoder: adapter.clone(),
                     transcript_paths: adapter.clone(),
                     validator: adapter.clone(),
@@ -210,7 +210,8 @@ impl AgentBindings {
                 // refusal mode; today's behavior matches the
                 // pre-B' `<dyn AgentAdapter>::for_attach` (always
                 // returns Ok with a NoOp wrapper).
-                let adapter: Arc<NoOpAdapter> = Arc::new(NoOpAdapter::new(other));
+                let adapter: Arc<NoOpAdapter> =
+                    Arc::new(NoOpAdapter::new(other, ctx.app_data_dir.clone()));
                 Ok(Self {
                     agent_type: other,
                     locator: adapter.clone(),
@@ -239,6 +240,7 @@ mod tests {
             agent_pid: 2,
             pty_start: SystemTime::UNIX_EPOCH,
             agent_type: AgentType::ClaudeCode,
+            app_data_dir: PathBuf::from("/tmp/vimeflow-data"),
             provider_home: Some(PathBuf::from("/home/u/.claude")),
             proc_root: None,
         }
@@ -252,6 +254,7 @@ mod tests {
             agent_pid: 2,
             pty_start: SystemTime::UNIX_EPOCH,
             agent_type: AgentType::Codex,
+            app_data_dir: PathBuf::from("/tmp/vimeflow-data"),
             provider_home: home,
             proc_root: None,
         }
@@ -265,6 +268,7 @@ mod tests {
             agent_pid: 2,
             pty_start: SystemTime::UNIX_EPOCH,
             agent_type: AgentType::Kimi,
+            app_data_dir: PathBuf::from("/tmp/vimeflow-data"),
             provider_home: home,
             proc_root: None,
         }
@@ -278,6 +282,7 @@ mod tests {
             agent_pid: 2,
             pty_start: SystemTime::UNIX_EPOCH,
             agent_type: AgentType::Aider,
+            app_data_dir: PathBuf::from("/tmp/vimeflow-data"),
             provider_home: None,
             proc_root: None,
         }
@@ -368,9 +373,8 @@ mod tests {
     // which asserts `CodexAdapter::with_locator` stores the exact `Arc`
     // it was handed rather than rebuilding one.
 
-    /// Claude's locator is the stateless `ClaudeStatusFileLocator` —
-    /// `locate(cwd, sid)` should return the same path shape the
-    /// pre-B' `ClaudeCodeAdapter::located_status_source` did, with
+    /// Claude's locator writes Vimeflow-owned status bridge files under
+    /// app data rather than the user's project tree, with
     /// `static_transcript_hint == None`.
     #[test]
     fn for_attach_claude_locator_returns_static_path() {
@@ -383,12 +387,9 @@ mod tests {
             .expect("locator infallible for claude");
         assert_eq!(
             located.status_path,
-            cwd.join(".vimeflow")
-                .join("sessions")
-                .join("sess-1")
-                .join("status.json"),
+            crate::terminal::bridge::session_status_file(&ctx.app_data_dir, &cwd, "sess-1"),
         );
-        assert_eq!(located.trust_root, cwd);
+        assert_eq!(located.trust_root, ctx.app_data_dir);
         assert_eq!(located.static_transcript_hint, None);
     }
 

--- a/crates/backend/src/agent/adapter/claude_code/mod.rs
+++ b/crates/backend/src/agent/adapter/claude_code/mod.rs
@@ -4,9 +4,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::agent::adapter::base::TranscriptHandle;
-use crate::agent::adapter::traits::{
-    StateDecoder, StatusSourceLocator, TranscriptPathValidator, TranscriptStreamer,
-};
+use crate::agent::adapter::traits::{StateDecoder, TranscriptPathValidator, TranscriptStreamer};
 use crate::agent::adapter::types::{
     stamp_snapshot, LocatedStatusSource, ParsedStatus, RawPath, StatusSnapshot,
     TranscriptPathSource, ValidateTranscriptError,
@@ -27,23 +25,17 @@ pub struct ClaudeCodeAdapter;
 
 /// Shared Claude status-file path builder.
 ///
-/// Both `ClaudeStatusFileLocator::locate` (used by
-/// `AgentBindings.locator`) and `ClaudeCodeAdapter`'s
-/// `StatusSourceLocator::locate` impl (delegated to from the
-/// transitional `AgentAdapter::located_status_source` façade) need to
-/// produce the same `LocatedStatusSource`. Pre-cycle-4 they each
-/// inlined the same `cwd.join(".vimeflow")...` chain, which would
-/// silently diverge if Claude's session-path schema ever changed
-/// (PR #261 cycle 3 review F10). One pure-function helper here means
-/// any future schema change is a single-site edit.
-pub(super) fn claude_status_path(cwd: &Path, session_id: &str) -> LocatedStatusSource {
+/// Produce Claude's Vimeflow-owned status bridge path. The file lives under
+/// app data, not the user's project tree, while still bucketing by workspace
+/// cwd so simultaneous projects with the same PTY id cannot collide.
+pub(super) fn claude_status_path(
+    app_data_dir: &Path,
+    cwd: &Path,
+    session_id: &str,
+) -> LocatedStatusSource {
     LocatedStatusSource {
-        status_path: cwd
-            .join(".vimeflow")
-            .join("sessions")
-            .join(session_id)
-            .join("status.json"),
-        trust_root: cwd.to_path_buf(),
+        status_path: crate::terminal::bridge::session_status_file(app_data_dir, cwd, session_id),
+        trust_root: app_data_dir.to_path_buf(),
         static_transcript_hint: None,
         // Claude has no attach-time agent-session id surfaced through
         // the locator — the runtime keys on the Vimeflow PTY session id
@@ -75,21 +67,11 @@ impl TranscriptPathSource for ClaudeCodeAdapter {
 // `AgentAdapter` methods now delegate to these for the duration of
 // step B' (until B'' / D' migrate the callers).
 
-impl StatusSourceLocator for ClaudeCodeAdapter {
-    fn locate(&self, cwd: &Path, session_id: &str) -> Result<LocatedStatusSource, String> {
-        Ok(claude_status_path(cwd, session_id))
-    }
-}
-
 impl StateDecoder for ClaudeCodeAdapter {
     /// `session_id` is ignored — Claude's parser deserializes the whole
     /// JSON document atomically (one `Result`), so there's no per-line
     /// warn site that needs the context.
-    fn decode(
-        &self,
-        _session_id: Option<&str>,
-        raw: &str,
-    ) -> Result<StatusSnapshot, String> {
+    fn decode(&self, _session_id: Option<&str>, raw: &str) -> Result<StatusSnapshot, String> {
         statusline::parse_statusline_snapshot(raw)
     }
 }
@@ -124,10 +106,11 @@ impl AgentAdapter for ClaudeCodeAdapter {
 
     fn located_status_source(
         &self,
+        app_data_dir: &Path,
         cwd: &Path,
         session_id: &str,
     ) -> Result<LocatedStatusSource, String> {
-        <Self as StatusSourceLocator>::locate(self, cwd, session_id)
+        Ok(claude_status_path(app_data_dir, cwd, session_id))
     }
 
     fn parse_status(&self, session_id: &str, raw: &str) -> Result<ParsedStatus, String> {
@@ -166,20 +149,22 @@ mod tests {
     }
 
     #[test]
-    fn located_status_source_returns_claude_path_under_cwd() {
+    fn located_status_source_returns_claude_path_under_app_data() {
         let adapter = ClaudeCodeAdapter;
+        let app_data_dir = PathBuf::from("/tmp/vimeflow-data");
         let cwd = PathBuf::from("/tmp/ws");
-        let src =
-            <ClaudeCodeAdapter as AgentAdapter>::located_status_source(&adapter, &cwd, "sess-1")
-                .expect("claude status source is infallible");
+        let src = <ClaudeCodeAdapter as AgentAdapter>::located_status_source(
+            &adapter,
+            &app_data_dir,
+            &cwd,
+            "sess-1",
+        )
+        .expect("claude status source is infallible");
         assert_eq!(
             src.status_path,
-            cwd.join(".vimeflow")
-                .join("sessions")
-                .join("sess-1")
-                .join("status.json")
+            crate::terminal::bridge::session_status_file(&app_data_dir, &cwd, "sess-1")
         );
-        assert_eq!(src.trust_root, cwd);
+        assert_eq!(src.trust_root, app_data_dir);
         // Claude always reports `None` for the static hint — Step 0c
         // contract: the transcript path is purely dynamic for Claude.
         assert_eq!(src.static_transcript_hint, None);

--- a/crates/backend/src/agent/adapter/codex/mod.rs
+++ b/crates/backend/src/agent/adapter/codex/mod.rs
@@ -172,6 +172,7 @@ impl AgentAdapter for CodexAdapter {
 
     fn located_status_source(
         &self,
+        _app_data_dir: &Path,
         cwd: &Path,
         session_id: &str,
     ) -> Result<LocatedStatusSource, String> {
@@ -445,8 +446,13 @@ mod status_source_tests {
         )));
         let cwd = codex_home.path().to_path_buf();
 
-        let src = <CodexAdapter as AgentAdapter>::located_status_source(&adapter, &cwd, "sid")
-            .expect("located_status_source should resolve");
+        let src = <CodexAdapter as AgentAdapter>::located_status_source(
+            &adapter,
+            codex_home.path(),
+            &cwd,
+            "sid",
+        )
+        .expect("located_status_source should resolve");
 
         assert_eq!(src.status_path, rollout_path);
         assert_eq!(src.trust_root, codex_home.path());
@@ -473,8 +479,13 @@ mod status_source_tests {
         )));
         let cwd = codex_home.path().to_path_buf();
 
-        let err = <CodexAdapter as AgentAdapter>::located_status_source(&adapter, &cwd, "sid")
-            .expect_err("empty codex_home should exhaust retry");
+        let err = <CodexAdapter as AgentAdapter>::located_status_source(
+            &adapter,
+            codex_home.path(),
+            &cwd,
+            "sid",
+        )
+        .expect_err("empty codex_home should exhaust retry");
         assert!(err.contains("retry exhausted"), "got: {}", err);
     }
 }

--- a/crates/backend/src/agent/adapter/kimi/mod.rs
+++ b/crates/backend/src/agent/adapter/kimi/mod.rs
@@ -110,7 +110,13 @@ impl TranscriptStreamer for KimiAdapter {
         let cwd = self.locator.resolved_cwd().or(cwd);
         // Hand the supervisor the locator so its status poll merges the fetched
         // plan-usage (and pushes it to idle sessions).
-        transcript::start_tailing(events, session_id, transcript_path, cwd, self.locator.clone())
+        transcript::start_tailing(
+            events,
+            session_id,
+            transcript_path,
+            cwd,
+            self.locator.clone(),
+        )
     }
 }
 
@@ -121,6 +127,7 @@ impl AgentAdapter for KimiAdapter {
 
     fn located_status_source(
         &self,
+        _app_data_dir: &Path,
         cwd: &Path,
         session_id: &str,
     ) -> Result<LocatedStatusSource, String> {

--- a/crates/backend/src/agent/adapter/mod.rs
+++ b/crates/backend/src/agent/adapter/mod.rs
@@ -48,6 +48,7 @@ pub trait AgentAdapter: Send + Sync + 'static {
     /// instead of an adapter-private side channel.
     fn located_status_source(
         &self,
+        app_data_dir: &Path,
         cwd: &Path,
         session_id: &str,
     ) -> Result<LocatedStatusSource, String>;
@@ -81,37 +82,45 @@ pub trait AgentAdapter: Send + Sync + 'static {
 // transitional decode/locate/validate/tail façade, unused in
 // production lifecycle paths.
 
-/// Stateless `StatusSourceLocator` for Claude Code.
+/// App-data scoped `StatusSourceLocator` for Claude Code.
 ///
 /// Step B' (#246): per frozen constraint #1, this type is
-/// **trivial and stateless** — no `dirs::home_dir()` lookups inside,
-/// no held fields, and `static_transcript_hint` is always `None`
-/// because Claude's transcript path is purely dynamic (arrives via
-/// the statusline JSON on every update).
-///
-/// Kept as a separate unit struct because `bindings.rs` constructs
-/// it directly (as `Arc<ClaudeStatusFileLocator>`), independent of
-/// the adapter. Both this impl and `ClaudeCodeAdapter`'s
-/// `StatusSourceLocator::locate` impl now route through
-/// `claude_code::claude_status_path` so a future Claude session-path
-/// schema change is a single-site edit (PR #261 cycle 3 review F10
-/// — both impls were previously byte-for-byte duplicates).
-pub(crate) struct ClaudeStatusFileLocator;
+/// Claude's transcript path is purely dynamic (arrives via the
+/// statusline JSON on every update), so `static_transcript_hint` is
+/// always `None`. The locator carries the Vimeflow app-data root so
+/// generated status bridge files stay out of the user's project tree.
+pub(crate) struct ClaudeStatusFileLocator {
+    app_data_dir: PathBuf,
+}
+
+impl ClaudeStatusFileLocator {
+    pub(crate) fn new(app_data_dir: PathBuf) -> Self {
+        Self { app_data_dir }
+    }
+}
 
 impl traits::StatusSourceLocator for ClaudeStatusFileLocator {
     fn locate(&self, cwd: &Path, session_id: &str) -> Result<LocatedStatusSource, String> {
-        Ok(claude_code::claude_status_path(cwd, session_id))
+        Ok(claude_code::claude_status_path(
+            &self.app_data_dir,
+            cwd,
+            session_id,
+        ))
     }
 }
 
 /// Fallback adapter for agents whose real adapter has not shipped yet.
 pub(crate) struct NoOpAdapter {
     agent_type: AgentType,
+    app_data_dir: PathBuf,
 }
 
 impl NoOpAdapter {
-    pub(crate) fn new(agent_type: AgentType) -> Self {
-        Self { agent_type }
+    pub(crate) fn new(agent_type: AgentType, app_data_dir: PathBuf) -> Self {
+        Self {
+            agent_type,
+            app_data_dir,
+        }
     }
 }
 
@@ -122,16 +131,15 @@ impl TranscriptPathSource for NoOpAdapter {}
 impl traits::StatusSourceLocator for NoOpAdapter {
     fn locate(&self, cwd: &Path, session_id: &str) -> Result<LocatedStatusSource, String> {
         // Same shape as ClaudeStatusFileLocator — gives the no-op
-        // adapter a plausible status path under cwd. The watcher
-        // never actually reads it because NoOp's decoder/streamer
-        // Errs out below.
+        // adapter a plausible app-data status path. The watcher never
+        // actually reads it because NoOp's decoder/streamer Errs out below.
         Ok(LocatedStatusSource {
-            status_path: cwd
-                .join(".vimeflow")
-                .join("sessions")
-                .join(session_id)
-                .join("status.json"),
-            trust_root: cwd.to_path_buf(),
+            status_path: crate::terminal::bridge::session_status_file(
+                &self.app_data_dir,
+                cwd,
+                session_id,
+            ),
+            trust_root: self.app_data_dir.clone(),
             static_transcript_hint: None,
             agent_session_id: None,
         })
@@ -182,6 +190,7 @@ impl AgentAdapter for NoOpAdapter {
 
     fn located_status_source(
         &self,
+        _app_data_dir: &Path,
         cwd: &Path,
         session_id: &str,
     ) -> Result<LocatedStatusSource, String> {
@@ -224,6 +233,7 @@ pub(crate) async fn start_agent_watcher_inner(
     watcher_state: AgentWatcherState,
     transcript_state: TranscriptState,
     events: Arc<dyn EventSink>,
+    app_data_dir: PathBuf,
     session_id: String,
 ) -> Result<(), String> {
     // Step F.5: delegate to `SessionLifecycle`. The service owns the
@@ -234,12 +244,13 @@ pub(crate) async fn start_agent_watcher_inner(
     // trust boundary and inlined orchestration; PR #302 cycle 3 docs
     // refresh).
     session_lifecycle::SessionLifecycle::new(pty_state, watcher_state, transcript_state, events)
-        .start(session_id)
+        .start(session_id, app_data_dir)
         .await
 }
 
 fn resolve_bind_inputs<F>(
     pty_state: &PtyState,
+    app_data_dir: &Path,
     session_id: &SessionId,
     detect: F,
 ) -> Result<AttachContext, String>
@@ -273,6 +284,7 @@ where
         agent_pid,
         pty_start,
         agent_type,
+        app_data_dir: app_data_dir.to_path_buf(),
         provider_home: spec.provider_home(),
         proc_root: crate::agent::config::default_proc_root(),
     })
@@ -373,6 +385,7 @@ pub(crate) fn make_test_session() -> crate::terminal::state::ManagedSession {
         writer,
         child,
         cwd: "/tmp/workspace".into(),
+        bridge_dir: None,
         shim_dir: None,
         generation: 0,
         ring: Arc::new(Mutex::new(crate::terminal::state::RingBuffer::new(64))),
@@ -387,7 +400,7 @@ mod noop_tests {
 
     #[test]
     fn agent_type_round_trips() {
-        let adapter = NoOpAdapter::new(AgentType::Codex);
+        let adapter = NoOpAdapter::new(AgentType::Codex, PathBuf::from("/tmp/vimeflow-data"));
         assert!(matches!(
             <NoOpAdapter as AgentAdapter>::agent_type(&adapter),
             AgentType::Codex
@@ -395,19 +408,22 @@ mod noop_tests {
     }
 
     #[test]
-    fn located_status_source_uses_claude_shaped_path() {
-        let adapter = NoOpAdapter::new(AgentType::Aider);
+    fn located_status_source_uses_app_data_bridge_path() {
+        let app_data_dir = PathBuf::from("/tmp/vimeflow-data");
+        let adapter = NoOpAdapter::new(AgentType::Aider, app_data_dir.clone());
         let cwd = PathBuf::from("/tmp/ws");
-        let src = <NoOpAdapter as AgentAdapter>::located_status_source(&adapter, &cwd, "sid")
-            .expect("noop adapter always resolves a status source");
+        let src = <NoOpAdapter as AgentAdapter>::located_status_source(
+            &adapter,
+            &app_data_dir,
+            &cwd,
+            "sid",
+        )
+        .expect("noop adapter always resolves a status source");
         assert_eq!(
             src.status_path,
-            cwd.join(".vimeflow")
-                .join("sessions")
-                .join("sid")
-                .join("status.json")
+            crate::terminal::bridge::session_status_file(&app_data_dir, &cwd, "sid")
         );
-        assert_eq!(src.trust_root, cwd);
+        assert_eq!(src.trust_root, app_data_dir);
         // NoOp adapters never know a static transcript path — Step 0c
         // contract: only Codex's locator returns Some.
         assert_eq!(src.static_transcript_hint, None);
@@ -420,7 +436,7 @@ mod noop_tests {
     /// agent — Aider, Generic).
     #[test]
     fn noop_transcript_path_source_returns_none_for_both_hints() {
-        let adapter = NoOpAdapter::new(AgentType::Aider);
+        let adapter = NoOpAdapter::new(AgentType::Aider, PathBuf::from("/tmp/vimeflow-data"));
         // Step B' (round 1 codex fix): the former
         // `AgentAdapter::transcript_path_source` accessor was
         // removed; reach the trait via a `&dyn TranscriptPathSource`
@@ -438,7 +454,7 @@ mod noop_tests {
 
     #[test]
     fn parse_status_returns_err() {
-        let adapter = NoOpAdapter::new(AgentType::Generic);
+        let adapter = NoOpAdapter::new(AgentType::Generic, PathBuf::from("/tmp/vimeflow-data"));
         assert!(<NoOpAdapter as AgentAdapter>::parse_status(&adapter, "sid", "{}").is_err());
     }
 
@@ -474,6 +490,7 @@ mod noop_tests {
             agent_pid: 12345,
             pty_start: SystemTime::UNIX_EPOCH,
             agent_type: AgentType::Codex,
+            app_data_dir: PathBuf::from("/tmp/vimeflow-data"),
             provider_home: Some(PathBuf::from("/home/u/.codex")),
             proc_root: None,
         };
@@ -491,14 +508,17 @@ mod noop_tests {
 
     #[test]
     fn resolve_bind_inputs_uses_detected_agent_pid_not_shell_pid() {
+        let app_data = tempfile::tempdir().expect("app data");
         let state = PtyState::new();
         let session_id = "sid".to_string();
         state
             .try_insert(session_id.clone(), super::make_test_session(), 64)
             .unwrap_or_else(|_| panic!("insert session"));
 
-        let attach = resolve_bind_inputs(&state, &session_id, |_| Some((AgentType::Codex, 4242)))
-            .expect("bind inputs");
+        let attach = resolve_bind_inputs(&state, app_data.path(), &session_id, |_| {
+            Some((AgentType::Codex, 4242))
+        })
+        .expect("bind inputs");
 
         assert!(matches!(attach.agent_type, AgentType::Codex));
         assert_ne!(attach.shell_pid, attach.agent_pid);
@@ -507,14 +527,17 @@ mod noop_tests {
 
     #[test]
     fn resolve_bind_inputs_populates_attach_context_fields() {
+        let app_data = tempfile::tempdir().expect("app data");
         let state = PtyState::new();
         let session_id = "sid-populate".to_string();
         state
             .try_insert(session_id.clone(), super::make_test_session(), 64)
             .unwrap_or_else(|_| panic!("insert session"));
 
-        let attach = resolve_bind_inputs(&state, &session_id, |_| Some((AgentType::Codex, 4242)))
-            .expect("bind inputs");
+        let attach = resolve_bind_inputs(&state, app_data.path(), &session_id, |_| {
+            Some((AgentType::Codex, 4242))
+        })
+        .expect("bind inputs");
 
         // Identity / attach facts surfaced into the typed struct.
         assert_eq!(attach.session_id, "sid-populate");
@@ -522,6 +545,7 @@ mod noop_tests {
         assert_eq!(attach.pty_start, SystemTime::UNIX_EPOCH);
         assert_eq!(attach.agent_pid, 4242);
         assert_eq!(attach.agent_type, AgentType::Codex);
+        assert_eq!(attach.app_data_dir, app_data.path());
 
         // `provider_home` resolves from the central registry; for Codex
         // it ends with `.codex`. Structural assertion (not pinning the
@@ -541,14 +565,17 @@ mod noop_tests {
 
     #[test]
     fn resolve_bind_inputs_provider_home_none_for_agents_without_subdir() {
+        let app_data = tempfile::tempdir().expect("app data");
         let state = PtyState::new();
         let session_id = "sid-aider".to_string();
         state
             .try_insert(session_id.clone(), super::make_test_session(), 64)
             .unwrap_or_else(|_| panic!("insert session"));
 
-        let attach = resolve_bind_inputs(&state, &session_id, |_| Some((AgentType::Aider, 9999)))
-            .expect("bind inputs");
+        let attach = resolve_bind_inputs(&state, app_data.path(), &session_id, |_| {
+            Some((AgentType::Aider, 9999))
+        })
+        .expect("bind inputs");
 
         assert_eq!(attach.agent_type, AgentType::Aider);
         // Aider has no `home_subdir` in the registry → provider_home is None.

--- a/crates/backend/src/agent/adapter/mod.rs
+++ b/crates/backend/src/agent/adapter/mod.rs
@@ -235,6 +235,7 @@ pub(crate) async fn start_agent_watcher_inner(
     events: Arc<dyn EventSink>,
     app_data_dir: PathBuf,
     session_id: String,
+    provider_home_override: Option<PathBuf>,
 ) -> Result<(), String> {
     // Step F.5: delegate to `SessionLifecycle`. The service owns the
     // attach-resolution, the `AgentBindings::for_attach` +
@@ -244,7 +245,7 @@ pub(crate) async fn start_agent_watcher_inner(
     // trust boundary and inlined orchestration; PR #302 cycle 3 docs
     // refresh).
     session_lifecycle::SessionLifecycle::new(pty_state, watcher_state, transcript_state, events)
-        .start(session_id, app_data_dir)
+        .start(session_id, app_data_dir, provider_home_override)
         .await
 }
 
@@ -252,6 +253,7 @@ fn resolve_bind_inputs<F>(
     pty_state: &PtyState,
     app_data_dir: &Path,
     session_id: &SessionId,
+    provider_home_override: Option<PathBuf>,
     detect: F,
 ) -> Result<AttachContext, String>
 where
@@ -286,6 +288,7 @@ where
         agent_type,
         app_data_dir: app_data_dir.to_path_buf(),
         provider_home: spec.provider_home(),
+        provider_home_override,
         proc_root: crate::agent::config::default_proc_root(),
     })
 }
@@ -492,6 +495,7 @@ mod noop_tests {
             agent_type: AgentType::Codex,
             app_data_dir: PathBuf::from("/tmp/vimeflow-data"),
             provider_home: Some(PathBuf::from("/home/u/.codex")),
+            provider_home_override: None,
             proc_root: None,
         };
         let bindings = bindings::AgentBindings::for_attach(&ctx).expect("codex bindings construct");
@@ -515,7 +519,7 @@ mod noop_tests {
             .try_insert(session_id.clone(), super::make_test_session(), 64)
             .unwrap_or_else(|_| panic!("insert session"));
 
-        let attach = resolve_bind_inputs(&state, app_data.path(), &session_id, |_| {
+        let attach = resolve_bind_inputs(&state, app_data.path(), &session_id, None, |_| {
             Some((AgentType::Codex, 4242))
         })
         .expect("bind inputs");
@@ -534,7 +538,7 @@ mod noop_tests {
             .try_insert(session_id.clone(), super::make_test_session(), 64)
             .unwrap_or_else(|_| panic!("insert session"));
 
-        let attach = resolve_bind_inputs(&state, app_data.path(), &session_id, |_| {
+        let attach = resolve_bind_inputs(&state, app_data.path(), &session_id, None, |_| {
             Some((AgentType::Codex, 4242))
         })
         .expect("bind inputs");
@@ -572,7 +576,7 @@ mod noop_tests {
             .try_insert(session_id.clone(), super::make_test_session(), 64)
             .unwrap_or_else(|_| panic!("insert session"));
 
-        let attach = resolve_bind_inputs(&state, app_data.path(), &session_id, |_| {
+        let attach = resolve_bind_inputs(&state, app_data.path(), &session_id, None, |_| {
             Some((AgentType::Aider, 9999))
         })
         .expect("bind inputs");

--- a/crates/backend/src/agent/adapter/session_lifecycle.rs
+++ b/crates/backend/src/agent/adapter/session_lifecycle.rs
@@ -6,8 +6,8 @@
 //! `TranscriptState`, `Arc<dyn EventSink>`) and exposes the two
 //! lifecycle verbs the IPC layer needs:
 //!
-//! - `start(session_id)` — resolve the [`AttachContext`] from live
-//!   `PtyState`, build the typed [`AgentBindings`], and run the verb
+//! - `start(session_id, app_data_dir)` — resolve the [`AttachContext`] from
+//!   live `PtyState`, build the typed [`AgentBindings`], and run the verb
 //!   sequence on the blocking pool.
 //! - `stop(session_id)` — remove the session's watcher from
 //!   `AgentWatcherState` (its `Drop` cascades the transcript-tail
@@ -21,7 +21,7 @@
 //! `start_agent_watcher_inner` delegates to this method rather than
 //! mapping independently.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -54,7 +54,7 @@ pub(crate) struct SessionLifecycle {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::sync::Arc;
     use std::time::SystemTime;
 
@@ -77,13 +77,14 @@ mod tests {
             agent_pid: 2,
             pty_start: SystemTime::UNIX_EPOCH,
             agent_type: AgentType::ClaudeCode,
+            app_data_dir: cwd.join("vimeflow-data"),
             provider_home: Some(PathBuf::from("/home/u/.claude")),
             proc_root: None,
         }
     }
 
-    fn write_claude_status(cwd: &std::path::Path, sid: &str) {
-        let dir = cwd.join(".vimeflow").join("sessions").join(sid);
+    fn write_claude_status(app_data_dir: &Path, cwd: &std::path::Path, sid: &str) {
+        let dir = crate::terminal::bridge::session_bridge_dir(app_data_dir, cwd, sid);
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(
             dir.join("status.json"),
@@ -147,6 +148,7 @@ mod tests {
 
     #[test]
     fn t_verb_resolve_attach() {
+        let app_data = TempDir::new().unwrap();
         let pty_state = PtyState::new();
         let sid = "sid-verb-resolve".to_string();
         pty_state
@@ -161,7 +163,7 @@ mod tests {
         );
 
         let attach = lifecycle
-            .resolve_attach(&sid, |_pid| Some((AgentType::Codex, 4242)))
+            .resolve_attach(&sid, app_data.path(), |_pid| Some((AgentType::Codex, 4242)))
             .expect("resolve_attach");
 
         // resolve_attach is a thin delegate to resolve_bind_inputs; this test
@@ -173,6 +175,7 @@ mod tests {
         assert_eq!(attach.session_id, sid);
         assert_eq!(attach.agent_type, AgentType::Codex);
         assert_eq!(attach.agent_pid, 4242);
+        assert_eq!(attach.app_data_dir, app_data.path());
     }
 
     #[test]
@@ -184,6 +187,7 @@ mod tests {
             agent_pid: 12345,
             pty_start: SystemTime::UNIX_EPOCH,
             agent_type: AgentType::Codex,
+            app_data_dir: PathBuf::from("/tmp/vimeflow-data"),
             provider_home: Some(PathBuf::from("/home/u/.codex")),
             proc_root: None,
         };
@@ -202,6 +206,7 @@ mod tests {
     #[test]
     fn t_verb_locate_happy_path() {
         let tmp = TempDir::new().unwrap();
+        let app_data = TempDir::new().unwrap();
         let sid = "test-sess".to_string();
         let ctx = AttachContext {
             session_id: sid.clone(),
@@ -210,6 +215,7 @@ mod tests {
             agent_pid: 2,
             pty_start: SystemTime::UNIX_EPOCH,
             agent_type: AgentType::ClaudeCode,
+            app_data_dir: app_data.path().to_path_buf(),
             provider_home: Some(PathBuf::from("/home/u/.claude")),
             proc_root: None,
         };
@@ -225,13 +231,9 @@ mod tests {
             .expect("locate happy path");
         assert_eq!(
             located.status_path,
-            tmp.path()
-                .join(".vimeflow")
-                .join("sessions")
-                .join(&sid)
-                .join("status.json")
+            crate::terminal::bridge::session_status_file(app_data.path(), tmp.path(), &sid)
         );
-        assert_eq!(located.trust_root, tmp.path());
+        assert_eq!(located.trust_root, app_data.path());
     }
 
     #[test]
@@ -241,7 +243,8 @@ mod tests {
             .expect("set KIMI_LIVE_PID")
             .parse()
             .expect("KIMI_LIVE_PID must be u32");
-        let stale_cwd = std::env::var("KIMI_STALE_CWD").unwrap_or_else(|_| "/home/will".to_string());
+        let stale_cwd =
+            std::env::var("KIMI_STALE_CWD").unwrap_or_else(|_| "/home/will".to_string());
         if let Ok(shell_pid) = std::env::var("KIMI_SHELL_PID") {
             let sp: u32 = shell_pid.parse().expect("KIMI_SHELL_PID must be u32");
             eprintln!(
@@ -259,6 +262,7 @@ mod tests {
             agent_pid,
             pty_start: SystemTime::now(),
             agent_type: AgentType::Kimi,
+            app_data_dir: PathBuf::from("/tmp/vimeflow-data"),
             provider_home: spec.provider_home(),
             proc_root: crate::agent::config::default_proc_root(),
         };
@@ -268,15 +272,18 @@ mod tests {
         );
         let bindings = AgentBindings::for_attach(&ctx).expect("for_attach kimi");
         eprintln!("[diag] for_attach OK agent_type={:?}", bindings.agent_type);
-        match bindings.locator.locate(PathBuf::from(&stale_cwd).as_path(), &sid) {
+        match bindings
+            .locator
+            .locate(PathBuf::from(&stale_cwd).as_path(), &sid)
+        {
             Ok(located) => {
                 eprintln!(
                     "[diag] LOCATE OK status_path={} trust_root={}",
                     located.status_path.display(),
                     located.trust_root.display()
                 );
-                let contents =
-                    std::fs::read_to_string(&located.status_path).expect("read located status_path");
+                let contents = std::fs::read_to_string(&located.status_path)
+                    .expect("read located status_path");
                 eprintln!("[diag] wire bytes={}", contents.len());
                 match bindings.decoder.decode(Some(&sid), &contents) {
                     Ok(snap) => eprintln!("[diag] DECODE OK {:?}", snap),
@@ -383,13 +390,10 @@ mod tests {
     #[test]
     fn t_verb_spawn_watch() {
         let tmp = TempDir::new().unwrap();
+        let app_data = TempDir::new().unwrap();
         let sid = "test-sess".to_string();
-        let status_path = tmp
-            .path()
-            .join(".vimeflow")
-            .join("sessions")
-            .join(&sid)
-            .join("status.json");
+        let status_path =
+            crate::terminal::bridge::session_status_file(app_data.path(), tmp.path(), &sid);
         std::fs::create_dir_all(status_path.parent().unwrap()).unwrap();
         std::fs::write(&status_path, r#"{"session_id":"sid","model":{}}"#).unwrap();
 
@@ -400,13 +404,14 @@ mod tests {
             agent_pid: 2,
             pty_start: SystemTime::UNIX_EPOCH,
             agent_type: AgentType::ClaudeCode,
+            app_data_dir: app_data.path().to_path_buf(),
             provider_home: Some(PathBuf::from("/home/u/.claude")),
             proc_root: None,
         };
         let bindings = AgentBindings::for_attach(&ctx).expect("for_attach");
         let located = LocatedStatusSource {
             status_path,
-            trust_root: tmp.path().to_path_buf(),
+            trust_root: app_data.path().to_path_buf(),
             static_transcript_hint: None,
             agent_session_id: None,
         };
@@ -464,9 +469,9 @@ mod tests {
     async fn t_lifecycle_1_start_inner_for_test_happy_path_registers_session() {
         let tmp = TempDir::new().unwrap();
         let sid = "test-sess".to_string();
-        write_claude_status(tmp.path(), &sid);
 
         let ctx = make_attach_ctx(tmp.path());
+        write_claude_status(&ctx.app_data_dir, tmp.path(), &sid);
         let bindings = AgentBindings::for_attach(&ctx).unwrap();
         let events: Arc<dyn EventSink> = Arc::new(FakeEventSink::new());
         let pty_state = PtyState::new();
@@ -582,11 +587,16 @@ impl SessionLifecycle {
         }
     }
 
-    fn resolve_attach<F>(&self, sid: &SessionId, detect: F) -> Result<AttachContext, String>
+    fn resolve_attach<F>(
+        &self,
+        sid: &SessionId,
+        app_data_dir: &Path,
+        detect: F,
+    ) -> Result<AttachContext, String>
     where
         F: FnOnce(u32) -> Option<(AgentType, u32)>,
     {
-        resolve_bind_inputs(&self.pty_state, sid, detect)
+        resolve_bind_inputs(&self.pty_state, app_data_dir, sid, detect)
     }
 
     fn bind_services(&self, ctx: &AttachContext) -> Result<AgentBindings, String> {
@@ -724,9 +734,32 @@ impl SessionLifecycle {
     /// handle's thread-join inside `remove`; deleted in this cycle because
     /// `insert`'s own `_displaced` drop already handles atomic replace).
     /// `AttachError` is mapped to `String` at this boundary.
-    pub(crate) async fn start(&self, session_id: String) -> Result<(), String> {
+    pub(crate) async fn start(
+        &self,
+        session_id: String,
+        app_data_dir: PathBuf,
+    ) -> Result<(), String> {
         crate::debug::debug_log("agent-attach", &format!("start session={}", session_id));
-        let attach = match self.resolve_attach(&session_id, detect_agent) {
+        let attach = match self.resolve_attach(&session_id, &app_data_dir, |shell_pid| {
+            let detected = detect_agent(shell_pid);
+
+            #[cfg(feature = "e2e-test")]
+            {
+                // E2E tests seed the watcher map instead of launching a real
+                // Claude/Codex process, but still exercise the normal watcher
+                // startup and status-file emission path.
+                detected.or_else(|| {
+                    self.watcher_state
+                        .agent_type_for_pty(&session_id)
+                        .map(|agent_type| (agent_type, shell_pid))
+                })
+            }
+
+            #[cfg(not(feature = "e2e-test"))]
+            {
+                detected
+            }
+        }) {
             Ok(attach) => attach,
             Err(e) => {
                 crate::debug::debug_log(

--- a/crates/backend/src/agent/adapter/session_lifecycle.rs
+++ b/crates/backend/src/agent/adapter/session_lifecycle.rs
@@ -79,6 +79,7 @@ mod tests {
             agent_type: AgentType::ClaudeCode,
             app_data_dir: cwd.join("vimeflow-data"),
             provider_home: Some(PathBuf::from("/home/u/.claude")),
+            provider_home_override: None,
             proc_root: None,
         }
     }
@@ -163,7 +164,7 @@ mod tests {
         );
 
         let attach = lifecycle
-            .resolve_attach(&sid, app_data.path(), |_pid| Some((AgentType::Codex, 4242)))
+            .resolve_attach(&sid, app_data.path(), None, |_pid| Some((AgentType::Codex, 4242)))
             .expect("resolve_attach");
 
         // resolve_attach is a thin delegate to resolve_bind_inputs; this test
@@ -189,6 +190,7 @@ mod tests {
             agent_type: AgentType::Codex,
             app_data_dir: PathBuf::from("/tmp/vimeflow-data"),
             provider_home: Some(PathBuf::from("/home/u/.codex")),
+            provider_home_override: None,
             proc_root: None,
         };
 
@@ -217,6 +219,7 @@ mod tests {
             agent_type: AgentType::ClaudeCode,
             app_data_dir: app_data.path().to_path_buf(),
             provider_home: Some(PathBuf::from("/home/u/.claude")),
+            provider_home_override: None,
             proc_root: None,
         };
         let bindings = AgentBindings::for_attach(&ctx).expect("for_attach");
@@ -264,6 +267,7 @@ mod tests {
             agent_type: AgentType::Kimi,
             app_data_dir: PathBuf::from("/tmp/vimeflow-data"),
             provider_home: spec.provider_home(),
+            provider_home_override: None,
             proc_root: crate::agent::config::default_proc_root(),
         };
         eprintln!(
@@ -406,6 +410,7 @@ mod tests {
             agent_type: AgentType::ClaudeCode,
             app_data_dir: app_data.path().to_path_buf(),
             provider_home: Some(PathBuf::from("/home/u/.claude")),
+            provider_home_override: None,
             proc_root: None,
         };
         let bindings = AgentBindings::for_attach(&ctx).expect("for_attach");
@@ -591,12 +596,19 @@ impl SessionLifecycle {
         &self,
         sid: &SessionId,
         app_data_dir: &Path,
+        provider_home_override: Option<PathBuf>,
         detect: F,
     ) -> Result<AttachContext, String>
     where
         F: FnOnce(u32) -> Option<(AgentType, u32)>,
     {
-        resolve_bind_inputs(&self.pty_state, app_data_dir, sid, detect)
+        resolve_bind_inputs(
+            &self.pty_state,
+            app_data_dir,
+            sid,
+            provider_home_override,
+            detect,
+        )
     }
 
     fn bind_services(&self, ctx: &AttachContext) -> Result<AgentBindings, String> {
@@ -738,9 +750,14 @@ impl SessionLifecycle {
         &self,
         session_id: String,
         app_data_dir: PathBuf,
+        provider_home_override: Option<PathBuf>,
     ) -> Result<(), String> {
         crate::debug::debug_log("agent-attach", &format!("start session={}", session_id));
-        let attach = match self.resolve_attach(&session_id, &app_data_dir, |shell_pid| {
+        let attach = match self.resolve_attach(
+            &session_id,
+            &app_data_dir,
+            provider_home_override,
+            |shell_pid| {
             let detected = detect_agent(shell_pid);
 
             #[cfg(feature = "e2e-test")]

--- a/crates/backend/src/runtime/ipc.rs
+++ b/crates/backend/src/runtime/ipc.rs
@@ -750,6 +750,30 @@ mod router {
             }
             #[cfg(feature = "e2e-test")]
             "list_active_pty_sessions" => encode_result(state.list_active_pty_sessions()),
+            #[cfg(feature = "e2e-test")]
+            "e2e_agent_bridge_info" => {
+                #[derive(Deserialize)]
+                #[serde(rename_all = "camelCase")]
+                struct P {
+                    session_id: String,
+                }
+
+                let p: P = serde_json::from_value(params).map_err(|e| format!("params: {e}"))?;
+                encode_result(state.e2e_agent_bridge_info(p.session_id)?)
+            }
+            #[cfg(feature = "e2e-test")]
+            "e2e_seed_live_agent" => {
+                #[derive(Deserialize)]
+                #[serde(rename_all = "camelCase")]
+                struct P {
+                    session_id: String,
+                    agent_type: crate::agent::types::AgentType,
+                }
+
+                let p: P = serde_json::from_value(params).map_err(|e| format!("params: {e}"))?;
+                state.e2e_seed_live_agent(p.session_id, p.agent_type)?;
+                Ok(Value::Null)
+            }
             #[cfg(test)]
             "__test_sleep_then_null" => {
                 #[derive(Deserialize)]

--- a/crates/backend/src/runtime/ipc.rs
+++ b/crates/backend/src/runtime/ipc.rs
@@ -774,6 +774,48 @@ mod router {
                 state.e2e_seed_live_agent(p.session_id, p.agent_type)?;
                 Ok(Value::Null)
             }
+            #[cfg(feature = "e2e-test")]
+            "e2e_emit_agent_status" => {
+                #[derive(Deserialize)]
+                #[serde(rename_all = "camelCase")]
+                struct P {
+                    session_id: String,
+                    status: crate::agent::types::AgentStatusEvent,
+                    num_turns: u32,
+                }
+
+                let p: P = serde_json::from_value(params).map_err(|e| format!("params: {e}"))?;
+                state.e2e_emit_agent_status(p.session_id, p.status, p.num_turns)?;
+                Ok(Value::Null)
+            }
+            #[cfg(feature = "e2e-test")]
+            "e2e_start_codex_watcher" => {
+                #[derive(Deserialize)]
+                #[serde(rename_all = "camelCase")]
+                struct P {
+                    session_id: String,
+                    home_dir: std::path::PathBuf,
+                }
+
+                let p: P = serde_json::from_value(params).map_err(|e| format!("params: {e}"))?;
+                let rollout_path = state.e2e_start_codex_watcher(p.session_id, p.home_dir).await?;
+                Ok(serde_json::to_value(rollout_path.to_string_lossy().to_string())
+                    .map_err(|e| format!("serialize rollout path: {e}"))?)
+            }
+            #[cfg(feature = "e2e-test")]
+            "e2e_start_kimi_watcher" => {
+                #[derive(Deserialize)]
+                #[serde(rename_all = "camelCase")]
+                struct P {
+                    session_id: String,
+                    home_dir: std::path::PathBuf,
+                }
+
+                let p: P = serde_json::from_value(params).map_err(|e| format!("params: {e}"))?;
+                let wire_path = state.e2e_start_kimi_watcher(p.session_id, p.home_dir).await?;
+                Ok(serde_json::to_value(wire_path.to_string_lossy().to_string())
+                    .map_err(|e| format!("serialize wire path: {e}"))?)
+            }
             #[cfg(test)]
             "__test_sleep_then_null" => {
                 #[derive(Deserialize)]

--- a/crates/backend/src/runtime/ipc.rs
+++ b/crates/backend/src/runtime/ipc.rs
@@ -556,7 +556,7 @@ mod router {
                 }
 
                 let p: P = serde_json::from_value(params).map_err(|e| format!("params: {e}"))?;
-                state.start_agent_watcher(p.session_id).await?;
+                state.start_agent_watcher(p.session_id, None).await?;
                 Ok(Value::Null)
             }
             "stop_agent_watcher" => {

--- a/crates/backend/src/runtime/state.rs
+++ b/crates/backend/src/runtime/state.rs
@@ -672,10 +672,12 @@ impl BackendState {
         std::fs::write(
             &index_path,
             format!(
-                "{{\"sessionId\":\"{}\",\"sessionDir\":\"{}\",\"workDir\":\"{}\"}}\n",
-                session_dir_name,
-                session_dir.to_str().ok_or("session dir is not utf-8")?,
-                cwd,
+                "{}\n",
+                serde_json::json!({
+                    "sessionId": session_dir_name,
+                    "sessionDir": session_dir.to_str().ok_or("session dir is not utf-8")?,
+                    "workDir": cwd,
+                })
             ),
         )
         .map_err(|e| format!("create kimi index: {e}"))?;

--- a/crates/backend/src/runtime/state.rs
+++ b/crates/backend/src/runtime/state.rs
@@ -401,7 +401,11 @@ impl BackendState {
         Ok(detected)
     }
 
-    pub async fn start_agent_watcher(&self, session_id: String) -> Result<(), String> {
+    pub async fn start_agent_watcher(
+        &self,
+        session_id: String,
+        provider_home_override: Option<PathBuf>,
+    ) -> Result<(), String> {
         crate::agent::adapter::start_agent_watcher_inner(
             self.pty.clone(),
             self.agents.clone(),
@@ -409,6 +413,7 @@ impl BackendState {
             self.events.clone(),
             self.app_data_dir.clone(),
             session_id,
+            provider_home_override,
         )
         .await
     }
@@ -515,9 +520,9 @@ impl BackendState {
 
     /// Set up a hermetic Codex home under `home_dir`, seed the locator
     /// SQLite databases so the Codex watcher can resolve a rollout file for
-    /// `session_id`, start the watcher, then restore the original `HOME`.
-    /// Returns the absolute path to the empty rollout file the test should
-    /// write to.
+    /// `session_id`, and start the watcher with `home_dir/.codex` threaded
+    /// as an explicit provider-home override. Returns the absolute path to
+    /// the empty rollout file the test should write to.
     #[cfg(feature = "e2e-test")]
     pub async fn e2e_start_codex_watcher(
         &self,
@@ -598,13 +603,9 @@ impl BackendState {
         )
         .map_err(|e| format!("create logs table: {e}"))?;
 
-        let prev_home = std::env::var_os("HOME");
-        std::env::set_var("HOME", &home_dir);
-        let result = self.start_agent_watcher(session_id.clone()).await;
-        match prev_home {
-            Some(v) => std::env::set_var("HOME", v),
-            None => std::env::remove_var("HOME"),
-        }
+        let result = self
+            .start_agent_watcher(session_id.clone(), Some(codex_home))
+            .await;
         result?;
 
         Ok(rollout_path)
@@ -612,9 +613,9 @@ impl BackendState {
 
     /// Set up a hermetic Kimi home under `home_dir`, seed the locator
     /// filesystem layout so the Kimi watcher can resolve a wire file for
-    /// `session_id`, start the watcher, then restore the original
-    /// `KIMI_CODE_HOME`. Returns the absolute path to the wire file the test
-    /// should write to.
+    /// `session_id`, and start the watcher with `home_dir` threaded as an
+    /// explicit provider-home override. Returns the absolute path to the wire
+    /// file the test should write to.
     #[cfg(feature = "e2e-test")]
     pub async fn e2e_start_kimi_watcher(
         &self,
@@ -679,13 +680,9 @@ impl BackendState {
         )
         .map_err(|e| format!("create kimi index: {e}"))?;
 
-        let prev_kimi_home = std::env::var_os("KIMI_CODE_HOME");
-        std::env::set_var("KIMI_CODE_HOME", &home_dir);
-        let result = self.start_agent_watcher(session_id).await;
-        match prev_kimi_home {
-            Some(v) => std::env::set_var("KIMI_CODE_HOME", v),
-            None => std::env::remove_var("KIMI_CODE_HOME"),
-        }
+        let result = self
+            .start_agent_watcher(session_id, Some(home_dir))
+            .await;
         result?;
 
         Ok(wire_path)

--- a/crates/backend/src/runtime/state.rs
+++ b/crates/backend/src/runtime/state.rs
@@ -7,9 +7,9 @@ use crate::agent::types::{
 use crate::agent::{sanitize_title, AgentWatcherState, TranscriptState};
 use crate::git::watcher::GitWatcherState;
 use crate::terminal::cache::SessionCache;
-use crate::terminal::workspace_layout::{WorkspaceLayoutCache, WorkspaceLayoutStore};
 use crate::terminal::state::PtyState;
 use crate::terminal::types::SessionId;
+use crate::terminal::workspace_layout::{WorkspaceLayoutCache, WorkspaceLayoutStore};
 
 use super::event_sink::EventSink;
 
@@ -37,6 +37,7 @@ fn ensure_rename_supported(agent_type: &AgentType) -> Result<(), RenameAgentSess
 
 /// Consolidated runtime-neutral backend state.
 pub struct BackendState {
+    app_data_dir: PathBuf,
     pty: PtyState,
     sessions: Arc<SessionCache>,
     workspace_layouts: Arc<WorkspaceLayoutCache>,
@@ -53,10 +54,17 @@ pub struct BackendState {
 
 impl BackendState {
     pub fn new(app_data_dir: PathBuf, events: Arc<dyn EventSink>) -> Self {
+        if let Err(err) = std::fs::create_dir_all(&app_data_dir) {
+            log::warn!(
+                "BackendState::new: failed to create app data dir {}: {err}",
+                app_data_dir.display()
+            );
+        }
         let cache_path = app_data_dir.join("sessions.json");
         let layouts_path = app_data_dir.join("workspace-layouts.json");
         let kimi_usage_consent_path = app_data_dir.join("kimi-usage-consent.json");
         Self {
+            app_data_dir,
             pty: PtyState::new(),
             sessions: Arc::new(SessionCache::load_or_recover(cache_path)),
             workspace_layouts: Arc::new(WorkspaceLayoutCache::new(layouts_path)),
@@ -368,7 +376,22 @@ impl BackendState {
         &self,
         session_id: String,
     ) -> Result<Option<crate::agent::types::AgentDetectedEvent>, String> {
-        crate::agent::commands::detect_agent_in_session_inner(&self.pty, session_id).await
+        let detected =
+            crate::agent::commands::detect_agent_in_session_inner(&self.pty, session_id.clone())
+                .await?;
+
+        #[cfg(feature = "e2e-test")]
+        if detected.is_none() {
+            if let Some(agent_type) = self.agents.agent_type_for_pty(&session_id) {
+                return Ok(Some(crate::agent::types::AgentDetectedEvent {
+                    pid: self.pty.get_pid(&session_id).unwrap_or(0),
+                    session_id,
+                    agent_type,
+                }));
+            }
+        }
+
+        Ok(detected)
     }
 
     pub async fn start_agent_watcher(&self, session_id: String) -> Result<(), String> {
@@ -377,6 +400,7 @@ impl BackendState {
             self.agents.clone(),
             self.transcripts.clone(),
             self.events.clone(),
+            self.app_data_dir.clone(),
             session_id,
         )
         .await
@@ -397,6 +421,71 @@ impl BackendState {
     pub fn list_active_pty_sessions(&self) -> Vec<String> {
         self.pty.active_ids()
     }
+
+    #[cfg(feature = "e2e-test")]
+    pub fn e2e_agent_bridge_info(&self, session_id: String) -> Result<E2eAgentBridgeInfo, String> {
+        let (cwd, bridge_dir, shim_dir) = {
+            let sessions = self
+                .pty
+                .inner_sessions()
+                .lock()
+                .map_err(|_| "failed to lock sessions".to_string())?;
+            let session = sessions
+                .get(&session_id)
+                .ok_or_else(|| format!("session not found: {session_id}"))?;
+
+            (
+                session.cwd.clone(),
+                session.bridge_dir.clone(),
+                session.shim_dir.clone(),
+            )
+        };
+        let status_file = bridge_dir.as_ref().map(|dir| {
+            PathBuf::from(dir.as_str())
+                .join("status.json")
+                .to_string_lossy()
+                .to_string()
+        });
+
+        Ok(E2eAgentBridgeInfo {
+            session_id: session_id.clone(),
+            cwd,
+            app_data_dir: self.app_data_dir.to_string_lossy().to_string(),
+            bridge_dir,
+            status_file,
+            shim_dir,
+            agent_type: self.agents.agent_type_for_pty(&session_id),
+        })
+    }
+
+    #[cfg(feature = "e2e-test")]
+    pub fn e2e_seed_live_agent(
+        &self,
+        session_id: String,
+        agent_type: AgentType,
+    ) -> Result<(), String> {
+        if !self.pty.contains(&session_id) {
+            return Err(format!("session not found: {session_id}"));
+        }
+
+        self.agents
+            .insert_agent_type_for_test(self.transcripts.clone(), session_id, agent_type);
+
+        Ok(())
+    }
+}
+
+#[cfg(feature = "e2e-test")]
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct E2eAgentBridgeInfo {
+    pub session_id: String,
+    pub cwd: String,
+    pub app_data_dir: String,
+    pub bridge_dir: Option<String>,
+    pub status_file: Option<String>,
+    pub shim_dir: Option<String>,
+    pub agent_type: Option<AgentType>,
 }
 
 #[cfg(test)]
@@ -509,6 +598,7 @@ mod tests {
             }),
             child: Box::new(NoopChild),
             cwd: "/tmp".into(),
+            bridge_dir: None,
             shim_dir: None,
             generation: 0,
             ring: Arc::new(Mutex::new(RingBuffer::new(64))),
@@ -581,7 +671,10 @@ mod tests {
         // Reloading the same app-data dir (e.g. next launch) recovers ON;
         // file-independent recovery is proven in the consent module's tests.
         state.load_kimi_usage_consent();
-        assert!(state.get_kimi_usage_consent(), "reload keeps persisted true");
+        assert!(
+            state.get_kimi_usage_consent(),
+            "reload keeps persisted true"
+        );
 
         state.set_kimi_usage_consent(false).expect("persist off");
         assert!(!state.get_kimi_usage_consent());
@@ -620,10 +713,7 @@ mod tests {
             session_id: "burner-shutdown".to_string(),
             data: "x".to_string(),
         });
-        assert!(
-            write.is_err(),
-            "shutdown should have reaped the burner PTY"
-        );
+        assert!(write.is_err(), "shutdown should have reaped the burner PTY");
     }
 
     #[test]

--- a/crates/backend/src/runtime/state.rs
+++ b/crates/backend/src/runtime/state.rs
@@ -1,8 +1,13 @@
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::SystemTime;
+
+#[cfg(feature = "e2e-test")]
+use rusqlite::{params, Connection};
 
 use crate::agent::types::{
-    AgentType, RenameAgentSessionError, RenameAgentSessionErrorReason, RenameAgentSessionRequest,
+    AgentStatusEvent, AgentTurnEvent, AgentType, RenameAgentSessionError,
+    RenameAgentSessionErrorReason, RenameAgentSessionRequest,
 };
 use crate::agent::{sanitize_title, AgentWatcherState, TranscriptState};
 use crate::git::watcher::GitWatcherState;
@@ -64,9 +69,11 @@ impl BackendState {
         let layouts_path = app_data_dir.join("workspace-layouts.json");
         let kimi_usage_consent_path = app_data_dir.join("kimi-usage-consent.json");
         Self {
-            app_data_dir,
+            app_data_dir: app_data_dir.clone(),
             pty: PtyState::new(),
-            sessions: Arc::new(SessionCache::load_or_recover(cache_path)),
+            sessions: Arc::new(
+                SessionCache::load_or_recover(cache_path).with_app_data_dir(app_data_dir),
+            ),
             workspace_layouts: Arc::new(WorkspaceLayoutCache::new(layouts_path)),
             agents: AgentWatcherState::new(),
             transcripts: TranscriptState::new(),
@@ -472,6 +479,216 @@ impl BackendState {
             .insert_agent_type_for_test(self.transcripts.clone(), session_id, agent_type);
 
         Ok(())
+    }
+
+    /// Emit `agent-status` and `agent-turn` events through the backend's
+    /// EventSink. Used by E2E tests to exercise the backend serialization
+    /// and IPC path for Codex/Kimi without requiring a live agent process or
+    /// transcript fixtures. The file-watcher path remains tested separately
+    /// for Claude; this helper narrows the gap for agents whose watcher
+    /// fixtures are not yet hermetic in CI.
+    #[cfg(feature = "e2e-test")]
+    pub fn e2e_emit_agent_status(
+        &self,
+        session_id: String,
+        status: AgentStatusEvent,
+        num_turns: u32,
+    ) -> Result<(), String> {
+        if !self.pty.contains(&session_id) {
+            return Err(format!("session not found: {session_id}"));
+        }
+
+        let turn = AgentTurnEvent {
+            session_id: session_id.clone(),
+            num_turns,
+        };
+
+        let status_payload =
+            crate::runtime::event_sink::serialize_event(&status).map_err(|e| format!("{e}"))?;
+        let turn_payload =
+            crate::runtime::event_sink::serialize_event(&turn).map_err(|e| format!("{e}"))?;
+
+        self.events.emit_json("agent-status", status_payload)?;
+        self.events.emit_json("agent-turn", turn_payload)?;
+        Ok(())
+    }
+
+    /// Set up a hermetic Codex home under `home_dir`, seed the locator
+    /// SQLite databases so the Codex watcher can resolve a rollout file for
+    /// `session_id`, start the watcher, then restore the original `HOME`.
+    /// Returns the absolute path to the empty rollout file the test should
+    /// write to.
+    #[cfg(feature = "e2e-test")]
+    pub async fn e2e_start_codex_watcher(
+        &self,
+        session_id: String,
+        home_dir: PathBuf,
+    ) -> Result<PathBuf, String> {
+        if !self.pty.contains(&session_id) {
+            return Err(format!("session not found: {session_id}"));
+        }
+
+        let cwd = self
+            .pty
+            .get_cwd(&session_id)
+            .ok_or_else(|| format!("cwd not found for session {session_id}"))?;
+        let pty_start = self
+            .pty
+            .get_started_at(&session_id)
+            .ok_or_else(|| format!("start time not found for session {session_id}"))?;
+
+        let codex_home = home_dir.join(".codex");
+        let sessions_dir = codex_home
+            .join("sessions")
+            .join("2026")
+            .join("06")
+            .join("19");
+        let rollout_path = sessions_dir.join(format!("rollout-{session_id}.jsonl"));
+
+        std::fs::create_dir_all(&sessions_dir)
+            .map_err(|e| format!("create codex sessions dir: {e}"))?;
+        std::fs::write(&rollout_path, b"")
+            .map_err(|e| format!("create empty rollout: {e}"))?;
+
+        let since_epoch = pty_start
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map_err(|e| format!("pty_start before epoch: {e}"))?;
+        let secs = since_epoch.as_secs() as i64;
+        let nanos = since_epoch.subsec_nanos() as i64;
+        let updated_at_ms = secs * 1000 + nanos / 1_000_000;
+
+        let state_db = codex_home.join("state.sqlite");
+        let state = Connection::open(&state_db).map_err(|e| format!("open state db: {e}"))?;
+        state
+            .execute_batch(
+                "CREATE TABLE threads (
+                    id TEXT PRIMARY KEY,
+                    rollout_path TEXT NOT NULL,
+                    cwd TEXT,
+                    updated_at_ms INTEGER NOT NULL
+                );",
+            )
+            .map_err(|e| format!("create threads table: {e}"))?;
+        state
+            .execute(
+                "INSERT INTO threads (id, rollout_path, cwd, updated_at_ms)
+                 VALUES (?1, ?2, ?3, ?4)",
+                params![
+                    format!("tid-e2e-{session_id}"),
+                    rollout_path.to_str().ok_or("rollout path is not utf-8")?,
+                    cwd,
+                    updated_at_ms,
+                ],
+            )
+            .map_err(|e| format!("insert thread row: {e}"))?;
+
+        let logs_db = codex_home.join("logs.sqlite");
+        let logs = Connection::open(&logs_db).map_err(|e| format!("open logs db: {e}"))?;
+        logs.execute_batch(
+            "CREATE TABLE logs (
+                id INTEGER PRIMARY KEY,
+                ts INTEGER NOT NULL,
+                ts_nanos INTEGER NOT NULL,
+                level TEXT,
+                target TEXT,
+                process_uuid TEXT NOT NULL,
+                thread_id TEXT
+            );
+            CREATE INDEX idx_logs_ts ON logs(ts DESC, ts_nanos DESC, id DESC);",
+        )
+        .map_err(|e| format!("create logs table: {e}"))?;
+
+        let prev_home = std::env::var_os("HOME");
+        std::env::set_var("HOME", &home_dir);
+        let result = self.start_agent_watcher(session_id.clone()).await;
+        match prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+        result?;
+
+        Ok(rollout_path)
+    }
+
+    /// Set up a hermetic Kimi home under `home_dir`, seed the locator
+    /// filesystem layout so the Kimi watcher can resolve a wire file for
+    /// `session_id`, start the watcher, then restore the original
+    /// `KIMI_CODE_HOME`. Returns the absolute path to the wire file the test
+    /// should write to.
+    #[cfg(feature = "e2e-test")]
+    pub async fn e2e_start_kimi_watcher(
+        &self,
+        session_id: String,
+        home_dir: PathBuf,
+    ) -> Result<PathBuf, String> {
+        if !self.pty.contains(&session_id) {
+            return Err(format!("session not found: {session_id}"));
+        }
+
+        let cwd = self
+            .pty
+            .get_cwd(&session_id)
+            .ok_or_else(|| format!("cwd not found for session {session_id}"))?;
+        let pty_start = self
+            .pty
+            .get_started_at(&session_id)
+            .ok_or_else(|| format!("start time not found for session {session_id}"))?;
+
+        let since_epoch = pty_start
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map_err(|e| format!("pty_start before epoch: {e}"))?;
+        let created_at_ms = since_epoch.as_millis() as u64 + 1000;
+
+        let cwd_path = PathBuf::from(&cwd);
+        let basename = cwd_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("workspace");
+        let bucket = {
+            use sha2::{Digest, Sha256};
+            let digest = Sha256::digest(cwd.as_bytes());
+            let hex: String = digest.iter().take(6).map(|b| format!("{b:02x}")).collect();
+            format!("wd_{basename}_{hex}")
+        };
+        let session_dir_name = format!("session_e2e_{session_id}");
+        let session_dir = home_dir
+            .join("sessions")
+            .join(&bucket)
+            .join(&session_dir_name);
+        let wire_path = session_dir.join("agents").join("main").join("wire.jsonl");
+
+        std::fs::create_dir_all(wire_path.parent().expect("wire parent"))
+            .map_err(|e| format!("create kimi wire dirs: {e}"))?;
+        std::fs::write(
+            &wire_path,
+            format!(
+                "{{\"type\":\"metadata\",\"created_at\":{created_at_ms}}}\n"
+            ),
+        )
+        .map_err(|e| format!("create kimi wire: {e}"))?;
+
+        let index_path = home_dir.join("session_index.jsonl");
+        std::fs::write(
+            &index_path,
+            format!(
+                "{{\"sessionId\":\"{}\",\"sessionDir\":\"{}\",\"workDir\":\"{}\"}}\n",
+                session_dir_name,
+                session_dir.to_str().ok_or("session dir is not utf-8")?,
+                cwd,
+            ),
+        )
+        .map_err(|e| format!("create kimi index: {e}"))?;
+
+        let prev_kimi_home = std::env::var_os("KIMI_CODE_HOME");
+        std::env::set_var("KIMI_CODE_HOME", &home_dir);
+        let result = self.start_agent_watcher(session_id).await;
+        match prev_kimi_home {
+            Some(v) => std::env::set_var("KIMI_CODE_HOME", v),
+            None => std::env::remove_var("KIMI_CODE_HOME"),
+        }
+        result?;
+
+        Ok(wire_path)
     }
 }
 

--- a/crates/backend/src/terminal/bridge.rs
+++ b/crates/backend/src/terminal/bridge.rs
@@ -71,6 +71,54 @@ fn sanitized_component(raw: &str) -> String {
     }
 }
 
+/// Quote a path so it survives being passed to `statusLine.command` and run
+/// through a POSIX shell. Wraps the value in single quotes; any embedded
+/// single quote is escaped by exiting the quoted string, emitting an escaped
+/// quote, and re-entering.
+fn shell_quote_path(path: &str) -> String {
+    if path.is_empty() {
+        return "''".to_string();
+    }
+    // A conservative whitelist: if the path contains no shell metacharacters,
+    // leave it unquoted. Otherwise wrap the whole thing in single quotes.
+    let needs_quote = path.bytes().any(|b| {
+        b.is_ascii_whitespace()
+            || b == b'\''
+            || b == b'"'
+            || b == b'`'
+            || b == b'$'
+            || b == b'\\'
+            || b == b'|'
+            || b == b'&'
+            || b == b';'
+            || b == b'<'
+            || b == b'>'
+            || b == b'('
+            || b == b')'
+            || b == b'#'
+            || b == b'*'
+            || b == b'?'
+            || b == b'['
+            || b == b']'
+            || b == b'!'
+            || b == b'~'
+    });
+    if !needs_quote {
+        return path.to_string();
+    }
+    let mut quoted = String::with_capacity(path.len() + 2);
+    quoted.push('\'');
+    for ch in path.chars() {
+        if ch == '\'' {
+            quoted.push_str("'\\''");
+        } else {
+            quoted.push(ch);
+        }
+    }
+    quoted.push('\'');
+    quoted
+}
+
 fn cwd_basename(cwd: &Path) -> String {
     cwd.file_name()
         .and_then(OsStr::to_str)
@@ -78,10 +126,26 @@ fn cwd_basename(cwd: &Path) -> String {
         .unwrap_or_else(|| "workspace".to_string())
 }
 
+/// Maximum bytes for the sanitized basename portion of a workspace bridge
+/// bucket, leaving room for the hyphen separator and the 12-character hex
+/// hash (6 bytes × 2 hex digits) on filesystems with a 255-byte filename
+/// limit.
+const MAX_BUCKET_BASENAME_BYTES: usize = 242;
+
 fn workspace_bridge_bucket(cwd: &Path) -> String {
     let digest = Sha256::digest(cwd.to_string_lossy().as_bytes());
     let hex: String = digest.iter().take(6).map(|b| format!("{b:02x}")).collect();
-    format!("{}-{}", cwd_basename(cwd), hex)
+    let basename = cwd_basename(cwd);
+    let truncated = if basename.len() > MAX_BUCKET_BASENAME_BYTES {
+        basename
+            .char_indices()
+            .take_while(|(i, _)| *i < MAX_BUCKET_BASENAME_BYTES)
+            .map(|(_, ch)| ch)
+            .collect()
+    } else {
+        basename
+    };
+    format!("{}-{}", truncated, hex)
 }
 
 pub(crate) fn workspace_bridge_root(app_data_dir: &Path, cwd: &Path) -> PathBuf {
@@ -231,7 +295,7 @@ pub fn generate_bridge_files(
     let settings = serde_json::json!({
         "statusLine": {
             "type": "command",
-            "command": script_path.to_string_lossy(),
+            "command": shell_quote_path(&script_path.to_string_lossy()),
             "refreshInterval": 5
         }
     });
@@ -376,6 +440,43 @@ mod tests {
         assert_ne!(first, second);
         assert!(first.starts_with(&app_data));
         assert!(second.starts_with(&app_data));
+    }
+
+    #[test]
+    fn workspace_bridge_bucket_truncates_long_basenames() {
+        let app_data = PathBuf::from("/tmp/vimeflow-data");
+        let long_name = "a".repeat(300);
+        let cwd = PathBuf::from(format!("/tmp/{long_name}"));
+
+        let bucket = workspace_bridge_bucket(&cwd);
+        let bucket_bytes = bucket.as_bytes();
+        assert!(
+            bucket_bytes.len() <= 255,
+            "bucket component must fit in a 255-byte filesystem filename: {bucket}"
+        );
+        // Truncated basename + hyphen + 6-char hash.
+        assert_eq!(
+            bucket.matches('-').count(),
+            1,
+            "bucket should contain exactly one separator: {bucket}"
+        );
+        let (basename, hash) = bucket.rsplit_once('-').unwrap();
+        assert_eq!(hash.len(), 12, "hash suffix should be 12 hex chars");
+        assert_eq!(basename.len(), MAX_BUCKET_BASENAME_BYTES);
+    }
+
+    #[test]
+    fn shell_quote_path_quotes_metacharacters() {
+        assert_eq!(shell_quote_path("/safe/path"), "/safe/path");
+        assert_eq!(
+            shell_quote_path("/Users/foo/Application Support/vimeflow/statusline.sh"),
+            "'/Users/foo/Application Support/vimeflow/statusline.sh'"
+        );
+        assert_eq!(
+            shell_quote_path("/path/with'quote/statusline.sh"),
+            "'/path/with'\\''quote/statusline.sh'"
+        );
+        assert_eq!(shell_quote_path(""), "''");
     }
 
     #[test]

--- a/crates/backend/src/terminal/bridge.rs
+++ b/crates/backend/src/terminal/bridge.rs
@@ -4,16 +4,24 @@
 //! Claude Code (or other agents) to write statusline JSON to a known location
 //! for Vimeflow's file watcher to pick up.
 
+use sha2::{Digest, Sha256};
+use std::ffi::OsStr;
 use std::fs;
+use std::io::Write;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
-use std::io::Write;
+
+const BRIDGE_RUNTIME_DIR: &str = "runtime";
+const BRIDGE_WORKSPACES_DIR: &str = "workspaces";
+const BRIDGE_SESSIONS_DIR: &str = "sessions";
 
 /// Result of generating statusline bridge files
 #[derive(Debug, Clone)]
 #[allow(dead_code)] // Fields read by spawn_pty and future cleanup logic
 pub struct BridgeFiles {
+    /// Directory containing the generated per-session status bridge files
+    pub agent_status_dir_path: PathBuf,
     /// Path to the generated statusline script
     pub script_path: PathBuf,
     /// Directory prepended to PATH so aliases like `env ... claude` are bridged
@@ -30,6 +38,67 @@ pub struct BridgeFiles {
     pub zsh_env_path: PathBuf,
     /// Path to generated zsh rc file used when the user's shell is zsh
     pub zsh_rc_path: PathBuf,
+}
+
+fn sanitized_component(raw: &str) -> String {
+    let mut component = String::with_capacity(raw.len());
+    let mut previous_was_dash = false;
+
+    for ch in raw.chars() {
+        let next = if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' {
+            ch.to_ascii_lowercase()
+        } else {
+            '-'
+        };
+
+        if next == '-' {
+            if previous_was_dash {
+                continue;
+            }
+            previous_was_dash = true;
+        } else {
+            previous_was_dash = false;
+        }
+
+        component.push(next);
+    }
+
+    let trimmed = component.trim_matches('-');
+    if trimmed.is_empty() {
+        "workspace".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn cwd_basename(cwd: &Path) -> String {
+    cwd.file_name()
+        .and_then(OsStr::to_str)
+        .map(sanitized_component)
+        .unwrap_or_else(|| "workspace".to_string())
+}
+
+fn workspace_bridge_bucket(cwd: &Path) -> String {
+    let digest = Sha256::digest(cwd.to_string_lossy().as_bytes());
+    let hex: String = digest.iter().take(6).map(|b| format!("{b:02x}")).collect();
+    format!("{}-{}", cwd_basename(cwd), hex)
+}
+
+pub(crate) fn workspace_bridge_root(app_data_dir: &Path, cwd: &Path) -> PathBuf {
+    app_data_dir
+        .join(BRIDGE_RUNTIME_DIR)
+        .join(BRIDGE_WORKSPACES_DIR)
+        .join(workspace_bridge_bucket(cwd))
+}
+
+pub(crate) fn session_bridge_dir(app_data_dir: &Path, cwd: &Path, session_id: &str) -> PathBuf {
+    workspace_bridge_root(app_data_dir, cwd)
+        .join(BRIDGE_SESSIONS_DIR)
+        .join(session_id)
+}
+
+pub(crate) fn session_status_file(app_data_dir: &Path, cwd: &Path, session_id: &str) -> PathBuf {
+    session_bridge_dir(app_data_dir, cwd, session_id).join("status.json")
 }
 
 /// Write a script file atomically and make it executable on Unix.
@@ -77,7 +146,7 @@ fn write_executable_script(path: &Path, content: &str) -> std::io::Result<()> {
 /// 5. `<dir>/.zshenv` and `<dir>/.zshrc` — zsh-specific startup hooks (when shell is zsh)
 ///
 /// # Arguments
-/// * `agent_status_dir` - Directory to create files in (e.g. `.vimeflow/sessions/<id>/`)
+/// * `agent_status_dir` - Directory to create files in (typically under app data)
 /// * `session_id` - Session identifier for the comment header
 /// * `shim_dir` - Optional directory for the PATH shim; `None` falls back to `<agent_status_dir>/bin`
 ///
@@ -96,7 +165,10 @@ pub fn generate_bridge_files(
         .map_err(|e| format!("failed to create agent status directory: {}", e))?;
 
     let script_path = dir.join("statusline.sh");
-    let shim_dir_path = shim_dir.map(Path::new).map(|p| p.to_path_buf()).unwrap_or_else(|| dir.join("bin"));
+    let shim_dir_path = shim_dir
+        .map(Path::new)
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| dir.join("bin"));
     let claude_shim_path = shim_dir_path.join("claude");
     let settings_path = dir.join("settings.json");
     let status_file_path = dir.join("status.json");
@@ -228,6 +300,7 @@ pub fn generate_bridge_files(
     );
 
     Ok(BridgeFiles {
+        agent_status_dir_path: dir.to_path_buf(),
         script_path,
         shim_dir_path,
         claude_shim_path,
@@ -269,6 +342,41 @@ mod tests {
     use std::os::unix::fs::PermissionsExt;
     #[cfg(unix)]
     use std::process::{Command, Stdio};
+
+    #[test]
+    fn session_bridge_dir_uses_app_data_safe_workspace_bucket() {
+        let app_data = PathBuf::from("/tmp/Vimeflow Data");
+        let cwd = PathBuf::from("/Users/test/Project With Quote's");
+
+        let dir = session_bridge_dir(&app_data, &cwd, "session-abc");
+        let workspace_root = workspace_bridge_root(&app_data, &cwd);
+        let bucket = workspace_root
+            .file_name()
+            .and_then(OsStr::to_str)
+            .expect("workspace bucket should be UTF-8");
+
+        assert!(dir.starts_with(&app_data));
+        assert_eq!(dir, workspace_root.join("sessions").join("session-abc"));
+        assert!(!dir.components().any(|c| c.as_os_str() == ".vimeflow"));
+        assert!(bucket.starts_with("project-with-quote-s-"));
+        assert!(
+            bucket
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'),
+            "bucket should be safe as one macOS/Linux path component: {bucket}"
+        );
+    }
+
+    #[test]
+    fn workspace_bridge_bucket_distinguishes_same_basename_paths() {
+        let app_data = PathBuf::from("/tmp/vimeflow-data");
+        let first = workspace_bridge_root(&app_data, Path::new("/tmp/one/app"));
+        let second = workspace_bridge_root(&app_data, Path::new("/tmp/two/app"));
+
+        assert_ne!(first, second);
+        assert!(first.starts_with(&app_data));
+        assert!(second.starts_with(&app_data));
+    }
 
     #[test]
     fn generates_bridge_files_in_temp_dir() {
@@ -563,8 +671,12 @@ mod tests {
         let dir = tmp.path().join("session-cleanup");
         let shim = tmp.path().join("shims").join("session-cleanup");
 
-        generate_bridge_files(dir.to_str().unwrap(), "session-cleanup", Some(shim.to_str().unwrap()))
-            .unwrap();
+        generate_bridge_files(
+            dir.to_str().unwrap(),
+            "session-cleanup",
+            Some(shim.to_str().unwrap()),
+        )
+        .unwrap();
         assert!(dir.exists());
         assert!(shim.exists());
 

--- a/crates/backend/src/terminal/cache.rs
+++ b/crates/backend/src/terminal/cache.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 const SCHEMA_VERSION: u32 = 1;
@@ -82,6 +82,10 @@ impl SessionCache {
             path,
             data: Mutex::new(data),
         })
+    }
+
+    pub fn app_data_dir(&self) -> Option<PathBuf> {
+        self.path.parent().map(Path::to_path_buf)
     }
 
     /// Load from disk; if corrupted, move aside and start empty.
@@ -230,8 +234,8 @@ impl SessionCache {
             .parent()
             .ok_or_else(|| "cache path has no parent".to_string())?;
         fs::create_dir_all(parent).map_err(|e| format!("mkdir: {e}"))?;
-        let mut tmp = tempfile::NamedTempFile::new_in(parent)
-            .map_err(|e| format!("create tempfile: {e}"))?;
+        let mut tmp =
+            tempfile::NamedTempFile::new_in(parent).map_err(|e| format!("create tempfile: {e}"))?;
         let bytes = serde_json::to_vec_pretty(data).map_err(|e| format!("serialize: {e}"))?;
         tmp.write_all(&bytes).map_err(|e| format!("write: {e}"))?;
         tmp.persist(&self.path)

--- a/crates/backend/src/terminal/cache.rs
+++ b/crates/backend/src/terminal/cache.rs
@@ -64,6 +64,11 @@ impl Default for SessionCacheData {
 #[derive(Debug)]
 pub struct SessionCache {
     path: PathBuf,
+    /// The Vimeflow data root that owns this cache. Stored explicitly (rather
+    /// than derived from `path.parent()`) so `sessions.json` can move to a
+    /// subdirectory without silently redirecting bridge/status directories to
+    /// the wrong parent.
+    app_data_dir: PathBuf,
     data: Mutex<SessionCacheData>,
 }
 
@@ -78,14 +83,27 @@ impl SessionCache {
         } else {
             SessionCacheData::default()
         };
+        let app_data_dir = path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| path.clone());
         Ok(Self {
             path,
+            app_data_dir,
             data: Mutex::new(data),
         })
     }
 
+    /// Override the data root inferred from the cache path. Production code
+    /// (BackendState) uses this to pin the true `app_data_dir` instead of
+    /// relying on the cache-file placement convention.
+    pub fn with_app_data_dir(mut self, app_data_dir: PathBuf) -> Self {
+        self.app_data_dir = app_data_dir;
+        self
+    }
+
     pub fn app_data_dir(&self) -> Option<PathBuf> {
-        self.path.parent().map(Path::to_path_buf)
+        Some(self.app_data_dir.clone())
     }
 
     /// Load from disk; if corrupted, move aside and start empty.
@@ -113,8 +131,13 @@ impl SessionCache {
                 // rename above failed, the corrupt file is still at `path`;
                 // re-running `Self::load(path)` would re-parse it and Err
                 // again, and the previous `.expect(...)` would panic.
+                let app_data_dir = path
+                    .parent()
+                    .map(Path::to_path_buf)
+                    .unwrap_or_else(|| path.clone());
                 Self {
                     path,
+                    app_data_dir,
                     data: Mutex::new(SessionCacheData::default()),
                 }
             }
@@ -281,6 +304,22 @@ mod tests {
         assert_eq!(snap.session_order.len(), 0);
         assert!(snap.sessions.is_empty());
         assert!(snap.active_session_id.is_none());
+    }
+
+    #[test]
+    fn explicit_app_data_dir_is_preserved_independently_of_cache_path() {
+        let dir = TempDir::new().unwrap();
+        let app_data_dir = dir.path().join("runtime").join("app-data");
+        let cache_path = app_data_dir.join("db").join("sessions.json");
+
+        let cache = SessionCache::load(cache_path.clone())
+            .unwrap()
+            .with_app_data_dir(app_data_dir.clone());
+
+        assert_eq!(cache.app_data_dir(), Some(app_data_dir));
+        // The cache file lives in a subdirectory, but the reported data root
+        // is the explicit app_data_dir — not the cache file's immediate parent.
+        assert_ne!(cache.app_data_dir(), cache_path.parent().map(Path::to_path_buf));
     }
 
     #[test]

--- a/crates/backend/src/terminal/commands.rs
+++ b/crates/backend/src/terminal/commands.rs
@@ -1,6 +1,6 @@
 //! PTY operation helpers consumed by the runtime-neutral backend state.
 
-use portable_pty::{CommandBuilder, PtySize, native_pty_system};
+use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 use std::io::Read;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -172,10 +172,10 @@ pub(crate) async fn spawn_pty_inner(
     // Generate statusline bridge files — skipped for ephemeral (burner) PTYs.
     let bridge_enabled = request.enable_agent_bridge && !request.ephemeral;
     let (bridge_files, bridge_cleanup_dir, shim_cleanup_dir) = if bridge_enabled {
-        let dir = cwd
-            .join(".vimeflow")
-            .join("sessions")
-            .join(&request.session_id);
+        let app_data_dir = cache
+            .app_data_dir()
+            .ok_or_else(|| "session cache path has no app data parent".to_string())?;
+        let dir = super::bridge::session_bridge_dir(&app_data_dir, &cwd, &request.session_id);
         let cleanup_dir = (!dir.exists()).then_some(dir.clone());
         let shim_dir = dirs::cache_dir()
             .map(|c| c.join("vimeflow-shims"))
@@ -371,6 +371,9 @@ pub(crate) async fn spawn_pty_inner(
         writer,
         child,
         cwd: cwd.to_string_lossy().to_string(),
+        bridge_dir: bridge_files
+            .as_ref()
+            .map(|f| f.agent_status_dir_path.to_string_lossy().to_string()),
         shim_dir: bridge_files
             .as_ref()
             .map(|f| f.shim_dir_path.to_string_lossy().to_string()),
@@ -559,15 +562,9 @@ pub(crate) fn kill_pty_inner(
 
     // Clean up bridge files and shim directory for the session.
     if let Some(session) = removed {
-        let cwd = std::path::Path::new(&session.cwd);
-        let bridge_dir = cwd
-            .join(".vimeflow")
-            .join("sessions")
-            .join(&request.session_id);
-        let _ = super::bridge::cleanup_bridge_files(
-            &bridge_dir.to_string_lossy(),
-            session.shim_dir.as_deref(),
-        );
+        if let Some(bridge_dir) = session.bridge_dir.as_deref() {
+            let _ = super::bridge::cleanup_bridge_files(bridge_dir, session.shim_dir.as_deref());
+        }
     }
 
     // Clean up cache: remove from sessions map and session_order
@@ -667,12 +664,9 @@ pub(crate) fn kill_pty_inner(
                     // killed pane held the active flag. Otherwise preserve
                     // whatever active marker already exists on a survivor.
                     let needs_active_promotion = was_active
-                        && !sibling_ids.iter().any(|id| {
-                            data.groupings
-                                .get(id)
-                                .map(|g| g.active)
-                                .unwrap_or(false)
-                        });
+                        && !sibling_ids
+                            .iter()
+                            .any(|id| data.groupings.get(id).map(|g| g.active).unwrap_or(false));
 
                     for (idx, sibling_id) in sibling_ids.iter().enumerate() {
                         if let Some(grouping) = data.groupings.get_mut(sibling_id) {
@@ -1223,12 +1217,9 @@ async fn read_pty_output(
 
     // Clean up bridge files and shim directory for the session.
     if let Some(session) = removed {
-        let cwd = std::path::Path::new(&session.cwd);
-        let bridge_dir = cwd.join(".vimeflow").join("sessions").join(&session_id);
-        let _ = super::bridge::cleanup_bridge_files(
-            &bridge_dir.to_string_lossy(),
-            session.shim_dir.as_deref(),
-        );
+        if let Some(bridge_dir) = session.bridge_dir.as_deref() {
+            let _ = super::bridge::cleanup_bridge_files(bridge_dir, session.shim_dir.as_deref());
+        }
     }
 
     Ok(())
@@ -1435,7 +1426,13 @@ mod tests {
         let cwd = temp_dir.path().join("burner-workspace");
         std::fs::create_dir_all(&cwd).expect("create cwd");
         let session_id = "burner-no-bridge".to_string();
-        let bridge_dir = cwd.join(".vimeflow").join("sessions").join(&session_id);
+        let canonical_cwd = std::fs::canonicalize(&cwd).expect("canonical cwd");
+        let bridge_dir = crate::terminal::bridge::session_bridge_dir(
+            temp_dir.path(),
+            &canonical_cwd,
+            &session_id,
+        );
+        let workspace_bridge_dir = cwd.join(".vimeflow");
 
         let request = SpawnPtyRequest {
             session_id: session_id.clone(),
@@ -1451,6 +1448,10 @@ mod tests {
         assert!(
             !bridge_dir.exists(),
             "ephemeral PTY must not create a bridge dir even when enable_agent_bridge is true"
+        );
+        assert!(
+            !workspace_bridge_dir.exists(),
+            "ephemeral PTY must not create project-local .vimeflow"
         );
 
         let _ = state.remove(&session_id);
@@ -1526,11 +1527,12 @@ mod tests {
         let cwd = temp_dir.path().join("workspace with spaces and quote's");
         std::fs::create_dir_all(&cwd).expect("create cwd");
         let session_id = "bridge-live-test".to_string();
-        let status_path = cwd
-            .join(".vimeflow")
-            .join("sessions")
-            .join(&session_id)
-            .join("status.json");
+        let canonical_cwd = std::fs::canonicalize(&cwd).expect("canonical cwd");
+        let status_path = crate::terminal::bridge::session_status_file(
+            temp_dir.path(),
+            &canonical_cwd,
+            &session_id,
+        );
 
         let request = SpawnPtyRequest {
             session_id: session_id.clone(),
@@ -1547,6 +1549,10 @@ mod tests {
         assert!(
             status_path.parent().expect("status parent").exists(),
             "spawn_pty should create the bridge session directory"
+        );
+        assert!(
+            !cwd.join(".vimeflow").exists(),
+            "spawn_pty should not create project-local .vimeflow"
         );
 
         write_pty_inner(
@@ -1578,6 +1584,10 @@ mod tests {
             },
         )
         .expect("kill bridge test session");
+        assert!(
+            !status_path.parent().expect("status parent").exists(),
+            "kill_pty should clean up the app-data bridge session directory"
+        );
     }
 
     #[tokio::test]
@@ -1854,7 +1864,7 @@ mod tests {
 
     #[tokio::test]
     async fn spawn_pty_caps_at_64_active_sessions() {
-        let (state, cache, events, _temp_dir) = create_test_state_with_cache();
+        let (state, cache, events, temp_dir) = create_test_state_with_cache();
 
         let cwd_temp_dir = TempDir::new().expect("failed to create cwd temp dir");
         let cwd = cwd_temp_dir.path().to_string_lossy().to_string();
@@ -1884,11 +1894,12 @@ mod tests {
             enable_agent_bridge: true,
             ephemeral: false,
         };
-        let rejected_bridge_dir = cwd_temp_dir
-            .path()
-            .join(".vimeflow")
-            .join("sessions")
-            .join("session-65");
+        let canonical_cwd = std::fs::canonicalize(cwd_temp_dir.path()).expect("canonical cwd");
+        let rejected_bridge_dir = crate::terminal::bridge::session_bridge_dir(
+            temp_dir.path(),
+            &canonical_cwd,
+            "session-65",
+        );
 
         let result =
             spawn_pty_inner(state.clone(), cache.clone(), events.clone(), request_65).await;
@@ -1901,6 +1912,10 @@ mod tests {
         assert!(
             !rejected_bridge_dir.exists(),
             "failed spawn should remove generated bridge directory"
+        );
+        assert!(
+            !cwd_temp_dir.path().join(".vimeflow").exists(),
+            "failed spawn should not leave project-local .vimeflow"
         );
 
         // Cleanup: remove all 64 sessions
@@ -1957,7 +1972,7 @@ mod tests {
 
     fn make_failing_kill_session() -> crate::terminal::state::ManagedSession {
         use crate::terminal::state::{ManagedSession, RingBuffer};
-        use portable_pty::{CommandBuilder, PtySize, native_pty_system};
+        use portable_pty::{native_pty_system, CommandBuilder, PtySize};
         let pty_system = native_pty_system();
         let pty_pair = pty_system
             .openpty(PtySize {
@@ -1979,6 +1994,7 @@ mod tests {
             writer,
             child: Box::new(FailingKillChild),
             cwd: "/tmp".into(),
+            bridge_dir: None,
             shim_dir: None,
             generation: 0,
             ring: Arc::new(Mutex::new(RingBuffer::new(64))),
@@ -2361,12 +2377,48 @@ mod tests {
                     layout: "grid3x2".into(),
                     working_directory: Some(cwd.clone()),
                     panes: vec![
-                        WorkspacePaneSnapshot { pty_id: "pty-a".into(), pane_id: "p0".into(), pane_index: 0, agent_type: "generic".into(), active: true },
-                        WorkspacePaneSnapshot { pty_id: "pty-b".into(), pane_id: "p1".into(), pane_index: 1, agent_type: "generic".into(), active: false },
-                        WorkspacePaneSnapshot { pty_id: "pty-c".into(), pane_id: "p2".into(), pane_index: 2, agent_type: "generic".into(), active: false },
-                        WorkspacePaneSnapshot { pty_id: "pty-d".into(), pane_id: "p3".into(), pane_index: 3, agent_type: "generic".into(), active: false },
-                        WorkspacePaneSnapshot { pty_id: "pty-e".into(), pane_id: "p4".into(), pane_index: 4, agent_type: "generic".into(), active: false },
-                        WorkspacePaneSnapshot { pty_id: "pty-f".into(), pane_id: "p5".into(), pane_index: 5, agent_type: "generic".into(), active: false },
+                        WorkspacePaneSnapshot {
+                            pty_id: "pty-a".into(),
+                            pane_id: "p0".into(),
+                            pane_index: 0,
+                            agent_type: "generic".into(),
+                            active: true,
+                        },
+                        WorkspacePaneSnapshot {
+                            pty_id: "pty-b".into(),
+                            pane_id: "p1".into(),
+                            pane_index: 1,
+                            agent_type: "generic".into(),
+                            active: false,
+                        },
+                        WorkspacePaneSnapshot {
+                            pty_id: "pty-c".into(),
+                            pane_id: "p2".into(),
+                            pane_index: 2,
+                            agent_type: "generic".into(),
+                            active: false,
+                        },
+                        WorkspacePaneSnapshot {
+                            pty_id: "pty-d".into(),
+                            pane_id: "p3".into(),
+                            pane_index: 3,
+                            agent_type: "generic".into(),
+                            active: false,
+                        },
+                        WorkspacePaneSnapshot {
+                            pty_id: "pty-e".into(),
+                            pane_id: "p4".into(),
+                            pane_index: 4,
+                            agent_type: "generic".into(),
+                            active: false,
+                        },
+                        WorkspacePaneSnapshot {
+                            pty_id: "pty-f".into(),
+                            pane_id: "p5".into(),
+                            pane_index: 5,
+                            agent_type: "generic".into(),
+                            active: false,
+                        },
                     ],
                 }],
             },

--- a/crates/backend/src/terminal/state.rs
+++ b/crates/backend/src/terminal/state.rs
@@ -74,6 +74,10 @@ pub struct ManagedSession {
     /// Current working directory
     #[allow(dead_code)]
     pub cwd: String,
+    /// Bridge directory path for this session, used for cleanup.
+    /// Stored at spawn time so cleanup uses the exact app-data path that
+    /// generated the statusline files.
+    pub bridge_dir: Option<String>,
     /// Shim directory path for this session, used for cleanup.
     /// Stored at spawn time so cleanup reads the same path even if
     /// `dirs::cache_dir()` env variables change between spawn and kill.
@@ -640,6 +644,7 @@ mod tests {
             writer,
             child,
             cwd: "/tmp".into(),
+            bridge_dir: None,
             shim_dir: None,
             generation: 0,
             ring: Arc::new(Mutex::new(super::RingBuffer::new(64))),
@@ -713,6 +718,7 @@ mod tests {
             writer,
             child: Box::new(FailingKillChild),
             cwd: "/tmp".into(),
+            bridge_dir: None,
             shim_dir: None,
             generation: 0,
             ring: Arc::new(Mutex::new(super::RingBuffer::new(64))),

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -77,7 +77,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Error Surfacing](patterns/error-surfacing.md)                                                       | error-handling     | 41       | 13   | 2026-06-17   |
 | [File Tree Paths](patterns/file-tree-paths.md)                                                       | files              | 4        | 0    | 2026-04-10   |
 | [Scope Boundary](patterns/scope-boundary.md)                                                         | review-process     | 8        | 3    | 2026-06-01   |
-| [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 21       | 9    | 2026-06-19   |
+| [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 22       | 9    | 2026-06-19   |
 | [Module Boundaries](patterns/module-boundaries.md)                                                   | code-quality       | 16       | 3    | 2026-06-15   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 13       | 3    | 2026-06-15   |
 | [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 20       | 1    | 2026-06-18   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -77,7 +77,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Error Surfacing](patterns/error-surfacing.md)                                                       | error-handling     | 41       | 13   | 2026-06-17   |
 | [File Tree Paths](patterns/file-tree-paths.md)                                                       | files              | 4        | 0    | 2026-04-10   |
 | [Scope Boundary](patterns/scope-boundary.md)                                                         | review-process     | 8        | 3    | 2026-06-01   |
-| [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 22       | 9    | 2026-06-19   |
+| [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 24       | 10   | 2026-06-19   |
 | [Module Boundaries](patterns/module-boundaries.md)                                                   | code-quality       | 16       | 3    | 2026-06-15   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 13       | 3    | 2026-06-15   |
 | [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 20       | 1    | 2026-06-18   |
@@ -92,7 +92,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Prototype Handoff Artifacts](patterns/prototype-handoff-artifacts.md)                               | review-process     | 2        | 0    | 2026-06-12   |
 | [CloudFormation Environment Prefix Coupling](patterns/cloudformation-environment-prefix-coupling.md) | infrastructure     | 1        | 0    | 2026-06-12   |
 | [CloudFormation Stale References](patterns/cloudformation-stale-references.md)                       | infrastructure     | 2        | 1    | 2026-06-12   |
-| [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 4        | 1    | 2026-06-19   |
+| [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 5        | 2    | 2026-06-19   |
 | [Unsafe Block Safety Comments](patterns/unsafe-block-safety-comments.md)                             | security           | 1        | 0    | 2026-06-14   |
 | [Type Contract Safety](patterns/type-contract-safety.md)                                             | code-quality       | 7        | 3    | 2026-06-19   |
 | [String Construction Hygiene](patterns/string-construction-hygiene.md)                               | code-quality       | 1        | 0    | 2026-06-15   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -50,11 +50,11 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Fixed-Position Portals](patterns/fixed-position-portals.md)                                         | react-patterns     | 1        | 0    | 2026-06-12   |
 | [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 15       | 12   | 2026-06-16   |
-| [Cross-Platform Paths](patterns/cross-platform-paths.md)                                             | cross-platform     | 7        | 3    | 2026-06-17   |
+| [Cross-Platform Paths](patterns/cross-platform-paths.md)                                             | cross-platform     | 8        | 4    | 2026-06-19   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                                                       | code-quality       | 7        | 0    | 2026-06-11   |
 | [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 12       | 9    | 2026-06-19   |
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
-| [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
+| [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 8        | 2    | 2026-06-19   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 3        | 0    | 2026-06-16   |
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 74       | 34   | 2026-06-18   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
@@ -77,7 +77,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Error Surfacing](patterns/error-surfacing.md)                                                       | error-handling     | 41       | 13   | 2026-06-17   |
 | [File Tree Paths](patterns/file-tree-paths.md)                                                       | files              | 4        | 0    | 2026-04-10   |
 | [Scope Boundary](patterns/scope-boundary.md)                                                         | review-process     | 8        | 3    | 2026-06-01   |
-| [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 20       | 8    | 2026-06-15   |
+| [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 21       | 9    | 2026-06-19   |
 | [Module Boundaries](patterns/module-boundaries.md)                                                   | code-quality       | 16       | 3    | 2026-06-15   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 13       | 3    | 2026-06-15   |
 | [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 20       | 1    | 2026-06-18   |
@@ -85,7 +85,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [UI Visual Regression](patterns/ui-visual-regression.md)                                             | code-quality       | 9        | 4    | 2026-06-13   |
 | [Status Indicator Display](patterns/status-indicator-display.md)                                     | code-quality       | 3        | 0    | 2026-05-26   |
 | [Parser Resilience](patterns/parser-resilience.md)                                                   | code-quality       | 11       | 8    | 2026-06-12   |
-| [Persisted State Invariants](patterns/persisted-state-invariants.md)                                 | correctness        | 10       | 4    | 2026-06-19   |
+| [Persisted State Invariants](patterns/persisted-state-invariants.md)                                 | correctness        | 11       | 5    | 2026-06-19   |
 | [macOS Window Chrome](patterns/macos-window-chrome.md)                                               | cross-platform     | 9        | 2    | 2026-06-15   |
 | [Guard Branch Correctness](patterns/guard-branch-correctness.md)                                     | correctness        | 2        | 0    | 2026-06-19   |
 | [Identifier Prefix Matching](patterns/identifier-prefix-matching.md)                                 | correctness        | 4        | 2    | 2026-06-17   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -107,3 +107,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Shared Controller Segmentation](patterns/shared-controller-segmentation.md)                         | react-patterns     | 2        | 0    | 2026-06-18   |
 | [Vite HMR Static Dependencies](patterns/vite-hmr-static-deps.md)                                     | code-quality       | 3        | 2    | 2026-06-18   |
 | [Custom Pane Layout Preservation](patterns/custom-pane-layout-preservation.md)                       | correctness        | 1        | 0    | 2026-06-19   |
+| [Async Global State Mutation](patterns/async-global-state-mutation.md)                               | backend            | 1        | 0    | 2026-06-19   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -95,7 +95,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 5        | 2    | 2026-06-19   |
 | [Unsafe Block Safety Comments](patterns/unsafe-block-safety-comments.md)                             | security           | 1        | 0    | 2026-06-14   |
 | [Type Contract Safety](patterns/type-contract-safety.md)                                             | code-quality       | 7        | 3    | 2026-06-19   |
-| [String Construction Hygiene](patterns/string-construction-hygiene.md)                               | code-quality       | 1        | 0    | 2026-06-15   |
+| [String Construction Hygiene](patterns/string-construction-hygiene.md)                               | code-quality       | 2        | 1    | 2026-06-19   |
 | [Agent-State Guards](patterns/agent-state-guards.md)                                                 | correctness        | 3        | 2    | 2026-06-15   |
 | [React Prop Contracts](patterns/react-prop-contracts.md)                                             | react-patterns     | 5        | 4    | 2026-06-17   |
 | [Stale Retained Interactions](patterns/stale-retained-interactions.md)                               | react-patterns     | 2        | 0    | 2026-06-15   |

--- a/docs/reviews/patterns/async-global-state-mutation.md
+++ b/docs/reviews/patterns/async-global-state-mutation.md
@@ -1,0 +1,29 @@
+---
+id: async-global-state-mutation
+category: backend
+created: 2026-06-19
+last_updated: 2026-06-19
+ref_count: 0
+---
+
+# Async Global State Mutation
+
+## Summary
+
+Mutating process-wide state (environment variables, global registries, static
+configuration) around an `.await` is a concurrency hazard in async Rust: other
+Tokio tasks or background threads can observe the temporary value while the
+current task is yielded. Prefer threading hermetic values explicitly through the
+call chain so helper code stays local and deterministic, especially in E2E and
+test fixtures that need isolated homes or configs.
+
+## Findings
+
+### 1. E2E watcher helpers mutate process-wide env vars across await
+
+- **Source:** github-codex-connector | PR #563 round 1 | 2026-06-19
+- **Severity:** MEDIUM
+- **File:** `crates/backend/src/runtime/state.rs`
+- **Finding:** `e2e_start_codex_watcher` and `e2e_start_kimi_watcher` set `HOME` / `KIMI_CODE_HOME`, awaited `start_agent_watcher`, then restored the variable. In the E2E backend process, other Tokio tasks or background threads could run during that window and observe the temporary home, causing flaky watcher setup or incorrect path resolution outside the intended test helper.
+- **Fix:** Added `provider_home_override: Option<PathBuf>` to `AttachContext` and threaded it through `start_agent_watcher` / `start_agent_watcher_inner` / `SessionLifecycle::start` / `resolve_bind_inputs`. The Codex and Kimi binding arms now prefer the explicit override over registry-resolved `provider_home` (and, for Kimi, over `$KIMI_CODE_HOME`). The E2E helpers pass the hermetic home directly instead of mutating process-wide environment variables.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/cross-platform-paths.md
+++ b/docs/reviews/patterns/cross-platform-paths.md
@@ -2,8 +2,8 @@
 id: cross-platform-paths
 category: cross-platform
 created: 2026-04-09
-last_updated: 2026-06-17
-ref_count: 3
+last_updated: 2026-06-19
+ref_count: 4
 ---
 
 # Cross-Platform Paths
@@ -78,4 +78,13 @@ consider using path libraries for cross-platform code.
 - **File:** `src/features/workspace/utils/editorFileLifecycleStatus.ts` L207-210
 - **Finding:** The guard comparing `filesCwd` to `gitStatusCwd` used raw `!==`, so trailing slashes, tilde expansion, or case-only differences on case-insensitive volumes made equivalent directories look different. The function then returned `null`, silently disabling the `NEW`/`DELETED` lifecycle crumb for the selected editor file even though the file was inside the reported git status directory.
 - **Fix:** Reuse the shared `normalizePathForComparison` helper (which expands `~`, normalizes separators, strips trailing slashes, and lowercases on macOS/Windows) before comparing both cwd values.
+
+### 8. Workspace bucket basename could exceed filesystem component limits
+
+- **Source:** github-codex-connector | PR #563 cycle 1 | 2026-06-19
+- **Severity:** P2 / MEDIUM
+- **File:** `crates/backend/src/terminal/bridge.rs` L84 (original)
+- **Finding:** `workspace_bridge_bucket` constructed an app-data directory component from the sanitized cwd basename plus a `_<sha256>` suffix. When the project directory name was long but still a valid filename, the combined component exceeded common filesystems' 255-byte component limit, causing `create_dir_all` to fail and leaving the session without a generated bridge.
+- **Fix:** Truncate the sanitized basename to `MAX_BUCKET_BASENAME_BYTES = 242` bytes (leaving room for the underscore, 6-hex hash, and margin) before appending the hash suffix. The resulting component stays well under 255 bytes even on conservative filesystems.
+- **Commit:** same commit as this entry
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/dead-code.md
+++ b/docs/reviews/patterns/dead-code.md
@@ -3,7 +3,7 @@ id: dead-code
 category: code-quality
 created: 2026-06-13
 last_updated: 2026-06-19
-ref_count: 1
+ref_count: 2
 ---
 
 # Dead Code
@@ -51,4 +51,13 @@ code and should be removed.
 - **File:** `src/features/terminal/components/SplitView/SplitView.tsx`
 - **Finding:** The helper returned `p${slotIndex}` when the index was outside `definition.slots.length`, but every caller is already bounded by `layout.capacity`, which equals `definition.slots.length`. The fallback was unreachable and, once custom non-`p{N}` slot ids are wired, would silently place a pane outside the generated CSS grid.
 - **Fix:** Replaced the silent fallback with an explicit out-of-bounds error so any future capacity/slot bookkeeping divergence fails loudly instead of dropping a pane.
+- **Commit:** same commit as this entry
+
+### 5. `emitAgentStatus` helper and payload factory are dead code in E2E spec
+
+- **Source:** github-claude | PR #563 round 3 | 2026-06-19
+- **Severity:** LOW
+- **File:** `tests/e2e/agent/specs/agent-runtime-regressions.spec.ts`
+- **Finding:** The `emitAgentStatus` function called `invokeBackend('e2e_emit_agent_status', ...)` but had no call sites in the spec. The `AgentStatusPayload` interface and `createAgentStatusPayload` factory existed only to support it. The dead code implied coverage for a direct-emit status scenario that did not exist.
+- **Fix:** Removed the unused `emitAgentStatus` helper, `AgentStatusPayload` interface, and `createAgentStatusPayload` factory from the spec.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/e2e-testing.md
+++ b/docs/reviews/patterns/e2e-testing.md
@@ -3,7 +3,7 @@ id: e2e-testing
 category: e2e-testing
 created: 2026-04-19
 last_updated: 2026-06-19
-ref_count: 9
+ref_count: 10
 ---
 
 # E2E Testing
@@ -244,4 +244,22 @@ completely different root causes. The generic fast-failure modes:
 - **File:** `electron/backend-methods.ts`, `electron/backend-methods.test.ts`
 - **Finding:** The Rust IPC router adds `e2e_start_codex_watcher` and `e2e_start_kimi_watcher`, and `tests/e2e/agent/specs/agent-runtime-regressions.spec.ts` calls both via `window.__VIMEFLOW_E2E__.invokeBackend`. `electron/backend-methods.ts` only allows `list_active_pty_sessions`, `e2e_agent_bridge_info`, and `e2e_seed_live_agent` when `allowE2eMethods` is enabled, so the preload gate rejects both calls.
 - **Fix:** Added `e2e_start_codex_watcher` and `e2e_start_kimi_watcher` to `e2eBackendMethods` in `electron/backend-methods.ts` and covered them in `electron/backend-methods.test.ts` for default denial and explicit E2E enablement.
+- **Commit:** same commit as this entry
+
+### 23. e2e_emit_agent_status missing from Electron preload allowlist
+
+- **Source:** github-claude | PR #563 round 3 | 2026-06-19
+- **Severity:** HIGH
+- **File:** `electron/backend-methods.ts`, `electron/backend-methods.test.ts`
+- **Finding:** The Rust IPC router added `e2e_emit_agent_status` behind `#[cfg(feature = "e2e-test")]`, and the new E2E spec defined a helper that called `invokeBackend('e2e_emit_agent_status', ...)`. The PR extended `e2eBackendMethods` for four other new E2E probe methods but omitted `e2e_emit_agent_status`, so the Electron main process would reject the call with "Method not allowed" before it reached Rust.
+- **Fix:** Added `e2e_emit_agent_status` to `e2eBackendMethods` and covered it in both the default-denial test and the `allowE2eMethods` `test.each` block in `electron/backend-methods.test.ts`.
+- **Commit:** same commit as this entry
+
+### 24. Watcher E2E test assumes ambient PTY has agent bridge enabled
+
+- **Source:** github-claude | PR #563 round 3 | 2026-06-19
+- **Severity:** MEDIUM
+- **File:** `tests/e2e/agent/specs/agent-runtime-regressions.spec.ts`
+- **Finding:** The "ingests app-data status files" scenario called `waitForVisiblePtyId()` to reuse the app's initial terminal PTY, then asserted `info.statusFile` was populated. `statusFile` is only non-null when the PTY was spawned with `enable_agent_bridge: true`. The assertion therefore depended on the E2E launch configuration rather than the test itself, and a violation would fail with a confusing "statusFile should be populated" message.
+- **Fix:** Replaced the ambient-PTY reuse with a frontend-driven new session (`button[aria-label="New session"]`), waited for the visible PTY to change, and used that dedicated bridge-enabled session for the watcher/UI assertions. Added cleanup that closes the spawned tab after the scenario.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/e2e-testing.md
+++ b/docs/reviews/patterns/e2e-testing.md
@@ -2,8 +2,8 @@
 id: e2e-testing
 category: e2e-testing
 created: 2026-04-19
-last_updated: 2026-06-15
-ref_count: 8
+last_updated: 2026-06-19
+ref_count: 9
 ---
 
 # E2E Testing
@@ -227,3 +227,12 @@ completely different root causes. The generic fast-failure modes:
 - **Finding:** The core WDIO config keeps Mocha's per-test timeout at 30s, but the browser overlay spec can legitimately spend more than that across sequential helper waits: 20s for the terminal, 10s for the split slot, 15s for the browser pane, 15s for CDP registration, plus the command-palette and bounds-capture waits. On a cold CI run Mocha aborted the test with a generic timeout even though the helper-specific budgets were still in progress, hiding the real bottleneck.
 - **Fix:** Chained `.timeout(60_000)` on the `it(…)` call — the Mocha `Runnable.prototype.timeout()` API — in the browser overlay spec, giving the sequential waits enough headroom while leaving the project-wide 30s default in place for faster specs. This keeps the timeout local to the one spec that needs it.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 21. Codex/Kimi E2E status tests bypassed the real watcher pipeline
+
+- **Source:** github-claude + local-codex verify | PR #563 cycle 1 | 2026-06-19
+- **Severity:** LOW
+- **File:** `tests/e2e/agent/specs/agent-runtime-regressions.spec.ts` L225-240 (original), plus new backend E2E helpers
+- **Finding:** The Claude status test wrote a real `status.json`, started the real file watcher, and waited for the sidebar to update. The Codex/Kimi equivalent injected `agent-status`/`agent-turn` events directly through the renderer E2E bridge, testing React rendering but not the Rust-to-frontend event pipeline or the agent-specific filesystem/watcher paths.
+- **Fix:** Added backend E2E helpers `e2e_start_codex_watcher` and `e2e_start_kimi_watcher` that seed a hermetic agent home (`~/.codex` or `KIMI_CODE_HOME`), create the locator-recognizable session directories and metadata, start the real agent watcher, restore the original env, and return the fixture path for the test to write. The spec now exercises real watcher ingestion for both Codex and Kimi before emitting agent-turn events.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/e2e-testing.md
+++ b/docs/reviews/patterns/e2e-testing.md
@@ -236,3 +236,12 @@ completely different root causes. The generic fast-failure modes:
 - **Finding:** The Claude status test wrote a real `status.json`, started the real file watcher, and waited for the sidebar to update. The Codex/Kimi equivalent injected `agent-status`/`agent-turn` events directly through the renderer E2E bridge, testing React rendering but not the Rust-to-frontend event pipeline or the agent-specific filesystem/watcher paths.
 - **Fix:** Added backend E2E helpers `e2e_start_codex_watcher` and `e2e_start_kimi_watcher` that seed a hermetic agent home (`~/.codex` or `KIMI_CODE_HOME`), create the locator-recognizable session directories and metadata, start the real agent watcher, restore the original env, and return the fixture path for the test to write. The spec now exercises real watcher ingestion for both Codex and Kimi before emitting agent-turn events.
 - **Commit:** same commit as this entry
+
+### 22. e2e_start_codex/kimi_watcher missing from Electron preload allowlist
+
+- **Source:** github-claude | PR #563 round 2 | 2026-06-19
+- **Severity:** HIGH
+- **File:** `electron/backend-methods.ts`, `electron/backend-methods.test.ts`
+- **Finding:** The Rust IPC router adds `e2e_start_codex_watcher` and `e2e_start_kimi_watcher`, and `tests/e2e/agent/specs/agent-runtime-regressions.spec.ts` calls both via `window.__VIMEFLOW_E2E__.invokeBackend`. `electron/backend-methods.ts` only allows `list_active_pty_sessions`, `e2e_agent_bridge_info`, and `e2e_seed_live_agent` when `allowE2eMethods` is enabled, so the preload gate rejects both calls.
+- **Fix:** Added `e2e_start_codex_watcher` and `e2e_start_kimi_watcher` to `e2eBackendMethods` in `electron/backend-methods.ts` and covered them in `electron/backend-methods.test.ts` for default denial and explicit E2E enablement.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/generated-shell-scripts.md
+++ b/docs/reviews/patterns/generated-shell-scripts.md
@@ -2,8 +2,8 @@
 id: generated-shell-scripts
 category: backend
 created: 2026-06-02
-last_updated: 2026-06-03
-ref_count: 1
+last_updated: 2026-06-19
+ref_count: 2
 ---
 
 # Generated Shell Scripts
@@ -82,4 +82,13 @@ end to avoid leaking ephemeral artifacts.
 - **File:** `crates/backend/src/terminal/bridge.rs`
 - **Finding:** The PATH reconstruction in the generated `init.sh` converted colons to newlines, filtered the shim dir, converted back, then stripped the trailing colon with `${new_path%:}`. A trailing colon in the original PATH (the POSIX convention for appending `.`) was indistinguishable from the sentinel the final `tr '\n' ':'` added. After `${new_path%:}`, the user's intentional trailing colon was removed and never restored, so `export PATH="$VIMEFLOW_CLAUDE_SHIM_DIR${new_path:+:$new_path}"` omitted the `.` entry.
 - **Fix:** Capture whether PATH ends with `:` before transformation (`case "$PATH" in *:) path_ends_colon=1 ;; esac`), then restore it after stripping the sentinel colon (`[ -n "$path_ends_colon" ] && new_path="${new_path}:"`).
+- **Commit:** same commit as this entry
+
+### 8. Generated Claude `settings.json` command path was not shell-quoted
+
+- **Source:** github-codex-connector | PR #563 cycle 1 | 2026-06-19
+- **Severity:** P1 / HIGH
+- **File:** `crates/backend/src/terminal/bridge.rs` L178 (original)
+- **Finding:** After moving bridge files under app data, macOS sessions placed the statusline script under `Application Support/.../statusline.sh`. `generate_bridge_files` wrote the raw `script_path` into Claude's `statusLine.command`, which Claude runs in a shell. The unquoted path split on the space, so the statusline script never executed and agent status stayed inactive on macOS.
+- **Fix:** Added a `shell_quote_path` helper that wraps paths containing non-shell-safe characters in single quotes (with embedded single-quote handling) and used it when serializing `statusLine.command` in the generated `settings.json`.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/persisted-state-invariants.md
+++ b/docs/reviews/patterns/persisted-state-invariants.md
@@ -3,7 +3,7 @@ id: persisted-state-invariants
 category: correctness
 created: 2026-06-08
 last_updated: 2026-06-19
-ref_count: 4
+ref_count: 5
 ---
 
 # Persisted State Invariants
@@ -102,4 +102,13 @@ Durable user-facing state (workspace shapes, caches, settings files) can be malf
 - **File:** `src/features/terminal/layout-registry/layoutDefinition.ts`
 - **Finding:** `gridAreaNameForSlotId` replaces non-alphanumeric characters with `-`, so distinct ids such as `slot:a b` and `slot:a-b` map to the same CSS grid-area name. A persisted custom layout passing validation could therefore place multiple panes in one grid area, causing overlap or an invalid grid template at runtime.
 - **Fix:** Added `duplicate-grid-area` validation in `validateSlots` that rejects layouts whose sanitized slot ids produce colliding grid-area names.
+- **Commit:** same commit as this entry
+
+### 11. `SessionCache` derived `app_data_dir` implicitly from its cache-file parent
+
+- **Source:** github-claude | PR #563 cycle 1 | 2026-06-19
+- **Severity:** MEDIUM
+- **File:** `crates/backend/src/terminal/cache.rs` L87-89 (original)
+- **Finding:** `SessionCache::app_data_dir()` derived the Vimeflow data root by calling `.parent()` on `self.path` (`sessions.json`). The invariant that the cache file is always a direct child of `app_data_dir` was established by convention in `BackendState::new` and not enforced by the type system. Moving the cache path (e.g., `db/sessions.json`) would silently write bridge/status files under the wrong parent with no compile-time or runtime warning.
+- **Fix:** Stored `app_data_dir: PathBuf` explicitly in `SessionCache`, initialized it in `SessionCache::new`/`with_path`, and added `BackendState::with_app_data_dir` so the root is pinned once at construction rather than inferred from the cache path. `spawn_pty_inner` now uses the explicit field instead of `cache.app_data_dir()`.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/string-construction-hygiene.md
+++ b/docs/reviews/patterns/string-construction-hygiene.md
@@ -2,22 +2,20 @@
 id: string-construction-hygiene
 category: code-quality
 created: 2026-06-15
-last_updated: 2026-06-15
-ref_count: 0
+last_updated: 2026-06-19
+ref_count: 1
 ---
 
 # String Construction Hygiene
 
 ## Summary
 
-When building structured strings (SVG path commands, query fragments, log lines,
-etc.) by accumulating values in a loop, the accumulator often carries a trailing
-separator or whitespace. Interpolating that accumulator into a larger template
-without trimming or using a join-based approach produces doubled delimiters,
-trailing spaces, or malformed commands. The defect is usually silent because the
-consumer (SVG parser, shell, template engine) tolerates the extra whitespace,
-but it makes the output inconsistent and can mask real formatting bugs. Prefer
-`Array.join` for separators, or trim the accumulator before interpolation.
+When building structured strings (JSON records, SVG path commands, query fragments, log lines,
+etc.), prefer a proper serializer or join/trim utilities over manual interpolation. Manual
+templating forgets escaping (quotes, backslashes, delimiters), leaves trailing separators or
+whitespace, and produces malformed output that consumers often swallow silently. For JSON and
+similar formats, always use a serialization library; for delimited lists, use `Array.join` or
+trim the accumulator before interpolation.
 
 ## Findings
 
@@ -28,4 +26,13 @@ but it makes the output inconsistent and can mask real formatting bugs. Prefer
 - **File:** `src/features/agent-status/hooks/useReservoirFlow.ts`
 - **Finding:** `buildReservoirSurface` built `fill` by interpolating the raw `crest` accumulator (`fill: \`${crest}L ${TANK_WIDTH} ${height} L 0 ${height} Z\``). The loop appended a trailing space after each point, leaving a double space before the closing commands. SVG parsers tolerate the extra whitespace, but the returned `fill`was inconsistent with the already-trimmed`crest`.
 - **Fix:** Trimmed the accumulator before interpolation: `fill: \`${crest.trim()} L ${TANK_WIDTH} ${height} L 0 ${height} Z\``.
+- **Commit:** same commit as this entry
+
+### 2. Kimi E2E `session_index.jsonl` built with manual JSON interpolation
+
+- **Source:** github-claude | PR #563 round 7 | 2026-06-19
+- **Severity:** MEDIUM
+- **File:** `crates/backend/src/runtime/state.rs`
+- **Finding:** `e2e_start_kimi_watcher` wrote `session_index.jsonl` with `format!("{{\"sessionId\":\"{}\",\"sessionDir\":\"{}\",\"workDir\":\"{}\"}}\n", ...)`. If the working directory contained `"` or `\\`, the JSONL line became malformed and the Kimi locator silently failed to resolve the seeded wire file.
+- **Fix:** Replaced manual interpolation with `serde_json::json!({"sessionId": session_dir_name, "sessionDir": ..., "workDir": cwd}).to_string()` followed by a newline.
 - **Commit:** same commit as this entry

--- a/electron/backend-methods.test.ts
+++ b/electron/backend-methods.test.ts
@@ -45,13 +45,15 @@ describe('isAllowedBackendMethod', () => {
 
   test('rejects e2e-only methods by default', () => {
     expect(isAllowedBackendMethod('list_active_pty_sessions')).toBe(false)
+    expect(isAllowedBackendMethod('e2e_agent_bridge_info')).toBe(false)
+    expect(isAllowedBackendMethod('e2e_seed_live_agent')).toBe(false)
   })
 
-  test('allows e2e-only methods when explicitly enabled', () => {
-    expect(
-      isAllowedBackendMethod('list_active_pty_sessions', {
-        allowE2eMethods: true,
-      })
-    ).toBe(true)
+  test.each([
+    'list_active_pty_sessions',
+    'e2e_agent_bridge_info',
+    'e2e_seed_live_agent',
+  ])('allows e2e-only method %s when explicitly enabled', (method) => {
+    expect(isAllowedBackendMethod(method, { allowE2eMethods: true })).toBe(true)
   })
 })

--- a/electron/backend-methods.test.ts
+++ b/electron/backend-methods.test.ts
@@ -47,12 +47,16 @@ describe('isAllowedBackendMethod', () => {
     expect(isAllowedBackendMethod('list_active_pty_sessions')).toBe(false)
     expect(isAllowedBackendMethod('e2e_agent_bridge_info')).toBe(false)
     expect(isAllowedBackendMethod('e2e_seed_live_agent')).toBe(false)
+    expect(isAllowedBackendMethod('e2e_start_codex_watcher')).toBe(false)
+    expect(isAllowedBackendMethod('e2e_start_kimi_watcher')).toBe(false)
   })
 
   test.each([
     'list_active_pty_sessions',
     'e2e_agent_bridge_info',
     'e2e_seed_live_agent',
+    'e2e_start_codex_watcher',
+    'e2e_start_kimi_watcher',
   ])('allows e2e-only method %s when explicitly enabled', (method) => {
     expect(isAllowedBackendMethod(method, { allowE2eMethods: true })).toBe(true)
   })

--- a/electron/backend-methods.test.ts
+++ b/electron/backend-methods.test.ts
@@ -49,6 +49,7 @@ describe('isAllowedBackendMethod', () => {
     expect(isAllowedBackendMethod('e2e_seed_live_agent')).toBe(false)
     expect(isAllowedBackendMethod('e2e_start_codex_watcher')).toBe(false)
     expect(isAllowedBackendMethod('e2e_start_kimi_watcher')).toBe(false)
+    expect(isAllowedBackendMethod('e2e_emit_agent_status')).toBe(false)
   })
 
   test.each([
@@ -57,6 +58,7 @@ describe('isAllowedBackendMethod', () => {
     'e2e_seed_live_agent',
     'e2e_start_codex_watcher',
     'e2e_start_kimi_watcher',
+    'e2e_emit_agent_status',
   ])('allows e2e-only method %s when explicitly enabled', (method) => {
     expect(isAllowedBackendMethod(method, { allowE2eMethods: true })).toBe(true)
   })

--- a/electron/backend-methods.ts
+++ b/electron/backend-methods.ts
@@ -37,7 +37,11 @@ const backendMethods = new Set([
   'discard_file',
 ])
 
-const e2eBackendMethods = new Set(['list_active_pty_sessions'])
+const e2eBackendMethods = new Set([
+  'list_active_pty_sessions',
+  'e2e_agent_bridge_info',
+  'e2e_seed_live_agent',
+])
 
 interface BackendMethodOptions {
   allowE2eMethods?: boolean

--- a/electron/backend-methods.ts
+++ b/electron/backend-methods.ts
@@ -43,6 +43,7 @@ const e2eBackendMethods = new Set([
   'e2e_seed_live_agent',
   'e2e_start_codex_watcher',
   'e2e_start_kimi_watcher',
+  'e2e_emit_agent_status',
 ])
 
 interface BackendMethodOptions {

--- a/electron/backend-methods.ts
+++ b/electron/backend-methods.ts
@@ -41,6 +41,8 @@ const e2eBackendMethods = new Set([
   'list_active_pty_sessions',
   'e2e_agent_bridge_info',
   'e2e_seed_live_agent',
+  'e2e_start_codex_watcher',
+  'e2e_start_kimi_watcher',
 ])
 
 interface BackendMethodOptions {

--- a/src/features/browser/components/BrowserPane.test.tsx
+++ b/src/features/browser/components/BrowserPane.test.tsx
@@ -306,6 +306,7 @@ describe('BrowserPane', () => {
     let frameCallback: FrameRequestCallback | null = null
     let nextFrameId = 1
     let intervalCallback: (() => void) | null = null
+    let intervalId: number | undefined
     let intervalCleared = false
 
     const disconnectSpy = vi
@@ -324,24 +325,42 @@ describe('BrowserPane', () => {
       .spyOn(window, 'cancelAnimationFrame')
       .mockImplementation(() => undefined)
 
+    const originalSetInterval = window.setInterval
+
     const setIntervalSpy = vi
       .spyOn(window, 'setInterval')
       .mockImplementation(
-        (handler: unknown): ReturnType<typeof window.setInterval> => {
-          if (typeof handler === 'function') {
+        (
+          handler: unknown,
+          delay?: number,
+          ...rest: unknown[]
+        ): number => {
+          const id = originalSetInterval(
+            handler as TimerHandler,
+            delay,
+            ...rest
+          )
+          // Capture only the post-idle polling interval (250 ms) used by the
+          // pane; let other intervals (e.g. waitFor polling) delegate to the
+          // real timer so earlier waitFor calls can retry.
+          if (delay === 250 && typeof handler === 'function') {
             intervalCallback = handler as () => void
+            intervalId = id
           }
 
-          return 123 as unknown as ReturnType<typeof window.setInterval>
+          return id
         }
       )
+
+    const originalClearInterval = window.clearInterval
 
     const clearIntervalSpy = vi
       .spyOn(window, 'clearInterval')
       .mockImplementation((id: unknown): void => {
-        if (id === 123) {
+        if (id === intervalId) {
           intervalCleared = true
         }
+        originalClearInterval(id as number)
       })
 
     try {

--- a/src/features/browser/components/BrowserPane.test.tsx
+++ b/src/features/browser/components/BrowserPane.test.tsx
@@ -306,7 +306,7 @@ describe('BrowserPane', () => {
     let frameCallback: FrameRequestCallback | null = null
     let nextFrameId = 1
     let intervalCallback: (() => void) | null = null
-    let intervalId: number | undefined
+    let intervalId: ReturnType<typeof window.setInterval> | undefined
     let intervalCleared = false
 
     const disconnectSpy = vi
@@ -334,12 +334,12 @@ describe('BrowserPane', () => {
           handler: unknown,
           delay?: number,
           ...rest: unknown[]
-        ): number => {
+        ): ReturnType<typeof window.setInterval> => {
           const id = originalSetInterval(
             handler as TimerHandler,
             delay,
             ...rest
-          )
+          ) as unknown as ReturnType<typeof window.setInterval>
           // Capture only the post-idle polling interval (250 ms) used by the
           // pane; let other intervals (e.g. waitFor polling) delegate to the
           // real timer so earlier waitFor calls can retry.
@@ -360,7 +360,7 @@ describe('BrowserPane', () => {
         if (id === intervalId) {
           intervalCleared = true
         }
-        originalClearInterval(id as number)
+        originalClearInterval(id as ReturnType<typeof window.setInterval>)
       })
 
     try {

--- a/src/lib/backend.ts
+++ b/src/lib/backend.ts
@@ -76,6 +76,13 @@ export const __resetBackendEventSubscriptions = (): void => {
   backendEventSubscriptions.clear()
 }
 
+export const __dispatchBackendEventForE2e = (
+  event: string,
+  payload: unknown
+): void => {
+  dispatchBackendEvent(event, payload)
+}
+
 const requireBridge = (): BackendApi => {
   if (typeof window === 'undefined' || !window.vimeflow) {
     throw new Error(

--- a/src/lib/e2e-bridge.ts
+++ b/src/lib/e2e-bridge.ts
@@ -140,6 +140,7 @@ const getVisiblePtyId = (): string | null => {
   const focusedWrapper = pane.querySelector<HTMLElement>(
     '[data-testid="terminal-pane-wrapper"][data-focused="true"]'
   )
+
   const focusedSlot = focusedWrapper?.closest<HTMLElement>(
     '[data-testid="split-view-slot"][data-pty-id]'
   )

--- a/src/lib/e2e-bridge.ts
+++ b/src/lib/e2e-bridge.ts
@@ -1,5 +1,5 @@
 import type { Terminal } from '@xterm/xterm'
-import { invoke } from './backend'
+import { __dispatchBackendEventForE2e, invoke } from './backend'
 import { getAllPtySessionIds } from '../features/terminal/ptySessionMap'
 import { terminalCache } from '../features/terminal/components/TerminalPane/Body'
 import {
@@ -131,12 +131,48 @@ const getVisibleSessionId = (): string | null => {
   return pane?.dataset.sessionId ?? null
 }
 
+const getVisiblePtyId = (): string | null => {
+  const pane = findActivePane()
+  if (!pane) {
+    return null
+  }
+
+  const focusedWrapper = pane.querySelector<HTMLElement>(
+    '[data-testid="terminal-pane-wrapper"][data-focused="true"]'
+  )
+  const focusedSlot = focusedWrapper?.closest<HTMLElement>(
+    '[data-testid="split-view-slot"][data-pty-id]'
+  )
+  if (focusedSlot?.dataset.ptyId) {
+    return focusedSlot.dataset.ptyId
+  }
+
+  const firstSlot = pane.querySelector<HTMLElement>(
+    '[data-testid="split-view-slot"][data-pty-id]'
+  )
+  if (firstSlot?.dataset.ptyId) {
+    return firstSlot.dataset.ptyId
+  }
+
+  const bodyContainer = pane.querySelector<HTMLElement>(
+    '[data-testid="terminal-pane"][data-pty-id]'
+  )
+
+  return bodyContainer?.dataset.ptyId ?? null
+}
+
 if (import.meta.env.VITE_E2E) {
   window.__VIMEFLOW_E2E__ = {
     getTerminalBuffer: readVisibleTerminalBuffer,
     getTerminalBufferForSession: readTerminalBufferForSession,
     getVisibleSessionId,
+    getVisiblePtyId,
     getActiveSessionIds: getAllPtySessionIds,
+    invokeBackend: async <T>(
+      method: string,
+      args?: Record<string, unknown>
+    ): Promise<T> => invoke<T>(method, args),
+    emitBackendEvent: __dispatchBackendEventForE2e,
     listActivePtySessions: async (): Promise<string[]> =>
       invoke<string[]>('list_active_pty_sessions'),
     startBrowserPaneBoundsCapture,

--- a/src/types/e2e.d.ts
+++ b/src/types/e2e.d.ts
@@ -10,7 +10,13 @@ declare global {
       getTerminalBuffer(): string
       getTerminalBufferForSession(sessionId: string): string
       getVisibleSessionId(): string | null
+      getVisiblePtyId(): string | null
       getActiveSessionIds(): string[]
+      invokeBackend<T>(
+        method: string,
+        args?: Record<string, unknown>
+      ): Promise<T>
+      emitBackendEvent(event: string, payload: unknown): void
       listActivePtySessions(): Promise<string[]>
       startBrowserPaneBoundsCapture(): boolean
       clearBrowserPaneBoundsCaptures(): void

--- a/tests/e2e/agent/specs/agent-runtime-regressions.spec.ts
+++ b/tests/e2e/agent/specs/agent-runtime-regressions.spec.ts
@@ -1,0 +1,420 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  pressEnterInActiveTerminal,
+  typeInActiveTerminal,
+} from '../../shared/terminal.js'
+
+type E2eAgentType = 'claudeCode' | 'codex' | 'kimi' | 'aider' | 'generic'
+
+interface E2eAgentBridgeInfo {
+  sessionId: string
+  cwd: string
+  appDataDir: string
+  bridgeDir: string | null
+  statusFile: string | null
+  shimDir: string | null
+  agentType: E2eAgentType | null
+}
+
+const waitForE2eBridge = async (): Promise<void> => {
+  await browser
+    .waitUntil(
+      async () =>
+        await browser.execute(
+          () => typeof window.__VIMEFLOW_E2E__ !== 'undefined'
+        ),
+      { timeout: 20_000, interval: 250 }
+    )
+    .catch(() => {
+      throw new Error(
+        'window.__VIMEFLOW_E2E__ missing — rebuild with VITE_E2E=1'
+      )
+    })
+}
+
+const waitForVisiblePtyId = async (): Promise<string> => {
+  let lastValue: string | null = null
+  await browser.waitUntil(
+    async () => {
+      lastValue = await browser.execute(
+        () => window.__VIMEFLOW_E2E__?.getVisiblePtyId() ?? null
+      )
+
+      return lastValue !== null
+    },
+    {
+      timeout: 20_000,
+      interval: 250,
+      timeoutMsg: 'visible PTY id never resolved',
+    }
+  )
+
+  assert.ok(lastValue)
+
+  return lastValue
+}
+
+const invokeBackend = async <T>(
+  method: string,
+  args?: Record<string, unknown>
+): Promise<T> =>
+  await browser.execute(
+    async (backendMethod: string, backendArgs?: Record<string, unknown>) =>
+      await window.__VIMEFLOW_E2E__!.invokeBackend<T>(
+        backendMethod,
+        backendArgs
+      ),
+    method,
+    args
+  )
+
+const seedClaudeAgent = async (ptyId: string): Promise<void> => {
+  await invokeBackend<null>('e2e_seed_live_agent', {
+    sessionId: ptyId,
+    agentType: 'claudeCode',
+  })
+}
+
+const createClaudeStatusline = (): string => {
+  const reset = Math.floor(Date.now() / 1000) + 3600
+
+  return JSON.stringify({
+    session_id: 'e2e-agent-session',
+    version: 'e2e',
+    model: {
+      id: 'claude-sonnet-4-5',
+      display_name: 'Claude Sonnet 4.5',
+    },
+    context_window: {
+      used_percentage: 42,
+      remaining_percentage: 58,
+      context_window_size: 200_000,
+      total_input_tokens: 80_000,
+      total_output_tokens: 4_000,
+      current_usage: {
+        input_tokens: 1200,
+        output_tokens: 300,
+        cache_creation_input_tokens: 200,
+        cache_read_input_tokens: 700,
+      },
+    },
+    cost: {
+      total_cost_usd: 1.23,
+      total_duration_ms: 120_000,
+      total_api_duration_ms: 90_000,
+      total_lines_added: 12,
+      total_lines_removed: 3,
+    },
+    rate_limits: {
+      five_hour: {
+        used_percentage: 17,
+        resets_at: reset,
+      },
+      seven_day: {
+        used_percentage: 23,
+        resets_at: reset + 86_400,
+      },
+    },
+  })
+}
+
+const emitAgentTurn = async (
+  sessionId: string,
+  turns: number
+): Promise<void> => {
+  await browser.execute(
+    (ptyId: string, numTurns: number) => {
+      window.__VIMEFLOW_E2E__?.emitBackendEvent('agent-turn', {
+        sessionId: ptyId,
+        numTurns,
+      })
+    },
+    sessionId,
+    turns
+  )
+}
+
+const textForSelector = async (selector: string): Promise<string> =>
+  await browser.execute((target: string) => {
+    const el = document.querySelector<HTMLElement>(target)
+
+    return el?.textContent ?? ''
+  }, selector)
+
+const bufferHasExactLine = (buffer: string, expected: string): boolean =>
+  buffer
+    .replaceAll('\r', '\n')
+    .split('\n')
+    .some((line) => line.trim() === expected)
+
+describe('Agent runtime regressions', () => {
+  before(async () => {
+    await waitForE2eBridge()
+    await (
+      await $('[data-testid="terminal-pane"]')
+    ).waitForDisplayed({
+      timeout: 20_000,
+    })
+  })
+
+  it('stores bridge files under app data and leaves project .vimeflow absent', async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'vimeflow-e2e-'))
+    const projectDir = path.join(tempRoot, 'Project With Spaces & Symbols')
+    fs.mkdirSync(projectDir)
+    const sessionId = `e2e_bridge_${Date.now()}`
+    let bridgeDir: string | null = null
+    let shimDir: string | null = null
+
+    try {
+      await invokeBackend('spawn_pty', {
+        request: {
+          sessionId,
+          cwd: projectDir,
+          shell: null,
+          env: null,
+          enableAgentBridge: true,
+          ephemeral: false,
+        },
+      })
+
+      const info = await invokeBackend<E2eAgentBridgeInfo>(
+        'e2e_agent_bridge_info',
+        { sessionId }
+      )
+      bridgeDir = info.bridgeDir
+      shimDir = info.shimDir
+
+      assert.equal(info.cwd, fs.realpathSync(projectDir))
+      assert.ok(info.bridgeDir, 'bridgeDir should be populated')
+      assert.ok(info.statusFile, 'statusFile should be populated')
+      assert.ok(info.shimDir, 'shimDir should be populated')
+
+      const bridgeRelativeToAppData = path.relative(
+        info.appDataDir,
+        info.bridgeDir
+      )
+      assert.ok(
+        bridgeRelativeToAppData.length > 0 &&
+          !bridgeRelativeToAppData.startsWith('..') &&
+          !path.isAbsolute(bridgeRelativeToAppData),
+        `bridge dir should live inside app data: ${info.bridgeDir}`
+      )
+      assert.equal(path.dirname(info.statusFile), info.bridgeDir)
+      assert.equal(
+        info.bridgeDir.split(path.sep).includes('.vimeflow'),
+        false,
+        `bridge dir must not use a .vimeflow path component: ${info.bridgeDir}`
+      )
+      assert.ok(
+        info.bridgeDir.split(path.sep).includes('runtime'),
+        `bridge dir should use the app-data runtime bucket: ${info.bridgeDir}`
+      )
+      assert.ok(
+        info.bridgeDir.split(path.sep).includes('workspaces'),
+        `bridge dir should include a workspace bucket: ${info.bridgeDir}`
+      )
+      assert.equal(fs.existsSync(path.join(projectDir, '.vimeflow')), false)
+
+      await invokeBackend('write_pty', {
+        request: {
+          sessionId,
+          data: 'printf vimeflow_bridge_e2e > "$VIMEFLOW_STATUS_FILE"\n',
+        },
+      })
+
+      await browser.waitUntil(
+        () =>
+          fs.existsSync(info.statusFile!) &&
+          fs.readFileSync(info.statusFile!, 'utf8') === 'vimeflow_bridge_e2e',
+        {
+          timeout: 10_000,
+          interval: 250,
+          timeoutMsg:
+            'spawned shell did not write through VIMEFLOW_STATUS_FILE',
+        }
+      )
+      assert.equal(fs.existsSync(path.join(projectDir, '.vimeflow')), false)
+    } finally {
+      await invokeBackend('kill_pty', {
+        request: {
+          sessionId,
+        },
+      }).catch(() => undefined)
+      fs.rmSync(tempRoot, { recursive: true, force: true })
+    }
+
+    if (bridgeDir) {
+      await browser.waitUntil(() => !fs.existsSync(bridgeDir), {
+        timeout: 10_000,
+        interval: 250,
+        timeoutMsg: `bridge dir was not cleaned up: ${bridgeDir}`,
+      })
+    }
+    if (shimDir) {
+      await browser.waitUntil(() => !fs.existsSync(shimDir), {
+        timeout: 10_000,
+        interval: 250,
+        timeoutMsg: `shim dir was not cleaned up: ${shimDir}`,
+      })
+    }
+  })
+
+  it('ingests app-data status files through the watcher into the sidebar card and status panel', async () => {
+    const ptyId = await waitForVisiblePtyId()
+    await seedClaudeAgent(ptyId)
+    const cardSelector = '[data-testid="sidebar-agent-status-card"]'
+
+    await invokeBackend<null>('start_agent_watcher', { sessionId: ptyId })
+    const info = await invokeBackend<E2eAgentBridgeInfo>(
+      'e2e_agent_bridge_info',
+      { sessionId: ptyId }
+    )
+
+    assert.equal(info.agentType, 'claudeCode')
+    assert.ok(info.statusFile, 'statusFile should be populated')
+    assert.ok(
+      path
+        .relative(info.appDataDir, info.statusFile)
+        .split(path.sep)
+        .includes('runtime'),
+      `status file should live under the app-data runtime bucket: ${info.statusFile}`
+    )
+
+    fs.mkdirSync(path.dirname(info.statusFile), { recursive: true })
+    fs.writeFileSync(info.statusFile, createClaudeStatusline(), 'utf8')
+    await emitAgentTurn(ptyId, 4)
+
+    await browser.waitUntil(
+      async () => {
+        const cardText = await textForSelector(cardSelector)
+
+        return (
+          cardText.includes('Claude Sonnet 4.5') &&
+          cardText.includes('4 turns') &&
+          !cardText.includes('No active agent')
+        )
+      },
+      {
+        timeout: 15_000,
+        interval: 500,
+        timeoutMsg:
+          'sidebar agent status card did not render watcher-ingested metrics',
+      }
+    )
+
+    const panel = await $('[data-testid="agent-status-panel"]')
+    await panel.waitForDisplayed({ timeout: 10_000 })
+    await (
+      await $('[data-testid="agent-status-panel-body-content"]')
+    ).waitForDisplayed({ timeout: 10_000 })
+
+    const cardText = await textForSelector(cardSelector)
+    assert.equal(cardText.includes('No active agent'), false)
+  })
+
+  it('renames the active agent terminal and writes /rename into the PTY', async () => {
+    const ptyId = await waitForVisiblePtyId()
+    const title = `e2e-renamed-${Date.now()}`
+    await seedClaudeAgent(ptyId)
+
+    await invokeBackend<null>('rename_agent_session', { ptyId, title })
+
+    await browser.waitUntil(
+      async () => {
+        const buffer = await browser.execute(
+          (sessionId: string) =>
+            window.__VIMEFLOW_E2E__?.getTerminalBufferForSession(sessionId) ??
+            '',
+          ptyId
+        )
+
+        return buffer.includes(`/rename ${title}`)
+      },
+      {
+        timeout: 10_000,
+        interval: 250,
+        timeoutMsg: 'backend rename did not write /rename into the PTY',
+      }
+    )
+
+    await browser.execute(
+      (sessionId: string, renamedTitle: string) => {
+        window.__VIMEFLOW_E2E__?.emitBackendEvent('agent-session-title', {
+          sessionId,
+          agentSessionId: 'e2e-agent-session',
+          title: renamedTitle,
+          source: 'user-renamed',
+        })
+      },
+      ptyId,
+      title
+    )
+
+    await browser.waitUntil(
+      async () => {
+        const headerText = await textForSelector(
+          '[data-testid="terminal-pane-header"]'
+        )
+
+        return headerText.includes(title)
+      },
+      {
+        timeout: 10_000,
+        interval: 250,
+        timeoutMsg: 'terminal header did not show renamed agent title',
+      }
+    )
+  })
+
+  it('restores the previous terminal session after renderer reload', async () => {
+    const ptyIdBeforeReload = await waitForVisiblePtyId()
+    const marker = `vimeflow_restore_${Date.now()}`
+
+    await typeInActiveTerminal(`printf '%s\\n' '${marker}'`)
+    await pressEnterInActiveTerminal()
+    await browser.waitUntil(
+      async () => {
+        const buffer = await browser.execute(
+          () => window.__VIMEFLOW_E2E__?.getTerminalBuffer() ?? ''
+        )
+
+        return bufferHasExactLine(buffer, marker)
+      },
+      {
+        timeout: 10_000,
+        interval: 250,
+        timeoutMsg: 'terminal did not print restore marker before reload',
+      }
+    )
+
+    await browser.execute(() => {
+      window.location.reload()
+    })
+    await waitForE2eBridge()
+    await (
+      await $('[data-testid="terminal-pane"]')
+    ).waitForDisplayed({
+      timeout: 20_000,
+    })
+    const ptyIdAfterReload = await waitForVisiblePtyId()
+    assert.equal(ptyIdAfterReload, ptyIdBeforeReload)
+
+    await browser.waitUntil(
+      async () => {
+        const buffer = await browser.execute(
+          () => window.__VIMEFLOW_E2E__?.getTerminalBuffer() ?? ''
+        )
+
+        return bufferHasExactLine(buffer, marker)
+      },
+      {
+        timeout: 20_000,
+        interval: 500,
+        timeoutMsg: 'terminal replay did not restore pre-reload buffer',
+      }
+    )
+  })
+})

--- a/tests/e2e/agent/specs/agent-runtime-regressions.spec.ts
+++ b/tests/e2e/agent/specs/agent-runtime-regressions.spec.ts
@@ -226,17 +226,170 @@ const emitAgentStatus = async (
   payload: AgentStatusPayload,
   turns: number
 ): Promise<void> => {
-  await browser.execute(
-    (statusPayload: AgentStatusPayload, numTurns: number) => {
-      window.__VIMEFLOW_E2E__?.emitBackendEvent('agent-status', statusPayload)
-      window.__VIMEFLOW_E2E__?.emitBackendEvent('agent-turn', {
-        sessionId: statusPayload.sessionId,
-        numTurns,
+  await invokeBackend<null>('e2e_emit_agent_status', {
+    sessionId: payload.sessionId,
+    status: payload,
+    numTurns: turns,
+  })
+}
+
+const writeKimiWire = (
+  wirePath: string,
+  scenario: AgentStatusScenario
+): void => {
+  const sessionId = `e2e-${scenario.agentType}-session`
+  const timestamp = Date.now()
+  const reset = Math.floor(Date.now() / 1000) + 3600
+  const lines: string[] = [
+    JSON.stringify({
+      type: 'config.update',
+      time: timestamp,
+      modelAlias: scenario.modelDisplayName,
+    }),
+  ]
+
+  for (let i = 0; i < scenario.turns; i += 1) {
+    lines.push(
+      JSON.stringify({
+        type: 'turn.prompt',
+        time: timestamp + i,
+        origin: { kind: 'user' },
+      }),
+      JSON.stringify({
+        type: 'usage.record',
+        time: timestamp + i + 1,
+        model: scenario.modelDisplayName,
+        usage: {
+          inputOther: 1100,
+          inputCacheRead: 150,
+          inputCacheCreation: 0,
+          output: 250,
+        },
       })
-    },
-    payload,
-    turns
+    )
+  }
+
+  lines.push(
+    JSON.stringify({
+      type: 'usage.record',
+      time: timestamp + scenario.turns + 2,
+      model: scenario.modelDisplayName,
+      rateLimits: {
+        fiveHour: { usedPercent: 19, windowMinutes: 300, resetsAt: reset },
+        sevenDay: {
+          usedPercent: 27,
+          windowMinutes: 10080,
+          resetsAt: reset + 86_400,
+        },
+      },
+      usage: {
+        inputOther: 1100 * scenario.turns,
+        inputCacheRead: 150 * scenario.turns,
+        inputCacheCreation: 0,
+        output: 250 * scenario.turns,
+      },
+    })
   )
+
+  fs.appendFileSync(wirePath, `${lines.join('\n')}\n`, 'utf8')
+}
+
+const writeCodexRollout = (
+  rolloutPath: string,
+  ptyId: string,
+  scenario: AgentStatusScenario
+): void => {
+  const sessionId = `e2e-${scenario.agentType}-session`
+  const timestamp = new Date().toISOString()
+  const reset = Math.floor(Date.now() / 1000) + 3600
+  const lines = [
+    JSON.stringify({
+      timestamp,
+      type: 'session_meta',
+      payload: {
+        id: sessionId,
+        timestamp,
+        cwd: process.cwd(),
+        originator: 'codex_exec',
+        cli_version: 'e2e',
+        source: 'exec',
+        model_provider: 'openai',
+      },
+    }),
+    JSON.stringify({
+      timestamp,
+      type: 'turn_context',
+      payload: {
+        turn_id: `turn-${scenario.agentType}`,
+        cwd: process.cwd(),
+        model: scenario.modelDisplayName,
+        personality: 'pragmatic',
+        effort: 'xhigh',
+      },
+    }),
+    JSON.stringify({
+      timestamp,
+      type: 'event_msg',
+      payload: {
+        type: 'task_started',
+        turn_id: `turn-${scenario.agentType}`,
+        started_at: Math.floor(Date.now() / 1000),
+        model_context_window: 200_000,
+        collaboration_mode_kind: 'default',
+      },
+    }),
+    JSON.stringify({
+      timestamp,
+      type: 'event_msg',
+      payload: {
+        type: 'token_count',
+        info: {
+          total_token_usage: {
+            input_tokens: 1100,
+            cached_input_tokens: 150,
+            output_tokens: 250,
+            reasoning_output_tokens: 0,
+            total_tokens: 1350,
+          },
+          last_token_usage: {
+            input_tokens: 1100,
+            cached_input_tokens: 150,
+            output_tokens: 250,
+            reasoning_output_tokens: 0,
+            total_tokens: 1350,
+          },
+          model_context_window: 200_000,
+        },
+        rate_limits: {
+          limit_id: 'codex',
+          primary: {
+            used_percent: 19,
+            window_minutes: 300,
+            resets_at: reset,
+          },
+          secondary: {
+            used_percent: 27,
+            window_minutes: 10080,
+            resets_at: reset + 86_400,
+          },
+          plan_type: 'prolite',
+        },
+      },
+    }),
+    JSON.stringify({
+      timestamp,
+      type: 'event_msg',
+      payload: {
+        type: 'task_complete',
+        turn_id: `turn-${scenario.agentType}`,
+        completed_at: Math.floor(Date.now() / 1000),
+        duration_ms: 95_000,
+        last_agent_message: 'done',
+      },
+    }),
+  ]
+
+  fs.writeFileSync(rolloutPath, `${lines.join('\n')}\n`, 'utf8')
 }
 
 const emitAgentTurn = async (
@@ -435,6 +588,13 @@ describe('Agent runtime regressions', () => {
 
   it('renders seeded Codex and Kimi statuses in the sidebar card and status panel', async () => {
     const ptyId = await waitForVisiblePtyId()
+    const codexHome = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'vimeflow-codex-e2e-')
+    )
+    const kimiHome = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'vimeflow-kimi-e2e-')
+    )
+
     const scenarios: AgentStatusScenario[] = [
       {
         agentType: 'codex',
@@ -455,31 +615,48 @@ describe('Agent runtime regressions', () => {
     const cardSelector = '[data-testid="sidebar-agent-status-card"]'
     const panelSelector = '[data-testid="agent-status-panel"]'
 
-    for (const scenario of scenarios) {
-      await seedAgent(ptyId, scenario.agentType)
-      await emitAgentStatus(
-        createAgentStatusPayload(ptyId, scenario),
-        scenario.turns
-      )
+    try {
+      for (const scenario of scenarios) {
+        await seedAgent(ptyId, scenario.agentType)
 
-      await browser.waitUntil(
-        async () => {
-          const cardText = await textForSelector(cardSelector)
-          const panelText = await textForSelector(panelSelector)
-
-          return (
-            cardText.includes(scenario.modelDisplayName) &&
-            cardText.includes(`${scenario.turns} turns`) &&
-            !cardText.includes('No active agent') &&
-            panelText.includes(scenario.panelLabel)
+        if (scenario.agentType === 'codex') {
+          const rolloutPath = await invokeBackend<string>(
+            'e2e_start_codex_watcher',
+            { sessionId: ptyId, homeDir: codexHome }
           )
-        },
-        {
-          timeout: 15_000,
-          interval: 500,
-          timeoutMsg: `${scenario.agentType} status did not render in sidebar and panel`,
+          writeCodexRollout(rolloutPath, ptyId, scenario)
+          await emitAgentTurn(ptyId, scenario.turns)
+        } else {
+          const wirePath = await invokeBackend<string>(
+            'e2e_start_kimi_watcher',
+            { sessionId: ptyId, homeDir: kimiHome }
+          )
+          writeKimiWire(wirePath, scenario)
+          await emitAgentTurn(ptyId, scenario.turns)
         }
-      )
+
+        await browser.waitUntil(
+          async () => {
+            const cardText = await textForSelector(cardSelector)
+            const panelText = await textForSelector(panelSelector)
+
+            return (
+              cardText.includes(scenario.modelDisplayName) &&
+              cardText.includes(`${scenario.turns} turns`) &&
+              !cardText.includes('No active agent') &&
+              panelText.includes(scenario.panelLabel)
+            )
+          },
+          {
+            timeout: 15_000,
+            interval: 500,
+            timeoutMsg: `${scenario.agentType} status did not render in sidebar and panel`,
+          }
+        )
+      }
+    } finally {
+      fs.rmSync(codexHome, { recursive: true, force: true })
+      fs.rmSync(kimiHome, { recursive: true, force: true })
     }
   })
 

--- a/tests/e2e/agent/specs/agent-runtime-regressions.spec.ts
+++ b/tests/e2e/agent/specs/agent-runtime-regressions.spec.ts
@@ -497,9 +497,8 @@ describe('Agent runtime regressions', () => {
         async () => {
           const buffer = await browser.execute(
             (sessionId: string) =>
-              window.__VIMEFLOW_E2E__?.getTerminalBufferForSession(
-                sessionId
-              ) ?? '',
+              window.__VIMEFLOW_E2E__?.getTerminalBufferForSession(sessionId) ??
+              '',
             ptyId
           )
 

--- a/tests/e2e/agent/specs/agent-runtime-regressions.spec.ts
+++ b/tests/e2e/agent/specs/agent-runtime-regressions.spec.ts
@@ -19,6 +19,54 @@ interface E2eAgentBridgeInfo {
   agentType: E2eAgentType | null
 }
 
+interface AgentStatusPayload {
+  sessionId: string
+  agentSessionId: string
+  modelId: string
+  modelDisplayName: string
+  version: string
+  contextWindow: {
+    usedPercentage: number
+    remainingPercentage: number
+    contextWindowSize: number
+    totalInputTokens: number
+    totalOutputTokens: number
+    currentUsage: {
+      inputTokens: number
+      outputTokens: number
+      cacheCreationInputTokens: number
+      cacheReadInputTokens: number
+    }
+  }
+  cost: {
+    totalCostUsd: number
+    totalDurationMs: number
+    totalApiDurationMs: number
+    totalLinesAdded: number
+    totalLinesRemoved: number
+  }
+  rateLimits: {
+    fiveHour: {
+      usedPercentage: number
+      resetsAt: number
+    }
+    sevenDay: {
+      usedPercentage: number
+      resetsAt: number
+    }
+  }
+  usageFetched: boolean
+}
+
+interface AgentStatusScenario {
+  agentType: E2eAgentType
+  modelDisplayName: string
+  modelId: string
+  panelLabel: string
+  turns: number
+  usageFetched?: boolean
+}
+
 const waitForE2eBridge = async (): Promise<void> => {
   await browser
     .waitUntil(
@@ -71,11 +119,18 @@ const invokeBackend = async <T>(
     args
   )
 
-const seedClaudeAgent = async (ptyId: string): Promise<void> => {
+const seedAgent = async (
+  ptyId: string,
+  agentType: E2eAgentType
+): Promise<void> => {
   await invokeBackend<null>('e2e_seed_live_agent', {
     sessionId: ptyId,
-    agentType: 'claudeCode',
+    agentType,
   })
+}
+
+const seedClaudeAgent = async (ptyId: string): Promise<void> => {
+  await seedAgent(ptyId, 'claudeCode')
 }
 
 const createClaudeStatusline = (): string => {
@@ -119,6 +174,69 @@ const createClaudeStatusline = (): string => {
       },
     },
   })
+}
+
+const createAgentStatusPayload = (
+  sessionId: string,
+  scenario: AgentStatusScenario
+): AgentStatusPayload => {
+  const reset = Math.floor(Date.now() / 1000) + 3600
+
+  return {
+    sessionId,
+    agentSessionId: `e2e-${scenario.agentType}-session`,
+    modelId: scenario.modelId,
+    modelDisplayName: scenario.modelDisplayName,
+    version: 'e2e',
+    contextWindow: {
+      usedPercentage: 31,
+      remainingPercentage: 69,
+      contextWindowSize: 200_000,
+      totalInputTokens: 62_000,
+      totalOutputTokens: 5_000,
+      currentUsage: {
+        inputTokens: 1100,
+        outputTokens: 250,
+        cacheCreationInputTokens: 150,
+        cacheReadInputTokens: 650,
+      },
+    },
+    cost: {
+      totalCostUsd: 0.91,
+      totalDurationMs: 95_000,
+      totalApiDurationMs: 70_000,
+      totalLinesAdded: 8,
+      totalLinesRemoved: 2,
+    },
+    rateLimits: {
+      fiveHour: {
+        usedPercentage: 19,
+        resetsAt: reset,
+      },
+      sevenDay: {
+        usedPercentage: 27,
+        resetsAt: reset + 86_400,
+      },
+    },
+    usageFetched: scenario.usageFetched ?? false,
+  }
+}
+
+const emitAgentStatus = async (
+  payload: AgentStatusPayload,
+  turns: number
+): Promise<void> => {
+  await browser.execute(
+    (statusPayload: AgentStatusPayload, numTurns: number) => {
+      window.__VIMEFLOW_E2E__?.emitBackendEvent('agent-status', statusPayload)
+      window.__VIMEFLOW_E2E__?.emitBackendEvent('agent-turn', {
+        sessionId: statusPayload.sessionId,
+        numTurns,
+      })
+    },
+    payload,
+    turns
+  )
 }
 
 const emitAgentTurn = async (
@@ -315,58 +433,113 @@ describe('Agent runtime regressions', () => {
     assert.equal(cardText.includes('No active agent'), false)
   })
 
-  it('renames the active agent terminal and writes /rename into the PTY', async () => {
+  it('renders seeded Codex and Kimi statuses in the sidebar card and status panel', async () => {
     const ptyId = await waitForVisiblePtyId()
-    const title = `e2e-renamed-${Date.now()}`
-    await seedClaudeAgent(ptyId)
-
-    await invokeBackend<null>('rename_agent_session', { ptyId, title })
-
-    await browser.waitUntil(
-      async () => {
-        const buffer = await browser.execute(
-          (sessionId: string) =>
-            window.__VIMEFLOW_E2E__?.getTerminalBufferForSession(sessionId) ??
-            '',
-          ptyId
-        )
-
-        return buffer.includes(`/rename ${title}`)
+    const scenarios: AgentStatusScenario[] = [
+      {
+        agentType: 'codex',
+        modelDisplayName: 'GPT-5 Codex',
+        modelId: 'gpt-5-codex',
+        panelLabel: 'CODEX',
+        turns: 2,
       },
       {
-        timeout: 10_000,
-        interval: 250,
-        timeoutMsg: 'backend rename did not write /rename into the PTY',
-      }
-    )
-
-    await browser.execute(
-      (sessionId: string, renamedTitle: string) => {
-        window.__VIMEFLOW_E2E__?.emitBackendEvent('agent-session-title', {
-          sessionId,
-          agentSessionId: 'e2e-agent-session',
-          title: renamedTitle,
-          source: 'user-renamed',
-        })
+        agentType: 'kimi',
+        modelDisplayName: 'Kimi K2.7',
+        modelId: 'kimi-code/k2.7',
+        panelLabel: 'KIMI',
+        turns: 3,
+        usageFetched: true,
       },
-      ptyId,
-      title
-    )
+    ]
+    const cardSelector = '[data-testid="sidebar-agent-status-card"]'
+    const panelSelector = '[data-testid="agent-status-panel"]'
 
-    await browser.waitUntil(
-      async () => {
-        const headerText = await textForSelector(
-          '[data-testid="terminal-pane-header"]'
-        )
+    for (const scenario of scenarios) {
+      await seedAgent(ptyId, scenario.agentType)
+      await emitAgentStatus(
+        createAgentStatusPayload(ptyId, scenario),
+        scenario.turns
+      )
 
-        return headerText.includes(title)
-      },
-      {
-        timeout: 10_000,
-        interval: 250,
-        timeoutMsg: 'terminal header did not show renamed agent title',
-      }
-    )
+      await browser.waitUntil(
+        async () => {
+          const cardText = await textForSelector(cardSelector)
+          const panelText = await textForSelector(panelSelector)
+
+          return (
+            cardText.includes(scenario.modelDisplayName) &&
+            cardText.includes(`${scenario.turns} turns`) &&
+            !cardText.includes('No active agent') &&
+            panelText.includes(scenario.panelLabel)
+          )
+        },
+        {
+          timeout: 15_000,
+          interval: 500,
+          timeoutMsg: `${scenario.agentType} status did not render in sidebar and panel`,
+        }
+      )
+    }
+  })
+
+  it('renames Claude and Codex agent terminals and writes /rename into the PTY', async () => {
+    const ptyId = await waitForVisiblePtyId()
+    const agents: E2eAgentType[] = ['claudeCode', 'codex']
+
+    for (const agentType of agents) {
+      const title = `e2e-${agentType}-renamed-${Date.now()}`
+      await seedAgent(ptyId, agentType)
+
+      await invokeBackend<null>('rename_agent_session', { ptyId, title })
+
+      await browser.waitUntil(
+        async () => {
+          const buffer = await browser.execute(
+            (sessionId: string) =>
+              window.__VIMEFLOW_E2E__?.getTerminalBufferForSession(
+                sessionId
+              ) ?? '',
+            ptyId
+          )
+
+          return buffer.includes(`/rename ${title}`)
+        },
+        {
+          timeout: 10_000,
+          interval: 250,
+          timeoutMsg: `${agentType} rename did not write /rename into the PTY`,
+        }
+      )
+
+      await browser.execute(
+        (sessionId: string, renamedTitle: string) => {
+          window.__VIMEFLOW_E2E__?.emitBackendEvent('agent-session-title', {
+            sessionId,
+            agentSessionId: 'e2e-agent-session',
+            title: renamedTitle,
+            source: 'user-renamed',
+          })
+        },
+        ptyId,
+        title
+      )
+
+      await browser.waitUntil(
+        async () => {
+          const headerText = await textForSelector(
+            '[data-testid="terminal-pane-header"]'
+          )
+
+          return headerText.includes(title)
+        },
+        {
+          timeout: 10_000,
+          interval: 250,
+          timeoutMsg: `terminal header did not show ${agentType} renamed title`,
+        }
+      )
+    }
   })
 
   it('restores the previous terminal session after renderer reload', async () => {

--- a/tests/e2e/agent/specs/agent-runtime-regressions.spec.ts
+++ b/tests/e2e/agent/specs/agent-runtime-regressions.spec.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import { clickBySelector } from '../../shared/actions.js'
 import {
   pressEnterInActiveTerminal,
   typeInActiveTerminal,
@@ -17,45 +18,6 @@ interface E2eAgentBridgeInfo {
   statusFile: string | null
   shimDir: string | null
   agentType: E2eAgentType | null
-}
-
-interface AgentStatusPayload {
-  sessionId: string
-  agentSessionId: string
-  modelId: string
-  modelDisplayName: string
-  version: string
-  contextWindow: {
-    usedPercentage: number
-    remainingPercentage: number
-    contextWindowSize: number
-    totalInputTokens: number
-    totalOutputTokens: number
-    currentUsage: {
-      inputTokens: number
-      outputTokens: number
-      cacheCreationInputTokens: number
-      cacheReadInputTokens: number
-    }
-  }
-  cost: {
-    totalCostUsd: number
-    totalDurationMs: number
-    totalApiDurationMs: number
-    totalLinesAdded: number
-    totalLinesRemoved: number
-  }
-  rateLimits: {
-    fiveHour: {
-      usedPercentage: number
-      resetsAt: number
-    }
-    sevenDay: {
-      usedPercentage: number
-      resetsAt: number
-    }
-  }
-  usageFetched: boolean
 }
 
 interface AgentStatusScenario {
@@ -173,63 +135,6 @@ const createClaudeStatusline = (): string => {
         resets_at: reset + 86_400,
       },
     },
-  })
-}
-
-const createAgentStatusPayload = (
-  sessionId: string,
-  scenario: AgentStatusScenario
-): AgentStatusPayload => {
-  const reset = Math.floor(Date.now() / 1000) + 3600
-
-  return {
-    sessionId,
-    agentSessionId: `e2e-${scenario.agentType}-session`,
-    modelId: scenario.modelId,
-    modelDisplayName: scenario.modelDisplayName,
-    version: 'e2e',
-    contextWindow: {
-      usedPercentage: 31,
-      remainingPercentage: 69,
-      contextWindowSize: 200_000,
-      totalInputTokens: 62_000,
-      totalOutputTokens: 5_000,
-      currentUsage: {
-        inputTokens: 1100,
-        outputTokens: 250,
-        cacheCreationInputTokens: 150,
-        cacheReadInputTokens: 650,
-      },
-    },
-    cost: {
-      totalCostUsd: 0.91,
-      totalDurationMs: 95_000,
-      totalApiDurationMs: 70_000,
-      totalLinesAdded: 8,
-      totalLinesRemoved: 2,
-    },
-    rateLimits: {
-      fiveHour: {
-        usedPercentage: 19,
-        resetsAt: reset,
-      },
-      sevenDay: {
-        usedPercentage: 27,
-        resetsAt: reset + 86_400,
-      },
-    },
-    usageFetched: scenario.usageFetched ?? false,
-  }
-}
-
-const emitAgentStatus = async (
-  payload: AgentStatusPayload,
-  turns: number
-): Promise<void> => {
-  await invokeBackend<null>('e2e_emit_agent_status', {
-    sessionId: payload.sessionId,
-    status: payload,
-    numTurns: turns,
   })
 }
 
@@ -534,56 +439,92 @@ describe('Agent runtime regressions', () => {
   })
 
   it('ingests app-data status files through the watcher into the sidebar card and status panel', async () => {
-    const ptyId = await waitForVisiblePtyId()
-    await seedClaudeAgent(ptyId)
+    const initialPtyId = await waitForVisiblePtyId()
     const cardSelector = '[data-testid="sidebar-agent-status-card"]'
 
-    await invokeBackend<null>('start_agent_watcher', { sessionId: ptyId })
-    const info = await invokeBackend<E2eAgentBridgeInfo>(
-      'e2e_agent_bridge_info',
-      { sessionId: ptyId }
-    )
-
-    assert.equal(info.agentType, 'claudeCode')
-    assert.ok(info.statusFile, 'statusFile should be populated')
-    assert.ok(
-      path
-        .relative(info.appDataDir, info.statusFile)
-        .split(path.sep)
-        .includes('runtime'),
-      `status file should live under the app-data runtime bucket: ${info.statusFile}`
-    )
-
-    fs.mkdirSync(path.dirname(info.statusFile), { recursive: true })
-    fs.writeFileSync(info.statusFile, createClaudeStatusline(), 'utf8')
-    await emitAgentTurn(ptyId, 4)
-
+    // Spawn a dedicated bridge-enabled PTY through the frontend session manager
+    // so the test controls its own precondition and the UI observes it as active.
+    await clickBySelector('button[aria-label="New session"]')
+    let ptyId: string | undefined
     await browser.waitUntil(
       async () => {
-        const cardText = await textForSelector(cardSelector)
-
-        return (
-          cardText.includes('Claude Sonnet 4.5') &&
-          cardText.includes('4 turns') &&
-          !cardText.includes('No active agent')
-        )
+        const visible = await waitForVisiblePtyId()
+        if (visible !== initialPtyId) {
+          ptyId = visible
+          return true
+        }
+        return false
       },
       {
         timeout: 15_000,
-        interval: 500,
-        timeoutMsg:
-          'sidebar agent status card did not render watcher-ingested metrics',
+        interval: 250,
+        timeoutMsg: 'new bridge-enabled session did not become the visible PTY',
       }
     )
 
-    const panel = await $('[data-testid="agent-status-panel"]')
-    await panel.waitForDisplayed({ timeout: 10_000 })
-    await (
-      await $('[data-testid="agent-status-panel-body-content"]')
-    ).waitForDisplayed({ timeout: 10_000 })
+    assert.ok(ptyId, 'spawned PTY id should be resolved')
 
-    const cardText = await textForSelector(cardSelector)
-    assert.equal(cardText.includes('No active agent'), false)
+    try {
+      await seedClaudeAgent(ptyId)
+
+      await invokeBackend<null>('start_agent_watcher', { sessionId: ptyId })
+      const info = await invokeBackend<E2eAgentBridgeInfo>(
+        'e2e_agent_bridge_info',
+        { sessionId: ptyId }
+      )
+
+      assert.equal(info.agentType, 'claudeCode')
+      assert.ok(info.statusFile, 'statusFile should be populated')
+      assert.ok(
+        path
+          .relative(info.appDataDir, info.statusFile)
+          .split(path.sep)
+          .includes('runtime'),
+        `status file should live under the app-data runtime bucket: ${info.statusFile}`
+      )
+
+      fs.mkdirSync(path.dirname(info.statusFile), { recursive: true })
+      fs.writeFileSync(info.statusFile, createClaudeStatusline(), 'utf8')
+      await emitAgentTurn(ptyId, 4)
+
+      await browser.waitUntil(
+        async () => {
+          const cardText = await textForSelector(cardSelector)
+
+          return (
+            cardText.includes('Claude Sonnet 4.5') &&
+            cardText.includes('4 turns') &&
+            !cardText.includes('No active agent')
+          )
+        },
+        {
+          timeout: 15_000,
+          interval: 500,
+          timeoutMsg:
+            'sidebar agent status card did not render watcher-ingested metrics',
+        }
+      )
+
+      const panel = await $('[data-testid="agent-status-panel"]')
+      await panel.waitForDisplayed({ timeout: 10_000 })
+      await (
+        await $('[data-testid="agent-status-panel-body-content"]')
+      ).waitForDisplayed({ timeout: 10_000 })
+
+      const cardText = await textForSelector(cardSelector)
+      assert.equal(cardText.includes('No active agent'), false)
+    } finally {
+      await browser.execute(() => {
+        const tabs = Array.from(
+          document.querySelectorAll<HTMLElement>('[data-testid="session-tab"]')
+        )
+        const latestTab = tabs[tabs.length - 1]
+        const closeButton = latestTab?.querySelector<HTMLButtonElement>(
+          '[data-testid="close-tab-button"]'
+        )
+        closeButton?.click()
+      })
+    }
   })
 
   it('renders seeded Codex and Kimi statuses in the sidebar card and status panel', async () => {


### PR DESCRIPTION
## Summary
- Move agent bridge/status runtime files from project-local `.vimeflow` paths into the app-data runtime workspace bucket.
- Thread the app-data bridge path through terminal spawn/cache state and agent status locators so spawn, watcher, and cleanup share the same path source.
- Add E2E-only hooks plus an agent regression spec for app-data path placement, watcher-ingested status UI, agent rename behavior, and renderer reload session restore.

## Why
Non-Vimeflow projects can have `.vimeflow` gitignored or otherwise noisy. Agent bridge/runtime status files should be Vimeflow app data, not project working tree files.

## Verification
- `git diff --check`
- `npm run test -- --run electron/backend-methods.test.ts src/lib/backend.test.ts`
- `cargo check --manifest-path crates/backend/Cargo.toml --features e2e-test`
- `npm run test:e2e:build`
- `npm run test:e2e:agent:run`
- `cargo test --manifest-path crates/backend/Cargo.toml bridge --features e2e-test`

## Reviewer Notes
- The new E2E status test writes real Claude statusline JSON to the relocated app-data `status.json`, starts the real watcher, and waits for the sidebar/panel to update from the backend event path.
- E2E-only backend methods are behind the Rust `e2e-test` feature and Electron's E2E allowlist.

Refs VIM-178