### PR TITLE
Add custom workspace layout creator

### DIFF
--- a/crates/backend/src/terminal/workspace_layout.rs
+++ b/crates/backend/src/terminal/workspace_layout.rs
@@ -166,7 +166,7 @@ const MAX_SESSIONS: usize = 64;
 const MAX_BUILTIN_PANES: usize = 6; // grid3x2 capacity
 const MAX_CUSTOM_PANE_LAYOUTS: usize = 32;
 const MIN_LAYOUT_TRACKS: usize = 1;
-const MAX_LAYOUT_TRACKS: usize = 4;
+const MAX_LAYOUT_TRACKS: usize = 24;
 const MIN_LAYOUT_SLOTS: usize = 1;
 const MAX_LAYOUT_SLOTS: usize = 16;
 const MAX_TABS: usize = 50;
@@ -1253,6 +1253,38 @@ mod tests {
 
         assert_eq!(store.sessions[0].layout, "custom:grid4x2");
         assert_eq!(store.sessions[0].panes.len(), 8);
+    }
+
+    #[test]
+    fn repairs_custom_layout_with_twenty_four_tracks() {
+        let columns: Vec<serde_json::Value> = (0..24)
+            .map(|index| json!({ "id": format!("col-{index}"), "units": 1 }))
+            .collect();
+        let store = repair_workspace_layout(
+            json!({
+              "version": 1,
+              "customPaneLayouts": [{
+                "schemaVersion": 1,
+                "id": "custom:wide",
+                "title": "Wide",
+                "source": "workspace",
+                "tracks": {
+                  "columns": columns,
+                  "rows": [{ "id": "row-0", "units": 24 }]
+                },
+                "slots": [
+                  { "id": "slot:p0", "rect": { "col": 0, "row": 0, "colSpan": 24, "rowSpan": 1 } }
+                ],
+                "addOrder": ["slot:p0"]
+              }],
+              "sessions": []
+            }),
+            "proj",
+            "/",
+        );
+
+        assert_eq!(store.custom_pane_layouts.len(), 1);
+        assert_eq!(store.custom_pane_layouts[0].id, "custom:wide");
     }
 
     #[test]

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -106,5 +106,5 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Schema Version Decoupling](patterns/schema-version-decoupling.md)                                   | correctness        | 1        | 0    | 2026-06-19   |
 | [Shared Controller Segmentation](patterns/shared-controller-segmentation.md)                         | react-patterns     | 2        | 0    | 2026-06-18   |
 | [Vite HMR Static Dependencies](patterns/vite-hmr-static-deps.md)                                     | code-quality       | 3        | 2    | 2026-06-18   |
-| [Custom Pane Layout Preservation](patterns/custom-pane-layout-preservation.md)                       | correctness        | 8        | 4    | 2026-06-20   |
+| [Custom Pane Layout Preservation](patterns/custom-pane-layout-preservation.md)                       | correctness        | 9        | 4    | 2026-06-21   |
 | [Pane Slot Identity](patterns/pane-slot-identity.md)                                                 | correctness        | 2        | 0    | 2026-06-19   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -59,7 +59,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 74       | 34   | 2026-06-18   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 88       | 25   | 2026-06-16   |
-| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 68       | 27   | 2026-06-20   |
+| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 69       | 27   | 2026-06-20   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 64       | 23   | 2026-06-17   |
 | [Canonical Path Dedupe](patterns/canonical-path-dedupe.md)                                           | correctness        | 2        | 0    | 2026-06-14   |
@@ -106,5 +106,5 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Schema Version Decoupling](patterns/schema-version-decoupling.md)                                   | correctness        | 1        | 0    | 2026-06-19   |
 | [Shared Controller Segmentation](patterns/shared-controller-segmentation.md)                         | react-patterns     | 2        | 0    | 2026-06-18   |
 | [Vite HMR Static Dependencies](patterns/vite-hmr-static-deps.md)                                     | code-quality       | 3        | 2    | 2026-06-18   |
-| [Custom Pane Layout Preservation](patterns/custom-pane-layout-preservation.md)                       | correctness        | 5        | 2    | 2026-06-20   |
+| [Custom Pane Layout Preservation](patterns/custom-pane-layout-preservation.md)                       | correctness        | 6        | 2    | 2026-06-20   |
 | [Pane Slot Identity](patterns/pane-slot-identity.md)                                                 | correctness        | 2        | 0    | 2026-06-19   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -59,7 +59,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 74       | 34   | 2026-06-18   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 88       | 25   | 2026-06-16   |
-| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 70       | 28   | 2026-06-20   |
+| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 72       | 29   | 2026-06-20   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 64       | 23   | 2026-06-17   |
 | [Canonical Path Dedupe](patterns/canonical-path-dedupe.md)                                           | correctness        | 2        | 0    | 2026-06-14   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -59,7 +59,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 74       | 34   | 2026-06-18   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 88       | 25   | 2026-06-16   |
-| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 69       | 27   | 2026-06-20   |
+| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 70       | 28   | 2026-06-20   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 64       | 23   | 2026-06-17   |
 | [Canonical Path Dedupe](patterns/canonical-path-dedupe.md)                                           | correctness        | 2        | 0    | 2026-06-14   |
@@ -74,7 +74,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Git Operations](patterns/git-operations.md)                                                         | correctness        | 26       | 11   | 2026-06-13   |
 | [CodeMirror Integration](patterns/codemirror-integration.md)                                         | editor             | 20       | 5    | 2026-06-17   |
 | [Editor File Existence Probe](patterns/editor-file-existence-probe.md)                               | files              | 3        | 0    | 2026-06-18   |
-| [Error Surfacing](patterns/error-surfacing.md)                                                       | error-handling     | 41       | 13   | 2026-06-17   |
+| [Error Surfacing](patterns/error-surfacing.md)                                                       | error-handling     | 42       | 14   | 2026-06-20   |
 | [File Tree Paths](patterns/file-tree-paths.md)                                                       | files              | 4        | 0    | 2026-04-10   |
 | [Scope Boundary](patterns/scope-boundary.md)                                                         | review-process     | 8        | 3    | 2026-06-01   |
 | [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 20       | 8    | 2026-06-15   |
@@ -94,7 +94,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [CloudFormation Stale References](patterns/cloudformation-stale-references.md)                       | infrastructure     | 2        | 1    | 2026-06-12   |
 | [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 4        | 1    | 2026-06-19   |
 | [Unsafe Block Safety Comments](patterns/unsafe-block-safety-comments.md)                             | security           | 1        | 0    | 2026-06-14   |
-| [Type Contract Safety](patterns/type-contract-safety.md)                                             | code-quality       | 7        | 3    | 2026-06-19   |
+| [Type Contract Safety](patterns/type-contract-safety.md)                                             | code-quality       | 8        | 4    | 2026-06-20   |
 | [String Construction Hygiene](patterns/string-construction-hygiene.md)                               | code-quality       | 1        | 0    | 2026-06-15   |
 | [Agent-State Guards](patterns/agent-state-guards.md)                                                 | correctness        | 3        | 2    | 2026-06-15   |
 | [React Prop Contracts](patterns/react-prop-contracts.md)                                             | react-patterns     | 5        | 4    | 2026-06-17   |
@@ -106,5 +106,5 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Schema Version Decoupling](patterns/schema-version-decoupling.md)                                   | correctness        | 1        | 0    | 2026-06-19   |
 | [Shared Controller Segmentation](patterns/shared-controller-segmentation.md)                         | react-patterns     | 2        | 0    | 2026-06-18   |
 | [Vite HMR Static Dependencies](patterns/vite-hmr-static-deps.md)                                     | code-quality       | 3        | 2    | 2026-06-18   |
-| [Custom Pane Layout Preservation](patterns/custom-pane-layout-preservation.md)                       | correctness        | 6        | 2    | 2026-06-20   |
+| [Custom Pane Layout Preservation](patterns/custom-pane-layout-preservation.md)                       | correctness        | 7        | 3    | 2026-06-20   |
 | [Pane Slot Identity](patterns/pane-slot-identity.md)                                                 | correctness        | 2        | 0    | 2026-06-19   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -74,7 +74,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Git Operations](patterns/git-operations.md)                                                         | correctness        | 26       | 11   | 2026-06-13   |
 | [CodeMirror Integration](patterns/codemirror-integration.md)                                         | editor             | 20       | 5    | 2026-06-17   |
 | [Editor File Existence Probe](patterns/editor-file-existence-probe.md)                               | files              | 3        | 0    | 2026-06-18   |
-| [Error Surfacing](patterns/error-surfacing.md)                                                       | error-handling     | 42       | 14   | 2026-06-20   |
+| [Error Surfacing](patterns/error-surfacing.md)                                                       | error-handling     | 43       | 15   | 2026-06-20   |
 | [File Tree Paths](patterns/file-tree-paths.md)                                                       | files              | 4        | 0    | 2026-04-10   |
 | [Scope Boundary](patterns/scope-boundary.md)                                                         | review-process     | 8        | 3    | 2026-06-01   |
 | [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 20       | 8    | 2026-06-15   |
@@ -106,5 +106,5 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Schema Version Decoupling](patterns/schema-version-decoupling.md)                                   | correctness        | 1        | 0    | 2026-06-19   |
 | [Shared Controller Segmentation](patterns/shared-controller-segmentation.md)                         | react-patterns     | 2        | 0    | 2026-06-18   |
 | [Vite HMR Static Dependencies](patterns/vite-hmr-static-deps.md)                                     | code-quality       | 3        | 2    | 2026-06-18   |
-| [Custom Pane Layout Preservation](patterns/custom-pane-layout-preservation.md)                       | correctness        | 7        | 3    | 2026-06-20   |
+| [Custom Pane Layout Preservation](patterns/custom-pane-layout-preservation.md)                       | correctness        | 8        | 4    | 2026-06-20   |
 | [Pane Slot Identity](patterns/pane-slot-identity.md)                                                 | correctness        | 2        | 0    | 2026-06-19   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -45,7 +45,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | ---------------------------------------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md)                                                     | security           | 24       | 6    | 2026-06-17   |
 | [Native Surface Occlusion](patterns/native-surface-occlusion.md)                                     | correctness        | 3        | 0    | 2026-06-15   |
-| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 53       | 22   | 2026-06-20   |
+| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 54       | 23   | 2026-06-20   |
 | [Imperative Animation Ownership](patterns/imperative-animation-ownership.md)                         | react-patterns     | 7        | 3    | 2026-06-17   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Fixed-Position Portals](patterns/fixed-position-portals.md)                                         | react-patterns     | 1        | 0    | 2026-06-12   |
@@ -106,5 +106,5 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Schema Version Decoupling](patterns/schema-version-decoupling.md)                                   | correctness        | 1        | 0    | 2026-06-19   |
 | [Shared Controller Segmentation](patterns/shared-controller-segmentation.md)                         | react-patterns     | 2        | 0    | 2026-06-18   |
 | [Vite HMR Static Dependencies](patterns/vite-hmr-static-deps.md)                                     | code-quality       | 3        | 2    | 2026-06-18   |
-| [Custom Pane Layout Preservation](patterns/custom-pane-layout-preservation.md)                       | correctness        | 4        | 1    | 2026-06-20   |
+| [Custom Pane Layout Preservation](patterns/custom-pane-layout-preservation.md)                       | correctness        | 5        | 2    | 2026-06-20   |
 | [Pane Slot Identity](patterns/pane-slot-identity.md)                                                 | correctness        | 2        | 0    | 2026-06-19   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -59,7 +59,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 74       | 34   | 2026-06-18   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 88       | 25   | 2026-06-16   |
-| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 72       | 29   | 2026-06-20   |
+| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 73       | 29   | 2026-06-20   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 64       | 23   | 2026-06-17   |
 | [Canonical Path Dedupe](patterns/canonical-path-dedupe.md)                                           | correctness        | 2        | 0    | 2026-06-14   |
@@ -74,7 +74,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Git Operations](patterns/git-operations.md)                                                         | correctness        | 26       | 11   | 2026-06-13   |
 | [CodeMirror Integration](patterns/codemirror-integration.md)                                         | editor             | 20       | 5    | 2026-06-17   |
 | [Editor File Existence Probe](patterns/editor-file-existence-probe.md)                               | files              | 3        | 0    | 2026-06-18   |
-| [Error Surfacing](patterns/error-surfacing.md)                                                       | error-handling     | 43       | 15   | 2026-06-20   |
+| [Error Surfacing](patterns/error-surfacing.md)                                                       | error-handling     | 44       | 15   | 2026-06-20   |
 | [File Tree Paths](patterns/file-tree-paths.md)                                                       | files              | 4        | 0    | 2026-04-10   |
 | [Scope Boundary](patterns/scope-boundary.md)                                                         | review-process     | 8        | 3    | 2026-06-01   |
 | [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 20       | 8    | 2026-06-15   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -45,7 +45,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | ---------------------------------------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md)                                                     | security           | 24       | 6    | 2026-06-17   |
 | [Native Surface Occlusion](patterns/native-surface-occlusion.md)                                     | correctness        | 3        | 0    | 2026-06-15   |
-| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 52       | 22   | 2026-06-19   |
+| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 53       | 22   | 2026-06-20   |
 | [Imperative Animation Ownership](patterns/imperative-animation-ownership.md)                         | react-patterns     | 7        | 3    | 2026-06-17   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Fixed-Position Portals](patterns/fixed-position-portals.md)                                         | react-patterns     | 1        | 0    | 2026-06-12   |
@@ -59,7 +59,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 74       | 34   | 2026-06-18   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 88       | 25   | 2026-06-16   |
-| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 67       | 27   | 2026-06-18   |
+| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 68       | 27   | 2026-06-20   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 64       | 23   | 2026-06-17   |
 | [Canonical Path Dedupe](patterns/canonical-path-dedupe.md)                                           | correctness        | 2        | 0    | 2026-06-14   |
@@ -84,7 +84,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Verify Render Target](patterns/verify-render-target.md)                                             | code-quality       | 2        | 0    | 2026-05-24   |
 | [UI Visual Regression](patterns/ui-visual-regression.md)                                             | code-quality       | 9        | 4    | 2026-06-13   |
 | [Status Indicator Display](patterns/status-indicator-display.md)                                     | code-quality       | 3        | 0    | 2026-05-26   |
-| [Parser Resilience](patterns/parser-resilience.md)                                                   | code-quality       | 11       | 8    | 2026-06-12   |
+| [Parser Resilience](patterns/parser-resilience.md)                                                   | code-quality       | 12       | 8    | 2026-06-20   |
 | [Persisted State Invariants](patterns/persisted-state-invariants.md)                                 | correctness        | 10       | 4    | 2026-06-19   |
 | [macOS Window Chrome](patterns/macos-window-chrome.md)                                               | cross-platform     | 9        | 2    | 2026-06-15   |
 | [Guard Branch Correctness](patterns/guard-branch-correctness.md)                                     | correctness        | 2        | 0    | 2026-06-19   |
@@ -106,5 +106,5 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Schema Version Decoupling](patterns/schema-version-decoupling.md)                                   | correctness        | 1        | 0    | 2026-06-19   |
 | [Shared Controller Segmentation](patterns/shared-controller-segmentation.md)                         | react-patterns     | 2        | 0    | 2026-06-18   |
 | [Vite HMR Static Dependencies](patterns/vite-hmr-static-deps.md)                                     | code-quality       | 3        | 2    | 2026-06-18   |
-| [Custom Pane Layout Preservation](patterns/custom-pane-layout-preservation.md)                       | correctness        | 1        | 0    | 2026-06-19   |
+| [Custom Pane Layout Preservation](patterns/custom-pane-layout-preservation.md)                       | correctness        | 2        | 0    | 2026-06-20   |
 | [Pane Slot Identity](patterns/pane-slot-identity.md)                                                 | correctness        | 2        | 0    | 2026-06-19   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -106,5 +106,5 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Schema Version Decoupling](patterns/schema-version-decoupling.md)                                   | correctness        | 1        | 0    | 2026-06-19   |
 | [Shared Controller Segmentation](patterns/shared-controller-segmentation.md)                         | react-patterns     | 2        | 0    | 2026-06-18   |
 | [Vite HMR Static Dependencies](patterns/vite-hmr-static-deps.md)                                     | code-quality       | 3        | 2    | 2026-06-18   |
-| [Custom Pane Layout Preservation](patterns/custom-pane-layout-preservation.md)                       | correctness        | 2        | 0    | 2026-06-20   |
+| [Custom Pane Layout Preservation](patterns/custom-pane-layout-preservation.md)                       | correctness        | 4        | 1    | 2026-06-20   |
 | [Pane Slot Identity](patterns/pane-slot-identity.md)                                                 | correctness        | 2        | 0    | 2026-06-19   |

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -3,7 +3,7 @@ id: accessibility
 category: a11y
 created: 2026-04-09
 last_updated: 2026-06-20
-ref_count: 28
+ref_count: 29
 ---
 
 # Accessibility
@@ -648,4 +648,22 @@ handlers must not trap focus without implementing the promised behavior.
 - **File:** `src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.tsx` L196-280
 - **Finding:** Custom layout rows were rendered as raw `<div>` and `<button>` elements inside `Menu`, so they never registered with the floating-ui list navigation model. Arrow-key navigation reached only the built-in layout checkboxes and skipped the custom section.
 - **Fix:** Added a `Menu.Row` primitive that registers arbitrary row content with the shared menu roving-focus model. Custom layout rows now use `Menu.Row`, expose an explicit row label, and have regression coverage proving arrow keys can reach the custom section.
+- **Commit:** same commit as this entry
+
+### 63. Layout creator empty grid cells ignored keyboard activation
+
+- **Source:** github-codex-connector | PR #569 round 6 | 2026-06-20
+- **Severity:** HIGH
+- **File:** `src/features/terminal/components/LayoutCreator/LayoutCreatorModal.tsx` L466-479
+- **Finding:** Empty layout grid cells rendered as enabled buttons with aria labels and tab stops, but only handled pointerdown. Native keyboard activation dispatches click, so Enter/Space on the focused cell announced an actionable control that did nothing.
+- **Fix:** Added a keyboard/synthetic click path for paintable cells that commits the same 1x1 slot as pointer single-cell painting, while ignoring pointer-generated clicks to avoid double-adds after pointerup. Added regression coverage for Enter on an empty grid cell.
+- **Commit:** same commit as this entry
+
+### 64. Nested action button arrow keys leaked into Menu.Row navigation
+
+- **Source:** github-codex-connector | PR #569 round 6 | 2026-06-20
+- **Severity:** MEDIUM
+- **File:** `src/components/Menu.tsx` L499-522
+- **Finding:** `Menu.Row` allowed ArrowUp/ArrowDown keydown events from focused descendant buttons to bubble into the menu's roving-focus handler, moving focus away from the nested action before the user completed that interaction.
+- **Fix:** Stopped ArrowUp/ArrowDown propagation when the key event originates from a descendant rather than the row itself. Added regression coverage that a nested row button keeps focus on ArrowDown.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -667,3 +667,12 @@ handlers must not trap focus without implementing the promised behavior.
 - **Finding:** `Menu.Row` allowed ArrowUp/ArrowDown keydown events from focused descendant buttons to bubble into the menu's roving-focus handler, moving focus away from the nested action before the user completed that interaction.
 - **Fix:** Stopped ArrowUp/ArrowDown propagation when the key event originates from a descendant rather than the row itself. Added regression coverage that a nested row button keeps focus on ArrowDown.
 - **Commit:** same commit as this entry
+
+### 65. Menu.Row intercepted nested button activation keys
+
+- **Source:** github-claude | PR #569 round 7 | 2026-06-20
+- **Severity:** HIGH
+- **File:** `src/components/Menu.tsx` L502-518
+- **Finding:** `Menu.Row` handled Enter/Space on bubbled keydown events from descendant buttons, preventing native button activation and firing the row's layout-pick action instead. Keyboard users could not activate nested edit/delete/toggle controls without triggering the wrong menu action.
+- **Fix:** Returned early for descendant keydown events so only the focused row handles Enter/Space, stopped descendant ArrowUp/ArrowDown during capture before roving focus sees them, and ignored clicks that bubble from nested interactive controls. Added regression coverage for descendant Enter activation.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -2,7 +2,7 @@
 id: accessibility
 category: a11y
 created: 2026-04-09
-last_updated: 2026-06-18
+last_updated: 2026-06-20
 ref_count: 27
 ---
 
@@ -621,4 +621,13 @@ handlers must not trap focus without implementing the promised behavior.
 - **File:** `src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.tsx`
 - **Finding:** The new `LayoutDisplayMenu` trigger was an icon-only button with an `aria-label` but no visible hover label. The prior stub in `WorkspaceView` had a `Tooltip` wrapper and the design system requires unified `Tooltip` usage for icon-only controls, so the new functional control was harder for sighted users to discover.
 - **Fix:** Added `tooltip` and `tooltipPlacement` props to the `Menu` primitive so it can wrap its cloned trigger with the shared `Tooltip`. `LayoutDisplayMenu` now passes `tooltip="Configure displayed layouts"` to `Menu`; `Tooltip` composes its hover/focus handlers with `Menu`'s trigger reference props so keyboard and click behavior are preserved.
+- **Commit:** same commit as this entry
+
+### 60. Layout creator modal lacks focus trap and focus restoration
+
+- **Source:** github-codex-connector (P2 / MEDIUM) | PR #569 round 1 | 2026-06-20
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/terminal/components/LayoutCreator/LayoutCreatorModal.tsx` L833-833
+- **Finding:** The layout creator dialog declared `aria-modal="true"` but only handled Escape and ⌘Enter. It did not trap Tab focus or restore the previously focused element, so keyboard users could tab into the workspace behind the overlay and trigger unrelated controls while the modal was active.
+- **Fix:** Added a `panelRef` and `previousFocusRef`, captured focus before open to focus the name input, restored focus on close, and added a document keydown handler that cycles Tab/Shift+Tab among the modal panel's focusable elements.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -3,7 +3,7 @@ id: accessibility
 category: a11y
 created: 2026-04-09
 last_updated: 2026-06-20
-ref_count: 27
+ref_count: 28
 ---
 
 # Accessibility
@@ -639,4 +639,13 @@ handlers must not trap focus without implementing the promised behavior.
 - **File:** `src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.tsx` L79-294
 - **Finding:** `LayoutDisplayMenu` closed custom-layout actions by changing the `Menu` key. The remount destroyed the focused row and trigger, so delete left focus on `document.body`, while create/edit opened the modal after the wrong focus restoration target had been captured.
 - **Fix:** Added a `closeSignal` prop to the shared `Menu` primitive so callers can request an internal close without remounting the trigger. `LayoutDisplayMenu` focuses its trigger before sending the close signal, and custom pick/edit/delete/create actions all route through that path.
+- **Commit:** same commit as this entry
+
+### 62. Custom multi-action menu rows bypass roving keyboard navigation
+
+- **Source:** github-claude | PR #569 round 5 | 2026-06-20
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.tsx` L196-280
+- **Finding:** Custom layout rows were rendered as raw `<div>` and `<button>` elements inside `Menu`, so they never registered with the floating-ui list navigation model. Arrow-key navigation reached only the built-in layout checkboxes and skipped the custom section.
+- **Fix:** Added a `Menu.Row` primitive that registers arbitrary row content with the shared menu roving-focus model. Custom layout rows now use `Menu.Row`, expose an explicit row label, and have regression coverage proving arrow keys can reach the custom section.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -631,3 +631,12 @@ handlers must not trap focus without implementing the promised behavior.
 - **Finding:** The layout creator dialog declared `aria-modal="true"` but only handled Escape and ⌘Enter. It did not trap Tab focus or restore the previously focused element, so keyboard users could tab into the workspace behind the overlay and trigger unrelated controls while the modal was active.
 - **Fix:** Added a `panelRef` and `previousFocusRef`, captured focus before open to focus the name input, restored focus on close, and added a document keydown handler that cycles Tab/Shift+Tab among the modal panel's focusable elements.
 - **Commit:** same commit as this entry
