### PR TITLE
feat(terminal): gate Ghostty native driver providers

### DIFF
--- a/src/features/terminal/components/TerminalPane/terminalRendererRegistry.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalRendererRegistry.test.ts
@@ -5,6 +5,7 @@ import type {
   TerminalRendererAdapter,
   TerminalRendererCapabilities,
 } from '../../types'
+import type { GhosttyVtRenderStateDriver } from './ghosttyVtRenderStateDriver'
 
 type TerminalRendererRegistryModule =
   typeof import('./terminalRendererRegistry')
@@ -20,6 +21,7 @@ const plainTextRendererMocks = vi.hoisted(() => ({
 
 const ghosttyRendererMocks = vi.hoisted(() => ({
   createInstance: vi.fn(),
+  createTerminalRenderer: vi.fn(),
   moduleLoaded: vi.fn(),
 }))
 
@@ -54,12 +56,19 @@ vi.mock('./plainTextInstance', () => {
 vi.mock('./ghosttyInstance', () => {
   ghosttyRendererMocks.moduleLoaded()
 
+  const ghosttyTerminalRenderer: TerminalRendererAdapter = {
+    id: 'ghostty',
+    capabilities: rendererCapabilities.bytes,
+    createInstance: ghosttyRendererMocks.createInstance,
+  }
+
+  ghosttyRendererMocks.createTerminalRenderer.mockImplementation(
+    (): TerminalRendererAdapter => ghosttyTerminalRenderer
+  )
+
   return {
-    ghosttyTerminalRenderer: {
-      id: 'ghostty',
-      capabilities: rendererCapabilities.bytes,
-      createInstance: ghosttyRendererMocks.createInstance,
-    },
+    ghosttyTerminalRenderer,
+    createGhosttyTerminalRenderer: ghosttyRendererMocks.createTerminalRenderer,
   }
 })
 
@@ -213,9 +222,99 @@ describe('terminalRendererRegistry', () => {
     )
     expect(await registry.createConfiguredTerminalInstance()).toBe(instance)
     expect(ghosttyRendererMocks.moduleLoaded).toHaveBeenCalledOnce()
+    expect(ghosttyRendererMocks.createTerminalRenderer).not.toHaveBeenCalled()
     expect(ghosttyRendererMocks.createInstance).toHaveBeenCalledOnce()
     expect(plainTextRendererMocks.moduleLoaded).not.toHaveBeenCalled()
     expect(xtermRendererMocks.createInstance).not.toHaveBeenCalled()
+  })
+
+  test('keeps the Ghostty render-state provider gate off by default', async () => {
+    vi.stubEnv('VITE_GHOSTTY_RENDER_STATE_DRIVER_PROVIDER', 'native-test')
+
+    const registry = await importTerminalRendererRegistry()
+    const instance = createTerminalInstance()
+
+    const createVtRenderStateDriver = vi.fn(
+      (): GhosttyVtRenderStateDriver => ({
+        writeBytes: vi.fn(),
+        readSnapshot: () => ({ rows: [] }),
+      })
+    )
+
+    xtermRendererMocks.createInstance.mockReturnValue(instance)
+    registry.registerGhosttyRenderStateDriverProvider({
+      id: 'native-test',
+      createVtRenderStateDriver,
+    })
+
+    expect(await registry.getTerminalRendererAdapter()).toEqual(
+      expect.objectContaining({ id: 'xterm' })
+    )
+    expect(await registry.createConfiguredTerminalInstance()).toBe(instance)
+    expect(ghosttyRendererMocks.moduleLoaded).not.toHaveBeenCalled()
+    expect(ghosttyRendererMocks.createTerminalRenderer).not.toHaveBeenCalled()
+    expect(createVtRenderStateDriver).not.toHaveBeenCalled()
+  })
+
+  test('creates the bundled ghostty renderer with a selected render-state provider', async () => {
+    vi.stubEnv('VITE_TERMINAL_RENDERER', 'ghostty')
+    vi.stubEnv('VITE_GHOSTTY_RENDER_STATE_DRIVER_PROVIDER', 'native-test')
+
+    const registry = await importTerminalRendererRegistry()
+    const instance = createTerminalInstance()
+
+    const createVtRenderStateDriver = vi.fn(
+      (): GhosttyVtRenderStateDriver => ({
+        writeBytes: vi.fn(),
+        readSnapshot: () => ({ rows: [] }),
+      })
+    )
+
+    ghosttyRendererMocks.createInstance.mockReturnValue(instance)
+    registry.registerGhosttyRenderStateDriverProvider({
+      id: ' native-test ',
+      createVtRenderStateDriver,
+    })
+
+    expect(await registry.getTerminalRendererAdapter()).toEqual(
+      expect.objectContaining({
+        id: 'ghostty',
+        capabilities: rendererCapabilities.bytes,
+      })
+    )
+    expect(await registry.createConfiguredTerminalInstance()).toBe(instance)
+    expect(ghosttyRendererMocks.createTerminalRenderer).toHaveBeenCalledWith({
+      createVtRenderStateDriver,
+    })
+    expect(ghosttyRendererMocks.createInstance).toHaveBeenCalledOnce()
+    expect(xtermRendererMocks.createInstance).not.toHaveBeenCalled()
+  })
+
+  test('fails closed when a selected Ghostty render-state provider is unavailable', async () => {
+    vi.stubEnv('VITE_TERMINAL_RENDERER', 'ghostty')
+    vi.stubEnv('VITE_GHOSTTY_RENDER_STATE_DRIVER_PROVIDER', 'missing-native')
+
+    const registry = await importTerminalRendererRegistry()
+
+    await expect(registry.getTerminalRendererAdapter()).rejects.toThrow(
+      'Unavailable Ghostty render-state driver provider: missing-native'
+    )
+    expect(ghosttyRendererMocks.moduleLoaded).not.toHaveBeenCalled()
+    expect(ghosttyRendererMocks.createTerminalRenderer).not.toHaveBeenCalled()
+  })
+
+  test('rejects empty Ghostty render-state provider ids', async () => {
+    const registry = await importTerminalRendererRegistry()
+
+    expect(() =>
+      registry.registerGhosttyRenderStateDriverProvider({
+        id: ' ',
+        createVtRenderStateDriver: (): GhosttyVtRenderStateDriver => ({
+          writeBytes: vi.fn(),
+          readSnapshot: () => ({ rows: [] }),
+        }),
+      })
+    ).toThrow('Ghostty render-state driver provider id is required')
   })
 
   test('keeps xterm as the default when environment selection is blank', async () => {
@@ -310,6 +409,26 @@ describe('terminalRendererRegistry', () => {
 
     expect(() => registry.setTerminalRendererAdapter('custom')).toThrow(
       'Unknown terminal renderer adapter: custom'
+    )
+  })
+
+  test('resets registered Ghostty render-state driver providers', async () => {
+    vi.stubEnv('VITE_TERMINAL_RENDERER', 'ghostty')
+    vi.stubEnv('VITE_GHOSTTY_RENDER_STATE_DRIVER_PROVIDER', 'native-test')
+
+    const registry = await importTerminalRendererRegistry()
+
+    registry.registerGhosttyRenderStateDriverProvider({
+      id: 'native-test',
+      createVtRenderStateDriver: (): GhosttyVtRenderStateDriver => ({
+        writeBytes: vi.fn(),
+        readSnapshot: () => ({ rows: [] }),
+      }),
+    })
+    registry._resetTerminalRendererRegistryForTest()
+
+    await expect(registry.getTerminalRendererAdapter()).rejects.toThrow(
+      'Unavailable Ghostty render-state driver provider: native-test'
     )
   })
 

--- a/src/features/terminal/components/TerminalPane/terminalRendererRegistry.ts
+++ b/src/features/terminal/components/TerminalPane/terminalRendererRegistry.ts
@@ -1,12 +1,23 @@
 // cspell:ignore ghostty
 import type { TerminalInstance, TerminalRendererAdapter } from '../../types'
 import { GHOSTTY_TERMINAL_RENDERER_ID } from './ghosttyRendererMetadata'
+import type { GhosttyVtRenderStateDriverFactory } from './ghosttyVtRenderStateDriver'
 import { PLAIN_TEXT_TERMINAL_RENDERER_ID } from './plainTextRendererMetadata'
 import { xtermTerminalRenderer } from './xtermInstance'
+
+export interface GhosttyRenderStateDriverProvider {
+  readonly id: string
+  readonly createVtRenderStateDriver: GhosttyVtRenderStateDriverFactory
+}
 
 const terminalRendererAdapters = new Map<string, TerminalRendererAdapter>([
   [xtermTerminalRenderer.id, xtermTerminalRenderer],
 ])
+
+const ghosttyRenderStateDriverProviders = new Map<
+  string,
+  GhosttyRenderStateDriverProvider
+>()
 
 let activeTerminalRendererId = xtermTerminalRenderer.id
 let hasConfiguredTerminalRendererFromEnvironment = false
@@ -35,6 +46,18 @@ const readEnvironmentRendererId = (): string | null => {
   return normalizedRendererId.length > 0 ? normalizedRendererId : null
 }
 
+const readGhosttyRenderStateDriverProviderId = (): string | null => {
+  const providerId = import.meta.env.VITE_GHOSTTY_RENDER_STATE_DRIVER_PROVIDER
+
+  if (typeof providerId !== 'string') {
+    return null
+  }
+
+  const normalizedProviderId = providerId.trim()
+
+  return normalizedProviderId.length > 0 ? normalizedProviderId : null
+}
+
 export const registerTerminalRendererAdapter = (
   adapter: TerminalRendererAdapter
 ): void => {
@@ -49,6 +72,46 @@ export const registerTerminalRendererAdapter = (
     id: rendererId,
   })
 }
+
+export const registerGhosttyRenderStateDriverProvider = (
+  provider: GhosttyRenderStateDriverProvider
+): void => {
+  const providerId = provider.id.trim()
+
+  if (providerId.length === 0) {
+    throw new Error('Ghostty render-state driver provider id is required')
+  }
+
+  ghosttyRenderStateDriverProviders.set(providerId, {
+    ...provider,
+    id: providerId,
+  })
+}
+
+const loadBundledGhosttyRenderer =
+  async (): Promise<TerminalRendererAdapter> => {
+    const providerId = readGhosttyRenderStateDriverProviderId()
+
+    if (!providerId) {
+      const { ghosttyTerminalRenderer } = await import('./ghosttyInstance')
+
+      return ghosttyTerminalRenderer
+    }
+
+    const provider = ghosttyRenderStateDriverProviders.get(providerId)
+
+    if (!provider) {
+      throw new Error(
+        `Unavailable Ghostty render-state driver provider: ${providerId}`
+      )
+    }
+
+    const { createGhosttyTerminalRenderer } = await import('./ghosttyInstance')
+
+    return createGhosttyTerminalRenderer({
+      createVtRenderStateDriver: provider.createVtRenderStateDriver,
+    })
+  }
 
 const registerBundledEnvironmentRenderer = async (): Promise<void> => {
   if (
@@ -65,7 +128,7 @@ const registerBundledEnvironmentRenderer = async (): Promise<void> => {
     shouldRegisterBundledGhosttyRenderer &&
     !terminalRendererAdapters.has(GHOSTTY_TERMINAL_RENDERER_ID)
   ) {
-    const { ghosttyTerminalRenderer } = await import('./ghosttyInstance')
+    const ghosttyTerminalRenderer = await loadBundledGhosttyRenderer()
 
     bundledGhosttyRenderer = ghosttyTerminalRenderer
     registerTerminalRendererAdapter(ghosttyTerminalRenderer)
@@ -136,6 +199,7 @@ export const createConfiguredTerminalInstance =
 
 export const _resetTerminalRendererRegistryForTest = (): void => {
   terminalRendererAdapters.clear()
+  ghosttyRenderStateDriverProviders.clear()
   terminalRendererAdapters.set(xtermTerminalRenderer.id, xtermTerminalRenderer)
 
   if (bundledPlainTextRenderer) {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_TERMINAL_RENDERER?: string
+  readonly VITE_GHOSTTY_RENDER_STATE_DRIVER_PROVIDER?: string
 }
 
 declare const __APP_VERSION__: string


### PR DESCRIPTION
## Summary

- add a Ghostty render-state driver provider registry keyed by `VITE_GHOSTTY_RENDER_STATE_DRIVER_PROVIDER`
- route selected providers through `createGhosttyTerminalRenderer(options)` while preserving the existing bundled Ghostty renderer path when no provider is selected
- fail closed when a provider is requested but unavailable, and keep xterm/default behavior untouched
- cover default-off behavior, provider-selected construction, unavailable-provider errors, metadata preservation, empty provider ids, and test reset cleanup

## Verification

- `npx vitest run src/features/terminal/components/TerminalPane/terminalRendererRegistry.test.ts src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts`
- `npm run type-check`
- `npm run lint`
- `npm run format:check`
- `npm run test:e2e:ghostty`
- `npm run test`: 302 files, 3911 passed, 3 skipped
- pre-push `npm run test`: 302 files, 3911 passed, 3 skipped

## Manual testing

Not required. This is a disabled-by-default provider gate with fake/test providers only; runtime Ghostty native integration is still Milestone 2.

Refs VIM-139