### PR TITLE
feat(terminal): sync Ghostty driver state

### DIFF
--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
@@ -219,6 +219,47 @@ describe('ghosttyInstance', () => {
     expect(cursor?.previousSibling?.textContent).toBe('rendered')
   })
 
+  test('syncs terminal size and clear resets into the VT render-state driver', () => {
+    const reset = vi.fn()
+    const resize = vi.fn()
+    const container = document.createElement('div')
+
+    const created = createTrackedGhosttyTerminal({
+      createVtRenderStateDriver: (): GhosttyVtRenderStateDriver => ({
+        writeBytes: vi.fn(),
+        readSnapshot: () => ({
+          rows: [],
+        }),
+        reset,
+        resize,
+      }),
+    })
+
+    expect(resize).toHaveBeenCalledWith({ cols: 80, rows: 24 })
+
+    setElementSize(container, 256, 180)
+    created.terminal.open(container)
+
+    expect(resize).toHaveBeenLastCalledWith({ cols: 30, rows: 10 })
+    expect(resize).toHaveBeenCalledTimes(2)
+
+    created.fitController.fit()
+
+    expect(resize).toHaveBeenCalledTimes(2)
+
+    setElementSize(container, 336, 216)
+    created.fitController.fit()
+
+    expect(resize).toHaveBeenLastCalledWith({ cols: 40, rows: 12 })
+    expect(resize).toHaveBeenCalledTimes(3)
+
+    created.terminal.clear()
+
+    expect(reset).toHaveBeenCalledOnce()
+    expect(resize).toHaveBeenLastCalledWith({ cols: 40, rows: 12 })
+    expect(resize).toHaveBeenCalledTimes(4)
+  })
+
   test('keeps VT render-state driver cwd effects on the terminal parser event path', () => {
     const bytes = new Uint8Array([0x1b, 0x5d, 0x37])
     const writeBytes = vi.fn()

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.ts
@@ -6,6 +6,7 @@ import type {
   TerminalRendererHandle,
   TerminalOutputWriter,
   TerminalParser,
+  TerminalSize,
   TerminalViewportReader,
 } from '../../types'
 import { GHOSTTY_TERMINAL_RENDERER_ID } from './ghosttyRendererMetadata'
@@ -48,6 +49,7 @@ class GhosttyTerminalModel {
   private readonly parserEngine: TerminalParserEngine
   private isDisposed = false
   private isRendererDisposed = false
+  private syncedParserEngineSize: TerminalSize | null = null
   readonly terminal: TerminalTextSurface
   readonly parser: TerminalParser
 
@@ -63,6 +65,19 @@ class GhosttyTerminalModel {
           : this.parserEngine.parseText(data, null),
     })
 
+    const originalTerminalOpen = this.terminal.open.bind(this.terminal)
+    this.terminal.open = (container): void => {
+      originalTerminalOpen(container)
+      this.syncParserEngineSize()
+    }
+
+    const originalTerminalClear = this.terminal.clear.bind(this.terminal)
+    this.terminal.clear = (): void => {
+      originalTerminalClear()
+      this.parserEngine.reset?.()
+      this.syncParserEngineSize({ force: true })
+    }
+
     const originalTerminalDispose = this.terminal.dispose.bind(this.terminal)
     this.terminal.dispose = (): void => {
       if (this.isDisposed) {
@@ -73,6 +88,8 @@ class GhosttyTerminalModel {
       originalTerminalDispose()
       this.parserEngine.dispose?.()
     }
+
+    this.syncParserEngineSize()
   }
 
   readonly output: TerminalOutputWriter = {
@@ -96,6 +113,7 @@ class GhosttyTerminalModel {
   readonly fitController: TerminalFitController = {
     fit: (): void => {
       this.terminal.fit()
+      this.syncParserEngineSize()
     },
   }
 
@@ -118,6 +136,24 @@ class GhosttyTerminalModel {
       fitController: this.fitController,
       attachRenderer: (): TerminalRendererHandle => this.rendererHandle,
     }
+  }
+
+  private syncParserEngineSize(options: { force?: boolean } = {}): void {
+    const size = {
+      cols: this.terminal.cols,
+      rows: this.terminal.rows,
+    }
+
+    if (
+      !options.force &&
+      this.syncedParserEngineSize?.cols === size.cols &&
+      this.syncedParserEngineSize.rows === size.rows
+    ) {
+      return
+    }
+
+    this.syncedParserEngineSize = size
+    this.parserEngine.resize?.(size)
   }
 }
 

--- a/src/features/terminal/components/TerminalPane/ghosttyParserEngine.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyParserEngine.test.ts
@@ -125,6 +125,45 @@ describe('ghosttyParserEngine', () => {
     expect(reset).not.toHaveBeenCalled()
   })
 
+  test('forwards resize and reset to the Ghostty byte parser adapter', () => {
+    const reset = vi.fn()
+    const resize = vi.fn()
+
+    const adapter: GhosttyByteParserAdapter = {
+      parseBytes: vi.fn(() => ({ visibleText: '' })),
+      reset,
+      resize,
+    }
+
+    const engine = createGhosttyParserEngine({ byteParserAdapter: adapter })
+
+    engine.resize?.({ cols: 120, rows: 30 })
+    engine.reset?.()
+
+    expect(resize).toHaveBeenCalledWith({ cols: 120, rows: 30 })
+    expect(reset).toHaveBeenCalledOnce()
+  })
+
+  test('ignores resize and reset after disposal', () => {
+    const reset = vi.fn()
+    const resize = vi.fn()
+
+    const adapter: GhosttyByteParserAdapter = {
+      parseBytes: vi.fn(() => ({ visibleText: '' })),
+      reset,
+      resize,
+    }
+
+    const engine = createGhosttyParserEngine({ byteParserAdapter: adapter })
+
+    engine.dispose?.()
+    engine.resize?.({ cols: 120, rows: 30 })
+    engine.reset?.()
+
+    expect(resize).not.toHaveBeenCalled()
+    expect(reset).not.toHaveBeenCalled()
+  })
+
   test('routes adapter parser events through the existing parser surface', () => {
     const parseBytes = vi.fn((input: GhosttyByteParserAdapterInput) => {
       input.emitEvent({

--- a/src/features/terminal/components/TerminalPane/ghosttyParserEngine.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyParserEngine.ts
@@ -2,6 +2,7 @@
 import type {
   TerminalParserEvent,
   TerminalParserOutputContext,
+  TerminalSize,
 } from '../../types'
 import { GHOSTTY_TERMINAL_CAPABILITIES } from './terminalRendererCapabilities'
 import {
@@ -25,6 +26,7 @@ export interface GhosttyByteParserAdapter {
     input: GhosttyByteParserAdapterInput
   ) => TerminalParserEngineOutput
   reset?: () => void
+  resize?: (size: TerminalSize) => void
   dispose?: () => void
 }
 
@@ -126,6 +128,23 @@ export class GhosttyControlSequenceParserEngine
     this.byteParserAdapter.reset?.()
 
     return super.parseInput(input)
+  }
+
+  reset(): void {
+    if (this.isDisposed) {
+      return
+    }
+
+    super.reset()
+    this.byteParserAdapter.reset?.()
+  }
+
+  resize(size: TerminalSize): void {
+    if (this.isDisposed) {
+      return
+    }
+
+    this.byteParserAdapter.resize?.(size)
   }
 
   dispose(): void {

--- a/src/features/terminal/components/TerminalPane/ghosttyVtByteParserAdapter.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtByteParserAdapter.test.ts
@@ -126,38 +126,46 @@ describe('ghosttyVtByteParserAdapter', () => {
     expect(emitEvent).not.toHaveBeenCalled()
   })
 
-  test('resets and disposes the VT parser driver once', () => {
+  test('forwards resize, reset, and dispose to the VT parser driver', () => {
     const reset = vi.fn()
+    const resize = vi.fn()
     const dispose = vi.fn()
 
     const adapter = createGhosttyVtByteParserAdapter(() => ({
       writeBytes: (): TerminalParserEngineOutput => ({ visibleText: '' }),
       reset,
+      resize,
       dispose,
     }))
 
+    adapter.resize?.({ cols: 120, rows: 30 })
     adapter.reset?.()
     adapter.dispose?.()
     adapter.dispose?.()
 
+    expect(resize).toHaveBeenCalledWith({ cols: 120, rows: 30 })
     expect(reset).toHaveBeenCalledOnce()
     expect(dispose).toHaveBeenCalledOnce()
   })
 
-  test('ignores reset after disposal', () => {
+  test('ignores resize and reset after disposal', () => {
     const reset = vi.fn()
+    const resize = vi.fn()
     const dispose = vi.fn()
 
     const adapter = createGhosttyVtByteParserAdapter(() => ({
       writeBytes: (): TerminalParserEngineOutput => ({ visibleText: '' }),
       reset,
+      resize,
       dispose,
     }))
 
     adapter.dispose?.()
+    adapter.resize?.({ cols: 120, rows: 30 })
     adapter.reset?.()
 
     expect(dispose).toHaveBeenCalledOnce()
+    expect(resize).not.toHaveBeenCalled()
     expect(reset).not.toHaveBeenCalled()
   })
 })

--- a/src/features/terminal/components/TerminalPane/ghosttyVtByteParserAdapter.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtByteParserAdapter.ts
@@ -4,6 +4,7 @@ import type {
   GhosttyByteParserAdapterInput,
 } from './ghosttyParserEngine'
 import type { TerminalParserEngineOutput } from './terminalParserEngine'
+import type { TerminalSize } from '../../types'
 
 export interface GhosttyVtParserEffects {
   readonly onCwdChange: (uri: string) => void
@@ -18,6 +19,7 @@ export interface GhosttyVtParserDriver {
    */
   writeBytes: (bytes: Uint8Array) => TerminalParserEngineOutput
   reset?: () => void
+  resize?: (size: TerminalSize) => void
   dispose?: () => void
 }
 
@@ -54,6 +56,14 @@ export class GhosttyVtByteParserAdapter implements GhosttyByteParserAdapter {
     }
 
     this.driver.reset?.()
+  }
+
+  resize(size: TerminalSize): void {
+    if (this.isDisposed) {
+      return
+    }
+
+    this.driver.resize?.(size)
   }
 
   dispose(): void {

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
@@ -125,8 +125,9 @@ describe('ghosttyVtRenderStateDriver', () => {
     })
   })
 
-  test('forwards lifecycle to the render-state driver', () => {
+  test('forwards lifecycle and size changes to the render-state driver', () => {
     const reset = vi.fn()
+    const resize = vi.fn()
     const dispose = vi.fn()
 
     const adapter = createGhosttyVtRenderStateByteParserAdapter(() => ({
@@ -135,14 +136,19 @@ describe('ghosttyVtRenderStateDriver', () => {
         rows: [],
       }),
       reset,
+      resize,
       dispose,
     }))
 
+    adapter.resize?.({ cols: 132, rows: 43 })
     adapter.reset?.()
     adapter.dispose?.()
     adapter.dispose?.()
+    adapter.resize?.({ cols: 80, rows: 24 })
     adapter.reset?.()
 
+    expect(resize).toHaveBeenCalledOnce()
+    expect(resize).toHaveBeenCalledWith({ cols: 132, rows: 43 })
     expect(reset).toHaveBeenCalledOnce()
     expect(dispose).toHaveBeenCalledOnce()
   })

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
@@ -4,6 +4,7 @@ import {
   type GhosttyByteParserAdapter,
   type GhosttyParserEngine,
 } from './ghosttyParserEngine'
+import type { TerminalSize } from '../../types'
 import {
   createGhosttyVtByteParserAdapter,
   type GhosttyVtParserDriver,
@@ -31,6 +32,7 @@ export interface GhosttyVtRenderStateDriver {
   writeBytes: (bytes: Uint8Array) => void
   readSnapshot: () => GhosttyVtRenderSnapshot
   reset?: () => void
+  resize?: (size: TerminalSize) => void
   dispose?: () => void
 }
 
@@ -55,6 +57,9 @@ export const createGhosttyVtRenderStateParserDriverFactory =
       },
       reset: (): void => {
         renderStateDriver.reset?.()
+      },
+      resize: (size): void => {
+        renderStateDriver.resize?.(size)
       },
       dispose: (): void => {
         renderStateDriver.dispose?.()

--- a/src/features/terminal/components/TerminalPane/terminalControlParser.ts
+++ b/src/features/terminal/components/TerminalPane/terminalControlParser.ts
@@ -439,6 +439,10 @@ export class TerminalControlSequenceParser implements TerminalParser {
     return this.consumeControlSequences(source, output)
   }
 
+  reset(): void {
+    this.pendingControlSequence = ''
+  }
+
   private consumeControlSequences(
     data: string,
     output: TerminalParserOutputContext | null

--- a/src/features/terminal/components/TerminalPane/terminalParserEngine.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalParserEngine.test.ts
@@ -269,6 +269,29 @@ describe('byte-capable control sequence parser engine', () => {
     })
   })
 
+  test('reset clears pending split control sequences', () => {
+    const engine = createByteEngine()
+    const handler = vi.fn()
+
+    engine.parser.onEvent(handler)
+
+    expect(
+      engine.parseOutput(
+        createByteChunk('before \x1b]7;file://local', 0, 'live')
+      )
+    ).toEqual({ visibleText: 'before ' })
+
+    engine.reset()
+
+    expect(
+      engine.parseOutput(
+        createByteChunk('host/tmp/ghostty\x07 after', 25, 'live')
+      )
+    ).toEqual({ visibleText: 'host/tmp/ghostty\x07 after' })
+
+    expect(handler).not.toHaveBeenCalled()
+  })
+
   test('supports OSC 7 sequences terminated with string terminator', () => {
     const engine = createByteEngine()
     const handler = vi.fn()

--- a/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
+++ b/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
@@ -5,6 +5,7 @@ import type {
   TerminalParserEvent,
   TerminalParserOutputContext,
   TerminalRendererCapabilities,
+  TerminalSize,
 } from '../../types'
 import { TerminalControlSequenceParser } from './terminalControlParser'
 import {
@@ -42,6 +43,8 @@ export interface TerminalParserEngine {
   ) => TerminalParserEngineOutput
   parseInput: (input: TerminalParserEngineInput) => TerminalParserEngineOutput
   parseOutput: (chunk: TerminalOutputChunk) => TerminalParserEngineOutput
+  reset?: () => void
+  resize?: (size: TerminalSize) => void
   dispose?: () => void
 }
 
@@ -99,6 +102,10 @@ export class TerminalControlSequenceParserEngine implements TerminalParserEngine
       ...selection,
       output: outputContextFromChunk(chunk),
     })
+  }
+
+  reset(): void {
+    this.parser.reset()
   }
 
   protected emitParserEvent(event: TerminalParserEvent): void {


### PR DESCRIPTION
## Summary
- add reset/resize hooks to the generic terminal parser engine contract
- forward Ghostty size and reset state through the parser, byte adapter, and VT render-state driver
- sync the Ghostty parser engine size on construction/open/fit and reset driver state on terminal clear

## Verification
- npx vitest run src/features/terminal/components/TerminalPane/terminalParserEngine.test.ts src/features/terminal/components/TerminalPane/ghosttyParserEngine.test.ts src/features/terminal/components/TerminalPane/ghosttyVtByteParserAdapter.test.ts src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
- npm run type-check
- npm run lint
- npm run format:check
- git diff --check
- pre-push: npm test (302 files, 3915 passed, 3 skipped)

## Manual testing
Not required. This is a provider/driver lifecycle contract change covered by unit tests and still behind the existing Ghostty provider path.

Refs VIM-139