+
+### 61. Programmatic menu close unmounts the focused row
+
+- **Source:** github-codex-connector | PR #569 round 4 | 2026-06-20
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.tsx` L79-294
+- **Finding:** `LayoutDisplayMenu` closed custom-layout actions by changing the `Menu` key. The remount destroyed the focused row and trigger, so delete left focus on `document.body`, while create/edit opened the modal after the wrong focus restoration target had been captured.
+- **Fix:** Added a `closeSignal` prop to the shared `Menu` primitive so callers can request an internal close without remounting the trigger. `LayoutDisplayMenu` focuses its trigger before sending the close signal, and custom pick/edit/delete/create actions all route through that path.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/custom-pane-layout-preservation.md
+++ b/docs/reviews/patterns/custom-pane-layout-preservation.md
@@ -2,7 +2,7 @@
 id: custom-pane-layout-preservation
 category: correctness
 created: 2026-06-19
-last_updated: 2026-06-19
+last_updated: 2026-06-20
 ref_count: 0
 ---
 
@@ -21,4 +21,13 @@ Custom pane layouts can define capacities larger than any builtin layout. When a
 - **File:** `src/features/terminal/layout-registry/layoutRegistry.ts` L104-106
 - **Finding:** `autoShrinkLayoutFor` fell back to `grid3x2` when the current custom layout was no longer registered and `nextPaneCount > 6`. The renderer kept all panes in memory, but the backend durable repair caps non-custom layouts at six panes, so the next save/reload silently dropped panes beyond the sixth.
 - **Fix:** In `setCustomPaneLayouts`, validate the incoming definitions first, then preserve any existing custom layout whose id is still used by a session with more panes than `MAX_BUILTIN_PANE_COUNT` and that is absent or under-capacity in the candidate registry. The preserved definition overrides rejected or insufficient replacements, preventing the over-capacity builtin fallback.
+- **Commit:** same commit as this entry
+
+### 2. Builtin layout pick allowed for session with more panes than builtin supports
+
+- **Source:** github-codex-connector (P1 / HIGH) | PR #569 round 1 | 2026-06-20
+- **Severity:** P1 / HIGH
+- **File:** `src/features/workspace/WorkspaceView.tsx` L532-532
+- **Finding:** When a custom layout held 7–16 panes, the top-chrome layout switcher still exposed builtin layouts. Selecting a builtin layout persisted the session under a non-custom layout while retaining more panes than any builtin supports. The backend durable repair caps non-custom layouts at six panes, so extra panes were silently dropped on the next restore.
+- **Fix:** Added a guard in `handlePickLayout` that rejects builtin layout picks whose capacity is below the active session's pane count. The session stays on its valid custom layout until panes are reduced.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/custom-pane-layout-preservation.md
+++ b/docs/reviews/patterns/custom-pane-layout-preservation.md
@@ -3,7 +3,7 @@ id: custom-pane-layout-preservation
 category: correctness
 created: 2026-06-19
 last_updated: 2026-06-20
-ref_count: 2
+ref_count: 3
 ---
 
 # Custom Pane Layout Preservation
@@ -66,4 +66,13 @@ Custom pane layouts can define capacities larger than any builtin layout. When a
 - **File:** `src/features/workspace/WorkspaceView.tsx` L1270-1295
 - **Finding:** `handleSaveCustomLayout` persisted the custom definition and then unconditionally called `setSessionLayout(activeSessionId, definition.id)`. When the active session had more panes than the saved layout supported, that later session-layout update could override the custom-layout preservation/migration guard and leave panes hidden under an undersized layout.
 - **Fix:** Guarded the auto-apply path with `activeSession.panes.length <= getPaneLayoutCapacity(definition)`. The definition is still saved and unhidden, but the active session is only rebound when the saved layout can display every pane.
+- **Commit:** same commit as this entry
+
+### 7. Capacity guard rejects layout picks without visible feedback
+
+- **Source:** github-claude | PR #569 round 5 | 2026-06-20
+- **Severity:** HIGH
+- **File:** `src/features/workspace/WorkspaceView.tsx` L1246-1258 and `src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.tsx` L196-280
+- **Finding:** The capacity guard correctly rejected layouts whose slot count was below the active session pane count, but the main switcher still displayed those choices and the display menu closed after a rejected custom-layout pick. The click appeared to do nothing and left users without a visible explanation.
+- **Fix:** `handlePickLayout` now returns a success boolean, the top pill switcher receives only layouts that can fit the active session (plus the active layout), and the display menu marks blocked custom layout apply actions disabled so rejected picks stay visible instead of closing silently.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/custom-pane-layout-preservation.md
+++ b/docs/reviews/patterns/custom-pane-layout-preservation.md
@@ -3,7 +3,7 @@ id: custom-pane-layout-preservation
 category: correctness
 created: 2026-06-19
 last_updated: 2026-06-20
-ref_count: 0
+ref_count: 1
 ---
 
 # Custom Pane Layout Preservation
@@ -30,4 +30,22 @@ Custom pane layouts can define capacities larger than any builtin layout. When a
 - **File:** `src/features/workspace/WorkspaceView.tsx` L532-532
 - **Finding:** When a custom layout held 7–16 panes, the top-chrome layout switcher still exposed builtin layouts. Selecting a builtin layout persisted the session under a non-custom layout while retaining more panes than any builtin supports. The backend durable repair caps non-custom layouts at six panes, so extra panes were silently dropped on the next restore.
 - **Fix:** Added a guard in `handlePickLayout` that rejects builtin layout picks whose capacity is below the active session's pane count. The session stays on its valid custom layout until panes are reduced.
+- **Commit:** same commit as this entry
+
+### 3. Imported custom layouts with too many tracks can pass UI validation and throw on Save
+
+- **Source:** github-codex-connector (P1 / HIGH) | PR #569 round 2 | 2026-06-20
+- **Severity:** P1 / HIGH
+- **File:** `src/features/terminal/components/LayoutCreator/layoutCreatorModel.ts` L212-254 and `src/features/terminal/components/LayoutCreator/LayoutCreatorModal.tsx` L716-884
+- **Finding:** `validateDraftLayout` only checked overlap, empty cells, and slot count. A JSON/YAML import with more than `MAX_LAYOUT_TRACKS` columns or rows but 16 or fewer covering slots could produce `validation.ok=true`, enabling Save. `definitionFromDraft` then invoked `validatePaneLayoutDefinition`, which enforced the 24-track cap and threw with no user-facing recovery.
+- **Fix:** Added a `trackOverCapacity` flag to `DraftLayoutValidation` and `validateDraftLayout`; it is included in the `ok` predicate and surfaced as a validation message in `LayoutCreatorModal` so Save remains disabled for over-capacity imports.
+- **Commit:** same commit as this entry
+
+### 4. Custom layout picks can hide active panes without a capacity guard
+
+- **Source:** github-codex-connector (P2 / LOW) | PR #569 round 2 | 2026-06-20
+- **Severity:** P2 / LOW
+- **File:** `src/features/workspace/WorkspaceView.tsx` L1246-1262
+- **Finding:** `handlePickLayout` only capacity-guarded builtin layouts. The display-menu custom-layout path could apply a custom layout whose capacity was smaller than the active session's pane count, immediately hiding panes without explanation.
+- **Fix:** Removed the builtin-only condition and applied the capacity check to all selected layouts via `layoutRegistry.capacityFor(layoutId)`.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/custom-pane-layout-preservation.md
+++ b/docs/reviews/patterns/custom-pane-layout-preservation.md
@@ -3,7 +3,7 @@ id: custom-pane-layout-preservation
 category: correctness
 created: 2026-06-19
 last_updated: 2026-06-20
-ref_count: 1
+ref_count: 2
 ---
 
 # Custom Pane Layout Preservation
@@ -48,4 +48,13 @@ Custom pane layouts can define capacities larger than any builtin layout. When a
 - **File:** `src/features/workspace/WorkspaceView.tsx` L1246-1262
 - **Finding:** `handlePickLayout` only capacity-guarded builtin layouts. The display-menu custom-layout path could apply a custom layout whose capacity was smaller than the active session's pane count, immediately hiding panes without explanation.
 - **Fix:** Removed the builtin-only condition and applied the capacity check to all selected layouts via `layoutRegistry.capacityFor(layoutId)`.
+- **Commit:** same commit as this entry
+
+### 5. Intentional custom layout delete is undone by preservation guard
+
+- **Source:** github-claude | PR #569 round 3 | 2026-06-20
+- **Severity:** HIGH
+- **File:** `src/features/sessions/hooks/useSessionManager.ts` L276-366 and `src/features/workspace/WorkspaceView.tsx` L1294-1314
+- **Finding:** `handleDeleteCustomLayout` called `setSessionLayout(activeSessionId, 'single')` before calling `setCustomPaneLayouts` to remove the layout. The preservation guard inside `setCustomPaneLayouts` read `sessionsRef.current` before the queued session-layout change had committed, so it still saw the deleted custom layout as needed by an over-capacity session and re-merged it, silently undoing the delete.
+- **Fix:** Added a `skipPreservation` option to `setCustomPaneLayouts`. `handleDeleteCustomLayout` passes `{ skipPreservation: true }` so the layout is removed unconditionally; the session migration then moves affected sessions to a fallback layout.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/custom-pane-layout-preservation.md
+++ b/docs/reviews/patterns/custom-pane-layout-preservation.md
@@ -3,7 +3,7 @@ id: custom-pane-layout-preservation
 category: correctness
 created: 2026-06-19
 last_updated: 2026-06-20
-ref_count: 3
+ref_count: 4
 ---
 
 # Custom Pane Layout Preservation
@@ -75,4 +75,13 @@ Custom pane layouts can define capacities larger than any builtin layout. When a
 - **File:** `src/features/workspace/WorkspaceView.tsx` L1246-1258 and `src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.tsx` L196-280
 - **Finding:** The capacity guard correctly rejected layouts whose slot count was below the active session pane count, but the main switcher still displayed those choices and the display menu closed after a rejected custom-layout pick. The click appeared to do nothing and left users without a visible explanation.
 - **Fix:** `handlePickLayout` now returns a success boolean, the top pill switcher receives only layouts that can fit the active session (plus the active layout), and the display menu marks blocked custom layout apply actions disabled so rejected picks stay visible instead of closing silently.
+- **Commit:** same commit as this entry
+
+### 8. Paint drag advertises a valid pane while the layout is already at the pane cap
+
+- **Source:** github-claude | PR #569 round 6 | 2026-06-20
+- **Severity:** LOW
+- **File:** `src/features/terminal/components/LayoutCreator/LayoutCreatorModal.tsx` L285-287
+- **Finding:** `previewValid` checked only spatial freedom, so after reaching `MAX_LAYOUT_SLOTS` a user could start a paint drag over an empty cell, see the valid green preview, release, and have `addSlotRect` refuse the pane with no visible feedback.
+- **Fix:** Included the slot-count cap in preview validity and disabled empty paint cells while the draft already has `MAX_LAYOUT_SLOTS` panes. Added a regression test that imports a 16-pane layout, adds an empty column, and verifies the empty paint cell is disabled.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/custom-pane-layout-preservation.md
+++ b/docs/reviews/patterns/custom-pane-layout-preservation.md
@@ -58,3 +58,12 @@ Custom pane layouts can define capacities larger than any builtin layout. When a
 - **Finding:** `handleDeleteCustomLayout` called `setSessionLayout(activeSessionId, 'single')` before calling `setCustomPaneLayouts` to remove the layout. The preservation guard inside `setCustomPaneLayouts` read `sessionsRef.current` before the queued session-layout change had committed, so it still saw the deleted custom layout as needed by an over-capacity session and re-merged it, silently undoing the delete.
 - **Fix:** Added a `skipPreservation` option to `setCustomPaneLayouts`. `handleDeleteCustomLayout` passes `{ skipPreservation: true }` so the layout is removed unconditionally; the session migration then moves affected sessions to a fallback layout.
 - **Commit:** same commit as this entry
+
+### 6. Saving an undersized custom layout can reapply it to an over-capacity session
+
+- **Source:** github-codex-connector | PR #569 round 4 | 2026-06-20
+- **Severity:** HIGH
+- **File:** `src/features/workspace/WorkspaceView.tsx` L1270-1295
+- **Finding:** `handleSaveCustomLayout` persisted the custom definition and then unconditionally called `setSessionLayout(activeSessionId, definition.id)`. When the active session had more panes than the saved layout supported, that later session-layout update could override the custom-layout preservation/migration guard and leave panes hidden under an undersized layout.
+- **Fix:** Guarded the auto-apply path with `activeSession.panes.length <= getPaneLayoutCapacity(definition)`. The definition is still saved and unhidden, but the active session is only rebound when the saved layout can display every pane.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/custom-pane-layout-preservation.md
+++ b/docs/reviews/patterns/custom-pane-layout-preservation.md
@@ -2,7 +2,7 @@
 id: custom-pane-layout-preservation
 category: correctness
 created: 2026-06-19
-last_updated: 2026-06-20
+last_updated: 2026-06-21
 ref_count: 4
 ---
 
@@ -84,4 +84,13 @@ Custom pane layouts can define capacities larger than any builtin layout. When a
 - **File:** `src/features/terminal/components/LayoutCreator/LayoutCreatorModal.tsx` L285-287
 - **Finding:** `previewValid` checked only spatial freedom, so after reaching `MAX_LAYOUT_SLOTS` a user could start a paint drag over an empty cell, see the valid green preview, release, and have `addSlotRect` refuse the pane with no visible feedback.
 - **Fix:** Included the slot-count cap in preview validity and disabled empty paint cells while the draft already has `MAX_LAYOUT_SLOTS` panes. Added a regression test that imports a 16-pane layout, adds an empty column, and verifies the empty paint cell is disabled.
+- **Commit:** same commit as this entry
+
+### 9. Reduced-capacity custom layout edits can be silently discarded
+
+- **Source:** github-codex-connector | PR #569 round 7 | 2026-06-21
+- **Severity:** HIGH
+- **File:** `src/features/workspace/WorkspaceView.tsx` L1301-1310
+- **Finding:** `handleSaveCustomLayout` saved edited definitions through `setCustomPaneLayouts` without marking the update as intentional. When an existing custom layout was edited down to fewer slots while an over-capacity session still referenced it, the preservation guard could restore the old definition and make the modal close as though the reduced-capacity edit had saved.
+- **Fix:** Pass `{ skipPreservation: true }` from `handleSaveCustomLayout` so intentional edits bypass the preservation guard, matching the delete path. The existing session migration path handles sessions that no longer fit the edited layout.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/error-surfacing.md
+++ b/docs/reviews/patterns/error-surfacing.md
@@ -3,7 +3,7 @@ id: error-surfacing
 category: error-handling
 created: 2026-04-10
 last_updated: 2026-06-20
-ref_count: 14
+ref_count: 15
 ---
 
 # Error Surfacing
@@ -413,4 +413,13 @@ failed" must mean the editor shows the original file, not the requested one.
 - **File:** `src/features/terminal/components/LayoutCreator/LayoutCreatorModal.tsx` L767-785
 - **Finding:** `handleSave` relied on draft validation before calling `definitionFromDraft`, but `definitionFromDraft` also runs schema validation and can throw if the validators diverge in a future change. An uncaught throw from the click handler would leave the modal open without user-facing feedback.
 - **Fix:** Wrapped `definitionFromDraft` and `onSave` in the same try/catch shape used by the code-import path and route the caught message to the modal's existing inline `codeError` surface.
+- **Commit:** same commit as this entry
+
+### 43. Layout creator save error routed to a hidden code-panel-only surface
+
+- **Source:** github-claude | PR #569 round 6 | 2026-06-20
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/components/LayoutCreator/LayoutCreatorModal.tsx` L777-789
+- **Finding:** The round-5 `handleSave` catch surfaced failures through `codeError`, but that message only rendered while the optional code panel was open. With the default closed panel, a save-time validation or `onSave` failure kept the modal open with no visible explanation.
+- **Fix:** Added a separate `saveError` state rendered unconditionally below the modal header, cleared it on successful save and draft/name edits, and covered the closed-code-panel failure path with a regression test.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/error-surfacing.md
+++ b/docs/reviews/patterns/error-surfacing.md
@@ -423,3 +423,12 @@ failed" must mean the editor shows the original file, not the requested one.
 - **Finding:** The round-5 `handleSave` catch surfaced failures through `codeError`, but that message only rendered while the optional code panel was open. With the default closed panel, a save-time validation or `onSave` failure kept the modal open with no visible explanation.
 - **Fix:** Added a separate `saveError` state rendered unconditionally below the modal header, cleared it on successful save and draft/name edits, and covered the closed-code-panel failure path with a regression test.
 - **Commit:** same commit as this entry
+
+### 44. Code apply left stale save-error banner visible
+
+- **Source:** github-claude | PR #569 round 7 | 2026-06-20
+- **Severity:** LOW
+- **File:** `src/features/terminal/components/LayoutCreator/LayoutCreatorModal.tsx` L875-884
+- **Finding:** After a failed save displayed the always-visible `saveError` banner, a successful code-panel Apply cleared only `codeError`. The draft updated correctly but the stale save banner stayed visible alongside valid layout state.
+- **Fix:** Clear `saveError` on the successful `applyCode` path alongside `codeError`, and add regression coverage that applying valid code removes a previously displayed save failure.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/error-surfacing.md
+++ b/docs/reviews/patterns/error-surfacing.md
@@ -2,8 +2,8 @@
 id: error-surfacing
 category: error-handling
 created: 2026-04-10
-last_updated: 2026-06-17
-ref_count: 13
+last_updated: 2026-06-20
+ref_count: 14
 ---
 
 # Error Surfacing
@@ -405,3 +405,12 @@ failed" must mean the editor shows the original file, not the requested one.
 - **Finding:** A `fileSystemService.readFile` call was used as an existence probe for the selected editor file. The bare `catch` set `selectedEditorFileExists(false)` for any rejection, so `resolveEditorFileLifecycleStatus` mapped permission errors, IPC failures, disk I/O errors, and remote-mount hiccups to `DELETED`. `DockPanel` makes clean `DELETED` buffers read-only, so a transient non-not-found failure could incorrectly lock editing of an existing file until a later successful check.
 - **Fix:** Added `isNotFoundError` helper that matches explicit not-found signals (`ENOENT`, `No such file or directory`, `os error 2`, Windows file-not-found text) on both string rejections and `Error` objects. The catch block now sets `selectedEditorFileExists(false)` only for not-found errors and preserves `null` (unknown) state for all other failures. Added regression tests for the helper classification and for `WorkspaceView` keeping the lifecycle status null on a permission-denied rejection.
 - **Commit:** see current commit
+
+### 42. Layout creator save path lets schema-validation throws escape
+
+- **Source:** github-claude | PR #569 round 5 | 2026-06-20
+- **Severity:** LOW
+- **File:** `src/features/terminal/components/LayoutCreator/LayoutCreatorModal.tsx` L767-785
+- **Finding:** `handleSave` relied on draft validation before calling `definitionFromDraft`, but `definitionFromDraft` also runs schema validation and can throw if the validators diverge in a future change. An uncaught throw from the click handler would leave the modal open without user-facing feedback.
+- **Fix:** Wrapped `definitionFromDraft` and `onSave` in the same try/catch shape used by the code-import path and route the caught message to the modal's existing inline `codeError` surface.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/parser-resilience.md
+++ b/docs/reviews/patterns/parser-resilience.md
@@ -2,7 +2,7 @@
 id: parser-resilience
 category: code-quality
 created: 2026-05-24
-last_updated: 2026-06-12
+last_updated: 2026-06-20
 ref_count: 8
 ---
 
@@ -210,4 +210,13 @@ true` and drop the chunk.
 - **File:** `eslint-rules/no-hardcoded-colors.js` L9
 - **Finding:** The new `no-hardcoded-colors` rule matched white/black utilities for `text`, `bg`, `border`, etc., but omitted the Tailwind gradient-stop prefixes `from`, `via`, and `to`. Class strings such as `from-white/5`, `via-black`, and `to-white/20` passed lint even though they are hardcoded colors, weakening the per-commit guard for the runtime theme migration.
 - **Fix:** Extended the white/black utility regex to include `from|via|to` and added invalid `RuleTester` cases for `from-white/5`, `via-black`, and `to-white/20`.
+- **Commit:** same commit as this entry
+
+### 12. YAML mode swallows validation errors, shows JSON SyntaxError instead
+
+- **Source:** github-claude | PR #569 round 1 | 2026-06-20
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/components/LayoutCreator/layoutCreatorModel.ts` L713-723
+- **Finding:** `parseDraftLayoutText` used a bare `catch {}` around `modelToDraft(parseYamlModel(trimmed))` so it could fall through to a JSON fallback. Valid YAML that produced a semantically invalid model (e.g., missing covered cells, overlapping panes) threw a descriptive validation error, but that error was discarded. The subsequent `JSON.parse(trimmed)` always failed on YAML text, surfacing a cryptic `SyntaxError: Unexpected token '-'` instead of the actionable validation message.
+- **Fix:** Capture the YAML error in a local variable, attempt the JSON fallback, and re-throw the original YAML error if the fallback also fails. This preserves descriptive validation messages for valid YAML with semantic problems while keeping the JSON-pasted-into-YAML-mode convenience path.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/react-lifecycle.md
+++ b/docs/reviews/patterns/react-lifecycle.md
@@ -2,7 +2,7 @@
 id: react-lifecycle
 category: react-patterns
 created: 2026-04-09
-last_updated: 2026-06-19
+last_updated: 2026-06-20
 ref_count: 22
 ---
 
@@ -506,4 +506,13 @@ to avoid unintended re-runs (e.g., PTY respawning on every cwd change).
 - **File:** `src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.tsx` L33-37
 - **Finding:** `LayoutSwitcher` created `const layoutById = new Map(layouts.map(...))` and `const layoutIds = layouts.map(...)` on every render. Because the component re-renders on every active-session change, fresh Map and array references prevented any downstream `React.memo` or `useMemo` that depended on those identities from firing.
 - **Fix:** Wrapped both `layoutIds` and `layoutById` in `useMemo(() => ..., [layouts])` so the references stay stable across unrelated re-renders.
+- **Commit:** same commit as this entry
+
+### 53. Custom layout save/delete reads stale `customPaneLayouts` closure
+
+- **Source:** github-claude | PR #569 round 1 | 2026-06-20
+- **Severity:** LOW
+- **File:** `src/features/workspace/WorkspaceView.tsx` L1265-1295
+- **Finding:** `handleSaveCustomLayout` and `handleDeleteCustomLayout` called `setCustomPaneLayouts([...customPaneLayouts.filter(...), ...])`, reading `customPaneLayouts` from the `useCallback` closure. The deps array recreated the callback when the list changed, but concurrent or batched updates between renders could operate on a stale snapshot and silently drop an interleaved layout change.
+- **Fix:** Switched both callbacks to the functional updater form `setCustomPaneLayouts(previous => ...)`. Also updated `useSessionManager`'s `setCustomPaneLayouts` wrapper to accept functional updaters and evaluate them inside the underlying `setCustomPaneLayoutsState` updater so the latest previous value is always used.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/react-lifecycle.md
+++ b/docs/reviews/patterns/react-lifecycle.md
@@ -3,7 +3,7 @@ id: react-lifecycle
 category: react-patterns
 created: 2026-04-09
 last_updated: 2026-06-20
-ref_count: 22
+ref_count: 23
 ---
 
 # React Lifecycle
@@ -515,4 +515,13 @@ to avoid unintended re-runs (e.g., PTY respawning on every cwd change).
 - **File:** `src/features/workspace/WorkspaceView.tsx` L1265-1295
 - **Finding:** `handleSaveCustomLayout` and `handleDeleteCustomLayout` called `setCustomPaneLayouts([...customPaneLayouts.filter(...), ...])`, reading `customPaneLayouts` from the `useCallback` closure. The deps array recreated the callback when the list changed, but concurrent or batched updates between renders could operate on a stale snapshot and silently drop an interleaved layout change.
 - **Fix:** Switched both callbacks to the functional updater form `setCustomPaneLayouts(previous => ...)`. Also updated `useSessionManager`'s `setCustomPaneLayouts` wrapper to accept functional updaters and evaluate them inside the underlying `setCustomPaneLayoutsState` updater so the latest previous value is always used.
+- **Commit:** same commit as this entry
+
+### 54. `setSessions` called as a side effect inside a state updater
+
+- **Source:** github-claude | PR #569 round 3 | 2026-06-20
+- **Severity:** MEDIUM
+- **File:** `src/features/sessions/hooks/useSessionManager.ts` L276-366
+- **Finding:** `setCustomPaneLayouts` computed the preserved layouts and migrated sessions inside the `setCustomPaneLayoutsState` functional updater, calling `setSessions` from within that updater. React functional updaters must be pure and may be invoked more than once in Strict Mode or replayed under concurrent rendering, which could queue duplicate session transformations.
+- **Fix:** Derived the next custom layout registry at top-level (using a `customPaneLayoutsRef` to read the current registry) and performed `setSessions` as a separate top-level functional update. The layout state still uses a direct `setCustomPaneLayoutsState(nextCustomLayouts)` call because the registry was already derived from the latest previous value.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/type-contract-safety.md
+++ b/docs/reviews/patterns/type-contract-safety.md
@@ -2,8 +2,8 @@
 id: type-contract-safety
 category: code-quality
 created: 2026-06-15
-last_updated: 2026-06-19
-ref_count: 3
+last_updated: 2026-06-20
+ref_count: 4
 ---
 
 # Type Contract Safety
@@ -87,3 +87,12 @@ expands.
 - **Finding:** `PersistedPaneLayoutDefinition` was declared as `Record<string, unknown>`, which erased the concrete shape of persisted custom pane layouts. The loose type made it easy to pass malformed data across the Electron persistence boundary without compile-time feedback.
 - **Fix:** Replaced the `Record<string, unknown>` alias with a concrete `PersistedPaneLayoutDefinition` interface and supporting `PersistedTrackSpec`, `PersistedPaneSlotRect`, and `PersistedPaneSlotSpec` types that mirror the renderer-side `PaneLayoutDefinition` shape using plain strings for the persisted boundary.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 8. `Menu.closeSignal` accepts reference-unstable sentinels
+
+- **Source:** github-claude | PR #569 round 5 | 2026-06-20
+- **Severity:** LOW
+- **File:** `src/components/Menu.tsx` L276
+- **Finding:** `closeSignal?: unknown` allowed callers to pass object or array values even though the close effect compares the value by strict equality. Reference-unstable values could close the menu on every render or fail to communicate the intended numeric counter semantics.
+- **Fix:** Narrowed the public prop to `number | undefined`, matching the only supported usage pattern: incrementing a primitive counter when a consumer needs to request a close.
+- **Commit:** same commit as this entry

--- a/src/components/Menu.test.tsx
+++ b/src/components/Menu.test.tsx
@@ -581,6 +581,37 @@ describe('Menu.Submenu', () => {
   })
 })
 
