### PR TITLE
refactor(terminal): add Ghostty renderer factory

### DIFF
--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
@@ -12,6 +12,7 @@ import type {
 } from './terminalParserEngine'
 import {
   GHOSTTY_TERMINAL_RENDERER_ID,
+  createGhosttyTerminalRenderer,
   createGhosttyTerminal,
   ghosttyTerminalRenderer,
   type GhosttyTerminalOptions,
@@ -86,6 +87,46 @@ describe('ghosttyInstance', () => {
       GHOSTTY_TERMINAL_CAPABILITIES
     )
     expect(ghosttyTerminalRenderer.createInstance).toBe(createGhosttyTerminal)
+  })
+
+  test('creates configured renderer instances with a VT render-state driver option', () => {
+    const writeBytes = vi.fn()
+
+    const renderer = createGhosttyTerminalRenderer({
+      createVtRenderStateDriver: (): GhosttyVtRenderStateDriver => ({
+        writeBytes,
+        readSnapshot: () => ({
+          rows: ['factory vt screen'],
+          cursor: {
+            rowIndex: 0,
+            columnOffset: 7,
+          },
+        }),
+      }),
+    })
+
+    const created = renderer.createInstance()
+    createdTerminals.add(created)
+
+    const bytes = new Uint8Array([0x76, 0x74])
+
+    created.output.writeOutput({
+      text: 'lossy fallback',
+      bytesBase64: encodeBase64(bytes),
+      offsetStart: 11,
+      byteLen: bytes.length,
+      phase: 'live',
+    })
+
+    const cursor = created.terminal.element?.querySelector(
+      '[data-terminal-cursor="true"]'
+    )
+
+    expect(renderer.id).toBe(GHOSTTY_TERMINAL_RENDERER_ID)
+    expect(renderer.capabilities).toBe(GHOSTTY_TERMINAL_CAPABILITIES)
+    expect(writeBytes).toHaveBeenCalledWith(bytes)
+    expect(created.viewportReader.readVisibleText()).toBe('factory vt screen')
+    expect(cursor?.previousSibling?.textContent).toBe('factory')
   })
 
   test('delegates output parsing through an injected parser engine', () => {

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.ts
@@ -125,6 +125,14 @@ export const createGhosttyTerminal = (
   options: GhosttyTerminalOptions = {}
 ): TerminalInstance => new GhosttyTerminalModel(options).createInstance()
 
+export const createGhosttyTerminalRenderer = (
+  options: GhosttyTerminalOptions = {}
+): TerminalRendererAdapter => ({
+  id: GHOSTTY_TERMINAL_RENDERER_ID,
+  capabilities: GHOSTTY_TERMINAL_CAPABILITIES,
+  createInstance: (): TerminalInstance => createGhosttyTerminal(options),
+})
+
 export const ghosttyTerminalRenderer: TerminalRendererAdapter = {
   id: GHOSTTY_TERMINAL_RENDERER_ID,
   capabilities: GHOSTTY_TERMINAL_CAPABILITIES,


### PR DESCRIPTION
## Summary

- add `createGhosttyTerminalRenderer(options)` so the Ghostty renderer adapter can be constructed with terminal options
- keep the existing exported `ghosttyTerminalRenderer` default path unchanged
- cover the factory with a VT render-state driver option test, proving future driver providers can reach the byte parser path through the renderer adapter

## Verification

- `npx vitest run src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts src/features/terminal/components/TerminalPane/ghosttyVtByteParserAdapter.test.ts`
- `npm run type-check`
- `npm run lint`
- `npm run format:check`
- `npm run test`
- pre-push `npm run test`

## Manual testing

Not required. This is a renderer factory/refactor slice only; default runtime behavior is unchanged.

Refs VIM-177