+describe('Menu.Row', () => {
+  test('nested button arrow keys do not move menu row focus', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <Menu trigger={<button type="button">Open</button>}>
+        <Menu.Row label="Layout Alpha">
+          <span>Layout Alpha</span>
+          <button type="button">Edit Alpha</button>
+        </Menu.Row>
+        <Menu.Row label="Layout Beta">
+          <span>Layout Beta</span>
+        </Menu.Row>
+      </Menu>
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Open' }))
+
+    const editButton = await screen.findByRole('button', {
+      name: 'Edit Alpha',
+    })
+    editButton.focus()
+    await user.keyboard('{ArrowDown}')
+
+    expect(editButton).toHaveFocus()
+    expect(
+      screen.getByRole('menuitem', { name: 'Layout Beta' })
+    ).not.toHaveFocus()
+  })
+})
+
 describe('Menu.Context', () => {
   test('renders nothing when closed', () => {
     const closed = false

--- a/src/components/Menu.test.tsx
+++ b/src/components/Menu.test.tsx
@@ -610,6 +610,34 @@ describe('Menu.Row', () => {
       screen.getByRole('menuitem', { name: 'Layout Beta' })
     ).not.toHaveFocus()
   })
+
+  test('nested button Enter activates the button instead of the menu row', async () => {
+    const user = userEvent.setup()
+    const onSelect = vi.fn()
+    const onEdit = vi.fn()
+
+    render(
+      <Menu trigger={<button type="button">Open</button>}>
+        <Menu.Row label="Layout Alpha" onSelect={onSelect}>
+          <span>Layout Alpha</span>
+          <button type="button" onClick={onEdit}>
+            Edit Alpha
+          </button>
+        </Menu.Row>
+      </Menu>
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Open' }))
+
+    const editButton = await screen.findByRole('button', {
+      name: 'Edit Alpha',
+    })
+    editButton.focus()
+    await user.keyboard('{Enter}')
+
+    expect(onEdit).toHaveBeenCalledOnce()
+    expect(onSelect).not.toHaveBeenCalled()
+  })
 })
 
 describe('Menu.Context', () => {

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -86,7 +86,7 @@ const SHORTCUT_CHIP_CLASSES =
   'shrink-0 rounded bg-on-surface/10 px-1.5 py-0.5 font-mono text-[10px] ' +
   'text-on-surface-variant'
 
-// 18×18 rounded check square ported from ViewSettingsDropdown's CheckIndicator:
+// 16×16 rounded check square ported from ViewSettingsDropdown's CheckIndicator:
 // checked => filled square with a `check` glyph; unchecked => thin
 // outline-variant border. Disabled rows tone the checked state down so the
 // indicator visually matches the muted label.
@@ -100,17 +100,17 @@ const CheckIndicator = ({
   <span
     aria-hidden="true"
     className={
-      'inline-flex items-center justify-center w-[18px] h-[18px] rounded-[4px] flex-shrink-0 ' +
+      'inline-flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-[4px] ' +
       (checked
         ? disabled
-          ? 'bg-on-surface-variant/12 text-on-surface-variant/55 border-[1.5px] border-on-surface-variant/20'
+          ? 'border border-on-surface-variant/20 bg-on-surface-variant/12 text-on-surface-variant/55'
           : 'bg-primary text-on-primary'
-        : 'bg-transparent border-[1.5px] border-on-surface-variant/30')
+        : 'border border-on-surface-variant/30 bg-transparent')
     }
     style={checked ? { fontVariationSettings: '"wght" 700' } : undefined}
   >
     {checked ? (
-      <span className="material-symbols-outlined text-[14px] leading-none">
+      <span className="material-symbols-outlined text-[12px] leading-none">
         check
       </span>
     ) : null}

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -512,7 +512,9 @@ const MenuRow = ({
     select()
   }
 
-  const handleKeyDownCapture: KeyboardEventHandler<HTMLDivElement> = (event) => {
+  const handleKeyDownCapture: KeyboardEventHandler<HTMLDivElement> = (
+    event
+  ) => {
     if (
       event.currentTarget === event.target ||
       (event.key !== 'ArrowUp' && event.key !== 'ArrowDown')

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -500,6 +500,15 @@ const MenuRow = ({
   }
 
   const handleKeyDown: KeyboardEventHandler<HTMLDivElement> = (event) => {
+    if (
+      event.currentTarget !== event.target &&
+      (event.key === 'ArrowUp' || event.key === 'ArrowDown')
+    ) {
+      event.stopPropagation()
+
+      return
+    }
+
     if (event.key !== 'Enter' && event.key !== ' ') {
       return
     }

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -500,12 +500,7 @@ const MenuRow = ({
   }
 
   const handleKeyDown: KeyboardEventHandler<HTMLDivElement> = (event) => {
-    if (
-      event.currentTarget !== event.target &&
-      (event.key === 'ArrowUp' || event.key === 'ArrowDown')
-    ) {
-      event.stopPropagation()
-
+    if (event.currentTarget !== event.target) {
       return
     }
 
@@ -517,6 +512,31 @@ const MenuRow = ({
     select()
   }
 
+  const handleKeyDownCapture: KeyboardEventHandler<HTMLDivElement> = (event) => {
+    if (
+      event.currentTarget === event.target ||
+      (event.key !== 'ArrowUp' && event.key !== 'ArrowDown')
+    ) {
+      return
+    }
+
+    event.stopPropagation()
+  }
+
+  const handleClick: MouseEventHandler<HTMLDivElement> = (event) => {
+    const target = event.target instanceof Element ? event.target : null
+
+    const nestedControl = target?.closest(
+      'button, a, input, textarea, select, [role="button"], [tabindex]:not([tabindex="-1"])'
+    )
+
+    if (nestedControl !== null && nestedControl !== event.currentTarget) {
+      return
+    }
+
+    select()
+  }
+
   return (
     <div
       role="menuitem"
@@ -525,8 +545,9 @@ const MenuRow = ({
       aria-disabled={disabled ? true : undefined}
       aria-label={label}
       className={className}
+      onKeyDownCapture={handleKeyDownCapture}
       {...menu.getItemProps({
-        onClick: select,
+        onClick: handleClick,
         onKeyDown: handleKeyDown,
       })}
     >

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -273,7 +273,7 @@ interface MenuProps {
   // cloned element and composes its own hover/focus handlers with Menu's.
   tooltip?: ReactNode
   tooltipPlacement?: Placement
-  closeSignal?: unknown
+  closeSignal?: number
 }
 
 // Generic anchored menu: a trigger element opens a portal-rendered, glass
@@ -472,6 +472,59 @@ const MenuSection = ({
     {children}
   </div>
 )
+
+interface MenuRowProps {
+  label: string
+  disabled?: boolean
+  onSelect?: () => void
+  className?: string
+  children: ReactNode
+}
+
+const MenuRow = ({
+  label,
+  disabled = false,
+  onSelect = undefined,
+  className = undefined,
+  children,
+}: MenuRowProps): ReactElement => {
+  const menu = useMenuContext()
+  const { index, ref } = useMenuRow(disabled, label)
+
+  const select = (): void => {
+    if (disabled) {
+      return
+    }
+
+    onSelect?.()
+  }
+
+  const handleKeyDown: KeyboardEventHandler<HTMLDivElement> = (event) => {
+    if (event.key !== 'Enter' && event.key !== ' ') {
+      return
+    }
+
+    event.preventDefault()
+    select()
+  }
+
+  return (
+    <div
+      role="menuitem"
+      ref={ref}
+      tabIndex={menu.activeIndex === index ? 0 : -1}
+      aria-disabled={disabled ? true : undefined}
+      aria-label={label}
+      className={className}
+      {...menu.getItemProps({
+        onClick: select,
+        onKeyDown: handleKeyDown,
+      })}
+    >
+      {children}
+    </div>
+  )
+}
 
 interface MenuItemProps {
   icon?: string
@@ -837,6 +890,7 @@ interface MenuComponent {
   (props: MenuProps): ReactElement
   Context: typeof MenuContextMenu
   Section: typeof MenuSection
+  Row: typeof MenuRow
   Item: typeof MenuItem
   Checkbox: typeof MenuCheckbox
   Submenu: typeof MenuSubmenu
@@ -845,6 +899,7 @@ interface MenuComponent {
 export const Menu = MenuRoot as MenuComponent
 Menu.Context = MenuContextMenu
 Menu.Section = MenuSection
+Menu.Row = MenuRow
 Menu.Item = MenuItem
 Menu.Checkbox = MenuCheckbox
 Menu.Submenu = MenuSubmenu

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -273,6 +273,7 @@ interface MenuProps {
   // cloned element and composes its own hover/focus handlers with Menu's.
   tooltip?: ReactNode
   tooltipPlacement?: Placement
+  closeSignal?: unknown
 }
 
 // Generic anchored menu: a trigger element opens a portal-rendered, glass
@@ -290,11 +291,13 @@ const MenuRoot = ({
   children,
   tooltip = undefined,
   tooltipPlacement = 'top',
+  closeSignal = undefined,
 }: MenuProps): ReactElement => {
   const [open, setOpen] = useState(false)
   const [activeIndex, setActiveIndex] = useState<number | null>(null)
   const [openSubmenuId, setOpenSubmenuId] = useState<string | null>(null)
   const openSubmenuIdRef = useRef(openSubmenuId)
+  const closeSignalRef = useRef(closeSignal)
   const listRef = useRef<(HTMLElement | null)[]>([])
   const labelsRef = useRef<(string | null)[]>([])
 
@@ -311,6 +314,15 @@ const MenuRoot = ({
     },
     [onOpenChange]
   )
+
+  useEffect(() => {
+    if (closeSignalRef.current === closeSignal) {
+      return
+    }
+
+    closeSignalRef.current = closeSignal
+    handleOpenChange(false)
+  }, [closeSignal, handleOpenChange])
 
   // Keep a live ref so the stable dismissWhen callback can read the currently
   // open submenu id without re-registering the listener each time it changes.

--- a/src/features/sessions/hooks/useSessionManager.test.ts
+++ b/src/features/sessions/hooks/useSessionManager.test.ts
@@ -5429,6 +5429,38 @@ describe('useSessionManager', () => {
       expect(result.current.sessions[0].layout).toBe('custom:grid-4x2')
     })
 
+    test('skipPreservation removes an over-capacity custom layout and migrates the session', async () => {
+      const service = createSequentialSpawnService()
+      const largeLayout = customGrid4x2()
+
+      const { result } = renderHook(() =>
+        useSessionManager(service, { autoCreateOnEmpty: false })
+      )
+      await waitFor(() => expect(result.current.loading).toBe(false))
+
+      const sessionId = await createInitialSession(result)
+
+      act(() => result.current.setCustomPaneLayouts([largeLayout]))
+      act(() => result.current.setSessionLayout(sessionId, 'custom:grid-4x2'))
+
+      for (let target = 2; target <= 8; target += 1) {
+        act(() => result.current.addPane(sessionId))
+        await waitFor(() => {
+          const session = result.current.sessions.find(
+            (s) => s.id === sessionId
+          )
+          expect(session?.panes).toHaveLength(target)
+        })
+      }
+
+      act(() =>
+        result.current.setCustomPaneLayouts([], { skipPreservation: true })
+      )
+
+      expect(result.current.customPaneLayouts).toEqual([])
+      expect(result.current.sessions[0].layout).toBe('grid3x2')
+    })
+
     test('addPane spawns in the session cwd and appends an active pane', async () => {
       const service = createSequentialSpawnService()
 

--- a/src/features/sessions/hooks/useSessionManager.ts
+++ b/src/features/sessions/hooks/useSessionManager.ts
@@ -83,7 +83,11 @@ export interface SessionManager {
   customPaneLayouts: readonly PaneLayoutDefinition[]
   layoutRegistry: PaneLayoutRegistry
   setCustomPaneLayouts: (
-    customPaneLayouts: readonly PaneLayoutDefinition[]
+    updater:
+      | readonly PaneLayoutDefinition[]
+      | ((
+          previous: readonly PaneLayoutDefinition[]
+        ) => readonly PaneLayoutDefinition[])
   ) => void
   setSessionLayout: (sessionId: string, layoutId: PaneLayoutId) => void
   setSessionActivePane: (sessionId: string, paneId: string) => void
@@ -270,76 +274,93 @@ export const useSessionManager = (
   layoutRegistryRef.current = layoutRegistry
 
   const setCustomPaneLayouts = useCallback(
-    (nextCustomPaneLayouts: readonly PaneLayoutDefinition[]): void => {
+    (
+      updater:
+        | readonly PaneLayoutDefinition[]
+        | ((
+            previous: readonly PaneLayoutDefinition[]
+          ) => readonly PaneLayoutDefinition[])
+    ): void => {
       // Custom layouts that support more panes than any builtin layout must be
       // preserved while sessions still depend on them. Otherwise
       // autoShrinkLayoutFor falls back to grid3x2, and the backend durable
       // repair caps non-custom layouts at six panes — silently dropping extra
       // panes on the next save/reload.
-      const candidateRegistry = new PaneLayoutRegistry(nextCustomPaneLayouts)
+      //
+      // Use the functional state updater so callers' functional updates are
+      // evaluated against the latest previous state, not the closure snapshot
+      // from the last render.
+      setCustomPaneLayoutsState((previous) => {
+        const nextCustomPaneLayouts =
+          typeof updater === 'function' ? updater(previous) : updater
+        const candidateRegistry = new PaneLayoutRegistry(nextCustomPaneLayouts)
 
-      const neededLayoutIds = new Set(
-        sessionsRef.current
-          .filter(
-            (session) =>
-              isCustomPaneLayoutId(session.layout) &&
-              session.panes.length > MAX_BUILTIN_PANE_COUNT
-          )
-          .map((session) => session.layout)
-      )
+        const neededLayoutIds = new Set(
+          sessionsRef.current
+            .filter(
+              (session) =>
+                isCustomPaneLayoutId(session.layout) &&
+                session.panes.length > MAX_BUILTIN_PANE_COUNT
+            )
+            .map((session) => session.layout)
+        )
 
-      const preservedLayouts = layoutRegistryRef.current.customLayouts.filter(
-        (layout) => {
-          if (!neededLayoutIds.has(layout.id)) {
-            return false
+        const preservedLayouts = layoutRegistryRef.current.customLayouts.filter(
+          (layout) => {
+            if (!neededLayoutIds.has(layout.id)) {
+              return false
+            }
+
+            const dependentPaneCount = Math.max(
+              ...sessionsRef.current
+                .filter((session) => session.layout === layout.id)
+                .map((session) => session.panes.length)
+            )
+
+            const candidateFits =
+              candidateRegistry.hasLayoutId(layout.id) &&
+              candidateRegistry.capacityFor(layout.id) >= dependentPaneCount
+
+            return !candidateFits
           }
+        )
 
-          const dependentPaneCount = Math.max(
-            ...sessionsRef.current
-              .filter((session) => session.layout === layout.id)
-              .map((session) => session.panes.length)
-          )
+        const preservedIds = new Set(
+          preservedLayouts.map((layout) => layout.id)
+        )
 
-          const candidateFits =
-            candidateRegistry.hasLayoutId(layout.id) &&
-            candidateRegistry.capacityFor(layout.id) >= dependentPaneCount
+        const mergedCustomPaneLayouts = [
+          ...nextCustomPaneLayouts.filter(
+            (layout) => !preservedIds.has(layout.id)
+          ),
+          ...preservedLayouts,
+        ]
 
-          return !candidateFits
-        }
-      )
+        const nextRegistry = new PaneLayoutRegistry(mergedCustomPaneLayouts)
 
-      const preservedIds = new Set(preservedLayouts.map((layout) => layout.id))
+        setSessions((prev) =>
+          prev.map((session) => {
+            const currentLayoutStillFits =
+              nextRegistry.hasLayoutId(session.layout) &&
+              session.panes.length <= nextRegistry.capacityFor(session.layout)
 
-      const mergedCustomPaneLayouts = [
-        ...nextCustomPaneLayouts.filter(
-          (layout) => !preservedIds.has(layout.id)
-        ),
-        ...preservedLayouts,
-      ]
+            if (currentLayoutStillFits) {
+              return session
+            }
 
-      const nextRegistry = new PaneLayoutRegistry(mergedCustomPaneLayouts)
+            const nextLayout = nextRegistry.autoShrinkLayoutFor(
+              session.panes.length,
+              session.layout
+            )
 
-      setCustomPaneLayoutsState(nextRegistry.customLayouts)
-      setSessions((prev) =>
-        prev.map((session) => {
-          const currentLayoutStillFits =
-            nextRegistry.hasLayoutId(session.layout) &&
-            session.panes.length <= nextRegistry.capacityFor(session.layout)
+            return nextLayout === session.layout
+              ? session
+              : { ...session, layout: nextLayout }
+          })
+        )
 
-          if (currentLayoutStillFits) {
-            return session
-          }
-
-          const nextLayout = nextRegistry.autoShrinkLayoutFor(
-            session.panes.length,
-            session.layout
-          )
-
-          return nextLayout === session.layout
-            ? session
-            : { ...session, layout: nextLayout }
-        })
-      )
+        return nextRegistry.customLayouts
+      })
     },
     []
   )

--- a/src/features/sessions/hooks/useSessionManager.ts
+++ b/src/features/sessions/hooks/useSessionManager.ts
@@ -87,7 +87,8 @@ export interface SessionManager {
       | readonly PaneLayoutDefinition[]
       | ((
           previous: readonly PaneLayoutDefinition[]
-        ) => readonly PaneLayoutDefinition[])
+        ) => readonly PaneLayoutDefinition[]),
+    setOptions?: { skipPreservation?: boolean }
   ) => void
   setSessionLayout: (sessionId: string, layoutId: PaneLayoutId) => void
   setSessionActivePane: (sessionId: string, paneId: string) => void
@@ -265,6 +266,8 @@ export const useSessionManager = (
   const [customPaneLayouts, setCustomPaneLayoutsState] = useState<
     readonly PaneLayoutDefinition[]
   >([])
+  const customPaneLayoutsRef = useRef(customPaneLayouts)
+  customPaneLayoutsRef.current = customPaneLayouts
 
   const layoutRegistry = useMemo(
     () => new PaneLayoutRegistry(customPaneLayouts),
@@ -279,7 +282,8 @@ export const useSessionManager = (
         | readonly PaneLayoutDefinition[]
         | ((
             previous: readonly PaneLayoutDefinition[]
-          ) => readonly PaneLayoutDefinition[])
+          ) => readonly PaneLayoutDefinition[]),
+      setOptions?: { skipPreservation?: boolean }
     ): void => {
       // Custom layouts that support more panes than any builtin layout must be
       // preserved while sessions still depend on them. Otherwise
@@ -287,14 +291,23 @@ export const useSessionManager = (
       // repair caps non-custom layouts at six panes — silently dropping extra
       // panes on the next save/reload.
       //
-      // Use the functional state updater so callers' functional updates are
-      // evaluated against the latest previous state, not the closure snapshot
-      // from the last render.
-      setCustomPaneLayoutsState((previous) => {
-        const nextCustomPaneLayouts =
-          typeof updater === 'function' ? updater(previous) : updater
-        const candidateRegistry = new PaneLayoutRegistry(nextCustomPaneLayouts)
+      // Derive the next registry at top-level (outside the layout-state
+      // updater) so the session migration can be performed as a separate
+      // top-level state update. Keeping setSessions out of the functional
+      // updater avoids impure-updater hazards under Strict Mode / concurrent
+      // rendering.
 
+      const previous = customPaneLayoutsRef.current
+
+      const nextCustomPaneLayouts =
+        typeof updater === 'function' ? updater(previous) : updater
+      const candidateRegistry = new PaneLayoutRegistry(nextCustomPaneLayouts)
+
+      let nextRegistry: PaneLayoutRegistry
+
+      if (setOptions?.skipPreservation) {
+        nextRegistry = candidateRegistry
+      } else {
         const neededLayoutIds = new Set(
           sessionsRef.current
             .filter(
@@ -336,31 +349,36 @@ export const useSessionManager = (
           ...preservedLayouts,
         ]
 
-        const nextRegistry = new PaneLayoutRegistry(mergedCustomPaneLayouts)
+        nextRegistry = new PaneLayoutRegistry(mergedCustomPaneLayouts)
+      }
 
-        setSessions((prev) =>
-          prev.map((session) => {
-            const currentLayoutStillFits =
-              nextRegistry.hasLayoutId(session.layout) &&
-              session.panes.length <= nextRegistry.capacityFor(session.layout)
+      const nextCustomLayouts = nextRegistry.customLayouts
 
-            if (currentLayoutStillFits) {
-              return session
-            }
+      // Migrate any sessions whose current layout is no longer available or
+      // no longer fits. This runs as a top-level update so it sees the latest
+      // sessions state (e.g. a layout change queued just before this call).
+      setSessions((prev) =>
+        prev.map((session) => {
+          const currentLayoutStillFits =
+            nextRegistry.hasLayoutId(session.layout) &&
+            session.panes.length <= nextRegistry.capacityFor(session.layout)
 
-            const nextLayout = nextRegistry.autoShrinkLayoutFor(
-              session.panes.length,
-              session.layout
-            )
+          if (currentLayoutStillFits) {
+            return session
+          }
 
-            return nextLayout === session.layout
-              ? session
-              : { ...session, layout: nextLayout }
-          })
-        )
+          const nextLayout = nextRegistry.autoShrinkLayoutFor(
+            session.panes.length,
+            session.layout
+          )
 
-        return nextRegistry.customLayouts
-      })
+          return nextLayout === session.layout
+            ? session
+            : { ...session, layout: nextLayout }
+        })
+      )
+
+      setCustomPaneLayoutsState(nextCustomLayouts)
     },
     []
   )

--- a/src/features/terminal/components/LayoutCreator/LayoutCreatorModal.test.tsx
+++ b/src/features/terminal/components/LayoutCreator/LayoutCreatorModal.test.tsx
@@ -6,6 +6,28 @@ import { LayoutCreatorModal } from './LayoutCreatorModal'
 
 type SaveSpy = (definition: PaneLayoutDefinition) => void
 
+const fullFourByFourLayout = {
+  tracks: {
+    columns: Array.from({ length: 4 }, (_, col) => ({
+      id: `col-${col}`,
+      units: 6,
+    })),
+    rows: Array.from({ length: 4 }, (_, row) => ({
+      id: `row-${row}`,
+      units: 6,
+    })),
+  },
+  slots: Array.from({ length: 16 }, (_, index) => ({
+    id: `slot:p${index}`,
+    rect: {
+      col: index % 4,
+      row: Math.floor(index / 4),
+      colSpan: 1,
+      rowSpan: 1,
+    },
+  })),
+}
+
 describe('LayoutCreatorModal', () => {
   test('saves the current draft as a canonical custom pane layout', async () => {
     const user = userEvent.setup()
@@ -134,5 +156,54 @@ describe('LayoutCreatorModal', () => {
       await screen.findByText('Imported layout supports up to 16 panes')
     ).toBeInTheDocument()
     expect(onSave).not.toHaveBeenCalled()
+  })
+
+  test('surfaces save errors when the code panel is closed', async () => {
+    const user = userEvent.setup()
+
+    const onSave = vi.fn<SaveSpy>(() => {
+      throw new Error('Layout schema drifted')
+    })
+
+    render(
+      <LayoutCreatorModal
+        isOpen
+        existingLayouts={[]}
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />
+    )
+
+    await user.type(screen.getByRole('textbox', { name: 'Layout name' }), 'Bad')
+    await user.click(screen.getByRole('button', { name: 'Save & apply' }))
+
+    expect(screen.getByText('Layout schema drifted')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Apply' })
+    ).not.toBeInTheDocument()
+  })
+
+  test('disables paint cells when pane count is already at the limit', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <LayoutCreatorModal
+        isOpen
+        existingLayouts={[]}
+        onSave={vi.fn<SaveSpy>()}
+        onCancel={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Code · JSON/YAML' }))
+    fireEvent.change(screen.getAllByRole('textbox')[1], {
+      target: { value: JSON.stringify(fullFourByFourLayout) },
+    })
+    await user.click(screen.getByRole('button', { name: 'Apply' }))
+    await user.click(screen.getByRole('button', { name: 'Add Cols' }))
+
+    expect(
+      screen.getByRole('button', { name: 'Add pane at column 5, row 1' })
+    ).toBeDisabled()
   })
 })

--- a/src/features/terminal/components/LayoutCreator/LayoutCreatorModal.test.tsx
+++ b/src/features/terminal/components/LayoutCreator/LayoutCreatorModal.test.tsx
@@ -1,0 +1,138 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, test, vi } from 'vitest'
+import type { PaneLayoutDefinition } from '../../layout-registry'
+import { LayoutCreatorModal } from './LayoutCreatorModal'
+
+type SaveSpy = (definition: PaneLayoutDefinition) => void
+
+describe('LayoutCreatorModal', () => {
+  test('saves the current draft as a canonical custom pane layout', async () => {
+    const user = userEvent.setup()
+    const onSave = vi.fn<SaveSpy>()
+
+    render(
+      <LayoutCreatorModal
+        isOpen
+        existingLayouts={[]}
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />
+    )
+
+    await user.clear(screen.getByRole('textbox', { name: 'Layout name' }))
+    await user.type(
+      screen.getByRole('textbox', { name: 'Layout name' }),
+      'Solo'
+    )
+    await user.click(screen.getByRole('button', { name: 'Save & apply' }))
+
+    expect(onSave).toHaveBeenCalledOnce()
+    expect(onSave.mock.calls[0][0]).toMatchObject({
+      title: 'Solo',
+      source: 'workspace',
+      tracks: {
+        columns: [{ id: 'col-0', units: 24 }],
+        rows: [{ id: 'row-0', units: 24 }],
+      },
+      slots: [
+        { id: 'slot:p0', rect: { col: 0, row: 0, colSpan: 1, rowSpan: 1 } },
+      ],
+      addOrder: ['slot:p0'],
+    })
+  })
+
+  test('imports code panel edits before saving', async () => {
+    const user = userEvent.setup()
+    const onSave = vi.fn<SaveSpy>()
+
+    render(
+      <LayoutCreatorModal
+        isOpen
+        existingLayouts={[]}
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />
+    )
+
+    await user.type(
+      screen.getByRole('textbox', { name: 'Layout name' }),
+      'Imported'
+    )
+    await user.click(screen.getByRole('button', { name: 'Code · JSON/YAML' }))
+    const codeTextArea = screen.getAllByRole('textbox')[1]
+    fireEvent.change(codeTextArea, {
+      target: {
+        value: JSON.stringify({
+          tracks: {
+            columns: [
+              { id: 'col-0', units: 12 },
+              { id: 'col-1', units: 12 },
+            ],
+            rows: [{ id: 'row-0', units: 24 }],
+          },
+          slots: [
+            {
+              id: 'slot:p0',
+              rect: { col: 0, row: 0, colSpan: 1, rowSpan: 1 },
+            },
+            {
+              id: 'slot:p1',
+              rect: { col: 1, row: 0, colSpan: 1, rowSpan: 1 },
+            },
+          ],
+        }),
+      },
+    })
+    await user.click(screen.getByRole('button', { name: 'Apply' }))
+    await user.click(screen.getByRole('button', { name: 'Save & apply' }))
+
+    expect(onSave.mock.calls[0][0].tracks.columns).toEqual([
+      { id: 'col-0', units: 12 },
+      { id: 'col-1', units: 12 },
+    ])
+    expect(onSave.mock.calls[0][0].slots).toHaveLength(2)
+  })
+
+  test('surfaces an import error for layouts above the pane limit', async () => {
+    const user = userEvent.setup()
+    const onSave = vi.fn<SaveSpy>()
+
+    render(
+      <LayoutCreatorModal
+        isOpen
+        existingLayouts={[]}
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Code · JSON/YAML' }))
+    const codeTextArea = screen.getAllByRole('textbox')[1]
+
+    fireEvent.change(codeTextArea, {
+      target: {
+        value: JSON.stringify({
+          tracks: {
+            columns: [{ id: 'col-0', units: 24 }],
+            rows: Array.from({ length: 17 }, (_, row) => ({
+              id: `row-${row}`,
+              units: row < 7 ? 2 : 1,
+            })),
+          },
+          slots: Array.from({ length: 17 }, (_, row) => ({
+            id: `slot:p${row}`,
+            rect: { col: 0, row, colSpan: 1, rowSpan: 1 },
+          })),
+        }),
+      },
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Apply' }))
+
+    expect(
+      await screen.findByText('Imported layout supports up to 16 panes')
+    ).toBeInTheDocument()
+    expect(onSave).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/terminal/components/LayoutCreator/LayoutCreatorModal.test.tsx
+++ b/src/features/terminal/components/LayoutCreator/LayoutCreatorModal.test.tsx
@@ -206,4 +206,33 @@ describe('LayoutCreatorModal', () => {
       screen.getByRole('button', { name: 'Add pane at column 5, row 1' })
     ).toBeDisabled()
   })
+
+  test('adds an empty grid cell through keyboard activation', async () => {
+    const user = userEvent.setup()
+    const onSave = vi.fn<SaveSpy>()
+
+    render(
+      <LayoutCreatorModal
+        isOpen
+        existingLayouts={[]}
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Add Cols' }))
+
+    const emptyCell = screen.getByRole('button', {
+      name: 'Add pane at column 2, row 1',
+    })
+    emptyCell.focus()
+    await user.keyboard('{Enter}')
+    await user.click(screen.getByRole('button', { name: 'Save & apply' }))
+
+    expect(onSave).toHaveBeenCalledOnce()
+    expect(onSave.mock.calls[0][0].slots).toHaveLength(2)
+    expect(onSave.mock.calls[0][0].slots[1]).toMatchObject({
+      rect: { col: 1, row: 0, colSpan: 1, rowSpan: 1 },
+    })
+  })
 })

--- a/src/features/terminal/components/LayoutCreator/LayoutCreatorModal.test.tsx
+++ b/src/features/terminal/components/LayoutCreator/LayoutCreatorModal.test.tsx
@@ -220,6 +220,10 @@ describe('LayoutCreatorModal', () => {
       />
     )
 
+    await user.type(
+      screen.getByRole('textbox', { name: 'Layout name' }),
+      'Keyboard layout'
+    )
     await user.click(screen.getByRole('button', { name: 'Add Cols' }))
 
     const emptyCell = screen.getByRole('button', {

--- a/src/features/terminal/components/LayoutCreator/LayoutCreatorModal.test.tsx
+++ b/src/features/terminal/components/LayoutCreator/LayoutCreatorModal.test.tsx
@@ -183,6 +183,32 @@ describe('LayoutCreatorModal', () => {
     ).not.toBeInTheDocument()
   })
 
+  test('successful code apply clears a stale save error', async () => {
+    const user = userEvent.setup()
+
+    const onSave = vi.fn<SaveSpy>(() => {
+      throw new Error('Layout schema drifted')
+    })
+
+    render(
+      <LayoutCreatorModal
+        isOpen
+        existingLayouts={[]}
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />
+    )
+
+    await user.type(screen.getByRole('textbox', { name: 'Layout name' }), 'Bad')
+    await user.click(screen.getByRole('button', { name: 'Save & apply' }))
+    expect(screen.getByText('Layout schema drifted')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Code · JSON/YAML' }))
+    await user.click(screen.getByRole('button', { name: 'Apply' }))
+
+    expect(screen.queryByText('Layout schema drifted')).not.toBeInTheDocument()
+  })
+
   test('disables paint cells when pane count is already at the limit', async () => {
     const user = userEvent.setup()
 

--- a/src/features/terminal/components/LayoutCreator/LayoutCreatorModal.tsx
+++ b/src/features/terminal/components/LayoutCreator/LayoutCreatorModal.tsx
@@ -893,6 +893,7 @@ export const LayoutCreatorModal = ({
       setDraft(parsedDraft)
       setCodeDirty(false)
       setCodeError(null)
+      setSaveError(null)
     } catch (error) {
       setCodeError(error instanceof Error ? error.message : 'Invalid layout')
     }

--- a/src/features/terminal/components/LayoutCreator/LayoutCreatorModal.tsx
+++ b/src/features/terminal/components/LayoutCreator/LayoutCreatorModal.tsx
@@ -1,0 +1,1029 @@
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent,
+  type ReactElement,
+} from 'react'
+import { Button } from '@/components/Button'
+import { IconButton } from '@/components/IconButton'
+import { SegmentedControl } from '@/components/SegmentedControl'
+import type { CustomPaneLayoutId } from '../../../sessions/types'
+import {
+  MAX_LAYOUT_TRACKS,
+  type PaneLayoutDefinition,
+} from '../../layout-registry'
+import {
+  addFirstFreeSlot,
+  addSlotRect,
+  createSingleDraftLayout,
+  definitionFromDraft,
+  draftFromDefinition,
+  formatDraftMeta,
+  LAYOUT_CREATOR_UNIT_TOTAL,
+  moveSlot,
+  occupancy,
+  parseDraftLayoutText,
+  rectFromCells,
+  rectFree,
+  removeSlot,
+  serializeDraftLayout,
+  setTrackCount,
+  updateTrackBoundary,
+  validateDraftLayout,
+  type DraftLayoutSlot,
+  type DraftPaneLayout,
+  type LayoutCreatorCodeFormat,
+} from './layoutCreatorModel'
+
+export interface LayoutCreatorModalProps {
+  isOpen: boolean
+  existingLayouts: readonly PaneLayoutDefinition[]
+  seedLayout?: PaneLayoutDefinition | undefined
+  editLayout?: PaneLayoutDefinition | undefined
+  onSave: (definition: PaneLayoutDefinition) => void
+  onCancel: () => void
+}
+
+interface GridCell {
+  readonly col: number
+  readonly row: number
+}
+
+interface DragState {
+  readonly mode: 'paint' | 'move' | 'resize' | 'gutter'
+  readonly start: GridCell
+  readonly slotIndex?: number
+  readonly originalSlot?: DraftLayoutSlot
+  readonly edge?: ResizeEdge
+  readonly axis?: 'cols' | 'rows'
+  readonly boundaryIndex?: number
+}
+
+interface GridCanvasProps {
+  draft: DraftPaneLayout
+  onDraftChange: (next: DraftPaneLayout) => void
+}
+
+const codeFormatOptions = [
+  { value: 'json', label: 'JSON', icon: 'data_object' },
+  { value: 'yaml', label: 'YAML', icon: 'notes' },
+] as const satisfies readonly {
+  readonly value: LayoutCreatorCodeFormat
+  readonly label: string
+  readonly icon: string
+}[]
+
+const creatorHintItems = [
+  { action: 'Click cells', detail: 'add panes' },
+  { action: 'Drag', detail: 'span an area' },
+  { action: 'Drag panes', detail: 'move' },
+  { action: 'Edges', detail: 'resize pane' },
+  { action: 'Outer grips', detail: 'resize tracks' },
+  { action: 'Right-click', detail: 'remove pane' },
+  { action: 'Esc', detail: 'close' },
+] as const
+
+const trackTemplate = (units: readonly number[]): string =>
+  units.map((unit) => `minmax(0, ${unit}fr)`).join(' ')
+
+const cellKey = ({ col, row }: GridCell): string => `${col}:${row}`
+
+type ResizeEdge = 'n' | 's' | 'e' | 'w' | 'se'
+
+const paneHues = [
+  'var(--color-agent-claude-accent)',
+  'var(--color-agent-codex-accent)',
+  'var(--color-agent-kimi-accent)',
+  'var(--color-agent-shell-accent)',
+] as const
+
+const hueForSlot = (slotIndex: number): string =>
+  paneHues[slotIndex % paneHues.length]
+
+const sum = (values: readonly number[]): number =>
+  values.reduce((total, value) => total + value, 0)
+
+const trackOffset = (
+  tracks: readonly number[],
+  start: number,
+  span: number
+): { readonly offset: number; readonly size: number } => {
+  const total = sum(tracks) || 1
+  const offset = tracks.slice(0, start).reduce((acc, unit) => acc + unit, 0)
+
+  const size = tracks
+    .slice(start, start + span)
+    .reduce((acc, unit) => acc + unit, 0)
+
+  return { offset: offset / total, size: size / total }
+}
+
+const slotGridStyleFor = (slot: DraftLayoutSlot): CSSProperties => ({
+  gridColumn: `${slot.col + 1} / span ${slot.colSpan}`,
+  gridRow: `${slot.row + 1} / span ${slot.rowSpan}`,
+})
+
+const innerBoundaryPosition = (ratio: number): string =>
+  `calc(${ratio * 100}% + ${0.5 - ratio}rem)`
+
+const gridTemplateStyleFor = (draft: DraftPaneLayout): CSSProperties => ({
+  gridTemplateColumns: trackTemplate(draft.cols),
+  gridTemplateRows: trackTemplate(draft.rows),
+})
+
+const outsideGutterButtonBaseClass =
+  'absolute z-20 grid place-items-center rounded-full border border-primary/20 bg-surface-container/85 text-primary/70 shadow-[0_8px_24px_color-mix(in_srgb,var(--color-primary)_14%,transparent)] backdrop-blur outline-none transition hover:border-primary/45 hover:bg-primary/10 hover:text-primary focus-visible:ring-1 focus-visible:ring-primary'
+
+const outsideColumnGutterButtonClass = `${outsideGutterButtonBaseClass} h-5 w-8`
+
+const outsideRowGutterButtonClass = `${outsideGutterButtonBaseClass} h-8 w-5`
+
+const paneStyleFor = (
+  slot: DraftLayoutSlot,
+  slotIndex: number
+): CSSProperties => {
+  const accent = hueForSlot(slotIndex)
+
+  return {
+    ...slotGridStyleFor(slot),
+    borderColor: `color-mix(in srgb, ${accent} 50%, transparent)`,
+    background: `linear-gradient(160deg, color-mix(in srgb, ${accent} 16%, transparent), color-mix(in srgb, ${accent} 7%, transparent))`,
+    boxShadow: `0 10px 28px color-mix(in srgb, ${accent} 14%, transparent)`,
+  }
+}
+
+const resizeRectFromCell = (
+  original: DraftLayoutSlot,
+  edge: ResizeEdge,
+  cell: GridCell
+): DraftLayoutSlot => {
+  const right = original.col + original.colSpan - 1
+  const bottom = original.row + original.rowSpan - 1
+  let nextCol = original.col
+  let nextRow = original.row
+  let nextColSpan = original.colSpan
+  let nextRowSpan = original.rowSpan
+
+  if (edge.includes('e')) {
+    const nextRight = Math.max(cell.col, original.col)
+    nextColSpan = nextRight - original.col + 1
+  }
+
+  if (edge.includes('s')) {
+    const nextBottom = Math.max(cell.row, original.row)
+    nextRowSpan = nextBottom - original.row + 1
+  }
+
+  if (edge.includes('w')) {
+    nextCol = Math.min(cell.col, right)
+    nextColSpan = right - nextCol + 1
+  }
+
+  if (edge.includes('n')) {
+    nextRow = Math.min(cell.row, bottom)
+    nextRowSpan = bottom - nextRow + 1
+  }
+
+  return {
+    col: nextCol,
+    row: nextRow,
+    colSpan: nextColSpan,
+    rowSpan: nextRowSpan,
+  }
+}
+
+const trackIndexFromPosition = (
+  positionPx: number,
+  totalPx: number,
+  tracks: readonly number[]
+): number | null => {
+  if (totalPx <= 0 || tracks.length === 0) {
+    return null
+  }
+
+  const boundedRatio = Math.min(Math.max(positionPx / totalPx, 0), 0.999_999)
+  const target = boundedRatio * sum(tracks)
+  let cursor = 0
+
+  for (let index = 0; index < tracks.length; index += 1) {
+    cursor += tracks[index]
+    if (target < cursor) {
+      return index
+    }
+  }
+
+  return tracks.length - 1
+}
+
+const gridCellFromPointer = (
+  event: ReactPointerEvent<HTMLElement> | PointerEvent,
+  gridElement: HTMLElement | null,
+  draft: DraftPaneLayout
+): GridCell | null => {
+  const rect = gridElement?.getBoundingClientRect()
+  if (rect === undefined) {
+    return null
+  }
+
+  const col = trackIndexFromPosition(
+    event.clientX - rect.left,
+    rect.width,
+    draft.cols
+  )
+
+  const row = trackIndexFromPosition(
+    event.clientY - rect.top,
+    rect.height,
+    draft.rows
+  )
+
+  return col === null || row === null ? null : { col, row }
+}
+
+const boundaryRatioFromPointer = (
+  event: ReactPointerEvent<HTMLElement> | PointerEvent,
+  gridElement: HTMLElement | null,
+  axis: 'cols' | 'rows'
+): number | null => {
+  const rect = gridElement?.getBoundingClientRect()
+  if (rect === undefined) {
+    return null
+  }
+
+  const size = axis === 'cols' ? rect.width : rect.height
+  if (size <= 0) {
+    return null
+  }
+
+  const offset =
+    axis === 'cols' ? event.clientX - rect.left : event.clientY - rect.top
+
+  return Math.min(Math.max(offset / size, 0), 1)
+}
+
+const GridCanvas = ({
+  draft,
+  onDraftChange,
+}: GridCanvasProps): ReactElement => {
+  const gridRef = useRef<HTMLDivElement | null>(null)
+  const [drag, setDrag] = useState<DragState | null>(null)
+  const [previewRect, setPreviewRect] = useState<DraftLayoutSlot | null>(null)
+  const colCount = draft.cols.length
+  const rowCount = draft.rows.length
+
+  const occupied = useMemo(
+    () => occupancy(colCount, rowCount, draft.slots),
+    [colCount, draft.slots, rowCount]
+  )
+
+  const previewValid =
+    previewRect === null ||
+    rectFree(colCount, rowCount, draft.slots, previewRect, null)
+
+  useEffect(() => {
+    if (drag === null) {
+      return undefined
+    }
+
+    const handlePointerMove = (event: PointerEvent): void => {
+      if (
+        drag.mode === 'gutter' &&
+        drag.axis !== undefined &&
+        drag.boundaryIndex !== undefined
+      ) {
+        const boundaryRatio = boundaryRatioFromPointer(
+          event,
+          gridRef.current,
+          drag.axis
+        )
+        if (boundaryRatio !== null) {
+          onDraftChange(
+            updateTrackBoundary(
+              draft,
+              drag.axis,
+              drag.boundaryIndex,
+              boundaryRatio
+            )
+          )
+        }
+
+        return
+      }
+
+      const cell = gridCellFromPointer(event, gridRef.current, draft)
+      if (cell === null) {
+        return
+      }
+
+      if (drag.mode === 'paint') {
+        setPreviewRect(rectFromCells(drag.start, cell))
+
+        return
+      }
+
+      const originalSlot = drag.originalSlot
+      const slotIndex = drag.slotIndex
+      if (originalSlot === undefined || slotIndex === undefined) {
+        return
+      }
+
+      const nextRect =
+        drag.mode === 'resize' && drag.edge !== undefined
+          ? resizeRectFromCell(originalSlot, drag.edge, cell)
+          : {
+              ...originalSlot,
+              col: cell.col,
+              row: cell.row,
+            }
+
+      onDraftChange(moveSlot(draft, slotIndex, nextRect))
+    }
+
+    const handlePointerUp = (event: PointerEvent): void => {
+      const cell = gridCellFromPointer(event, gridRef.current, draft)
+      if (drag.mode === 'paint' && cell !== null) {
+        onDraftChange(addSlotRect(draft, rectFromCells(drag.start, cell)))
+      }
+
+      setDrag(null)
+      setPreviewRect(null)
+    }
+
+    window.addEventListener('pointermove', handlePointerMove)
+    window.addEventListener('pointerup', handlePointerUp, { once: true })
+
+    return (): void => {
+      window.removeEventListener('pointermove', handlePointerMove)
+      window.removeEventListener('pointerup', handlePointerUp)
+    }
+  }, [draft, drag, onDraftChange])
+
+  const startPaint = (event: ReactPointerEvent<HTMLElement>): void => {
+    if (event.button !== 0) {
+      return
+    }
+
+    const cell = gridCellFromPointer(event, gridRef.current, draft)
+    if (cell === null) {
+      return
+    }
+
+    setDrag({ mode: 'paint', start: cell })
+    setPreviewRect({ ...cell, colSpan: 1, rowSpan: 1 })
+  }
+
+  const startMove = (
+    event: ReactPointerEvent<HTMLElement>,
+    slotIndex: number
+  ): void => {
+    if (event.button !== 0) {
+      return
+    }
+
+    event.stopPropagation()
+    const slot = draft.slots[slotIndex]
+
+    setDrag({
+      mode: 'move',
+      start: { col: slot.col, row: slot.row },
+      slotIndex,
+      originalSlot: slot,
+    })
+  }
+
+  const startResize = (
+    event: ReactPointerEvent<HTMLElement>,
+    slotIndex: number,
+    edge: ResizeEdge
+  ): void => {
+    if (event.button !== 0) {
+      return
+    }
+
+    event.stopPropagation()
+    const slot = draft.slots[slotIndex]
+
+    setDrag({
+      mode: 'resize',
+      start: { col: slot.col, row: slot.row },
+      slotIndex,
+      originalSlot: slot,
+      edge,
+    })
+  }
+
+  const startGutter = (
+    event: ReactPointerEvent<HTMLElement>,
+    axis: 'cols' | 'rows',
+    boundaryIndex: number
+  ): void => {
+    if (event.button !== 0) {
+      return
+    }
+
+    event.stopPropagation()
+    setDrag({
+      mode: 'gutter',
+      start: { col: 0, row: 0 },
+      axis,
+      boundaryIndex,
+    })
+  }
+
+  const remove = (slotIndex: number): void => {
+    onDraftChange(removeSlot(draft, slotIndex))
+  }
+
+  const preventContextMenu = (event: ReactMouseEvent): void => {
+    event.preventDefault()
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-[760px]">
+      <div
+        className="relative aspect-[8/5] overflow-visible rounded-[16px] border border-outline-variant/30 bg-surface-container-lowest/70 p-2 shadow-[inset_0_1px_0_color-mix(in_srgb,var(--color-on-surface)_8%,transparent)]"
+        onContextMenu={preventContextMenu}
+      >
+        <div
+          ref={gridRef}
+          className="absolute inset-2 grid gap-1.5"
+          style={gridTemplateStyleFor(draft)}
+        >
+          {Array.from({ length: rowCount }).flatMap((_, row) =>
+            Array.from({ length: colCount }).map((__, col) => {
+              const empty = occupied[row]?.[col] === -1
+
+              return (
+                <button
+                  key={cellKey({ col, row })}
+                  type="button"
+                  aria-label={`Add pane at column ${col + 1}, row ${row + 1}`}
+                  data-layout-creator-cell={cellKey({ col, row })}
+                  tabIndex={empty ? 0 : -1}
+                  className={`group relative rounded-lg outline-none transition focus-visible:ring-1 focus-visible:ring-primary/60 ${
+                    empty
+                      ? 'border border-dashed border-outline-variant/45 bg-surface-container/30 hover:border-primary/45 hover:bg-primary/10'
+                      : 'border border-transparent bg-transparent'
+                  }`}
+                  onPointerDown={empty ? startPaint : undefined}
+                >
+                  <span
+                    className={`pointer-events-none absolute inset-0 items-center justify-center text-primary/80 ${
+                      empty ? 'hidden group-hover:flex' : 'hidden'
+                    }`}
+                  >
+                    <span
+                      className="material-symbols-outlined rounded-lg border border-primary/30 bg-primary/15 p-1 text-[18px]"
+                      aria-hidden="true"
+                    >
+                      add
+                    </span>
+                  </span>
+                </button>
+              )
+            })
+          )}
+        </div>
+
+        {previewRect !== null && (
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-2 grid gap-1.5"
+            style={gridTemplateStyleFor(draft)}
+          >
+            <div
+              className={`rounded-[11px] border border-dashed ${
+                previewValid
+                  ? 'border-primary/70 bg-primary/15'
+                  : 'border-error bg-error/15'
+              }`}
+              style={slotGridStyleFor(previewRect)}
+            />
+          </div>
+        )}
+
+        <div
+          className="pointer-events-none absolute inset-2 grid gap-1.5"
+          style={gridTemplateStyleFor(draft)}
+        >
+          {draft.slots.map((slot, slotIndex) => (
+            <div
+              key={`${slot.col}:${slot.row}:${slot.colSpan}:${slot.rowSpan}:${slotIndex}`}
+              className="group relative select-none rounded-[12px] border transition-shadow pointer-events-auto"
+              style={paneStyleFor(slot, slotIndex)}
+              onPointerDown={(event): void => startMove(event, slotIndex)}
+              onContextMenu={(event): void => {
+                event.preventDefault()
+                event.stopPropagation()
+                remove(slotIndex)
+              }}
+            >
+              <div className="flex h-full w-full items-center justify-center rounded-[11px] border border-surface/30">
+                <span
+                  className="font-mono text-[clamp(0.8rem,2vw,1.35rem)] font-semibold"
+                  style={{ color: hueForSlot(slotIndex) }}
+                >
+                  p{slotIndex}
+                </span>
+              </div>
+              {(['n', 's', 'e', 'w', 'se'] as const).map((edge) => (
+                <span
+                  key={edge}
+                  aria-hidden="true"
+                  className={`absolute opacity-0 transition-opacity group-hover:opacity-100 ${
+                    edge === 'n'
+                      ? 'left-3 right-3 top-[-5px] h-2 cursor-n-resize'
+                      : edge === 's'
+                        ? 'bottom-[-5px] left-3 right-3 h-2 cursor-s-resize'
+                        : edge === 'e'
+                          ? 'bottom-3 right-[-5px] top-3 w-2 cursor-e-resize'
+                          : edge === 'w'
+                            ? 'bottom-3 left-[-5px] top-3 w-2 cursor-w-resize'
+                            : 'bottom-[-5px] right-[-5px] h-3 w-3 cursor-se-resize rounded-full bg-surface-container/80 ring-1 ring-primary/40'
+                  }`}
+                  onPointerDown={(event): void =>
+                    startResize(event, slotIndex, edge)
+                  }
+                />
+              ))}
+              {draft.slots.length > 1 && (
+                <span
+                  className="absolute right-1.5 top-1.5 opacity-0 transition-opacity group-hover:opacity-100"
+                  onPointerDown={(event): void => event.stopPropagation()}
+                >
+                  <IconButton
+                    icon="close"
+                    label={`Remove pane p${slotIndex}`}
+                    size="sm"
+                    className="h-5 w-5 bg-surface-container/85 text-on-surface-muted hover:text-error"
+                    onClick={(event): void => {
+                      event.stopPropagation()
+                      remove(slotIndex)
+                    }}
+                  />
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+        {draft.cols.slice(0, -1).map((_, boundaryIndex) => {
+          const boundary = trackOffset(draft.cols, 0, boundaryIndex + 1)
+          const left = innerBoundaryPosition(boundary.size)
+
+          return (
+            <div
+              key={`col-gutter-${boundaryIndex}`}
+              className="pointer-events-none absolute bottom-[-1.1rem] top-[-1.1rem] z-10 -translate-x-1/2"
+              style={{ left }}
+            >
+              <span
+                aria-hidden="true"
+                className="absolute left-1/2 top-0 block h-4 w-px -translate-x-1/2 bg-gradient-to-b from-primary/45 to-transparent"
+              />
+              <span
+                aria-hidden="true"
+                className="absolute bottom-0 left-1/2 block h-4 w-px -translate-x-1/2 bg-gradient-to-t from-primary/45 to-transparent"
+              />
+              <button
+                type="button"
+                aria-label={`Resize column ${boundaryIndex + 1} from top edge`}
+                className={`${outsideColumnGutterButtonClass} pointer-events-auto left-1/2 top-0 -translate-x-1/2 -translate-y-1/2 cursor-col-resize`}
+                onPointerDown={(event): void =>
+                  startGutter(event, 'cols', boundaryIndex)
+                }
+              >
+                <span className="block h-2.5 w-0.5 rounded-full bg-current shadow-[0_0_10px_currentColor]" />
+              </button>
+              <button
+                type="button"
+                aria-label={`Resize column ${boundaryIndex + 1} from bottom edge`}
+                className={`${outsideColumnGutterButtonClass} pointer-events-auto bottom-0 left-1/2 -translate-x-1/2 translate-y-1/2 cursor-col-resize`}
+                onPointerDown={(event): void =>
+                  startGutter(event, 'cols', boundaryIndex)
+                }
+              >
+                <span className="block h-2.5 w-0.5 rounded-full bg-current shadow-[0_0_10px_currentColor]" />
+              </button>
+            </div>
+          )
+        })}
+        {draft.rows.slice(0, -1).map((_, boundaryIndex) => {
+          const boundary = trackOffset(draft.rows, 0, boundaryIndex + 1)
+          const top = innerBoundaryPosition(boundary.size)
+
+          return (
+            <div
+              key={`row-gutter-${boundaryIndex}`}
+              className="pointer-events-none absolute left-[-1.1rem] right-[-1.1rem] z-10 -translate-y-1/2"
+              style={{ top }}
+            >
+              <span
+                aria-hidden="true"
+                className="absolute left-0 top-1/2 block h-px w-4 -translate-y-1/2 bg-gradient-to-r from-primary/45 to-transparent"
+              />
+              <span
+                aria-hidden="true"
+                className="absolute right-0 top-1/2 block h-px w-4 -translate-y-1/2 bg-gradient-to-l from-primary/45 to-transparent"
+              />
+              <button
+                type="button"
+                aria-label={`Resize row ${boundaryIndex + 1} from left edge`}
+                className={`${outsideRowGutterButtonClass} pointer-events-auto left-0 top-1/2 -translate-x-1/2 -translate-y-1/2 cursor-row-resize`}
+                onPointerDown={(event): void =>
+                  startGutter(event, 'rows', boundaryIndex)
+                }
+              >
+                <span className="block h-0.5 w-2.5 rounded-full bg-current shadow-[0_0_10px_currentColor]" />
+              </button>
+              <button
+                type="button"
+                aria-label={`Resize row ${boundaryIndex + 1} from right edge`}
+                className={`${outsideRowGutterButtonClass} pointer-events-auto right-0 top-1/2 -translate-y-1/2 translate-x-1/2 cursor-row-resize`}
+                onPointerDown={(event): void =>
+                  startGutter(event, 'rows', boundaryIndex)
+                }
+              >
+                <span className="block h-0.5 w-2.5 rounded-full bg-current shadow-[0_0_10px_currentColor]" />
+              </button>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+interface TrackStepperProps {
+  label: string
+  value: number
+  onChange: (next: number) => void
+}
+
+const TrackStepper = ({
+  label,
+  value,
+  onChange,
+}: TrackStepperProps): ReactElement => (
+  <div className="inline-flex items-center gap-2 rounded-full bg-surface-container/50 px-2 py-1 font-mono text-[11px] text-on-surface-variant">
+    <span className="uppercase tracking-[0.12em]">{label}</span>
+    <IconButton
+      icon="remove"
+      label={`Remove ${label}`}
+      size="sm"
+      disabled={value <= 1}
+      className="h-5 w-5"
+      onClick={(): void => onChange(value - 1)}
+    />
+    <span className="min-w-5 text-center text-on-surface">{value}</span>
+    <IconButton
+      icon="add"
+      label={`Add ${label}`}
+      size="sm"
+      disabled={value >= MAX_LAYOUT_TRACKS}
+      className="h-5 w-5"
+      onClick={(): void => onChange(value + 1)}
+    />
+  </div>
+)
+
+export const LayoutCreatorModal = ({
+  isOpen,
+  existingLayouts,
+  seedLayout = undefined,
+  editLayout = undefined,
+  onSave,
+  onCancel,
+}: LayoutCreatorModalProps): ReactElement | null => {
+  const titleId = useId()
+  const descriptionId = useId()
+  const nameInputRef = useRef<HTMLInputElement | null>(null)
+  const [name, setName] = useState('')
+  const [draft, setDraft] = useState<DraftPaneLayout>(createSingleDraftLayout)
+  const [codeOpen, setCodeOpen] = useState(false)
+  const [codeFormat, setCodeFormat] = useState<LayoutCreatorCodeFormat>('json')
+  const [codeText, setCodeText] = useState('')
+  const [codeDirty, setCodeDirty] = useState(false)
+  const [codeError, setCodeError] = useState<string | null>(null)
+
+  const validation = useMemo(() => validateDraftLayout(draft), [draft])
+  const canSave = validation.ok && name.trim().length > 0
+
+  const existingIds = useMemo(
+    () => new Set(existingLayouts.map((layout) => layout.id)),
+    [existingLayouts]
+  )
+
+  useEffect(() => {
+    if (!isOpen) {
+      return
+    }
+
+    const sourceLayout = editLayout ?? seedLayout
+    setName(editLayout?.title ?? '')
+    setDraft(draftFromDefinition(sourceLayout))
+    setCodeOpen(false)
+    setCodeFormat('json')
+    setCodeDirty(false)
+    setCodeError(null)
+    nameInputRef.current?.focus()
+  }, [editLayout, isOpen, seedLayout])
+
+  useEffect(() => {
+    if (!codeDirty) {
+      setCodeText(serializeDraftLayout(draft, codeFormat))
+    }
+  }, [codeDirty, codeFormat, draft])
+
+  const updateDraft = useCallback((next: DraftPaneLayout): void => {
+    setDraft(next)
+    setCodeDirty(false)
+    setCodeError(null)
+  }, [])
+
+  const handleSave = useCallback((): void => {
+    if (!canSave) {
+      return
+    }
+
+    const existingId =
+      editLayout?.id !== undefined
+        ? (editLayout.id as CustomPaneLayoutId)
+        : undefined
+
+    onSave(
+      definitionFromDraft({
+        title: name,
+        draft,
+        existingIds,
+        existingId,
+      })
+    )
+  }, [canSave, draft, editLayout?.id, existingIds, name, onSave])
+
+  useEffect(() => {
+    if (!isOpen) {
+      return undefined
+    }
+
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') {
+        onCancel()
+      }
+
+      if (event.key === 'Enter' && event.metaKey && canSave) {
+        event.preventDefault()
+        handleSave()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+
+    return (): void => {
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [canSave, handleSave, isOpen, onCancel])
+
+  const applyCode = (): void => {
+    try {
+      const parsedDraft = parseDraftLayoutText(codeText, codeFormat)
+      setDraft(parsedDraft)
+      setCodeDirty(false)
+      setCodeError(null)
+    } catch (error) {
+      setCodeError(error instanceof Error ? error.message : 'Invalid layout')
+    }
+  }
+
+  const copyCode = (): void => {
+    try {
+      void navigator.clipboard.writeText(codeText)
+    } catch {
+      // Clipboard is unavailable in some test/webview contexts; copying is optional.
+    }
+  }
+
+  const stopPropagation = (event: ReactMouseEvent): void => {
+    event.stopPropagation()
+  }
+
+  if (!isOpen) {
+    return null
+  }
+
+  const title = editLayout === undefined ? 'Layout Creator' : 'Edit layout'
+  const saveLabel = editLayout === undefined ? 'Save & apply' : 'Save changes'
+
+  const validationMessage = validation.ok
+    ? `Valid · ${validation.slotCount} panes, fully tiled`
+    : validation.overCapacity
+      ? `Too many panes · ${validation.slotCount}/${validation.maxSlots} max`
+      : validation.overlap
+        ? 'Panes overlap'
+        : `${validation.emptyCells} empty cells · fill or remove gaps`
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      aria-describedby={descriptionId}
+      data-workspace-overlay-id="layout-creator"
+      className="fixed inset-0 z-[120] flex items-center justify-center bg-surface-container-lowest/60 p-7 backdrop-blur-[14px]"
+      onMouseDown={onCancel}
+    >
+      <div
+        className="flex max-h-[92vh] w-full max-w-[960px] flex-col overflow-hidden rounded-2xl border border-primary/25 bg-surface-container/95 shadow-[0_30px_80px_color-mix(in_srgb,var(--color-scrim)_60%,transparent)]"
+        onMouseDown={stopPropagation}
+      >
+        <div className="flex items-center gap-3 border-b border-outline-variant/25 px-5 py-3.5">
+          <span
+            className="material-symbols-outlined text-[20px] text-primary"
+            aria-hidden="true"
+          >
+            dashboard_customize
+          </span>
+          <h2
+            id={titleId}
+            className="font-label text-sm font-semibold text-on-surface"
+          >
+            {title}
+          </h2>
+          <span aria-hidden="true" className="h-5 w-px bg-outline-variant/40" />
+          <input
+            ref={nameInputRef}
+            value={name}
+            aria-label="Layout name"
+            className="min-w-0 flex-1 rounded-lg border border-outline-variant/35 bg-surface-container-lowest/70 px-3 py-2 text-sm text-on-surface outline-none transition focus:border-primary/60"
+            onChange={(event): void => setName(event.target.value)}
+            onKeyDown={(event): void => {
+              if (event.key === 'Enter' && canSave) {
+                handleSave()
+              }
+            }}
+          />
+          <Button variant="ghost" size="sm" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            leadingIcon="check"
+            disabled={!canSave}
+            onClick={handleSave}
+          >
+            {saveLabel}
+          </Button>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-hidden px-3 py-3">
+          <div className="flex h-full min-h-0 flex-col gap-4 overflow-y-auto overflow-x-hidden rounded-xl px-2 py-1 pr-3 [scrollbar-gutter:stable] [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:border-2 [&::-webkit-scrollbar-thumb]:border-transparent [&::-webkit-scrollbar-thumb]:bg-outline-variant/35 [&::-webkit-scrollbar-thumb]:bg-clip-padding">
+            <p id={descriptionId} className="sr-only">
+              Compose a terminal pane layout from tracks and pane slots.
+            </p>
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                variant="primary"
+                size="sm"
+                leadingIcon="add_box"
+                disabled={draft.slots.length >= validation.maxSlots}
+                onClick={(): void => updateDraft(addFirstFreeSlot(draft))}
+              >
+                Add pane
+              </Button>
+              <TrackStepper
+                label="Cols"
+                value={draft.cols.length}
+                onChange={(next): void =>
+                  updateDraft(setTrackCount(draft, 'cols', next))
+                }
+              />
+              <TrackStepper
+                label="Rows"
+                value={draft.rows.length}
+                onChange={(next): void =>
+                  updateDraft(setTrackCount(draft, 'rows', next))
+                }
+              />
+              <Button
+                variant="ghost"
+                size="sm"
+                leadingIcon="restart_alt"
+                onClick={(): void => updateDraft(createSingleDraftLayout())}
+              >
+                Reset
+              </Button>
+              <span className="ml-auto font-mono text-[11px] text-on-surface-muted">
+                {LAYOUT_CREATOR_UNIT_TOTAL}-unit tracks
+              </span>
+            </div>
+
+            <GridCanvas draft={draft} onDraftChange={updateDraft} />
+
+            <div className="flex flex-wrap items-center gap-3 rounded-xl bg-surface-container-lowest/55 px-3 py-2 font-mono text-[11px]">
+              <span
+                className={`material-symbols-outlined text-[16px] ${
+                  validation.ok ? 'text-success' : 'text-error'
+                }`}
+                aria-hidden="true"
+              >
+                {validation.ok ? 'check_circle' : 'error'}
+              </span>
+              <span className={validation.ok ? 'text-success' : 'text-error'}>
+                {validationMessage}
+              </span>
+              <span className="text-on-surface-muted">
+                {formatDraftMeta(draft)}
+              </span>
+            </div>
+
+            <div className="border-t border-outline-variant/20 pt-3">
+              <Button
+                variant="ghost"
+                size="sm"
+                leadingIcon="data_object"
+                onClick={(): void => setCodeOpen((open) => !open)}
+              >
+                Code · JSON/YAML
+              </Button>
+            </div>
+
+            {codeOpen && (
+              <div className="rounded-xl border border-outline-variant/25 bg-surface-container-lowest/60 p-3">
+                <div className="mb-3 flex flex-wrap items-center gap-2">
+                  <div className="inline-flex items-center gap-2 rounded-full border border-outline-variant/20 bg-surface-container/70 p-1 pl-2 shadow-[inset_0_1px_0_color-mix(in_srgb,var(--color-on-surface)_8%,transparent)]">
+                    <span
+                      aria-hidden="true"
+                      className="material-symbols-outlined text-[15px] text-primary/75"
+                    >
+                      data_object
+                    </span>
+                    <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-on-surface-muted">
+                      Format
+                    </span>
+                    <SegmentedControl
+                      aria-label="Code format"
+                      variant="toolbar"
+                      className="rounded-full bg-surface-container-lowest/65 p-0.5"
+                      value={codeFormat}
+                      options={codeFormatOptions}
+                      buttonClassName="h-6 w-auto min-w-[58px] gap-1.5 rounded-full px-2.5 font-mono text-[10px] uppercase tracking-[0.08em]"
+                      iconClassName="material-symbols-outlined text-[13px]"
+                      onChange={(next): void => {
+                        setCodeFormat(next)
+                        setCodeDirty(false)
+                        setCodeError(null)
+                      }}
+                    />
+                  </div>
+                  <span className="flex-1" />
+                  <Button variant="ghost" size="sm" onClick={copyCode}>
+                    Copy
+                  </Button>
+                  <Button variant="primary" size="sm" onClick={applyCode}>
+                    Apply
+                  </Button>
+                </div>
+                <textarea
+                  value={codeText}
+                  className="min-h-[180px] w-full resize-y rounded-lg border border-outline-variant/30 bg-surface-container/65 p-3 font-mono text-[11px] leading-relaxed text-on-surface outline-none focus:border-primary/60"
+                  onChange={(event): void => {
+                    setCodeText(event.target.value)
+                    setCodeDirty(true)
+                    setCodeError(null)
+                  }}
+                />
+                {codeError !== null && (
+                  <p className="mt-2 font-mono text-[11px] text-error">
+                    {codeError}
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="border-t border-outline-variant/20 bg-surface-container-lowest/35 px-4 py-3">
+          <div className="flex flex-wrap items-center gap-1.5 rounded-xl border border-outline-variant/18 bg-surface-container/45 p-1.5 shadow-[inset_0_1px_0_color-mix(in_srgb,var(--color-on-surface)_7%,transparent)]">
+            {creatorHintItems.map((item) => (
+              <span
+                key={item.action}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-surface-container-lowest/55 px-2 py-1 font-mono text-[10px] text-on-surface-muted"
+              >
+                <span className="font-semibold text-on-surface-variant">
+                  {item.action}
+                </span>
+                <span>{item.detail}</span>
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/features/terminal/components/LayoutCreator/LayoutCreatorModal.tsx
+++ b/src/features/terminal/components/LayoutCreator/LayoutCreatorModal.tsx
@@ -6,6 +6,7 @@ import {
   useRef,
   useState,
   type CSSProperties,
+  type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
   type PointerEvent as ReactPointerEvent,
   type ReactElement,
@@ -394,6 +395,17 @@ const GridCanvas = ({
       addCell(cell)
     }
 
+  const handleCellKeyDown =
+    (cell: GridCell) =>
+    (event: ReactKeyboardEvent<HTMLButtonElement>): void => {
+      if (event.key !== 'Enter' && event.key !== ' ') {
+        return
+      }
+
+      event.preventDefault()
+      addCell(cell)
+    }
+
   const startMove = (
     event: ReactPointerEvent<HTMLElement>,
     slotIndex: number
@@ -491,6 +503,9 @@ const GridCanvas = ({
                   }`}
                   onPointerDown={canPaint ? startPaint : undefined}
                   onClick={canPaint ? handleCellClick({ col, row }) : undefined}
+                  onKeyDown={
+                    canPaint ? handleCellKeyDown({ col, row }) : undefined
+                  }
                 >
                   <span
                     className={`pointer-events-none absolute inset-0 items-center justify-center text-primary/80 ${

--- a/src/features/terminal/components/LayoutCreator/LayoutCreatorModal.tsx
+++ b/src/features/terminal/components/LayoutCreator/LayoutCreatorModal.tsx
@@ -16,6 +16,7 @@ import { SegmentedControl } from '@/components/SegmentedControl'
 import type { CustomPaneLayoutId } from '../../../sessions/types'
 import {
   MAX_LAYOUT_TRACKS,
+  MAX_LAYOUT_SLOTS,
   type PaneLayoutDefinition,
 } from '../../layout-registry'
 import {
@@ -284,7 +285,8 @@ const GridCanvas = ({
 
   const previewValid =
     previewRect === null ||
-    rectFree(colCount, rowCount, draft.slots, previewRect, null)
+    (draft.slots.length < MAX_LAYOUT_SLOTS &&
+      rectFree(colCount, rowCount, draft.slots, previewRect, null))
 
   useEffect(() => {
     if (drag === null) {
@@ -458,6 +460,7 @@ const GridCanvas = ({
           {Array.from({ length: rowCount }).flatMap((_, row) =>
             Array.from({ length: colCount }).map((__, col) => {
               const empty = occupied[row]?.[col] === -1
+              const canPaint = empty && draft.slots.length < MAX_LAYOUT_SLOTS
 
               return (
                 <button
@@ -465,17 +468,18 @@ const GridCanvas = ({
                   type="button"
                   aria-label={`Add pane at column ${col + 1}, row ${row + 1}`}
                   data-layout-creator-cell={cellKey({ col, row })}
-                  tabIndex={empty ? 0 : -1}
+                  disabled={!canPaint}
+                  tabIndex={canPaint ? 0 : -1}
                   className={`group relative rounded-lg outline-none transition focus-visible:ring-1 focus-visible:ring-primary/60 ${
-                    empty
+                    canPaint
                       ? 'border border-dashed border-outline-variant/45 bg-surface-container/30 hover:border-primary/45 hover:bg-primary/10'
                       : 'border border-transparent bg-transparent'
                   }`}
-                  onPointerDown={empty ? startPaint : undefined}
+                  onPointerDown={canPaint ? startPaint : undefined}
                 >
                   <span
                     className={`pointer-events-none absolute inset-0 items-center justify-center text-primary/80 ${
-                      empty ? 'hidden group-hover:flex' : 'hidden'
+                      canPaint ? 'hidden group-hover:flex' : 'hidden'
                     }`}
                   >
                     <span
@@ -712,6 +716,7 @@ export const LayoutCreatorModal = ({
   const [codeText, setCodeText] = useState('')
   const [codeDirty, setCodeDirty] = useState(false)
   const [codeError, setCodeError] = useState<string | null>(null)
+  const [saveError, setSaveError] = useState<string | null>(null)
 
   const validation = useMemo(() => validateDraftLayout(draft), [draft])
   const canSave = validation.ok && name.trim().length > 0
@@ -733,6 +738,7 @@ export const LayoutCreatorModal = ({
     setCodeFormat('json')
     setCodeDirty(false)
     setCodeError(null)
+    setSaveError(null)
   }, [editLayout, isOpen, seedLayout])
 
   useEffect(() => {
@@ -762,6 +768,7 @@ export const LayoutCreatorModal = ({
     setDraft(next)
     setCodeDirty(false)
     setCodeError(null)
+    setSaveError(null)
   }, [])
 
   const handleSave = useCallback((): void => {
@@ -784,8 +791,9 @@ export const LayoutCreatorModal = ({
         })
       )
       setCodeError(null)
+      setSaveError(null)
     } catch (error) {
-      setCodeError(error instanceof Error ? error.message : 'Invalid layout')
+      setSaveError(error instanceof Error ? error.message : 'Invalid layout')
     }
   }, [canSave, draft, editLayout?.id, existingIds, name, onSave])
 
@@ -923,7 +931,10 @@ export const LayoutCreatorModal = ({
             value={name}
             aria-label="Layout name"
             className="min-w-0 flex-1 rounded-lg border border-outline-variant/35 bg-surface-container-lowest/70 px-3 py-2 text-sm text-on-surface outline-none transition focus:border-primary/60"
-            onChange={(event): void => setName(event.target.value)}
+            onChange={(event): void => {
+              setName(event.target.value)
+              setSaveError(null)
+            }}
             onKeyDown={(event): void => {
               if (event.key === 'Enter' && canSave) {
                 handleSave()
@@ -943,6 +954,11 @@ export const LayoutCreatorModal = ({
             {saveLabel}
           </Button>
         </div>
+        {saveError !== null && (
+          <p className="border-b border-outline-variant/20 bg-error/10 px-5 py-2 font-mono text-[11px] text-error">
+            {saveError}
+          </p>
+        )}
 
         <div className="min-h-0 flex-1 overflow-hidden px-3 py-3">
           <div className="flex h-full min-h-0 flex-col gap-4 overflow-y-auto overflow-x-hidden rounded-xl px-2 py-1 pr-3 [scrollbar-gutter:stable] [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:border-2 [&::-webkit-scrollbar-thumb]:border-transparent [&::-webkit-scrollbar-thumb]:bg-outline-variant/35 [&::-webkit-scrollbar-thumb]:bg-clip-padding">

--- a/src/features/terminal/components/LayoutCreator/LayoutCreatorModal.tsx
+++ b/src/features/terminal/components/LayoutCreator/LayoutCreatorModal.tsx
@@ -876,11 +876,13 @@ export const LayoutCreatorModal = ({
 
   const validationMessage = validation.ok
     ? `Valid · ${validation.slotCount} panes, fully tiled`
-    : validation.overCapacity
-      ? `Too many panes · ${validation.slotCount}/${validation.maxSlots} max`
-      : validation.overlap
-        ? 'Panes overlap'
-        : `${validation.emptyCells} empty cells · fill or remove gaps`
+    : validation.trackOverCapacity
+      ? `Too many tracks · ${draft.cols.length}×${draft.rows.length} exceeds ${MAX_LAYOUT_TRACKS}×${MAX_LAYOUT_TRACKS}`
+      : validation.overCapacity
+        ? `Too many panes · ${validation.slotCount}/${validation.maxSlots} max`
+        : validation.overlap
+          ? 'Panes overlap'
+          : `${validation.emptyCells} empty cells · fill or remove gaps`
 
   return (
     <div

--- a/src/features/terminal/components/LayoutCreator/LayoutCreatorModal.tsx
+++ b/src/features/terminal/components/LayoutCreator/LayoutCreatorModal.tsx
@@ -380,6 +380,20 @@ const GridCanvas = ({
     setPreviewRect({ ...cell, colSpan: 1, rowSpan: 1 })
   }
 
+  const addCell = (cell: GridCell): void => {
+    onDraftChange(addSlotRect(draft, { ...cell, colSpan: 1, rowSpan: 1 }))
+  }
+
+  const handleCellClick =
+    (cell: GridCell) =>
+    (event: ReactMouseEvent<HTMLButtonElement>): void => {
+      if (event.detail !== 0) {
+        return
+      }
+
+      addCell(cell)
+    }
+
   const startMove = (
     event: ReactPointerEvent<HTMLElement>,
     slotIndex: number
@@ -476,6 +490,7 @@ const GridCanvas = ({
                       : 'border border-transparent bg-transparent'
                   }`}
                   onPointerDown={canPaint ? startPaint : undefined}
+                  onClick={canPaint ? handleCellClick({ col, row }) : undefined}
                 >
                   <span
                     className={`pointer-events-none absolute inset-0 items-center justify-center text-primary/80 ${

--- a/src/features/terminal/components/LayoutCreator/LayoutCreatorModal.tsx
+++ b/src/features/terminal/components/LayoutCreator/LayoutCreatorModal.tsx
@@ -774,14 +774,19 @@ export const LayoutCreatorModal = ({
         ? (editLayout.id as CustomPaneLayoutId)
         : undefined
 
-    onSave(
-      definitionFromDraft({
-        title: name,
-        draft,
-        existingIds,
-        existingId,
-      })
-    )
+    try {
+      onSave(
+        definitionFromDraft({
+          title: name,
+          draft,
+          existingIds,
+          existingId,
+        })
+      )
+      setCodeError(null)
+    } catch (error) {
+      setCodeError(error instanceof Error ? error.message : 'Invalid layout')
+    }
   }, [canSave, draft, editLayout?.id, existingIds, name, onSave])
 
   useEffect(() => {

--- a/src/features/terminal/components/LayoutCreator/LayoutCreatorModal.tsx
+++ b/src/features/terminal/components/LayoutCreator/LayoutCreatorModal.tsx
@@ -703,6 +703,8 @@ export const LayoutCreatorModal = ({
   const titleId = useId()
   const descriptionId = useId()
   const nameInputRef = useRef<HTMLInputElement | null>(null)
+  const panelRef = useRef<HTMLDivElement | null>(null)
+  const previousFocusRef = useRef<HTMLElement | null>(null)
   const [name, setName] = useState('')
   const [draft, setDraft] = useState<DraftPaneLayout>(createSingleDraftLayout)
   const [codeOpen, setCodeOpen] = useState(false)
@@ -731,8 +733,24 @@ export const LayoutCreatorModal = ({
     setCodeFormat('json')
     setCodeDirty(false)
     setCodeError(null)
-    nameInputRef.current?.focus()
   }, [editLayout, isOpen, seedLayout])
+
+  useEffect(() => {
+    if (!isOpen) {
+      return undefined
+    }
+
+    previousFocusRef.current =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null
+    nameInputRef.current?.focus()
+
+    return (): void => {
+      previousFocusRef.current?.focus()
+      previousFocusRef.current = null
+    }
+  }, [isOpen])
 
   useEffect(() => {
     if (!codeDirty) {
@@ -774,12 +792,49 @@ export const LayoutCreatorModal = ({
     const handleKeyDown = (event: KeyboardEvent): void => {
       if (event.key === 'Escape') {
         onCancel()
+
+        return
       }
 
       if (event.key === 'Enter' && event.metaKey && canSave) {
         event.preventDefault()
         handleSave()
+
+        return
       }
+
+      if (event.key !== 'Tab' || !panelRef.current) {
+        return
+      }
+
+      const focusable = Array.from(
+        panelRef.current.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), [href], input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        )
+      ).filter(
+        (element) =>
+          element.offsetParent !== null &&
+          element.getAttribute('aria-hidden') !== 'true'
+      )
+
+      if (focusable.length === 0) {
+        return
+      }
+
+      const currentIndex = focusable.indexOf(
+        document.activeElement as HTMLElement
+      )
+      const delta = event.shiftKey ? -1 : 1
+      let nextIndex: number
+
+      if (currentIndex === -1) {
+        nextIndex = event.shiftKey ? focusable.length - 1 : 0
+      } else {
+        nextIndex = (currentIndex + delta + focusable.length) % focusable.length
+      }
+
+      event.preventDefault()
+      focusable[nextIndex]?.focus()
     }
 
     document.addEventListener('keydown', handleKeyDown)
@@ -838,6 +893,7 @@ export const LayoutCreatorModal = ({
       onMouseDown={onCancel}
     >
       <div
+        ref={panelRef}
         className="flex max-h-[92vh] w-full max-w-[960px] flex-col overflow-hidden rounded-2xl border border-primary/25 bg-surface-container/95 shadow-[0_30px_80px_color-mix(in_srgb,var(--color-scrim)_60%,transparent)]"
         onMouseDown={stopPropagation}
       >

--- a/src/features/terminal/components/LayoutCreator/index.ts
+++ b/src/features/terminal/components/LayoutCreator/index.ts
@@ -1,0 +1,15 @@
+export {
+  LayoutCreatorModal,
+  type LayoutCreatorModalProps,
+} from './LayoutCreatorModal'
+
+export {
+  createSingleDraftLayout,
+  definitionFromDraft,
+  draftFromDefinition,
+  evenUnits,
+  parseDraftLayoutText,
+  serializeDraftLayout,
+  validateDraftLayout,
+  type DraftPaneLayout,
+} from './layoutCreatorModel'

--- a/src/features/terminal/components/LayoutCreator/layoutCreatorModel.test.ts
+++ b/src/features/terminal/components/LayoutCreator/layoutCreatorModel.test.ts
@@ -213,4 +213,19 @@ describe('layoutCreatorModel', () => {
 
     expect(parseDraftLayoutText(yaml, 'yaml')).toEqual(draft)
   })
+
+  test('rejects drafts whose track count exceeds the layout track cap', () => {
+    const draft = {
+      cols: Array.from({ length: 25 }, () => 1),
+      rows: [24],
+      slots: [{ col: 0, row: 0, colSpan: 1, rowSpan: 1 }],
+    }
+
+    expect(validateDraftLayout(draft)).toMatchObject({
+      ok: false,
+      trackOverCapacity: true,
+      overCapacity: false,
+      overlap: false,
+    })
+  })
 })

--- a/src/features/terminal/components/LayoutCreator/layoutCreatorModel.test.ts
+++ b/src/features/terminal/components/LayoutCreator/layoutCreatorModel.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, test } from 'vitest'
+import type { PaneLayoutDefinition } from '../../layout-registry'
+import {
+  addSlotRect,
+  addFirstFreeSlot,
+  createSingleDraftLayout,
+  definitionFromDraft,
+  draftFromDefinition,
+  evenUnits,
+  parseDraftLayoutText,
+  serializeDraftLayout,
+  setTrackCount,
+  updateTrackBoundary,
+  validateDraftLayout,
+} from './layoutCreatorModel'
+
+const mainWithBottomStack = (): PaneLayoutDefinition => ({
+  schemaVersion: 1,
+  id: 'custom:main-bottom',
+  title: 'Main + bottom stack',
+  source: 'workspace',
+  tracks: {
+    columns: [
+      { id: 'col-0', units: 8 },
+      { id: 'col-1', units: 8 },
+      { id: 'col-2', units: 8 },
+    ],
+    rows: [
+      { id: 'row-0', units: 16 },
+      { id: 'row-1', units: 8 },
+    ],
+  },
+  slots: [
+    { id: 'slot:p0', rect: { col: 0, row: 0, colSpan: 3, rowSpan: 1 } },
+    { id: 'slot:p1', rect: { col: 0, row: 1, colSpan: 1, rowSpan: 1 } },
+    { id: 'slot:p2', rect: { col: 1, row: 1, colSpan: 1, rowSpan: 1 } },
+    { id: 'slot:p3', rect: { col: 2, row: 1, colSpan: 1, rowSpan: 1 } },
+  ],
+  addOrder: ['slot:p0', 'slot:p1', 'slot:p2', 'slot:p3'],
+})
+
+describe('layoutCreatorModel', () => {
+  test('splits the 24-unit axis evenly', () => {
+    expect(evenUnits(3)).toEqual([8, 8, 8])
+    expect(evenUnits(5)).toEqual([5, 5, 5, 5, 4])
+    expect(evenUnits(24)).toHaveLength(24)
+  })
+
+  test('round-trips a custom definition through the draft editor model', () => {
+    const draft = draftFromDefinition(mainWithBottomStack())
+    const serialized = serializeDraftLayout(draft, 'json')
+    const parsed = parseDraftLayoutText(serialized, 'json')
+
+    expect(parsed).toEqual(draft)
+    expect(validateDraftLayout(parsed).ok).toBe(true)
+  })
+
+  test('emits canonical PaneLayoutDefinition with slot:p pane order ids', () => {
+    const definition = definitionFromDraft({
+      title: 'My layout',
+      draft: draftFromDefinition(mainWithBottomStack()),
+      existingIds: new Set(),
+    })
+
+    expect(definition.id).toMatch(/^custom:my-layout-/)
+    expect(definition.tracks.columns.map((track) => track.units)).toEqual([
+      8, 8, 8,
+    ])
+
+    expect(definition.addOrder).toEqual([
+      'slot:p0',
+      'slot:p1',
+      'slot:p2',
+      'slot:p3',
+    ])
+  })
+
+  test('detects gaps until every grid cell is covered', () => {
+    const draft = setTrackCount(createSingleDraftLayout(), 'cols', 2)
+
+    expect(validateDraftLayout(draft)).toMatchObject({
+      ok: false,
+      emptyCells: 1,
+    })
+
+    const filled = addSlotRect(draft, {
+      col: 1,
+      row: 0,
+      colSpan: 1,
+      rowSpan: 1,
+    })
+
+    expect(validateDraftLayout(filled).ok).toBe(true)
+  })
+
+  test('drops panes outside reduced rows instead of clamping them into overlaps', () => {
+    const draft = {
+      cols: [12, 12],
+      rows: [4, 4, 4, 4, 4, 4],
+      slots: Array.from({ length: 6 }).flatMap((_, row) => [
+        { col: 0, row, colSpan: 1, rowSpan: 1 },
+        { col: 1, row, colSpan: 1, rowSpan: 1 },
+      ]),
+    }
+
+    const reduced = setTrackCount(draft, 'rows', 3)
+
+    expect(reduced.slots).toEqual([
+      { col: 0, row: 0, colSpan: 1, rowSpan: 1 },
+      { col: 1, row: 0, colSpan: 1, rowSpan: 1 },
+      { col: 0, row: 1, colSpan: 1, rowSpan: 1 },
+      { col: 1, row: 1, colSpan: 1, rowSpan: 1 },
+      { col: 0, row: 2, colSpan: 1, rowSpan: 1 },
+      { col: 1, row: 2, colSpan: 1, rowSpan: 1 },
+    ])
+
+    expect(validateDraftLayout(reduced)).toMatchObject({
+      ok: true,
+      overlap: false,
+      emptyCells: 0,
+    })
+  })
+
+  test('drops panes outside reduced columns instead of clamping them into overlaps', () => {
+    const draft = {
+      cols: [8, 8, 8],
+      rows: [12, 12],
+      slots: [
+        { col: 0, row: 0, colSpan: 1, rowSpan: 1 },
+        { col: 1, row: 0, colSpan: 1, rowSpan: 1 },
+        { col: 2, row: 0, colSpan: 1, rowSpan: 1 },
+        { col: 0, row: 1, colSpan: 1, rowSpan: 1 },
+        { col: 1, row: 1, colSpan: 1, rowSpan: 1 },
+        { col: 2, row: 1, colSpan: 1, rowSpan: 1 },
+      ],
+    }
+
+    const reduced = setTrackCount(draft, 'cols', 2)
+
+    expect(reduced.slots).toEqual([
+      { col: 0, row: 0, colSpan: 1, rowSpan: 1 },
+      { col: 1, row: 0, colSpan: 1, rowSpan: 1 },
+      { col: 0, row: 1, colSpan: 1, rowSpan: 1 },
+      { col: 1, row: 1, colSpan: 1, rowSpan: 1 },
+    ])
+
+    expect(validateDraftLayout(reduced)).toMatchObject({
+      ok: true,
+      overlap: false,
+      emptyCells: 0,
+    })
+  })
+
+  test('adjusts adjacent tracks while preserving the 24-unit total', () => {
+    const draft = setTrackCount(createSingleDraftLayout(), 'cols', 2)
+    const adjusted = updateTrackBoundary(draft, 'cols', 0, 16 / 24)
+
+    expect(adjusted.cols).toEqual([16, 8])
+    expect(adjusted.cols.reduce((sum, unit) => sum + unit, 0)).toBe(24)
+  })
+
+  test('rejects otherwise tiled drafts that exceed the pane capacity', () => {
+    const draft = {
+      cols: [24],
+      rows: evenUnits(17),
+      slots: Array.from({ length: 17 }, (_, row) => ({
+        col: 0,
+        row,
+        colSpan: 1,
+        rowSpan: 1,
+      })),
+    }
+
+    expect(validateDraftLayout(draft)).toMatchObject({
+      ok: false,
+      overlap: false,
+      emptyCells: 0,
+      overCapacity: true,
+      slotCount: 17,
+      maxSlots: 16,
+    })
+
+    expect(() =>
+      definitionFromDraft({
+        title: 'Too many',
+        draft,
+        existingIds: new Set(),
+      })
+    ).toThrow('Layouts must have 1-16 slots.')
+  })
+
+  test('does not add panes after the pane capacity is reached', () => {
+    const draft = {
+      cols: [24],
+      rows: evenUnits(17),
+      slots: Array.from({ length: 16 }, (_, row) => ({
+        col: 0,
+        row,
+        colSpan: 1,
+        rowSpan: 1,
+      })),
+    }
+
+    expect(addFirstFreeSlot(draft)).toBe(draft)
+    expect(
+      addSlotRect(draft, { col: 0, row: 16, colSpan: 1, rowSpan: 1 })
+    ).toBe(draft)
+  })
+
+  test('parses the emitted yaml shape', () => {
+    const draft = draftFromDefinition(mainWithBottomStack())
+    const yaml = serializeDraftLayout(draft, 'yaml')
+
+    expect(parseDraftLayoutText(yaml, 'yaml')).toEqual(draft)
+  })
+})

--- a/src/features/terminal/components/LayoutCreator/layoutCreatorModel.ts
+++ b/src/features/terminal/components/LayoutCreator/layoutCreatorModel.ts
@@ -1,0 +1,819 @@
+import type {
+  CustomPaneLayoutId,
+  LayoutSlotId,
+  PaneLayoutId,
+} from '../../../sessions/types'
+import {
+  createIndexedPaneSlotId,
+  CUSTOM_PANE_LAYOUT_ID_PREFIX,
+  MAX_LAYOUT_TRACKS,
+  MAX_LAYOUT_SLOTS,
+  PANE_LAYOUT_SCHEMA_VERSION,
+  validatePaneLayoutDefinition,
+  type PaneLayoutDefinition,
+  type PaneSlotRect,
+} from '../../layout-registry'
+
+export const LAYOUT_CREATOR_UNIT_TOTAL = 24
+
+export const LAYOUT_CREATOR_MIN_UNITS = 1
+
+export type LayoutCreatorCodeFormat = 'json' | 'yaml'
+
+export type DraftLayoutSlot = PaneSlotRect
+
+export interface DraftPaneLayout {
+  readonly cols: readonly number[]
+  readonly rows: readonly number[]
+  readonly slots: readonly DraftLayoutSlot[]
+}
+
+export interface DraftLayoutValidation {
+  readonly ok: boolean
+  readonly emptyCells: number
+  readonly overlap: boolean
+  readonly overCapacity: boolean
+  readonly slotCount: number
+  readonly maxSlots: number
+}
+
+interface LayoutModel {
+  readonly tracks: {
+    readonly columns: readonly { readonly id: string; readonly units: number }[]
+    readonly rows: readonly { readonly id: string; readonly units: number }[]
+  }
+  readonly slots: readonly {
+    readonly id: LayoutSlotId
+    readonly rect: DraftLayoutSlot
+  }[]
+}
+
+type Axis = 'cols' | 'rows'
+
+export const createSingleDraftLayout = (): DraftPaneLayout => ({
+  cols: [LAYOUT_CREATOR_UNIT_TOTAL],
+  rows: [LAYOUT_CREATOR_UNIT_TOTAL],
+  slots: [{ col: 0, row: 0, colSpan: 1, rowSpan: 1 }],
+})
+
+export const evenUnits = (trackCount: number): readonly number[] => {
+  const count = Math.max(1, Math.min(MAX_LAYOUT_TRACKS, Math.floor(trackCount)))
+  const base = Math.floor(LAYOUT_CREATOR_UNIT_TOTAL / count)
+  const units = Array.from({ length: count }, () => base)
+  let remainder = LAYOUT_CREATOR_UNIT_TOTAL - base * count
+
+  for (let index = 0; remainder > 0; index += 1) {
+    units[index] += 1
+    remainder -= 1
+  }
+
+  return units
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null
+
+const finiteNumber = (value: unknown): number | null => {
+  if (typeof value !== 'number' && typeof value !== 'string') {
+    return null
+  }
+
+  const parsed = Number(value)
+
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+const finiteInteger = (value: unknown): number | null => {
+  const parsed = finiteNumber(value)
+
+  return parsed === null ? null : Math.round(parsed)
+}
+
+const normalizeUnits = (rawUnits: readonly number[]): readonly number[] => {
+  if (rawUnits.length === 0) {
+    return [LAYOUT_CREATOR_UNIT_TOTAL]
+  }
+
+  const positiveUnits = rawUnits.map((unit) =>
+    Number.isFinite(unit) && unit > 0 ? unit : LAYOUT_CREATOR_MIN_UNITS
+  )
+  const total = positiveUnits.reduce((sum, unit) => sum + unit, 0)
+
+  if (total <= 0) {
+    return evenUnits(positiveUnits.length)
+  }
+
+  const exact = positiveUnits.map(
+    (unit) => (unit / total) * LAYOUT_CREATOR_UNIT_TOTAL
+  )
+
+  const floors = exact.map((unit) =>
+    Math.max(LAYOUT_CREATOR_MIN_UNITS, Math.floor(unit))
+  )
+  const floorTotal = floors.reduce((sum, unit) => sum + unit, 0)
+
+  if (floorTotal > LAYOUT_CREATOR_UNIT_TOTAL) {
+    return evenUnits(positiveUnits.length)
+  }
+
+  const rankedRemainders = exact
+    .map((unit, index) => ({ index, remainder: unit - Math.floor(unit) }))
+    .sort((left, right) => right.remainder - left.remainder)
+
+  const normalized = [...floors]
+  let remainder = LAYOUT_CREATOR_UNIT_TOTAL - floorTotal
+  for (let index = 0; remainder > 0; index += 1) {
+    normalized[rankedRemainders[index % rankedRemainders.length].index] += 1
+    remainder -= 1
+  }
+
+  return normalized
+}
+
+const normalizeSlot = (
+  slot: DraftLayoutSlot,
+  colCount: number,
+  rowCount: number
+): DraftLayoutSlot => {
+  const col = Math.max(0, Math.min(slot.col, colCount - 1))
+  const row = Math.max(0, Math.min(slot.row, rowCount - 1))
+  const colSpan = Math.max(1, Math.min(slot.colSpan, colCount - col))
+  const rowSpan = Math.max(1, Math.min(slot.rowSpan, rowCount - row))
+
+  return { col, row, colSpan, rowSpan }
+}
+
+export const normalizeDraftLayout = (
+  draft: DraftPaneLayout
+): DraftPaneLayout => {
+  const cols = normalizeUnits(draft.cols)
+  const rows = normalizeUnits(draft.rows)
+
+  return {
+    cols,
+    rows,
+    slots: draft.slots.map((slot) =>
+      normalizeSlot(slot, cols.length, rows.length)
+    ),
+  }
+}
+
+export const occupancy = (
+  colCount: number,
+  rowCount: number,
+  slots: readonly DraftLayoutSlot[],
+  ignoreIndex: number | null = null
+): readonly (readonly number[])[] => {
+  const grid = Array.from({ length: rowCount }, () =>
+    Array.from({ length: colCount }, () => -1)
+  )
+
+  slots.forEach((slot, slotIndex) => {
+    if (slotIndex === ignoreIndex) {
+      return
+    }
+
+    for (let row = slot.row; row < slot.row + slot.rowSpan; row += 1) {
+      for (let col = slot.col; col < slot.col + slot.colSpan; col += 1) {
+        if (row >= 0 && row < rowCount && col >= 0 && col < colCount) {
+          grid[row][col] = slotIndex
+        }
+      }
+    }
+  })
+
+  return grid
+}
+
+export const rectFree = (
+  colCount: number,
+  rowCount: number,
+  slots: readonly DraftLayoutSlot[],
+  rect: DraftLayoutSlot,
+  ignoreIndex: number | null = null
+): boolean => {
+  const grid = occupancy(colCount, rowCount, slots, ignoreIndex)
+
+  for (let row = rect.row; row < rect.row + rect.rowSpan; row += 1) {
+    for (let col = rect.col; col < rect.col + rect.colSpan; col += 1) {
+      if (row < 0 || row >= rowCount || col < 0 || col >= colCount) {
+        return false
+      }
+
+      if (grid[row][col] !== -1) {
+        return false
+      }
+    }
+  }
+
+  return true
+}
+
+export const validateDraftLayout = (
+  draft: DraftPaneLayout
+): DraftLayoutValidation => {
+  const colCount = draft.cols.length
+  const rowCount = draft.rows.length
+
+  const grid = Array.from({ length: rowCount }, () =>
+    Array.from({ length: colCount }, () => -1)
+  )
+  let overlap = false
+
+  for (const [slotIndex, slot] of draft.slots.entries()) {
+    for (let row = slot.row; row < slot.row + slot.rowSpan; row += 1) {
+      for (let col = slot.col; col < slot.col + slot.colSpan; col += 1) {
+        if (row < 0 || row >= rowCount || col < 0 || col >= colCount) {
+          overlap = true
+
+          continue
+        }
+
+        if (grid[row][col] !== -1) {
+          overlap = true
+        }
+
+        grid[row][col] = slotIndex
+      }
+    }
+  }
+
+  const emptyCells = grid.reduce(
+    (sum, row) => sum + row.filter((cell) => cell === -1).length,
+    0
+  )
+
+  return {
+    ok: !overlap && emptyCells === 0 && draft.slots.length <= MAX_LAYOUT_SLOTS,
+    emptyCells,
+    overlap,
+    overCapacity: draft.slots.length > MAX_LAYOUT_SLOTS,
+    slotCount: draft.slots.length,
+    maxSlots: MAX_LAYOUT_SLOTS,
+  }
+}
+
+export const rectFromCells = (
+  start: { readonly col: number; readonly row: number },
+  end: { readonly col: number; readonly row: number }
+): DraftLayoutSlot => {
+  const col = Math.min(start.col, end.col)
+  const row = Math.min(start.row, end.row)
+  const colSpan = Math.abs(start.col - end.col) + 1
+  const rowSpan = Math.abs(start.row - end.row) + 1
+
+  return { col, row, colSpan, rowSpan }
+}
+
+const repairSlotsForTrackCount = (
+  slots: readonly DraftLayoutSlot[],
+  colCount: number,
+  rowCount: number
+): readonly DraftLayoutSlot[] => {
+  const repairedSlots: DraftLayoutSlot[] = []
+
+  slots.forEach((slot) => {
+    if (slot.col >= colCount || slot.row >= rowCount) {
+      return
+    }
+
+    const normalizedSlot = normalizeSlot(slot, colCount, rowCount)
+    if (rectFree(colCount, rowCount, repairedSlots, normalizedSlot)) {
+      repairedSlots.push(normalizedSlot)
+    }
+  })
+
+  return repairedSlots.length > 0
+    ? repairedSlots
+    : [{ col: 0, row: 0, colSpan: 1, rowSpan: 1 }]
+}
+
+export const setTrackCount = (
+  draft: DraftPaneLayout,
+  axis: Axis,
+  count: number
+): DraftPaneLayout => {
+  const shrinking =
+    axis === 'cols' ? count < draft.cols.length : count < draft.rows.length
+
+  const next = {
+    cols: axis === 'cols' ? evenUnits(count) : draft.cols,
+    rows: axis === 'rows' ? evenUnits(count) : draft.rows,
+    slots: draft.slots,
+  }
+
+  const normalized = normalizeDraftLayout(next)
+
+  if (!shrinking) {
+    return normalized
+  }
+
+  return {
+    ...normalized,
+    slots: repairSlotsForTrackCount(
+      draft.slots,
+      normalized.cols.length,
+      normalized.rows.length
+    ),
+  }
+}
+
+const updateBoundaryUnits = (
+  tracks: readonly number[],
+  boundaryIndex: number,
+  boundaryRatio: number
+): readonly number[] => {
+  if (boundaryIndex < 0 || boundaryIndex >= tracks.length - 1) {
+    return tracks
+  }
+
+  const next = [...tracks]
+  const left = next[boundaryIndex]
+  const right = next[boundaryIndex + 1]
+
+  const total = next.reduce((sum, unit) => sum + unit, 0)
+
+  const fixedLeading = next
+    .slice(0, boundaryIndex)
+    .reduce((sum, unit) => sum + unit, 0)
+  const pairTotal = left + right
+  const rawLeft = Math.round(boundaryRatio * total - fixedLeading)
+
+  const nextLeft = Math.min(
+    Math.max(rawLeft, LAYOUT_CREATOR_MIN_UNITS),
+    pairTotal - LAYOUT_CREATOR_MIN_UNITS
+  )
+
+  next[boundaryIndex] = nextLeft
+  next[boundaryIndex + 1] = pairTotal - nextLeft
+
+  return next
+}
+
+export const updateTrackBoundary = (
+  draft: DraftPaneLayout,
+  axis: Axis,
+  boundaryIndex: number,
+  boundaryRatio: number
+): DraftPaneLayout => {
+  if (axis === 'cols') {
+    return {
+      ...draft,
+      cols: updateBoundaryUnits(draft.cols, boundaryIndex, boundaryRatio),
+    }
+  }
+
+  return {
+    ...draft,
+    rows: updateBoundaryUnits(draft.rows, boundaryIndex, boundaryRatio),
+  }
+}
+
+export const addFirstFreeSlot = (draft: DraftPaneLayout): DraftPaneLayout => {
+  if (draft.slots.length >= MAX_LAYOUT_SLOTS) {
+    return draft
+  }
+
+  const grid = occupancy(draft.cols.length, draft.rows.length, draft.slots)
+
+  for (let row = 0; row < draft.rows.length; row += 1) {
+    for (let col = 0; col < draft.cols.length; col += 1) {
+      if (grid[row][col] === -1) {
+        return {
+          ...draft,
+          slots: [...draft.slots, { col, row, colSpan: 1, rowSpan: 1 }],
+        }
+      }
+    }
+  }
+
+  return draft
+}
+
+export const addSlotRect = (
+  draft: DraftPaneLayout,
+  rect: DraftLayoutSlot
+): DraftPaneLayout => {
+  if (draft.slots.length >= MAX_LAYOUT_SLOTS) {
+    return draft
+  }
+
+  if (
+    !rectFree(draft.cols.length, draft.rows.length, draft.slots, rect, null)
+  ) {
+    return draft
+  }
+
+  return { ...draft, slots: [...draft.slots, rect] }
+}
+
+export const moveSlot = (
+  draft: DraftPaneLayout,
+  slotIndex: number,
+  rect: DraftLayoutSlot
+): DraftPaneLayout => {
+  if (slotIndex < 0 || slotIndex >= draft.slots.length) {
+    return draft
+  }
+
+  const normalizedRect = normalizeSlot(
+    rect,
+    draft.cols.length,
+    draft.rows.length
+  )
+
+  if (
+    !rectFree(
+      draft.cols.length,
+      draft.rows.length,
+      draft.slots,
+      normalizedRect,
+      slotIndex
+    )
+  ) {
+    return draft
+  }
+
+  return {
+    ...draft,
+    slots: draft.slots.map((slot, index) =>
+      index === slotIndex ? normalizedRect : slot
+    ),
+  }
+}
+
+export const removeSlot = (
+  draft: DraftPaneLayout,
+  slotIndex: number
+): DraftPaneLayout => {
+  if (draft.slots.length <= 1) {
+    return draft
+  }
+
+  return {
+    ...draft,
+    slots: draft.slots.filter((_, index) => index !== slotIndex),
+  }
+}
+
+const draftToModel = (draft: DraftPaneLayout): LayoutModel => ({
+  tracks: {
+    columns: draft.cols.map((unit, index) => ({
+      id: `col-${index}`,
+      units: unit,
+    })),
+    rows: draft.rows.map((unit, index) => ({
+      id: `row-${index}`,
+      units: unit,
+    })),
+  },
+  slots: draft.slots.map((slot, index) => ({
+    id: createIndexedPaneSlotId(index),
+    rect: { ...slot },
+  })),
+})
+
+export const serializeDraftLayout = (
+  draft: DraftPaneLayout,
+  format: LayoutCreatorCodeFormat
+): string => {
+  const model = draftToModel(draft)
+  if (format === 'json') {
+    return JSON.stringify(model, null, 2)
+  }
+
+  const lines: string[] = ['tracks:', '  columns:']
+  model.tracks.columns.forEach((track) => {
+    lines.push(`    - id: ${track.id}`)
+    lines.push(`      units: ${track.units}`)
+  })
+  lines.push('  rows:')
+  model.tracks.rows.forEach((track) => {
+    lines.push(`    - id: ${track.id}`)
+    lines.push(`      units: ${track.units}`)
+  })
+  lines.push('slots:')
+  model.slots.forEach((slot) => {
+    lines.push(`  - id: ${slot.id}`)
+    lines.push(
+      `    rect: { col: ${slot.rect.col}, row: ${slot.rect.row}, colSpan: ${slot.rect.colSpan}, rowSpan: ${slot.rect.rowSpan} }`
+    )
+  })
+
+  return lines.join('\n')
+}
+
+const readTrackUnits = (value: unknown): readonly number[] => {
+  if (!Array.isArray(value)) {
+    throw new Error('Track axis must be an array')
+  }
+
+  const units = value.map((track) => {
+    if (!isRecord(track)) {
+      throw new Error('Each track must be an object')
+    }
+
+    const parsedUnits = finiteInteger(track.units)
+    if (parsedUnits === null || parsedUnits <= 0) {
+      throw new Error('Track units must be positive numbers')
+    }
+
+    return parsedUnits
+  })
+
+  if (units.length === 0) {
+    throw new Error('Need at least one column and row')
+  }
+
+  return units
+}
+
+const readSlotRect = (value: unknown): DraftLayoutSlot => {
+  if (!isRecord(value)) {
+    throw new Error('Each slot must be an object')
+  }
+
+  const rectValue = isRecord(value.rect) ? value.rect : value
+  const col = finiteInteger(rectValue.col)
+  const row = finiteInteger(rectValue.row)
+  const colSpan = finiteInteger(rectValue.colSpan)
+  const rowSpan = finiteInteger(rectValue.rowSpan)
+
+  if (
+    col === null ||
+    row === null ||
+    colSpan === null ||
+    rowSpan === null ||
+    colSpan <= 0 ||
+    rowSpan <= 0
+  ) {
+    throw new Error('Slot rects require col, row, colSpan, and rowSpan')
+  }
+
+  return { col, row, colSpan, rowSpan }
+}
+
+const modelToDraft = (value: unknown): DraftPaneLayout => {
+  if (!isRecord(value) || !isRecord(value.tracks)) {
+    throw new Error('Expected { tracks: { columns, rows }, slots }')
+  }
+
+  const cols = readTrackUnits(value.tracks.columns)
+  const rows = readTrackUnits(value.tracks.rows)
+  if (!Array.isArray(value.slots)) {
+    throw new Error('Slots must be an array')
+  }
+
+  const draft = normalizeDraftLayout({
+    cols,
+    rows,
+    slots: value.slots.map(readSlotRect),
+  })
+
+  const validation = validateDraftLayout(draft)
+  if (!validation.ok) {
+    throw new Error(
+      validation.overCapacity
+        ? `Imported layout supports up to ${validation.maxSlots} panes`
+        : validation.overlap
+          ? 'Imported layout has overlapping panes'
+          : 'Imported layout must cover every grid cell'
+    )
+  }
+
+  return draft
+}
+
+const parseYamlModel = (text: string): LayoutModel => {
+  const columns: { id: string; units: number }[] = []
+  const rows: { id: string; units: number }[] = []
+  const slots: { id: LayoutSlotId; rect: DraftLayoutSlot }[] = []
+  let section: 'columns' | 'rows' | 'slots' | null = null
+  let currentTrack: { id?: string; units?: number } | null = null
+  let currentSlot: { id?: LayoutSlotId; rect?: DraftLayoutSlot } | null = null
+
+  const commitTrack = (): void => {
+    if (currentTrack === null || section === 'slots') {
+      return
+    }
+
+    const units = currentTrack.units
+    if (units === undefined) {
+      return
+    }
+
+    const target = section === 'columns' ? columns : rows
+    target.push({ id: currentTrack.id ?? `${section}-${target.length}`, units })
+  }
+
+  const commitSlot = (): void => {
+    if (currentSlot?.rect === undefined) {
+      return
+    }
+
+    slots.push({
+      id: currentSlot.id ?? createIndexedPaneSlotId(slots.length),
+      rect: currentSlot.rect,
+    })
+  }
+
+  text
+    .replace(/\r/g, '')
+    .split('\n')
+    .forEach((rawLine) => {
+      const line = rawLine.trim()
+      if (line.length === 0 || line.startsWith('#') || line === 'tracks:') {
+        return
+      }
+
+      if (line === 'columns:' || line === 'rows:' || line === 'slots:') {
+        if (section === 'slots') {
+          commitSlot()
+          currentSlot = null
+        } else {
+          commitTrack()
+          currentTrack = null
+        }
+        section = line.slice(0, -1) as 'columns' | 'rows' | 'slots'
+
+        return
+      }
+
+      const itemBody = line.startsWith('- ') ? line.slice(2).trim() : line
+      if (line.startsWith('- ')) {
+        if (section === 'slots') {
+          commitSlot()
+          currentSlot = {}
+        } else {
+          commitTrack()
+          currentTrack = {}
+        }
+      }
+
+      const [key, ...rest] = itemBody.split(':')
+      if (!key || rest.length === 0) {
+        return
+      }
+
+      const value = rest.join(':').trim()
+      if (section === 'slots') {
+        currentSlot ??= {}
+        if (key === 'id') {
+          currentSlot.id = value as LayoutSlotId
+        }
+        if (key === 'rect') {
+          const rectValues = new Map(
+            value
+              .replace(/[{}]/g, '')
+              .split(',')
+              .map((pair) => pair.split(':').map((part) => part.trim()))
+              .filter((pair): pair is [string, string] => pair.length === 2)
+          )
+          currentSlot.rect = readSlotRect({
+            col: rectValues.get('col'),
+            row: rectValues.get('row'),
+            colSpan: rectValues.get('colSpan'),
+            rowSpan: rectValues.get('rowSpan'),
+          })
+        }
+
+        return
+      }
+
+      currentTrack ??= {}
+      if (key === 'id') {
+        currentTrack.id = value
+      }
+      if (key === 'units') {
+        const units = finiteInteger(value)
+        if (units !== null) {
+          currentTrack.units = units
+        }
+      }
+    })
+
+  commitSlot()
+  commitTrack()
+
+  return {
+    tracks: { columns, rows },
+    slots,
+  }
+}
+
+export const parseDraftLayoutText = (
+  text: string,
+  format: LayoutCreatorCodeFormat
+): DraftPaneLayout => {
+  const trimmed = text.trim()
+  if (trimmed.length === 0) {
+    throw new Error('Nothing to import')
+  }
+
+  if (format === 'yaml') {
+    try {
+      return modelToDraft(parseYamlModel(trimmed))
+    } catch {
+      // JSON is a useful fallback because pasted JSON is common and valid YAML.
+    }
+  }
+
+  const parsed: unknown = JSON.parse(trimmed)
+
+  return modelToDraft(parsed)
+}
+
+const slugify = (value: string): string =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+
+export const createCustomPaneLayoutId = (
+  title: string,
+  existingIds: ReadonlySet<PaneLayoutId>
+): CustomPaneLayoutId => {
+  const slug = slugify(title) || 'layout'
+
+  const suffix =
+    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID().slice(0, 8)
+      : Date.now().toString(36)
+  let candidate =
+    `${CUSTOM_PANE_LAYOUT_ID_PREFIX}${slug}-${suffix}` as CustomPaneLayoutId
+  let counter = 2
+
+  while (existingIds.has(candidate)) {
+    candidate =
+      `${CUSTOM_PANE_LAYOUT_ID_PREFIX}${slug}-${suffix}-${counter}` as CustomPaneLayoutId
+    counter += 1
+  }
+
+  return candidate
+}
+
+export const definitionFromDraft = ({
+  title,
+  draft,
+  existingIds,
+  existingId = undefined,
+}: {
+  readonly title: string
+  readonly draft: DraftPaneLayout
+  readonly existingIds: ReadonlySet<PaneLayoutId>
+  readonly existingId?: CustomPaneLayoutId | undefined
+}): PaneLayoutDefinition => {
+  const normalizedDraft = normalizeDraftLayout(draft)
+  const id = existingId ?? createCustomPaneLayoutId(title, existingIds)
+
+  const slots = normalizedDraft.slots.map((slot, index) => ({
+    id: createIndexedPaneSlotId(index),
+    rect: { ...slot },
+  }))
+
+  const definition: PaneLayoutDefinition = {
+    schemaVersion: PANE_LAYOUT_SCHEMA_VERSION,
+    id,
+    title: title.trim(),
+    source: 'workspace',
+    tracks: {
+      columns: normalizedDraft.cols.map((units, index) => ({
+        id: `col-${index}`,
+        units,
+      })),
+      rows: normalizedDraft.rows.map((units, index) => ({
+        id: `row-${index}`,
+        units,
+      })),
+    },
+    slots,
+    addOrder: slots.map((slot) => slot.id),
+  }
+
+  const validation = validatePaneLayoutDefinition(definition)
+  if (!validation.ok) {
+    throw new Error(validation.errors[0]?.message ?? 'Invalid layout')
+  }
+
+  return definition
+}
+
+export const draftFromDefinition = (
+  definition: PaneLayoutDefinition | undefined
+): DraftPaneLayout => {
+  if (definition === undefined) {
+    return createSingleDraftLayout()
+  }
+
+  return normalizeDraftLayout({
+    cols: definition.tracks.columns.map((track) => track.units),
+    rows: definition.tracks.rows.map((track) => track.units),
+    slots: definition.slots.map((slot) => ({ ...slot.rect })),
+  })
+}
+
+export const formatDraftMeta = (draft: DraftPaneLayout): string =>
+  `${draft.cols.length}x${draft.rows.length} grid · cols ${draft.cols.join(
+    '/'
+  )} · rows ${draft.rows.join('/')}`

--- a/src/features/terminal/components/LayoutCreator/layoutCreatorModel.ts
+++ b/src/features/terminal/components/LayoutCreator/layoutCreatorModel.ts
@@ -33,6 +33,7 @@ export interface DraftLayoutValidation {
   readonly emptyCells: number
   readonly overlap: boolean
   readonly overCapacity: boolean
+  readonly trackOverCapacity: boolean
   readonly slotCount: number
   readonly maxSlots: number
 }
@@ -243,11 +244,20 @@ export const validateDraftLayout = (
     0
   )
 
+  const trackOverCapacity =
+    draft.cols.length > MAX_LAYOUT_TRACKS ||
+    draft.rows.length > MAX_LAYOUT_TRACKS
+
   return {
-    ok: !overlap && emptyCells === 0 && draft.slots.length <= MAX_LAYOUT_SLOTS,
+    ok:
+      !overlap &&
+      emptyCells === 0 &&
+      draft.slots.length <= MAX_LAYOUT_SLOTS &&
+      !trackOverCapacity,
     emptyCells,
     overlap,
     overCapacity: draft.slots.length > MAX_LAYOUT_SLOTS,
+    trackOverCapacity,
     slotCount: draft.slots.length,
     maxSlots: MAX_LAYOUT_SLOTS,
   }
@@ -573,11 +583,13 @@ const modelToDraft = (value: unknown): DraftPaneLayout => {
   const validation = validateDraftLayout(draft)
   if (!validation.ok) {
     throw new Error(
-      validation.overCapacity
-        ? `Imported layout supports up to ${validation.maxSlots} panes`
-        : validation.overlap
-          ? 'Imported layout has overlapping panes'
-          : 'Imported layout must cover every grid cell'
+      validation.trackOverCapacity
+        ? `Imported layout has too many tracks (max ${MAX_LAYOUT_TRACKS})`
+        : validation.overCapacity
+          ? `Imported layout supports up to ${validation.maxSlots} panes`
+          : validation.overlap
+            ? 'Imported layout has overlapping panes'
+            : 'Imported layout must cover every grid cell'
     )
   }
 

--- a/src/features/terminal/components/LayoutCreator/layoutCreatorModel.ts
+++ b/src/features/terminal/components/LayoutCreator/layoutCreatorModel.ts
@@ -711,10 +711,24 @@ export const parseDraftLayoutText = (
   }
 
   if (format === 'yaml') {
+    let yamlError: unknown = null
     try {
       return modelToDraft(parseYamlModel(trimmed))
-    } catch {
+    } catch (error) {
+      yamlError = error
       // JSON is a useful fallback because pasted JSON is common and valid YAML.
+    }
+
+    try {
+      const parsed: unknown = JSON.parse(trimmed)
+
+      return modelToDraft(parsed)
+    } catch {
+      if (yamlError instanceof Error) {
+        throw yamlError
+      }
+
+      throw new Error('Invalid YAML')
     }
   }
 

--- a/src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.test.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.test.tsx
@@ -37,8 +37,9 @@ const customMainBottomLayout: PaneLayoutDefinition = {
 interface HarnessProps {
   activeLayoutId?: PaneLayoutId
   initialVisibleLayoutIds?: readonly PaneLayoutId[]
+  blockedLayoutIds?: readonly PaneLayoutId[]
   layouts?: readonly PaneLayoutDefinition[]
-  onPickLayout?: (layoutId: PaneLayoutId) => void
+  onPickLayout?: (layoutId: PaneLayoutId) => boolean
   onEditCustomLayout?: (layoutId: PaneLayoutId) => void
   onDeleteCustomLayout?: (layoutId: PaneLayoutId) => void
   onCreateCustomLayout?: () => void
@@ -54,6 +55,7 @@ const LayoutDisplayMenuHarness = ({
     'quad',
     'grid3x2',
   ],
+  blockedLayoutIds = [],
   layouts = [],
   onPickLayout = undefined,
   onEditCustomLayout = undefined,
@@ -74,6 +76,7 @@ const LayoutDisplayMenuHarness = ({
       <LayoutDisplayMenu
         activeLayoutId={activeLayoutId}
         visibleLayoutIds={visibleLayoutIds}
+        blockedLayoutIds={blockedLayoutIds}
         hiddenCustomLayoutIds={hiddenCustomLayoutIds}
         layouts={registry.layouts}
         onVisibleLayoutIdsChange={setVisibleLayoutIds}
@@ -193,7 +196,7 @@ describe('LayoutDisplayMenu', () => {
 
   test('shows custom layout actions and persists hidden custom ids', async () => {
     const user = userEvent.setup()
-    const onPickLayout = vi.fn()
+    const onPickLayout = vi.fn(() => true)
     const onEditCustomLayout = vi.fn()
     const onDeleteCustomLayout = vi.fn()
     const onCreateCustomLayout = vi.fn()
@@ -221,6 +224,7 @@ describe('LayoutDisplayMenu', () => {
     await user.click(screen.getByRole('button', { name: 'Edit Main + bottom' }))
 
     await openMenu()
+
     const trigger = screen.getByRole('button', {
       name: 'Configure displayed layouts',
     })
@@ -248,5 +252,43 @@ describe('LayoutDisplayMenu', () => {
 
     expect(onCreateCustomLayout).toHaveBeenCalledOnce()
     expect(trigger).toHaveFocus()
+  })
+
+  test('does not close or pick a blocked custom layout row', async () => {
+    const user = userEvent.setup()
+    const onPickLayout = vi.fn(() => true)
+
+    render(
+      <LayoutDisplayMenuHarness
+        blockedLayoutIds={['custom:main-bottom']}
+        layouts={[customMainBottomLayout]}
+        onPickLayout={onPickLayout}
+      />
+    )
+
+    await user.click(
+      screen.getByRole('button', { name: 'Configure displayed layouts' })
+    )
+
+    await user.click(await screen.findByRole('button', { name: 'Main + bottom' }))
+
+    expect(onPickLayout).not.toHaveBeenCalled()
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+  })
+
+  test('arrow-key navigation reaches custom layout rows', async () => {
+    const user = userEvent.setup()
+
+    render(<LayoutDisplayMenuHarness layouts={[customMainBottomLayout]} />)
+
+    screen.getByRole('button', { name: 'Configure displayed layouts' }).focus()
+    await user.keyboard('{ArrowDown}')
+    await screen.findByRole('menu')
+
+    await user.keyboard(
+      '{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}'
+    )
+
+    expect(screen.getByRole('menuitem', { name: 'Main + bottom' })).toHaveFocus()
   })
 })

--- a/src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.test.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.test.tsx
@@ -1,13 +1,47 @@
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { useState, type ReactElement } from 'react'
-import type { LayoutId, PaneLayoutId } from '../../../sessions/types'
+import type { PaneLayoutId } from '../../../sessions/types'
+import {
+  PaneLayoutRegistry,
+  type PaneLayoutDefinition,
+} from '../../layout-registry'
 import { LayoutDisplayMenu } from './LayoutDisplayMenu'
 
+const customMainBottomLayout: PaneLayoutDefinition = {
+  schemaVersion: 1,
+  id: 'custom:main-bottom',
+  title: 'Main + bottom',
+  source: 'workspace',
+  tracks: {
+    columns: [
+      { id: 'col-0', units: 8 },
+      { id: 'col-1', units: 8 },
+      { id: 'col-2', units: 8 },
+    ],
+    rows: [
+      { id: 'row-0', units: 16 },
+      { id: 'row-1', units: 8 },
+    ],
+  },
+  slots: [
+    { id: 'slot:p0', rect: { col: 0, row: 0, colSpan: 3, rowSpan: 1 } },
+    { id: 'slot:p1', rect: { col: 0, row: 1, colSpan: 1, rowSpan: 1 } },
+    { id: 'slot:p2', rect: { col: 1, row: 1, colSpan: 1, rowSpan: 1 } },
+    { id: 'slot:p3', rect: { col: 2, row: 1, colSpan: 1, rowSpan: 1 } },
+  ],
+  addOrder: ['slot:p0', 'slot:p1', 'slot:p2', 'slot:p3'],
+}
+
 interface HarnessProps {
-  activeLayoutId?: LayoutId
-  initialVisibleLayoutIds?: readonly LayoutId[]
+  activeLayoutId?: PaneLayoutId
+  initialVisibleLayoutIds?: readonly PaneLayoutId[]
+  layouts?: readonly PaneLayoutDefinition[]
+  onPickLayout?: (layoutId: PaneLayoutId) => void
+  onEditCustomLayout?: (layoutId: PaneLayoutId) => void
+  onDeleteCustomLayout?: (layoutId: PaneLayoutId) => void
+  onCreateCustomLayout?: () => void
 }
 
 const LayoutDisplayMenuHarness = ({
@@ -20,19 +54,37 @@ const LayoutDisplayMenuHarness = ({
     'quad',
     'grid3x2',
   ],
+  layouts = [],
+  onPickLayout = undefined,
+  onEditCustomLayout = undefined,
+  onDeleteCustomLayout = undefined,
+  onCreateCustomLayout = undefined,
 }: HarnessProps): ReactElement => {
   const [visibleLayoutIds, setVisibleLayoutIds] = useState(
-    initialVisibleLayoutIds as readonly PaneLayoutId[]
+    initialVisibleLayoutIds
   )
+
+  const [hiddenCustomLayoutIds, setHiddenCustomLayoutIds] = useState<
+    readonly PaneLayoutId[]
+  >([])
+  const registry = new PaneLayoutRegistry(layouts)
 
   return (
     <>
       <LayoutDisplayMenu
         activeLayoutId={activeLayoutId}
         visibleLayoutIds={visibleLayoutIds}
+        hiddenCustomLayoutIds={hiddenCustomLayoutIds}
+        layouts={registry.layouts}
         onVisibleLayoutIdsChange={setVisibleLayoutIds}
+        onHiddenCustomLayoutIdsChange={setHiddenCustomLayoutIds}
+        onPickLayout={onPickLayout}
+        onEditCustomLayout={onEditCustomLayout}
+        onDeleteCustomLayout={onDeleteCustomLayout}
+        onCreateCustomLayout={onCreateCustomLayout}
       />
       <output>{visibleLayoutIds.join(',')}</output>
+      <output>{hiddenCustomLayoutIds.join(',')}</output>
     </>
   )
 }
@@ -78,6 +130,29 @@ describe('LayoutDisplayMenu', () => {
     ).toBeInTheDocument()
   })
 
+  test('lets grid3x2 be hidden even though it starts visible by default', async () => {
+    const user = userEvent.setup()
+
+    render(<LayoutDisplayMenuHarness />)
+
+    await user.click(
+      screen.getByRole('button', { name: 'Configure displayed layouts' })
+    )
+
+    const gridLayout = await screen.findByRole('menuitemcheckbox', {
+      name: '3x2 grid',
+    })
+
+    expect(gridLayout).not.toHaveAttribute('aria-disabled', 'true')
+    expect(gridLayout).toHaveAttribute('aria-checked', 'true')
+
+    await user.click(gridLayout)
+
+    expect(
+      screen.getByText('single,vsplit,hsplit,threeRight,quad')
+    ).toBeInTheDocument()
+  })
+
   test('toggling a non-active layout updates the visible layout list', async () => {
     const user = userEvent.setup()
 
@@ -88,15 +163,15 @@ describe('LayoutDisplayMenu', () => {
     )
 
     await user.click(
-      await screen.findByRole('menuitemcheckbox', { name: '3x2 grid' })
+      await screen.findByRole('menuitemcheckbox', { name: 'Quad' })
     )
 
     expect(
-      screen.getByText('single,vsplit,hsplit,threeRight,quad')
+      screen.getByText('single,vsplit,hsplit,threeRight,grid3x2')
     ).toBeInTheDocument()
   })
 
-  test('normalizes single back into the visible list when callers omitted it', async () => {
+  test('normalizes the required single layout back into the visible list when callers omitted it', async () => {
     const user = userEvent.setup()
 
     render(
@@ -109,15 +184,63 @@ describe('LayoutDisplayMenu', () => {
       screen.getByRole('button', { name: 'Configure displayed layouts' })
     )
 
-    const singleLayout = await screen.findByRole('menuitemcheckbox', {
-      name: 'Single',
-    })
-
-    expect(singleLayout).toHaveAttribute('aria-checked', 'true')
     await waitFor(() => {
       expect(
         screen.getByText('single,vsplit,hsplit,threeRight')
       ).toBeInTheDocument()
     })
+  })
+
+  test('shows custom layout actions and persists hidden custom ids', async () => {
+    const user = userEvent.setup()
+    const onPickLayout = vi.fn()
+    const onEditCustomLayout = vi.fn()
+    const onDeleteCustomLayout = vi.fn()
+    const onCreateCustomLayout = vi.fn()
+
+    render(
+      <LayoutDisplayMenuHarness
+        layouts={[customMainBottomLayout]}
+        onPickLayout={onPickLayout}
+        onEditCustomLayout={onEditCustomLayout}
+        onDeleteCustomLayout={onDeleteCustomLayout}
+        onCreateCustomLayout={onCreateCustomLayout}
+      />
+    )
+
+    const openMenu = async (): Promise<void> => {
+      await user.click(
+        screen.getByRole('button', { name: 'Configure displayed layouts' })
+      )
+    }
+
+    await openMenu()
+    await user.click(screen.getByRole('button', { name: 'Main + bottom' }))
+
+    await openMenu()
+    await user.click(screen.getByRole('button', { name: 'Edit Main + bottom' }))
+
+    await openMenu()
+    await user.click(
+      screen.getByRole('button', { name: 'Delete Main + bottom' })
+    )
+
+    await openMenu()
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Hide Main + bottom from switcher',
+      })
+    )
+
+    expect(onPickLayout).toHaveBeenCalledWith('custom:main-bottom')
+    expect(onEditCustomLayout).toHaveBeenCalledWith('custom:main-bottom')
+    expect(onDeleteCustomLayout).toHaveBeenCalledWith('custom:main-bottom')
+    expect(screen.getByText('custom:main-bottom')).toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole('menuitem', { name: 'Create custom layout' })
+    )
+
+    expect(onCreateCustomLayout).toHaveBeenCalledOnce()
   })
 })

--- a/src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.test.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.test.tsx
@@ -270,7 +270,9 @@ describe('LayoutDisplayMenu', () => {
       screen.getByRole('button', { name: 'Configure displayed layouts' })
     )
 
-    await user.click(await screen.findByRole('button', { name: 'Main + bottom' }))
+    await user.click(
+      await screen.findByRole('button', { name: 'Main + bottom' })
+    )
 
     expect(onPickLayout).not.toHaveBeenCalled()
     expect(screen.getByRole('menu')).toBeInTheDocument()
@@ -289,6 +291,8 @@ describe('LayoutDisplayMenu', () => {
       '{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}'
     )
 
-    expect(screen.getByRole('menuitem', { name: 'Main + bottom' })).toHaveFocus()
+    expect(
+      screen.getByRole('menuitem', { name: 'Main + bottom' })
+    ).toHaveFocus()
   })
 })

--- a/src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.test.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.test.tsx
@@ -221,9 +221,14 @@ describe('LayoutDisplayMenu', () => {
     await user.click(screen.getByRole('button', { name: 'Edit Main + bottom' }))
 
     await openMenu()
+    const trigger = screen.getByRole('button', {
+      name: 'Configure displayed layouts',
+    })
     await user.click(
       screen.getByRole('button', { name: 'Delete Main + bottom' })
     )
+
+    expect(trigger).toHaveFocus()
 
     await openMenu()
     await user.click(
@@ -242,5 +247,6 @@ describe('LayoutDisplayMenu', () => {
     )
 
     expect(onCreateCustomLayout).toHaveBeenCalledOnce()
+    expect(trigger).toHaveFocus()
   })
 })

--- a/src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactElement } from 'react'
+import { useEffect, useRef, useState, type ReactElement } from 'react'
 import { IconButton } from '@/components/IconButton'
 import { Menu } from '@/components/Menu'
 import type { PaneLayoutId } from '../../../sessions/types'
@@ -77,11 +77,12 @@ export const LayoutDisplayMenu = ({
   onDeleteCustomLayout = undefined,
   onOpenChange = undefined,
 }: LayoutDisplayMenuProps): ReactElement => {
-  const [menuVersion, setMenuVersion] = useState(0)
+  const [closeSignal, setCloseSignal] = useState(0)
+  const triggerRef = useRef<HTMLButtonElement | null>(null)
 
   const closeMenu = (): void => {
-    setMenuVersion((version) => version + 1)
-    onOpenChange?.(false)
+    triggerRef.current?.focus()
+    setCloseSignal((signal) => signal + 1)
   }
 
   useEffect(() => {
@@ -97,14 +98,15 @@ export const LayoutDisplayMenu = ({
 
   return (
     <Menu
-      key={menuVersion}
       placement="bottom-end"
       aria-label="Displayed layouts"
       onOpenChange={onOpenChange}
       tooltip="Configure displayed layouts"
       tooltipPlacement="bottom"
+      closeSignal={closeSignal}
       trigger={
         <button
+          ref={triggerRef}
           type="button"
           aria-label="Configure displayed layouts"
           className="inline-flex h-5 w-6 items-center justify-center rounded text-on-surface-muted transition-colors hover:bg-primary/[0.08] hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
@@ -284,7 +286,13 @@ export const LayoutDisplayMenu = ({
       {onCreateCustomLayout !== undefined && (
         <Menu.Section>
           <div className="mx-1 my-1 h-px bg-outline-variant/25" />
-          <Menu.Item icon="dashboard_customize" onSelect={onCreateCustomLayout}>
+          <Menu.Item
+            icon="dashboard_customize"
+            onSelect={(): void => {
+              closeMenu()
+              onCreateCustomLayout()
+            }}
+          >
             Create custom layout
           </Menu.Item>
         </Menu.Section>

--- a/src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.tsx
@@ -11,11 +11,12 @@ import { LayoutGlyph } from './LayoutGlyph'
 export interface LayoutDisplayMenuProps {
   activeLayoutId: PaneLayoutId
   visibleLayoutIds: readonly PaneLayoutId[]
+  blockedLayoutIds?: readonly PaneLayoutId[]
   hiddenCustomLayoutIds?: readonly PaneLayoutId[]
   layouts?: readonly LayoutShape[]
   onVisibleLayoutIdsChange: (next: readonly PaneLayoutId[]) => void
   onHiddenCustomLayoutIdsChange?: (next: readonly PaneLayoutId[]) => void
-  onPickLayout?: (layoutId: PaneLayoutId) => void
+  onPickLayout?: (layoutId: PaneLayoutId) => boolean
   onCreateCustomLayout?: () => void
   onEditCustomLayout?: (layoutId: PaneLayoutId) => void
   onDeleteCustomLayout?: (layoutId: PaneLayoutId) => void
@@ -67,6 +68,7 @@ const buildNextVisibleLayoutIds = (
 export const LayoutDisplayMenu = ({
   activeLayoutId,
   visibleLayoutIds,
+  blockedLayoutIds = [],
   hiddenCustomLayoutIds = [],
   layouts = BUILTIN_PANE_LAYOUT_REGISTRY.layouts,
   onVisibleLayoutIdsChange,
@@ -199,20 +201,35 @@ export const LayoutDisplayMenu = ({
           {layouts
             .filter((layout) => layout.definition.source === 'workspace')
             .map((layout) => {
+              const blocked = blockedLayoutIds.includes(layout.id)
               const checked = !hiddenCustomLayoutIds.includes(layout.id)
               const isActive = layout.id === activeLayoutId
 
               return (
-                <div
+                <Menu.Row
                   key={layout.id}
-                  className="flex min-h-8 items-center gap-1 rounded px-2 py-1 text-xs text-on-surface transition-colors hover:bg-on-surface/10"
+                  label={layout.name}
+                  disabled={blocked}
+                  className={`flex min-h-8 items-center gap-1 rounded px-2 py-1 text-xs text-on-surface outline-none transition-colors focus-visible:bg-on-surface/10 ${
+                    blocked
+                      ? 'text-on-surface-variant/45'
+                      : 'hover:bg-on-surface/10'
+                  }`}
+                  onSelect={(): void => {
+                    if (onPickLayout?.(layout.id) === true) {
+                      closeMenu()
+                    }
+                  }}
                 >
                   <button
                     type="button"
+                    disabled={blocked}
                     className="flex min-w-0 flex-1 items-center gap-2.5 rounded text-left outline-none focus-visible:ring-1 focus-visible:ring-primary"
-                    onClick={(): void => {
-                      onPickLayout?.(layout.id)
-                      closeMenu()
+                    onClick={(event): void => {
+                      event.stopPropagation()
+                      if (onPickLayout?.(layout.id) === true) {
+                        closeMenu()
+                      }
                     }}
                   >
                     <span
@@ -233,7 +250,8 @@ export const LayoutDisplayMenu = ({
                     label={`Edit ${layout.name}`}
                     size="sm"
                     className="h-5 w-5 text-on-surface-muted hover:text-primary"
-                    onClick={(): void => {
+                    onClick={(event): void => {
+                      event.stopPropagation()
                       onEditCustomLayout?.(layout.id)
                       closeMenu()
                     }}
@@ -243,7 +261,8 @@ export const LayoutDisplayMenu = ({
                     label={`Delete ${layout.name}`}
                     size="sm"
                     className="h-5 w-5 text-on-surface-muted hover:text-error"
-                    onClick={(): void => {
+                    onClick={(event): void => {
+                      event.stopPropagation()
                       onDeleteCustomLayout?.(layout.id)
                       closeMenu()
                     }}
@@ -257,7 +276,8 @@ export const LayoutDisplayMenu = ({
                     }
                     aria-pressed={checked}
                     className={customDisplayCheckboxClass(checked)}
-                    onClick={(): void => {
+                    onClick={(event): void => {
+                      event.stopPropagation()
                       if (onHiddenCustomLayoutIdsChange === undefined) {
                         return
                       }
@@ -278,7 +298,7 @@ export const LayoutDisplayMenu = ({
                       />
                     )}
                   </button>
-                </div>
+                </Menu.Row>
               )
             })}
         </Menu.Section>

--- a/src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutDisplayMenu.tsx
@@ -1,4 +1,5 @@
-import { useEffect, type ReactElement } from 'react'
+import { useEffect, useState, type ReactElement } from 'react'
+import { IconButton } from '@/components/IconButton'
 import { Menu } from '@/components/Menu'
 import type { PaneLayoutId } from '../../../sessions/types'
 import {
@@ -10,19 +11,39 @@ import { LayoutGlyph } from './LayoutGlyph'
 export interface LayoutDisplayMenuProps {
   activeLayoutId: PaneLayoutId
   visibleLayoutIds: readonly PaneLayoutId[]
+  hiddenCustomLayoutIds?: readonly PaneLayoutId[]
   layouts?: readonly LayoutShape[]
   onVisibleLayoutIdsChange: (next: readonly PaneLayoutId[]) => void
+  onHiddenCustomLayoutIdsChange?: (next: readonly PaneLayoutId[]) => void
+  onPickLayout?: (layoutId: PaneLayoutId) => void
+  onCreateCustomLayout?: () => void
+  onEditCustomLayout?: (layoutId: PaneLayoutId) => void
+  onDeleteCustomLayout?: (layoutId: PaneLayoutId) => void
   onOpenChange?: (open: boolean) => void
 }
+
+const LOCKED_DISPLAY_LAYOUT_IDS = new Set<PaneLayoutId>(['single'])
+
+const isLockedDisplayLayout = (layoutId: PaneLayoutId): boolean =>
+  LOCKED_DISPLAY_LAYOUT_IDS.has(layoutId)
+
+const customDisplayCheckboxClass = (checked: boolean): string =>
+  `inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-[4px] outline-none transition-colors focus-visible:ring-1 focus-visible:ring-primary ${
+    checked
+      ? 'bg-primary text-on-primary'
+      : 'border border-on-surface-variant/30 bg-transparent text-on-surface-muted hover:border-primary/45 hover:text-primary'
+  }`
 
 const normalizeVisibleLayoutIds = (
   visibleLayoutIds: readonly PaneLayoutId[],
   layouts: readonly LayoutShape[]
 ): readonly PaneLayoutId[] =>
   layouts
+    .filter((layout) => layout.definition.source === 'builtin')
     .map((layout) => layout.id)
     .filter(
-      (layoutId) => layoutId === 'single' || visibleLayoutIds.includes(layoutId)
+      (layoutId) =>
+        isLockedDisplayLayout(layoutId) || visibleLayoutIds.includes(layoutId)
     )
 
 const buildNextVisibleLayoutIds = (
@@ -46,10 +67,23 @@ const buildNextVisibleLayoutIds = (
 export const LayoutDisplayMenu = ({
   activeLayoutId,
   visibleLayoutIds,
+  hiddenCustomLayoutIds = [],
   layouts = BUILTIN_PANE_LAYOUT_REGISTRY.layouts,
   onVisibleLayoutIdsChange,
+  onHiddenCustomLayoutIdsChange = undefined,
+  onPickLayout = undefined,
+  onCreateCustomLayout = undefined,
+  onEditCustomLayout = undefined,
+  onDeleteCustomLayout = undefined,
   onOpenChange = undefined,
 }: LayoutDisplayMenuProps): ReactElement => {
+  const [menuVersion, setMenuVersion] = useState(0)
+
+  const closeMenu = (): void => {
+    setMenuVersion((version) => version + 1)
+    onOpenChange?.(false)
+  }
+
   useEffect(() => {
     const normalized = normalizeVisibleLayoutIds(visibleLayoutIds, layouts)
 
@@ -63,6 +97,7 @@ export const LayoutDisplayMenu = ({
 
   return (
     <Menu
+      key={menuVersion}
       placement="bottom-end"
       aria-label="Displayed layouts"
       onOpenChange={onOpenChange}
@@ -113,45 +148,147 @@ export const LayoutDisplayMenu = ({
       }
     >
       <Menu.Section label="Displayed layouts">
-        {layouts.map((layout) => {
-          const layoutId = layout.id
+        {layouts
+          .filter((layout) => layout.definition.source === 'builtin')
+          .map((layout) => {
+            const layoutId = layout.id
 
-          const checked =
-            layoutId === 'single' || visibleLayoutIds.includes(layoutId)
-          const isActive = layoutId === activeLayoutId
+            const checked =
+              isLockedDisplayLayout(layoutId) ||
+              visibleLayoutIds.includes(layoutId)
+            const isActive = layoutId === activeLayoutId
+            const disabled = isLockedDisplayLayout(layoutId) || isActive
 
-          return (
-            <Menu.Checkbox
-              key={layoutId}
-              checked={checked || isActive}
-              disabled={layoutId === 'single' || isActive}
-              onChange={(next): void =>
-                onVisibleLayoutIdsChange(
-                  buildNextVisibleLayoutIds(
-                    visibleLayoutIds,
-                    layoutId,
-                    next,
-                    layouts
+            return (
+              <Menu.Checkbox
+                key={layoutId}
+                checked={checked || isActive}
+                disabled={disabled}
+                onChange={(next): void =>
+                  onVisibleLayoutIdsChange(
+                    buildNextVisibleLayoutIds(
+                      visibleLayoutIds,
+                      layoutId,
+                      next,
+                      layouts
+                    )
                   )
-                )
-              }
-            >
-              <span className="flex items-center gap-2.5">
-                <span
-                  aria-hidden="true"
-                  className="inline-flex h-4 w-4 shrink-0 items-center justify-center text-on-surface-variant"
-                >
-                  <LayoutGlyph
-                    layoutId={layoutId}
-                    definition={layout.definition}
-                  />
+                }
+              >
+                <span className="flex items-center gap-2.5">
+                  <span
+                    aria-hidden="true"
+                    className="inline-flex h-4 w-4 shrink-0 items-center justify-center text-on-surface-variant"
+                  >
+                    <LayoutGlyph
+                      layoutId={layoutId}
+                      definition={layout.definition}
+                    />
+                  </span>
+                  <span>{layout.name}</span>
                 </span>
-                <span>{layout.name}</span>
-              </span>
-            </Menu.Checkbox>
-          )
-        })}
+              </Menu.Checkbox>
+            )
+          })}
       </Menu.Section>
+      {layouts.some((layout) => layout.definition.source === 'workspace') && (
+        <Menu.Section label="Custom">
+          <div className="mx-1 my-1 h-px bg-outline-variant/25" />
+          {layouts
+            .filter((layout) => layout.definition.source === 'workspace')
+            .map((layout) => {
+              const checked = !hiddenCustomLayoutIds.includes(layout.id)
+              const isActive = layout.id === activeLayoutId
+
+              return (
+                <div
+                  key={layout.id}
+                  className="flex min-h-8 items-center gap-1 rounded px-2 py-1 text-xs text-on-surface transition-colors hover:bg-on-surface/10"
+                >
+                  <button
+                    type="button"
+                    className="flex min-w-0 flex-1 items-center gap-2.5 rounded text-left outline-none focus-visible:ring-1 focus-visible:ring-primary"
+                    onClick={(): void => {
+                      onPickLayout?.(layout.id)
+                      closeMenu()
+                    }}
+                  >
+                    <span
+                      aria-hidden="true"
+                      className={`inline-flex h-4 w-4 shrink-0 items-center justify-center ${
+                        isActive ? 'text-primary' : 'text-on-surface-variant'
+                      }`}
+                    >
+                      <LayoutGlyph
+                        layoutId={layout.id}
+                        definition={layout.definition}
+                      />
+                    </span>
+                    <span className="truncate">{layout.name}</span>
+                  </button>
+                  <IconButton
+                    icon="edit"
+                    label={`Edit ${layout.name}`}
+                    size="sm"
+                    className="h-5 w-5 text-on-surface-muted hover:text-primary"
+                    onClick={(): void => {
+                      onEditCustomLayout?.(layout.id)
+                      closeMenu()
+                    }}
+                  />
+                  <IconButton
+                    icon="delete"
+                    label={`Delete ${layout.name}`}
+                    size="sm"
+                    className="h-5 w-5 text-on-surface-muted hover:text-error"
+                    onClick={(): void => {
+                      onDeleteCustomLayout?.(layout.id)
+                      closeMenu()
+                    }}
+                  />
+                  <button
+                    type="button"
+                    aria-label={
+                      checked
+                        ? `Hide ${layout.name} from switcher`
+                        : `Show ${layout.name} in switcher`
+                    }
+                    aria-pressed={checked}
+                    className={customDisplayCheckboxClass(checked)}
+                    onClick={(): void => {
+                      if (onHiddenCustomLayoutIdsChange === undefined) {
+                        return
+                      }
+
+                      onHiddenCustomLayoutIdsChange(
+                        checked
+                          ? [...hiddenCustomLayoutIds, layout.id]
+                          : hiddenCustomLayoutIds.filter(
+                              (layoutId) => layoutId !== layout.id
+                            )
+                      )
+                    }}
+                  >
+                    {checked && (
+                      <span
+                        aria-hidden="true"
+                        className="h-2 w-1.5 rotate-45 border-b-2 border-r-2 border-current"
+                      />
+                    )}
+                  </button>
+                </div>
+              )
+            })}
+        </Menu.Section>
+      )}
+      {onCreateCustomLayout !== undefined && (
+        <Menu.Section>
+          <div className="mx-1 my-1 h-px bg-outline-variant/25" />
+          <Menu.Item icon="dashboard_customize" onSelect={onCreateCustomLayout}>
+            Create custom layout
+          </Menu.Item>
+        </Menu.Section>
+      )}
     </Menu>
   )
 }

--- a/src/features/terminal/components/LayoutSwitcher/LayoutGlyph.test.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutGlyph.test.tsx
@@ -3,6 +3,7 @@
 import { render } from '@testing-library/react'
 import { describe, expect, test } from 'vitest'
 import type { LayoutId } from '../../../sessions/types'
+import type { PaneLayoutDefinition } from '../../layout-registry'
 import { LayoutGlyph } from './LayoutGlyph'
 
 const lineCount = (svg: SVGElement): number =>
@@ -29,4 +30,34 @@ describe('LayoutGlyph', () => {
       expect(svg!.querySelectorAll('rect')).toHaveLength(1)
     }
   )
+
+  test('renders custom glyph slots from track units instead of equal cells', () => {
+    const definition: PaneLayoutDefinition = {
+      schemaVersion: 1,
+      id: 'custom:main-side',
+      title: 'Main side',
+      source: 'workspace',
+      tracks: {
+        columns: [
+          { id: 'col-0', units: 16 },
+          { id: 'col-1', units: 8 },
+        ],
+        rows: [{ id: 'row-0', units: 24 }],
+      },
+      slots: [
+        { id: 'slot:p0', rect: { col: 0, row: 0, colSpan: 1, rowSpan: 1 } },
+        { id: 'slot:p1', rect: { col: 1, row: 0, colSpan: 1, rowSpan: 1 } },
+      ],
+      addOrder: ['slot:p0', 'slot:p1'],
+    }
+
+    const { container } = render(
+      <LayoutGlyph layoutId="custom:main-side" definition={definition} />
+    )
+    const rects = Array.from(container.querySelectorAll('rect'))
+
+    expect(rects).toHaveLength(2)
+    expect(rects[0]).toHaveAttribute('width', '8')
+    expect(rects[1]).toHaveAttribute('width', '4')
+  })
 })

--- a/src/features/terminal/components/LayoutSwitcher/LayoutGlyph.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutGlyph.tsx
@@ -19,8 +19,25 @@ const GenericLayoutGlyph = ({
   const frameY = 1
   const frameWidth = 12
   const frameHeight = 9
-  const colCount = definition.tracks.columns.length
-  const rowCount = definition.tracks.rows.length
+  const columns = definition.tracks.columns.map((track) => track.units)
+  const rows = definition.tracks.rows.map((track) => track.units)
+  const colTotal = columns.reduce((total, unit) => total + unit, 0) || 1
+  const rowTotal = rows.reduce((total, unit) => total + unit, 0) || 1
+
+  const offset = (
+    tracks: readonly number[],
+    total: number,
+    start: number,
+    span: number
+  ): { readonly start: number; readonly size: number } => {
+    const leading = tracks.slice(0, start).reduce((sum, unit) => sum + unit, 0)
+
+    const size = tracks
+      .slice(start, start + span)
+      .reduce((sum, unit) => sum + unit, 0)
+
+    return { start: leading / total, size: size / total }
+  }
 
   return (
     <svg
@@ -30,11 +47,13 @@ const GenericLayoutGlyph = ({
       aria-hidden="true"
       focusable="false"
     >
-      {definition.slots.map((slot) => {
-        const x = frameX + (slot.rect.col / colCount) * frameWidth
-        const y = frameY + (slot.rect.row / rowCount) * frameHeight
-        const width = (slot.rect.colSpan / colCount) * frameWidth
-        const height = (slot.rect.rowSpan / rowCount) * frameHeight
+      {definition.slots.map((slot, slotIndex) => {
+        const col = offset(columns, colTotal, slot.rect.col, slot.rect.colSpan)
+        const row = offset(rows, rowTotal, slot.rect.row, slot.rect.rowSpan)
+        const x = frameX + col.start * frameWidth
+        const y = frameY + row.start * frameHeight
+        const width = col.size * frameWidth
+        const height = row.size * frameHeight
 
         return (
           <rect
@@ -44,7 +63,8 @@ const GenericLayoutGlyph = ({
             width={width}
             height={height}
             rx="0.9"
-            fill="none"
+            fill="currentColor"
+            fillOpacity={0.18 + (slotIndex % 3) * 0.1}
             stroke="currentColor"
             strokeWidth="0.8"
           />

--- a/src/features/terminal/components/LayoutSwitcher/layoutDisplayPreferences.test.ts
+++ b/src/features/terminal/components/LayoutSwitcher/layoutDisplayPreferences.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, test } from 'vitest'
+import {
+  HIDDEN_CUSTOM_LAYOUTS_STORAGE_KEY,
+  SHOWN_LAYOUTS_STORAGE_KEY,
+  readLayoutDisplayPreference,
+  writeLayoutDisplayPreference,
+} from './layoutDisplayPreferences'
+
+afterEach(() => {
+  localStorage.clear()
+})
+
+describe('layoutDisplayPreferences', () => {
+  test('returns fallback when no stored preference exists', () => {
+    expect(
+      readLayoutDisplayPreference(SHOWN_LAYOUTS_STORAGE_KEY, ['single'])
+    ).toEqual(['single'])
+  })
+
+  test('round-trips layout ids through localStorage', () => {
+    writeLayoutDisplayPreference(SHOWN_LAYOUTS_STORAGE_KEY, [
+      'single',
+      'grid3x2',
+      'custom:wide',
+    ])
+
+    expect(readLayoutDisplayPreference(SHOWN_LAYOUTS_STORAGE_KEY, [])).toEqual([
+      'single',
+      'grid3x2',
+      'custom:wide',
+    ])
+  })
+
+  test('drops malformed or unknown stored ids', () => {
+    localStorage.setItem(
+      HIDDEN_CUSTOM_LAYOUTS_STORAGE_KEY,
+      JSON.stringify(['custom:hidden', 'bogus', 42])
+    )
+
+    expect(
+      readLayoutDisplayPreference(HIDDEN_CUSTOM_LAYOUTS_STORAGE_KEY, [])
+    ).toEqual(['custom:hidden'])
+  })
+})

--- a/src/features/terminal/components/LayoutSwitcher/layoutDisplayPreferences.ts
+++ b/src/features/terminal/components/LayoutSwitcher/layoutDisplayPreferences.ts
@@ -1,0 +1,66 @@
+import type { PaneLayoutId } from '../../../sessions/types'
+import { isPaneLayoutId } from '../../layout-registry'
+
+export const SHOWN_LAYOUTS_STORAGE_KEY = 'vimeflow_shown_layouts'
+
+export const HIDDEN_CUSTOM_LAYOUTS_STORAGE_KEY = 'vimeflow_hidden_custom'
+
+const getStorage = (): Storage | null => {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  try {
+    return window.localStorage
+  } catch {
+    return null
+  }
+}
+
+const parseLayoutIds = (
+  raw: string | null,
+  fallback: readonly PaneLayoutId[]
+): readonly PaneLayoutId[] => {
+  if (raw === null) {
+    return fallback
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed)) {
+      return fallback
+    }
+
+    return parsed.filter(
+      (value): value is PaneLayoutId =>
+        typeof value === 'string' && isPaneLayoutId(value)
+    )
+  } catch {
+    return fallback
+  }
+}
+
+export const readLayoutDisplayPreference = (
+  storageKey: string,
+  fallback: readonly PaneLayoutId[]
+): readonly PaneLayoutId[] => {
+  const storage = getStorage()
+
+  return parseLayoutIds(storage?.getItem(storageKey) ?? null, fallback)
+}
+
+export const writeLayoutDisplayPreference = (
+  storageKey: string,
+  layoutIds: readonly PaneLayoutId[]
+): void => {
+  const storage = getStorage()
+  if (storage === null) {
+    return
+  }
+
+  try {
+    storage.setItem(storageKey, JSON.stringify(layoutIds))
+  } catch {
+    // Presentation preferences should never block workspace rendering.
+  }
+}

--- a/src/features/terminal/layout-registry/layoutDefinition.ts
+++ b/src/features/terminal/layout-registry/layoutDefinition.ts
@@ -99,7 +99,7 @@ export const PANE_LAYOUT_SCHEMA_VERSION: PaneLayoutSchemaVersion = 1
 
 export const MIN_LAYOUT_TRACKS = 1
 
-export const MAX_LAYOUT_TRACKS = 4
+export const MAX_LAYOUT_TRACKS = 24
 
 export const MIN_LAYOUT_SLOTS = 1
 

--- a/src/features/terminal/layout-registry/layoutRegistry.test.ts
+++ b/src/features/terminal/layout-registry/layoutRegistry.test.ts
@@ -108,4 +108,32 @@ describe('layoutRegistry', () => {
 
     expect(registry.autoShrinkLayoutFor(0, 'custom:grid-2x2')).toBe('single')
   })
+
+  test('accepts custom layouts with up to 24 tracks per axis', () => {
+    const layout: PaneLayoutDefinition = {
+      schemaVersion: 1,
+      id: 'custom:row-24',
+      title: 'Twenty four columns',
+      source: 'workspace',
+      tracks: {
+        columns: Array.from({ length: 24 }, (_, index) => ({
+          id: `col-${index}`,
+          units: 1,
+        })),
+        rows: [{ id: 'row-0', units: 24 }],
+      },
+      slots: [
+        {
+          id: 'slot:p0',
+          rect: { col: 0, row: 0, colSpan: 24, rowSpan: 1 },
+        },
+      ],
+      addOrder: ['slot:p0'],
+    }
+
+    const registry = new PaneLayoutRegistry([layout])
+
+    expect(registry.getLayout('custom:row-24')).not.toBeNull()
+    expect(registry.rejected).toEqual([])
+  })
 })

--- a/src/features/workspace/WorkspaceView.top-chrome.test.tsx
+++ b/src/features/workspace/WorkspaceView.top-chrome.test.tsx
@@ -7,6 +7,10 @@ import type { SessionManager } from '../sessions/hooks/useSessionManager'
 import type { AgentStatus } from '../agent-status/types'
 import type { Session, SessionStatus, LayoutId } from '../sessions/types'
 import { BUILTIN_PANE_LAYOUT_REGISTRY } from '../terminal/layout-registry'
+import {
+  HIDDEN_CUSTOM_LAYOUTS_STORAGE_KEY,
+  SHOWN_LAYOUTS_STORAGE_KEY,
+} from '../terminal/components/LayoutSwitcher/layoutDisplayPreferences'
 import { setSidebarCollapsed } from './utils/sidebarCollapsedStore'
 
 // Mock all WorkspaceView dependencies
@@ -191,6 +195,8 @@ describe('WorkspaceView – top chrome (main-stage handoff J2–J6)', () => {
   }
 
   beforeEach(async () => {
+    window.localStorage.removeItem(SHOWN_LAYOUTS_STORAGE_KEY)
+    window.localStorage.removeItem(HIDDEN_CUSTOM_LAYOUTS_STORAGE_KEY)
     Object.defineProperty(navigator, 'platform', {
       value: '',
       configurable: true,
@@ -295,6 +301,8 @@ describe('WorkspaceView – top chrome (main-stage handoff J2–J6)', () => {
   })
 
   afterEach(() => {
+    window.localStorage.removeItem(SHOWN_LAYOUTS_STORAGE_KEY)
+    window.localStorage.removeItem(HIDDEN_CUSTOM_LAYOUTS_STORAGE_KEY)
     act(() => {
       setSidebarCollapsed(false)
     })
@@ -514,6 +522,10 @@ describe('WorkspaceView – top chrome (main-stage handoff J2–J6)', () => {
   test('layout picks forward to setSessionLayout without touching pane semantics (J6)', async () => {
     const user = userEvent.setup()
     await setupSessionManager(mockSessions, 'session-2')
+    window.localStorage.setItem(
+      SHOWN_LAYOUTS_STORAGE_KEY,
+      JSON.stringify(['single', 'quad', 'grid3x2'])
+    )
     render(<WorkspaceView />)
 
     await user.click(screen.getByRole('button', { name: 'Quad' }))
@@ -556,11 +568,15 @@ describe('WorkspaceView – top chrome (main-stage handoff J2–J6)', () => {
     const user = userEvent.setup()
 
     await setupSessionManager(mockSessions, 'session-2')
+    window.localStorage.setItem(
+      SHOWN_LAYOUTS_STORAGE_KEY,
+      JSON.stringify(['single', 'hsplit', 'grid3x2'])
+    )
     render(<WorkspaceView />)
 
     const switcher = screen.getByTestId('layout-switcher')
     expect(
-      within(switcher).getByRole('button', { name: '3x2 grid' })
+      within(switcher).getByRole('button', { name: 'Horizontal split' })
     ).toBeInTheDocument()
 
     await user.click(
@@ -570,18 +586,18 @@ describe('WorkspaceView – top chrome (main-stage handoff J2–J6)', () => {
     )
 
     await user.click(
-      await screen.findByRole('menuitemcheckbox', { name: '3x2 grid' })
+      await screen.findByRole('menuitemcheckbox', { name: 'Horizontal split' })
     )
 
     expect(
       within(screen.getByTestId('layout-switcher')).queryByRole('button', {
-        name: '3x2 grid',
+        name: 'Horizontal split',
       })
     ).toBeNull()
 
     expect(
       within(screen.getByTestId('layout-switcher')).getByRole('button', {
-        name: 'Vertical split',
+        name: '3x2 grid',
       })
     ).toBeInTheDocument()
   })

--- a/src/features/workspace/WorkspaceView.top-chrome.test.tsx
+++ b/src/features/workspace/WorkspaceView.top-chrome.test.tsx
@@ -665,6 +665,10 @@ describe('WorkspaceView – top chrome (main-stage handoff J2–J6)', () => {
     await user.click(screen.getByRole('button', { name: 'Save & apply' }))
 
     expect(mockSessionManager.setCustomPaneLayouts).toHaveBeenCalledOnce()
+    expect(mockSessionManager.setCustomPaneLayouts).toHaveBeenCalledWith(
+      expect.any(Function),
+      { skipPreservation: true }
+    )
     expect(mockSessionManager.setSessionLayout).not.toHaveBeenCalled()
   })
 

--- a/src/features/workspace/WorkspaceView.top-chrome.test.tsx
+++ b/src/features/workspace/WorkspaceView.top-chrome.test.tsx
@@ -600,6 +600,47 @@ describe('WorkspaceView – top chrome (main-stage handoff J2–J6)', () => {
     expect(mockSessionManager.setSessionLayout).not.toHaveBeenCalled()
   })
 
+  test('saving an undersized custom layout does not apply it to an over-capacity session', async () => {
+    const user = userEvent.setup()
+    const baseSession = createMockSession('session-2', 'feature work', {
+      layout: 'vsplit',
+    })
+
+    const twoPaneSession: Session = {
+      ...baseSession,
+      panes: [
+        { ...baseSession.panes[0], id: 'p0', active: true },
+        {
+          id: 'p1',
+          ptyId: 'pty-session-2-1',
+          cwd: '/home/user',
+          agentType: 'claude-code',
+          status: 'running',
+          active: false,
+        },
+      ],
+    }
+
+    await setupSessionManager([twoPaneSession], 'session-2')
+    render(<WorkspaceView />)
+
+    await user.click(
+      screen.getByRole('button', { name: 'Configure displayed layouts' })
+    )
+    await user.click(
+      await screen.findByRole('menuitem', { name: 'Create custom layout' })
+    )
+    await user.clear(screen.getByRole('textbox', { name: 'Layout name' }))
+    await user.type(
+      screen.getByRole('textbox', { name: 'Layout name' }),
+      'Tiny'
+    )
+    await user.click(screen.getByRole('button', { name: 'Save & apply' }))
+
+    expect(mockSessionManager.setCustomPaneLayouts).toHaveBeenCalledOnce()
+    expect(mockSessionManager.setSessionLayout).not.toHaveBeenCalled()
+  })
+
   test('single layout: same chrome as the splits — config docked in the pillar', () => {
     render(<WorkspaceView />)
 

--- a/src/features/workspace/WorkspaceView.top-chrome.test.tsx
+++ b/src/features/workspace/WorkspaceView.top-chrome.test.tsx
@@ -6,7 +6,11 @@ import { WorkspaceView } from './WorkspaceView'
 import type { SessionManager } from '../sessions/hooks/useSessionManager'
 import type { AgentStatus } from '../agent-status/types'
 import type { Session, SessionStatus, LayoutId } from '../sessions/types'
-import { BUILTIN_PANE_LAYOUT_REGISTRY } from '../terminal/layout-registry'
+import {
+  BUILTIN_PANE_LAYOUT_REGISTRY,
+  PaneLayoutRegistry,
+  type PaneLayoutDefinition,
+} from '../terminal/layout-registry'
 import {
   HIDDEN_CUSTOM_LAYOUTS_STORAGE_KEY,
   SHOWN_LAYOUTS_STORAGE_KEY,
@@ -537,6 +541,63 @@ describe('WorkspaceView – top chrome (main-stage handoff J2–J6)', () => {
     expect(mockSessionManager.addPane).not.toHaveBeenCalled()
     expect(mockSessionManager.removePane).not.toHaveBeenCalled()
     expect(mockSessionManager.setSessionActivePane).not.toHaveBeenCalled()
+  })
+
+  test('custom layout pick is ignored when the session has more panes than it supports', async () => {
+    const user = userEvent.setup()
+
+    const tinyCustomLayout: PaneLayoutDefinition = {
+      schemaVersion: 1,
+      id: 'custom:tiny',
+      title: 'Tiny',
+      source: 'workspace',
+      tracks: {
+        columns: [{ id: 'col-0', units: 24 }],
+        rows: [{ id: 'row-0', units: 24 }],
+      },
+      slots: [
+        {
+          id: 'slot:p0',
+          rect: { col: 0, row: 0, colSpan: 1, rowSpan: 1 },
+        },
+      ],
+      addOrder: ['slot:p0'],
+    }
+
+    const baseSession = createMockSession('session-2', 'feature work', {
+      layout: 'single',
+    })
+
+    const twoPaneSession: Session = {
+      ...baseSession,
+      panes: [
+        { ...baseSession.panes[0], id: 'p0', active: true },
+        {
+          id: 'p1',
+          ptyId: 'pty-session-2-1',
+          cwd: '/home/user',
+          agentType: 'claude-code',
+          status: 'running',
+          active: false,
+        },
+      ],
+    }
+
+    await setupSessionManager([twoPaneSession], 'session-2')
+    mockSessionManager.layoutRegistry = new PaneLayoutRegistry([
+      tinyCustomLayout,
+    ])
+    mockSessionManager.customPaneLayouts = [tinyCustomLayout]
+    render(<WorkspaceView />)
+
+    await user.click(
+      screen.getByRole('button', { name: 'Configure displayed layouts' })
+    )
+    const menu = await screen.findByRole('menu')
+    const tinyLabel = await within(menu).findByText('Tiny')
+    await user.click(tinyLabel)
+
+    expect(mockSessionManager.setSessionLayout).not.toHaveBeenCalled()
   })
 
   test('single layout: same chrome as the splits — config docked in the pillar', () => {

--- a/src/features/workspace/WorkspaceView.top-chrome.test.tsx
+++ b/src/features/workspace/WorkspaceView.top-chrome.test.tsx
@@ -1,4 +1,11 @@
-import { render, screen, act, waitFor, within } from '@testing-library/react'
+import {
+  render,
+  screen,
+  act,
+  waitFor,
+  within,
+  fireEvent,
+} from '@testing-library/react'
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
 import userEvent from '@testing-library/user-event'
 import type { ReactElement, ReactNode } from 'react'
@@ -602,6 +609,7 @@ describe('WorkspaceView – top chrome (main-stage handoff J2–J6)', () => {
 
   test('saving an undersized custom layout does not apply it to an over-capacity session', async () => {
     const user = userEvent.setup()
+
     const baseSession = createMockSession('session-2', 'feature work', {
       layout: 'vsplit',
     })
@@ -627,9 +635,28 @@ describe('WorkspaceView – top chrome (main-stage handoff J2–J6)', () => {
     await user.click(
       screen.getByRole('button', { name: 'Configure displayed layouts' })
     )
+
     await user.click(
       await screen.findByRole('menuitem', { name: 'Create custom layout' })
     )
+    await user.click(screen.getByRole('button', { name: 'Code · JSON/YAML' }))
+    fireEvent.change(screen.getAllByRole('textbox')[1], {
+      target: {
+        value: JSON.stringify({
+          tracks: {
+            columns: [{ id: 'col-0', units: 24 }],
+            rows: [{ id: 'row-0', units: 24 }],
+          },
+          slots: [
+            {
+              id: 'slot:p0',
+              rect: { col: 0, row: 0, colSpan: 1, rowSpan: 1 },
+            },
+          ],
+        }),
+      },
+    })
+    await user.click(screen.getByRole('button', { name: 'Apply' }))
     await user.clear(screen.getByRole('textbox', { name: 'Layout name' }))
     await user.type(
       screen.getByRole('textbox', { name: 'Layout name' }),

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -89,7 +89,10 @@ import { sumLines } from '../diff/utils/sumLines'
 import { findActivePane } from '../sessions/utils/activeSessionPane'
 import { isShellPane } from '../sessions/utils/paneKind'
 import { selectVisiblePanes } from '../terminal/components/SplitView'
-import { type PaneLayoutDefinition } from '../terminal/layout-registry'
+import {
+  isBuiltinPaneLayoutId,
+  type PaneLayoutDefinition,
+} from '../terminal/layout-registry'
 import { lineDelta } from '../sessions/utils/lineDelta'
 import { isLiveStatus, isOpenSession } from '../sessions/utils/sessionStatus'
 import { pickNextVisibleSessionId } from '../sessions/utils/pickNextVisibleSessionId'
@@ -1242,12 +1245,20 @@ const WorkspaceViewContent = (): ReactElement => {
   // pane add/remove, active-pane, and layout semantics are untouched.
   const handlePickLayout = useCallback(
     (layoutId: PaneLayoutId): void => {
-      if (!activeSessionId) {
+      if (!activeSessionId || !activeSession) {
         return
       }
+
+      if (
+        isBuiltinPaneLayoutId(layoutId) &&
+        activeSession.panes.length > layoutRegistry.capacityFor(layoutId)
+      ) {
+        return
+      }
+
       setSessionLayout(activeSessionId, layoutId)
     },
-    [activeSessionId, setSessionLayout]
+    [activeSession, activeSessionId, layoutRegistry, setSessionLayout]
   )
 
   const handleCreateCustomLayout = useCallback((): void => {
@@ -1264,8 +1275,8 @@ const WorkspaceViewContent = (): ReactElement => {
 
   const handleSaveCustomLayout = useCallback(
     (definition: PaneLayoutDefinition): void => {
-      setCustomPaneLayouts([
-        ...customPaneLayouts.filter((layout) => layout.id !== definition.id),
+      setCustomPaneLayouts((previous) => [
+        ...previous.filter((layout) => layout.id !== definition.id),
         definition,
       ])
 
@@ -1278,7 +1289,12 @@ const WorkspaceViewContent = (): ReactElement => {
       setLayoutCreatorOpen(false)
       setLayoutCreatorEditId(null)
     },
-    [activeSessionId, customPaneLayouts, setCustomPaneLayouts, setSessionLayout]
+    [
+      activeSessionId,
+      setCustomPaneLayouts,
+      setHiddenCustomLayoutIds,
+      setSessionLayout,
+    ]
   )
 
   const handleDeleteCustomLayout = useCallback(
@@ -1286,8 +1302,8 @@ const WorkspaceViewContent = (): ReactElement => {
       if (activeSession?.layout === layoutId && activeSessionId) {
         setSessionLayout(activeSessionId, 'single')
       }
-      setCustomPaneLayouts(
-        customPaneLayouts.filter((layout) => layout.id !== layoutId)
+      setCustomPaneLayouts((previous) =>
+        previous.filter((layout) => layout.id !== layoutId)
       )
 
       setHiddenCustomLayoutIds((previous) =>
@@ -1297,8 +1313,8 @@ const WorkspaceViewContent = (): ReactElement => {
     [
       activeSession?.layout,
       activeSessionId,
-      customPaneLayouts,
       setCustomPaneLayouts,
+      setHiddenCustomLayoutIds,
       setSessionLayout,
     ]
   )

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -537,6 +537,32 @@ const WorkspaceViewContent = (): ReactElement => {
       .map((layout) => layout.id)
   }, [hiddenCustomLayoutIds, layoutRegistry.layouts, visibleLayoutIds])
 
+  const blockedLayoutIds = useMemo(
+    () =>
+      activeSession === undefined
+        ? []
+        : layoutRegistry.layouts
+            .filter(
+              (layout) =>
+                layout.id !== activeSession.layout &&
+                activeSession.panes.length > layout.capacity
+            )
+            .map((layout) => layout.id),
+    [activeSession, layoutRegistry.layouts]
+  )
+
+  const layoutSwitcherLayouts = useMemo(
+    () =>
+      activeSession === undefined
+        ? layoutRegistry.layouts
+        : layoutRegistry.layouts.filter(
+            (layout) =>
+              layout.id === activeSession.layout ||
+              activeSession.panes.length <= layout.capacity
+          ),
+    [activeSession, layoutRegistry.layouts]
+  )
+
   const layoutCreatorEditLayout = useMemo(() => {
     if (layoutCreatorEditId === null) {
       return undefined
@@ -1244,16 +1270,18 @@ const WorkspaceViewContent = (): ReactElement => {
   // forward to the same setSessionLayout the TerminalZone toolbar used, so
   // pane add/remove, active-pane, and layout semantics are untouched.
   const handlePickLayout = useCallback(
-    (layoutId: PaneLayoutId): void => {
+    (layoutId: PaneLayoutId): boolean => {
       if (!activeSessionId || !activeSession) {
-        return
+        return false
       }
 
       if (activeSession.panes.length > layoutRegistry.capacityFor(layoutId)) {
-        return
+        return false
       }
 
       setSessionLayout(activeSessionId, layoutId)
+
+      return true
     },
     [activeSession, activeSessionId, layoutRegistry, setSessionLayout]
   )
@@ -2536,12 +2564,13 @@ const WorkspaceViewContent = (): ReactElement => {
             <LayoutSwitcher
               activeLayoutId={activeSession.layout}
               visibleLayoutIds={visibleLayoutSwitcherIds}
-              layouts={layoutRegistry.layouts}
+              layouts={layoutSwitcherLayouts}
               onPick={handlePickLayout}
               trailing={
                 <LayoutDisplayMenu
                   activeLayoutId={activeSession.layout}
                   visibleLayoutIds={visibleLayoutIds}
+                  blockedLayoutIds={blockedLayoutIds}
                   hiddenCustomLayoutIds={hiddenCustomLayoutIds}
                   layouts={layoutRegistry.layouts}
                   onVisibleLayoutIdsChange={setVisibleLayoutIds}

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -13,6 +13,13 @@ import {
   LayoutDisplayMenu,
   LayoutSwitcher,
 } from '../terminal/components/LayoutSwitcher'
+import {
+  HIDDEN_CUSTOM_LAYOUTS_STORAGE_KEY,
+  SHOWN_LAYOUTS_STORAGE_KEY,
+  readLayoutDisplayPreference,
+  writeLayoutDisplayPreference,
+} from '../terminal/components/LayoutSwitcher/layoutDisplayPreferences'
+import { LayoutCreatorModal } from '../terminal/components/LayoutCreator'
 import { SidebarTopBar } from './components/SidebarTopBar'
 import { SidebarSettingsFooter } from './components/SidebarSettingsFooter'
 import { Sidebar } from '@/components/sidebar/Sidebar'
@@ -82,7 +89,7 @@ import { sumLines } from '../diff/utils/sumLines'
 import { findActivePane } from '../sessions/utils/activeSessionPane'
 import { isShellPane } from '../sessions/utils/paneKind'
 import { selectVisiblePanes } from '../terminal/components/SplitView'
-import { LAYOUT_IDS } from '../terminal/layout-registry'
+import { type PaneLayoutDefinition } from '../terminal/layout-registry'
 import { lineDelta } from '../sessions/utils/lineDelta'
 import { isLiveStatus, isOpenSession } from '../sessions/utils/sessionStatus'
 import { pickNextVisibleSessionId } from '../sessions/utils/pickNextVisibleSessionId'
@@ -186,6 +193,11 @@ const MACOS_WINDOW_CONTROL_SAFE_AREA_PX = 82
 const SIDEBAR_INITIAL = clampSize(SIDEBAR_DEFAULT, SIDEBAR_MIN, SIDEBAR_MAX)
 const COMPACT_WORKSPACE_QUERY = '(max-width: 899px)'
 
+const DEFAULT_VISIBLE_LAYOUT_IDS: readonly PaneLayoutId[] = [
+  'single',
+  'grid3x2',
+]
+
 const readCompactViewport = (): boolean =>
   typeof window !== 'undefined' &&
   typeof window.matchMedia === 'function' &&
@@ -226,7 +238,9 @@ const WorkspaceViewContent = (): ReactElement => {
   const {
     sessions,
     activeSessionId,
+    customPaneLayouts,
     layoutRegistry,
+    setCustomPaneLayouts,
     setActiveSessionId,
     createSession,
     createBrowserSession,
@@ -312,9 +326,23 @@ const WorkspaceViewContent = (): ReactElement => {
     useState(readCompactViewport)
   const [compactSidebarOpen, setCompactSidebarOpen] = useState(false)
 
-  const [visibleLayoutIds, setVisibleLayoutIds] =
-    useState<readonly PaneLayoutId[]>(LAYOUT_IDS)
+  const [visibleLayoutIds, setVisibleLayoutIds] = useState<
+    readonly PaneLayoutId[]
+  >(() =>
+    readLayoutDisplayPreference(
+      SHOWN_LAYOUTS_STORAGE_KEY,
+      DEFAULT_VISIBLE_LAYOUT_IDS
+    )
+  )
+
+  const [hiddenCustomLayoutIds, setHiddenCustomLayoutIds] = useState<
+    readonly PaneLayoutId[]
+  >(() => readLayoutDisplayPreference(HIDDEN_CUSTOM_LAYOUTS_STORAGE_KEY, []))
   const [isLayoutDisplayMenuOpen, setIsLayoutDisplayMenuOpen] = useState(false)
+  const [layoutCreatorOpen, setLayoutCreatorOpen] = useState(false)
+
+  const [layoutCreatorEditId, setLayoutCreatorEditId] =
+    useState<PaneLayoutId | null>(null)
 
   useEffect(() => {
     if (
@@ -337,6 +365,17 @@ const WorkspaceViewContent = (): ReactElement => {
       mediaQuery.removeEventListener('change', applyViewport)
     }
   }, [])
+
+  useEffect(() => {
+    writeLayoutDisplayPreference(SHOWN_LAYOUTS_STORAGE_KEY, visibleLayoutIds)
+  }, [visibleLayoutIds])
+
+  useEffect(() => {
+    writeLayoutDisplayPreference(
+      HIDDEN_CUSTOM_LAYOUTS_STORAGE_KEY,
+      hiddenCustomLayoutIds
+    )
+  }, [hiddenCustomLayoutIds])
 
   // Imperative ref to the persistent SidebarToggle so keyboard/scrim closes can
   // restore focus without relying on data-testid selectors.
@@ -477,6 +516,38 @@ const WorkspaceViewContent = (): ReactElement => {
     ? sessions.find((s) => s.id === activeSessionId)
     : undefined
 
+  const visibleLayoutSwitcherIds = useMemo(() => {
+    const hiddenCustomIds = new Set(hiddenCustomLayoutIds)
+
+    return layoutRegistry.layouts
+      .filter((layout) => {
+        if (layout.id === 'single') {
+          return true
+        }
+
+        if (layout.definition.source === 'workspace') {
+          return !hiddenCustomIds.has(layout.id)
+        }
+
+        return visibleLayoutIds.includes(layout.id)
+      })
+      .map((layout) => layout.id)
+  }, [hiddenCustomLayoutIds, layoutRegistry.layouts, visibleLayoutIds])
+
+  const layoutCreatorEditLayout = useMemo(() => {
+    if (layoutCreatorEditId === null) {
+      return undefined
+    }
+
+    const layout = layoutRegistry.getLayout(layoutCreatorEditId)?.definition
+
+    return layout?.source === 'workspace' ? layout : undefined
+  }, [layoutCreatorEditId, layoutRegistry])
+
+  const layoutCreatorSeedLayout = activeSession
+    ? layoutRegistry.getFallbackLayout(activeSession.layout).definition
+    : undefined
+
   // If the active session disappears while the layout-display menu is open,
   // the menu unmounts without firing onOpenChange(false). Reset the flag so
   // the top chrome restores the draggable region on macOS.
@@ -485,6 +556,16 @@ const WorkspaceViewContent = (): ReactElement => {
       setIsLayoutDisplayMenuOpen(false)
     }
   }, [activeSession])
+
+  useEffect(() => {
+    const customIds = new Set(
+      layoutRegistry.customLayouts.map((layout) => layout.id)
+    )
+
+    setHiddenCustomLayoutIds((previous) =>
+      previous.filter((layoutId) => customIds.has(layoutId))
+    )
+  }, [layoutRegistry.customLayouts])
 
   // Non-throwing variant: render-path callers cannot crash on transient
   // invariant violations. Mutation guards still use `getActivePane`.
@@ -1167,6 +1248,59 @@ const WorkspaceViewContent = (): ReactElement => {
       setSessionLayout(activeSessionId, layoutId)
     },
     [activeSessionId, setSessionLayout]
+  )
+
+  const handleCreateCustomLayout = useCallback((): void => {
+    setLayoutCreatorEditId(null)
+    setLayoutCreatorOpen(true)
+    setIsLayoutDisplayMenuOpen(false)
+  }, [])
+
+  const handleEditCustomLayout = useCallback((layoutId: PaneLayoutId): void => {
+    setLayoutCreatorEditId(layoutId)
+    setLayoutCreatorOpen(true)
+    setIsLayoutDisplayMenuOpen(false)
+  }, [])
+
+  const handleSaveCustomLayout = useCallback(
+    (definition: PaneLayoutDefinition): void => {
+      setCustomPaneLayouts([
+        ...customPaneLayouts.filter((layout) => layout.id !== definition.id),
+        definition,
+      ])
+
+      setHiddenCustomLayoutIds((previous) =>
+        previous.filter((layoutId) => layoutId !== definition.id)
+      )
+      if (activeSessionId) {
+        setSessionLayout(activeSessionId, definition.id)
+      }
+      setLayoutCreatorOpen(false)
+      setLayoutCreatorEditId(null)
+    },
+    [activeSessionId, customPaneLayouts, setCustomPaneLayouts, setSessionLayout]
+  )
+
+  const handleDeleteCustomLayout = useCallback(
+    (layoutId: PaneLayoutId): void => {
+      if (activeSession?.layout === layoutId && activeSessionId) {
+        setSessionLayout(activeSessionId, 'single')
+      }
+      setCustomPaneLayouts(
+        customPaneLayouts.filter((layout) => layout.id !== layoutId)
+      )
+
+      setHiddenCustomLayoutIds((previous) =>
+        previous.filter((hiddenLayoutId) => hiddenLayoutId !== layoutId)
+      )
+    },
+    [
+      activeSession?.layout,
+      activeSessionId,
+      customPaneLayouts,
+      setCustomPaneLayouts,
+      setSessionLayout,
+    ]
   )
 
   // Main-stage handoff J8: one bottom-bar affordance for both directions.
@@ -2127,6 +2261,7 @@ const WorkspaceViewContent = (): ReactElement => {
         unsavedChangesDialogOpen={showUnsavedDialog}
         burnerTerminalOpen={hasVisibleBurner}
         paneRenameOpen={paneRenameNode !== null}
+        layoutCreatorOpen={layoutCreatorOpen}
         dragOverlayOpen={isDragging}
         dockDragOverlayOpen={
           verticalDockElastic.isDragging || horizontalDockElastic.isDragging
@@ -2376,15 +2511,21 @@ const WorkspaceViewContent = (): ReactElement => {
           {activeSession && (
             <LayoutSwitcher
               activeLayoutId={activeSession.layout}
-              visibleLayoutIds={visibleLayoutIds}
+              visibleLayoutIds={visibleLayoutSwitcherIds}
               layouts={layoutRegistry.layouts}
               onPick={handlePickLayout}
               trailing={
                 <LayoutDisplayMenu
                   activeLayoutId={activeSession.layout}
                   visibleLayoutIds={visibleLayoutIds}
+                  hiddenCustomLayoutIds={hiddenCustomLayoutIds}
                   layouts={layoutRegistry.layouts}
                   onVisibleLayoutIdsChange={setVisibleLayoutIds}
+                  onHiddenCustomLayoutIdsChange={setHiddenCustomLayoutIds}
+                  onPickLayout={handlePickLayout}
+                  onCreateCustomLayout={handleCreateCustomLayout}
+                  onEditCustomLayout={handleEditCustomLayout}
+                  onDeleteCustomLayout={handleDeleteCustomLayout}
                   onOpenChange={setIsLayoutDisplayMenuOpen}
                 />
               }
@@ -2537,6 +2678,18 @@ const WorkspaceViewContent = (): ReactElement => {
           void handleDiscard()
         }}
         onCancel={handleCancel}
+      />
+
+      <LayoutCreatorModal
+        isOpen={layoutCreatorOpen}
+        existingLayouts={customPaneLayouts}
+        seedLayout={layoutCreatorSeedLayout}
+        editLayout={layoutCreatorEditLayout}
+        onSave={handleSaveCustomLayout}
+        onCancel={(): void => {
+          setLayoutCreatorOpen(false)
+          setLayoutCreatorEditId(null)
+        }}
       />
 
       {/* Drag overlay — prevents iframes/xterm from stealing mouse events */}

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -89,7 +89,10 @@ import { sumLines } from '../diff/utils/sumLines'
 import { findActivePane } from '../sessions/utils/activeSessionPane'
 import { isShellPane } from '../sessions/utils/paneKind'
 import { selectVisiblePanes } from '../terminal/components/SplitView'
-import type { PaneLayoutDefinition } from '../terminal/layout-registry'
+import {
+  getPaneLayoutCapacity,
+  type PaneLayoutDefinition,
+} from '../terminal/layout-registry'
 import { lineDelta } from '../sessions/utils/lineDelta'
 import { isLiveStatus, isOpenSession } from '../sessions/utils/sessionStatus'
 import { pickNextVisibleSessionId } from '../sessions/utils/pickNextVisibleSessionId'
@@ -1277,7 +1280,11 @@ const WorkspaceViewContent = (): ReactElement => {
       setHiddenCustomLayoutIds((previous) =>
         previous.filter((layoutId) => layoutId !== definition.id)
       )
-      if (activeSessionId) {
+      if (
+        activeSessionId &&
+        activeSession &&
+        activeSession.panes.length <= getPaneLayoutCapacity(definition)
+      ) {
         setSessionLayout(activeSessionId, definition.id)
       }
       setLayoutCreatorOpen(false)
@@ -1285,6 +1292,7 @@ const WorkspaceViewContent = (): ReactElement => {
     },
     [
       activeSessionId,
+      activeSession,
       setCustomPaneLayouts,
       setHiddenCustomLayoutIds,
       setSessionLayout,

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -1300,10 +1300,13 @@ const WorkspaceViewContent = (): ReactElement => {
 
   const handleSaveCustomLayout = useCallback(
     (definition: PaneLayoutDefinition): void => {
-      setCustomPaneLayouts((previous) => [
-        ...previous.filter((layout) => layout.id !== definition.id),
-        definition,
-      ])
+      setCustomPaneLayouts(
+        (previous) => [
+          ...previous.filter((layout) => layout.id !== definition.id),
+          definition,
+        ],
+        { skipPreservation: true }
+      )
 
       setHiddenCustomLayoutIds((previous) =>
         previous.filter((layoutId) => layoutId !== definition.id)

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -89,10 +89,7 @@ import { sumLines } from '../diff/utils/sumLines'
 import { findActivePane } from '../sessions/utils/activeSessionPane'
 import { isShellPane } from '../sessions/utils/paneKind'
 import { selectVisiblePanes } from '../terminal/components/SplitView'
-import {
-  isBuiltinPaneLayoutId,
-  type PaneLayoutDefinition,
-} from '../terminal/layout-registry'
+import type { PaneLayoutDefinition } from '../terminal/layout-registry'
 import { lineDelta } from '../sessions/utils/lineDelta'
 import { isLiveStatus, isOpenSession } from '../sessions/utils/sessionStatus'
 import { pickNextVisibleSessionId } from '../sessions/utils/pickNextVisibleSessionId'
@@ -1249,10 +1246,7 @@ const WorkspaceViewContent = (): ReactElement => {
         return
       }
 
-      if (
-        isBuiltinPaneLayoutId(layoutId) &&
-        activeSession.panes.length > layoutRegistry.capacityFor(layoutId)
-      ) {
+      if (activeSession.panes.length > layoutRegistry.capacityFor(layoutId)) {
         return
       }
 

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -1296,8 +1296,14 @@ const WorkspaceViewContent = (): ReactElement => {
       if (activeSession?.layout === layoutId && activeSessionId) {
         setSessionLayout(activeSessionId, 'single')
       }
-      setCustomPaneLayouts((previous) =>
-        previous.filter((layout) => layout.id !== layoutId)
+      // Intentional deletes must bypass the preservation guard that
+      // otherwise re-adds custom layouts still referenced by sessions with
+      // more panes than any builtin layout supports. The session migration
+      // queued here (and the explicit setSessionLayout above for the active
+      // session) moves affected sessions to a fallback layout.
+      setCustomPaneLayouts(
+        (previous) => previous.filter((layout) => layout.id !== layoutId),
+        { skipPreservation: true }
       )
 
       setHiddenCustomLayoutIds((previous) =>

--- a/src/features/workspace/overlays/WorkspaceOverlayRegistrations.tsx
+++ b/src/features/workspace/overlays/WorkspaceOverlayRegistrations.tsx
@@ -6,6 +6,7 @@ export interface WorkspaceOverlayRegistrationsProps {
   unsavedChangesDialogOpen: boolean
   burnerTerminalOpen: boolean
   paneRenameOpen: boolean
+  layoutCreatorOpen?: boolean
   dragOverlayOpen: boolean
   dockDragOverlayOpen: boolean
   bannerOpen: boolean
@@ -30,6 +31,7 @@ export const WorkspaceOverlayRegistrations = ({
   unsavedChangesDialogOpen,
   burnerTerminalOpen,
   paneRenameOpen,
+  layoutCreatorOpen = false,
   dragOverlayOpen,
   dockDragOverlayOpen,
   bannerOpen,
@@ -52,6 +54,13 @@ export const WorkspaceOverlayRegistrations = ({
     id: 'burner-terminal-popup',
     plane: 'dialog',
     isOpen: burnerTerminalOpen,
+    nativeOcclusion: 'global',
+  })
+
+  useOverlayRegistration({
+    id: 'layout-creator',
+    plane: 'dialog',
+    isOpen: layoutCreatorOpen,
     nativeOcclusion: 'global',
   })
 


### PR DESCRIPTION
## Summary
- Adds the VIM-166 custom workspace layout creator surface with 24-unit row/column tracks and slot-rectangle pane placement.
- Wires custom layouts into the layout display menu, including create/edit/delete/apply and persisted show/hide preferences.
- Keeps `single` mandatory, allows built-in/custom layout visibility control, and validates the 16-pane capacity before save/import.

## Review
- Claude local review using `agents/code-reviewer.md`: GREENLIGHT after fixing the >16-pane validation crash path.

## Validation
- `npm run type-check`: pass.
- `npx eslint src electron scripts`: pass.
- Focused Vitest layout/workspace suite: pass, 8 files / 62 tests.
- `git diff --cached --check`: pass before commit.
- Full pre-push `npm test`: local hook failed on unrelated existing/broad-suite issues: macOS path-casing expectation in `editorFileLifecycleStatus.test.ts`, plus `WorkspaceView` timeout failures under the full suite run. Focused changed-area tests pass.
