### PR TITLE
feat(command-palette): preview theme navigation

### DIFF
--- a/crates/backend/src/terminal/commands.rs
+++ b/crates/backend/src/terminal/commands.rs
@@ -557,6 +557,13 @@ pub(crate) fn kill_pty_inner(
     // emitting `pty-data` for a removed session) until eventual EOF.
     state.set_cancelled(&request.session_id);
 
+    // Give the child a bounded window to actually exit after SIGTERM before
+    // we tear down its bridge directory. On slower CI runners the shell can
+    // still be alive when cleanup runs, causing `remove_dir_all` to fail and
+    // leaving the session directory behind. Best-effort: if the child ignores
+    // SIGTERM we still proceed with cleanup so the caller is not blocked.
+    let _ = state.wait_for_exit(&request.session_id, std::time::Duration::from_secs(5));
+
     // Remove from state (no-op if NotPresent, the safe path above).
     let removed = state.remove(&request.session_id);
 

--- a/crates/backend/src/terminal/state.rs
+++ b/crates/backend/src/terminal/state.rs
@@ -4,7 +4,7 @@ use portable_pty::{Child, MasterPty};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::SystemTime;
+use std::time::{Duration, Instant, SystemTime};
 
 use super::types::SessionId;
 
@@ -361,6 +361,46 @@ impl PtyState {
         // code) must stay non-zero so a failed exit is never read as clean.
         let raw = status.exit_code();
         Some(i32::try_from(raw).unwrap_or(i32::MAX))
+    }
+
+    /// Wait for a session's child process to exit, up to `timeout`.
+    ///
+    /// Returns `Ok(Some(exit_code))` when the child exits within the timeout,
+    /// `Ok(None)` when the session is no longer present (already reaped), and
+    /// `Err` if polling the child fails unexpectedly.
+    pub fn wait_for_exit(
+        &self,
+        session_id: &SessionId,
+        timeout: Duration,
+    ) -> Result<Option<i32>, String> {
+        let start = Instant::now();
+        loop {
+            let mut sessions = self.sessions.lock().expect("failed to lock sessions");
+            let Some(session) = sessions.get_mut(session_id) else {
+                return Ok(None);
+            };
+            match session.child.try_wait() {
+                Ok(Some(status)) => {
+                    let raw = status.exit_code();
+                    return Ok(Some(i32::try_from(raw).unwrap_or(i32::MAX)));
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    return Err(format!(
+                        "failed to wait for session {} child: {}",
+                        session_id, e
+                    ));
+                }
+            }
+            drop(sessions);
+            if start.elapsed() >= timeout {
+                return Err(format!(
+                    "timeout waiting for session {} child to exit",
+                    session_id
+                ));
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
     }
 
     /// Get the resolved CWD for a session

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -107,5 +107,5 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Shared Controller Segmentation](patterns/shared-controller-segmentation.md)                         | react-patterns     | 2        | 0    | 2026-06-18   |
 | [Vite HMR Static Dependencies](patterns/vite-hmr-static-deps.md)                                     | code-quality       | 3        | 2    | 2026-06-18   |
 | [Custom Pane Layout Preservation](patterns/custom-pane-layout-preservation.md)                       | correctness        | 1        | 0    | 2026-06-19   |
-| [Transient UI Side Effects](patterns/transient-ui-side-effects.md)                                   | react-patterns     | 2        | 0    | 2026-06-20   |
+| [Transient UI Side Effects](patterns/transient-ui-side-effects.md)                                   | react-patterns     | 4        | 1    | 2026-06-20   |
 | [Async Global State Mutation](patterns/async-global-state-mutation.md)                               | backend            | 1        | 0    | 2026-06-19   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -107,3 +107,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Shared Controller Segmentation](patterns/shared-controller-segmentation.md)                         | react-patterns     | 2        | 0    | 2026-06-18   |
 | [Vite HMR Static Dependencies](patterns/vite-hmr-static-deps.md)                                     | code-quality       | 3        | 2    | 2026-06-18   |
 | [Custom Pane Layout Preservation](patterns/custom-pane-layout-preservation.md)                       | correctness        | 1        | 0    | 2026-06-19   |
+| [Transient UI Side Effects](patterns/transient-ui-side-effects.md)                                   | react-patterns     | 2        | 0    | 2026-06-20   |

--- a/docs/reviews/patterns/transient-ui-side-effects.md
+++ b/docs/reviews/patterns/transient-ui-side-effects.md
@@ -1,0 +1,48 @@
+---
+id: transient-ui-side-effects
+category: react-patterns
+created: 2026-06-20
+last_updated: 2026-06-20
+ref_count: 0
+---
+
+# Transient UI Side Effects
+
+## Summary
+
+Preview, hover, or highlight interactions that mutate observable UI state (e.g.
+themes, layouts, or focus) must keep persistent state unchanged until the user
+confirms the action. Capture the baseline state when the transient interaction
+starts, apply the preview only to ephemeral rendering, and restore the baseline
+if the user dismisses without confirming. Confirmed actions should then write
+to persistent state through a separate, explicit path.
+
+## Findings
+
+### 1. Theme not restored when palette is dismissed without selecting
+
+- **Source:** github-claude | PR #570 round 1 | 2026-06-20
+- **Severity:** HIGH
+- **File:** `src/features/command-palette/hooks/useCommandPalette.ts`
+- **Finding:** `selectedCommand?.preview?.()` was called for every highlighted
+theme entry, but `close()` reset only palette UI state and had no mechanism to
+restore the theme that was active before the preview started. Pressing Escape
+after browsing themes left the app on the last highlighted theme.
+- **Fix:** Captured `themeService.current().id` when the palette opens and
+restored it inside `close()` with `themeService.apply(originalThemeId)` before
+resetting state. The restore ref is cleared on execute so confirmed theme
+selections persist.
+- **Commit:** same commit as this entry
+
+### 2. Avoid persisting theme previews before confirmation
+
+- **Source:** github-codex-connector | PR #570 round 1 | 2026-06-20
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/workspace/commands/buildWorkspaceCommands.ts`
+- **Finding:** Theme leaf commands used `themeService.apply(theme.id)` in their
+`preview` callback, which wrote both the DOM and `localStorage`. Cancelling the
+palette left the previewed theme persisted.
+- **Fix:** Added a DOM-only `themeService.preview(id)` method and changed theme
+leaf `preview` callbacks to use it while keeping `execute` as the only path
+that calls `themeService.apply`.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/transient-ui-side-effects.md
+++ b/docs/reviews/patterns/transient-ui-side-effects.md
@@ -25,13 +25,13 @@ to persistent state through a separate, explicit path.
 - **Severity:** HIGH
 - **File:** `src/features/command-palette/hooks/useCommandPalette.ts`
 - **Finding:** `selectedCommand?.preview?.()` was called for every highlighted
-theme entry, but `close()` reset only palette UI state and had no mechanism to
-restore the theme that was active before the preview started. Pressing Escape
-after browsing themes left the app on the last highlighted theme.
+  theme entry, but `close()` reset only palette UI state and had no mechanism to
+  restore the theme that was active before the preview started. Pressing Escape
+  after browsing themes left the app on the last highlighted theme.
 - **Fix:** Captured `themeService.current().id` when the palette opens and
-restored it inside `close()` with `themeService.apply(originalThemeId)` before
-resetting state. The restore ref is cleared on execute so confirmed theme
-selections persist.
+  restored it inside `close()` with `themeService.apply(originalThemeId)` before
+  resetting state. The restore ref is cleared on execute so confirmed theme
+  selections persist.
 - **Commit:** same commit as this entry
 
 ### 2. Avoid persisting theme previews before confirmation
@@ -40,11 +40,11 @@ selections persist.
 - **Severity:** P2 / MEDIUM
 - **File:** `src/features/workspace/commands/buildWorkspaceCommands.ts`
 - **Finding:** Theme leaf commands used `themeService.apply(theme.id)` in their
-`preview` callback, which wrote both the DOM and `localStorage`. Cancelling the
-palette left the previewed theme persisted.
+  `preview` callback, which wrote both the DOM and `localStorage`. Cancelling the
+  palette left the previewed theme persisted.
 - **Fix:** Added a DOM-only `themeService.preview(id)` method and changed theme
-leaf `preview` callbacks to use it while keeping `execute` as the only path
-that calls `themeService.apply`.
+  leaf `preview` callbacks to use it while keeping `execute` as the only path
+  that calls `themeService.apply`.
 - **Commit:** same commit as this entry
 
 ### 3. Unconditional ref-null clears restore guard for non-theme commands
@@ -53,12 +53,12 @@ that calls `themeService.apply`.
 - **Severity:** HIGH
 - **File:** `src/features/command-palette/hooks/useCommandPalette.ts`
 - **Finding:** `executeSelected` cleared `originalThemeIdRef.current`
-unconditionally after any command ran, so a non-theme command executed after a
-theme preview lost the restore guard and `close()` skipped restoring the
-original theme.
+  unconditionally after any command ran, so a non-theme command executed after a
+  theme preview lost the restore guard and `close()` skipped restoring the
+  original theme.
 - **Fix:** Gated the ref clear on `selected.preview` so only commands that
-produced a visual preview clear the guard; non-theme commands leave the ref
-intact and `close()` restores the original theme.
+  produced a visual preview clear the guard; non-theme commands leave the ref
+  intact and `close()` restores the original theme.
 - **Commit:** same commit as this entry
 
 ### 4. Notify theme subscribers during previews
@@ -67,9 +67,9 @@ intact and `close()` restores the original theme.
 - **Severity:** P2 / MEDIUM
 - **File:** `src/theme/service.ts`
 - **Finding:** `themeService.preview` wrote DOM CSS variables but did not notify
-subscribers, so terminal and editor panes that rely on the subscription path
-stayed on the old colors during theme previews.
+  subscribers, so terminal and editor panes that rely on the subscription path
+  stayed on the old colors during theme previews.
 - **Fix:** Updated `preview` to set the active theme, write the DOM, and notify
-listeners while keeping `localStorage` writes reserved for confirmed `apply`
-calls.
+  listeners while keeping `localStorage` writes reserved for confirmed `apply`
+  calls.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/transient-ui-side-effects.md
+++ b/docs/reviews/patterns/transient-ui-side-effects.md
@@ -3,7 +3,7 @@ id: transient-ui-side-effects
 category: react-patterns
 created: 2026-06-20
 last_updated: 2026-06-20
-ref_count: 0
+ref_count: 1
 ---
 
 # Transient UI Side Effects
@@ -45,4 +45,31 @@ palette left the previewed theme persisted.
 - **Fix:** Added a DOM-only `themeService.preview(id)` method and changed theme
 leaf `preview` callbacks to use it while keeping `execute` as the only path
 that calls `themeService.apply`.
+- **Commit:** same commit as this entry
+
+### 3. Unconditional ref-null clears restore guard for non-theme commands
+
+- **Source:** github-claude | PR #570 round 2 | 2026-06-20
+- **Severity:** HIGH
+- **File:** `src/features/command-palette/hooks/useCommandPalette.ts`
+- **Finding:** `executeSelected` cleared `originalThemeIdRef.current`
+unconditionally after any command ran, so a non-theme command executed after a
+theme preview lost the restore guard and `close()` skipped restoring the
+original theme.
+- **Fix:** Gated the ref clear on `selected.preview` so only commands that
+produced a visual preview clear the guard; non-theme commands leave the ref
+intact and `close()` restores the original theme.
+- **Commit:** same commit as this entry
+
+### 4. Notify theme subscribers during previews
+
+- **Source:** github-codex-connector | PR #570 round 2 | 2026-06-20
+- **Severity:** P2 / MEDIUM
+- **File:** `src/theme/service.ts`
+- **Finding:** `themeService.preview` wrote DOM CSS variables but did not notify
+subscribers, so terminal and editor panes that rely on the subscription path
+stayed on the old colors during theme previews.
+- **Fix:** Updated `preview` to set the active theme, write the DOM, and notify
+listeners while keeping `localStorage` writes reserved for confirmed `apply`
+calls.
 - **Commit:** same commit as this entry

--- a/src/features/command-palette/data/defaultCommands.test.ts
+++ b/src/features/command-palette/data/defaultCommands.test.ts
@@ -24,13 +24,13 @@ test(':set theme lists every registered theme and applies on execute', () => {
   expect(themeService.current().id).toBe('gruvbox-light')
 
   findCommandById(defaultCommands, 'set-theme-tokyo-night')?.preview?.()
-  expect(themeService.current().id).toBe('tokyo-night')
+  expect(themeService.current().id).toBe('gruvbox-light')
 
   findCommandById(defaultCommands, 'set-theme-tokyo-night')?.execute?.('')
   expect(themeService.current().id).toBe('tokyo-night')
 
   findCommandById(defaultCommands, 'set-theme-dracula')?.preview?.()
-  expect(themeService.current().id).toBe('dracula')
+  expect(themeService.current().id).toBe('tokyo-night')
 
   findCommandById(defaultCommands, 'set-theme-dracula')?.execute?.('')
   expect(themeService.current().id).toBe('dracula')

--- a/src/features/command-palette/data/defaultCommands.test.ts
+++ b/src/features/command-palette/data/defaultCommands.test.ts
@@ -23,8 +23,14 @@ test(':set theme lists every registered theme and applies on execute', () => {
   findCommandById(defaultCommands, 'set-theme-gruvbox-light')?.execute?.('')
   expect(themeService.current().id).toBe('gruvbox-light')
 
+  findCommandById(defaultCommands, 'set-theme-tokyo-night')?.preview?.()
+  expect(themeService.current().id).toBe('tokyo-night')
+
   findCommandById(defaultCommands, 'set-theme-tokyo-night')?.execute?.('')
   expect(themeService.current().id).toBe('tokyo-night')
+
+  findCommandById(defaultCommands, 'set-theme-dracula')?.preview?.()
+  expect(themeService.current().id).toBe('dracula')
 
   findCommandById(defaultCommands, 'set-theme-dracula')?.execute?.('')
   expect(themeService.current().id).toBe('dracula')

--- a/src/features/command-palette/data/defaultCommands.ts
+++ b/src/features/command-palette/data/defaultCommands.ts
@@ -50,6 +50,9 @@ export const defaultCommands: Command[] = [
           label: theme.label,
           description: `Switch to ${theme.label}`,
           icon: 'palette',
+          preview: (): void => {
+            themeService.apply(theme.id)
+          },
           execute: (): void => {
             themeService.apply(theme.id)
           },

--- a/src/features/command-palette/data/defaultCommands.ts
+++ b/src/features/command-palette/data/defaultCommands.ts
@@ -51,7 +51,7 @@ export const defaultCommands: Command[] = [
           description: `Switch to ${theme.label}`,
           icon: 'palette',
           preview: (): void => {
-            themeService.apply(theme.id)
+            themeService.preview(theme.id)
           },
           execute: (): void => {
             themeService.apply(theme.id)

--- a/src/features/command-palette/hooks/useCommandPalette.test.ts
+++ b/src/features/command-palette/hooks/useCommandPalette.test.ts
@@ -116,6 +116,7 @@ describe('useCommandPalette', () => {
 
     test('close() restores the original theme after a non-theme command previews a theme leaf', () => {
       const nonThemeExecute = vi.fn()
+
       const commands: Command[] = [
         {
           id: 'theme',
@@ -158,7 +159,9 @@ describe('useCommandPalette', () => {
       ).toBe(true)
 
       // Select and execute the non-theme leaf without any preview callback.
-      const noopIndex = result.current.filteredResults.findIndex((cmd) => cmd.id === 'noop')
+      const noopIndex = result.current.filteredResults.findIndex(
+        (cmd) => cmd.id === 'noop'
+      )
 
       expect(noopIndex).not.toBe(-1)
 

--- a/src/features/command-palette/hooks/useCommandPalette.test.ts
+++ b/src/features/command-palette/hooks/useCommandPalette.test.ts
@@ -114,6 +114,63 @@ describe('useCommandPalette', () => {
       expect(themeService.current().id).toBe('obsidian-lens')
     })
 
+    test('close() restores the original theme after a non-theme command previews a theme leaf', () => {
+      const nonThemeExecute = vi.fn()
+      const commands: Command[] = [
+        {
+          id: 'theme',
+          label: ':theme',
+          icon: 'palette',
+          children: [
+            {
+              id: 'theme-flexoki',
+              label: 'Flexoki',
+              icon: 'palette',
+              preview: (): void => {
+                themeService.preview('flexoki')
+              },
+              execute: (): void => {
+                themeService.apply('flexoki')
+              },
+            },
+          ],
+        },
+        {
+          id: 'noop',
+          label: 'Flexible no-op',
+          icon: 'check',
+          execute: nonThemeExecute,
+        },
+      ]
+
+      themeService.apply('obsidian-lens')
+
+      const { result } = renderHook(() => useCommandPalette(commands))
+
+      act(() => {
+        result.current.open()
+        result.current.setQuery(':flex')
+      })
+
+      // Fuzzy search surfaces the theme leaf; preview changes the displayed theme.
+      expect(
+        result.current.filteredResults.some((cmd) => cmd.id === 'theme-flexoki')
+      ).toBe(true)
+
+      // Select and execute the non-theme leaf without any preview callback.
+      const noopIndex = result.current.filteredResults.findIndex((cmd) => cmd.id === 'noop')
+
+      expect(noopIndex).not.toBe(-1)
+
+      act(() => {
+        result.current.selectIndex(noopIndex)
+        result.current.executeSelected()
+      })
+
+      expect(nonThemeExecute).toHaveBeenCalled()
+      expect(themeService.current().id).toBe('obsidian-lens')
+    })
+
     test('disabled palette rejects opens and closes current state', async () => {
       const { result, rerender } = renderHook(
         ({ enabled }: { enabled: boolean }) =>

--- a/src/features/command-palette/hooks/useCommandPalette.test.ts
+++ b/src/features/command-palette/hooks/useCommandPalette.test.ts
@@ -1110,6 +1110,54 @@ describe('useCommandPalette', () => {
 
       expect(result.current.state.selectedIndex).toBe(5)
     })
+
+    test('previews namespace children as the highlight moves', async () => {
+      const previewCatppuccin = vi.fn()
+      const previewDracula = vi.fn()
+
+      const commands: Command[] = [
+        {
+          id: 'theme',
+          label: ':theme',
+          icon: 'palette',
+          children: [
+            {
+              id: 'theme-catppuccin',
+              label: 'Catppuccin',
+              icon: 'palette',
+              preview: previewCatppuccin,
+              execute: vi.fn(),
+            },
+            {
+              id: 'theme-dracula',
+              label: 'Dracula',
+              icon: 'palette',
+              preview: previewDracula,
+              execute: vi.fn(),
+            },
+          ],
+        },
+      ]
+
+      const { result } = renderHook(() => useCommandPalette(commands))
+
+      act(() => {
+        result.current.open()
+        result.current.executeSelected()
+      })
+
+      await waitFor(() => {
+        expect(previewCatppuccin).toHaveBeenCalled()
+      })
+
+      act(() => {
+        result.current.navigateDown()
+      })
+
+      await waitFor(() => {
+        expect(previewDracula).toHaveBeenCalled()
+      })
+    })
   })
 
   describe('executeSelected', () => {

--- a/src/features/command-palette/hooks/useCommandPalette.test.ts
+++ b/src/features/command-palette/hooks/useCommandPalette.test.ts
@@ -6,6 +6,7 @@ import {
 } from './useCommandPalette'
 import type { Command } from '../registry/types'
 import * as chordRegistry from '../chordRegistry'
+import { themeService } from '../../../theme'
 import type { BackendApi } from '../../../lib/backend'
 
 describe('useCommandPalette', () => {
@@ -73,6 +74,44 @@ describe('useCommandPalette', () => {
       expect(result.current.state.currentNamespace).toBe(null)
       // filteredResults is derived from query ':' so it shows all default commands
       expect(result.current.filteredResults.length).toBeGreaterThan(0)
+    })
+
+    test('close() restores the theme active when the palette opened', () => {
+      const commands: Command[] = [
+        {
+          id: 'theme',
+          label: ':theme',
+          icon: 'palette',
+          children: [
+            {
+              id: 'theme-flexoki',
+              label: 'Flexoki',
+              icon: 'palette',
+              preview: (): void => {
+                themeService.preview('flexoki')
+              },
+              execute: (): void => {
+                themeService.apply('flexoki')
+              },
+            },
+          ],
+        },
+      ]
+
+      themeService.apply('obsidian-lens')
+
+      const { result } = renderHook(() => useCommandPalette(commands))
+
+      act(() => {
+        result.current.open()
+        result.current.executeSelected()
+      })
+
+      act(() => {
+        result.current.close()
+      })
+
+      expect(themeService.current().id).toBe('obsidian-lens')
     })
 
     test('disabled palette rejects opens and closes current state', async () => {

--- a/src/features/command-palette/hooks/useCommandPalette.ts
+++ b/src/features/command-palette/hooks/useCommandPalette.ts
@@ -162,6 +162,17 @@ export const useCommandPalette = (
     return Math.min(state.selectedIndex, filteredResults.length - 1)
   }, [state.selectedIndex, filteredResults.length])
 
+  const selectedCommand =
+    clampedSelectedIndex >= 0 ? filteredResults[clampedSelectedIndex] : null
+
+  useEffect(() => {
+    if (!state.isOpen) {
+      return
+    }
+
+    selectedCommand?.preview?.()
+  }, [selectedCommand, state.isOpen])
+
   const openWithQuery = useCallback(
     (query: string): void => {
       if (!isEnabledRef.current) {
@@ -266,7 +277,11 @@ export const useCommandPalette = (
       return
     }
 
-    const selected = filteredResults[clampedSelectedIndex]
+    const selected = selectedCommand
+
+    if (!selected) {
+      return
+    }
 
     // If it's a namespace, drill into it
     if (selected.children && selected.children.length > 0) {
@@ -301,9 +316,9 @@ export const useCommandPalette = (
     }
   }, [
     clampedSelectedIndex,
-    filteredResults,
     parsedQuery.args,
     parsedQuery.commandVerb,
+    selectedCommand,
     state.currentNamespace,
     close,
   ])

--- a/src/features/command-palette/hooks/useCommandPalette.ts
+++ b/src/features/command-palette/hooks/useCommandPalette.ts
@@ -18,6 +18,7 @@ import { getAllLeaves, traverseNamespace } from '../registry/commandTree'
 import { parseQuery } from '../registry/parseQuery'
 import * as chordRegistry from '../chordRegistry'
 import { listenCommandPaletteToggle } from '../../../lib/backend'
+import { themeService } from '../../../theme'
 import {
   COMMAND_PALETTE_SHORTCUT_KEYS,
   isCommandPaletteToggle,
@@ -66,6 +67,7 @@ export const useCommandPalette = (
   const leaderTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const leaderActiveRef = useRef(false)
   const isEnabledRef = useRef(isEnabled)
+  const originalThemeIdRef = useRef<string | null>(null)
 
   isEnabledRef.current = isEnabled
 
@@ -181,6 +183,8 @@ export const useCommandPalette = (
         return
       }
 
+      originalThemeIdRef.current = themeService.current().id
+
       setState((prev) => ({
         ...prev,
         isOpen: true,
@@ -198,6 +202,12 @@ export const useCommandPalette = (
 
   const close = useCallback((): void => {
     clearLeaderWindow()
+
+    if (originalThemeIdRef.current !== null) {
+      themeService.apply(originalThemeIdRef.current)
+      originalThemeIdRef.current = null
+    }
+
     setState((prev) => ({
       ...prev,
       isOpen: false,
@@ -312,6 +322,7 @@ export const useCommandPalette = (
           : parsedQuery.args
 
       selected.execute(executionArgs)
+      originalThemeIdRef.current = null
       close()
     }
   }, [

--- a/src/features/command-palette/hooks/useCommandPalette.ts
+++ b/src/features/command-palette/hooks/useCommandPalette.ts
@@ -18,7 +18,7 @@ import { getAllLeaves, traverseNamespace } from '../registry/commandTree'
 import { parseQuery } from '../registry/parseQuery'
 import * as chordRegistry from '../chordRegistry'
 import { listenCommandPaletteToggle } from '../../../lib/backend'
-import { themeService } from '../../../theme'
+import { themeService, type ThemeId } from '../../../theme'
 import {
   COMMAND_PALETTE_SHORTCUT_KEYS,
   isCommandPaletteToggle,
@@ -67,7 +67,7 @@ export const useCommandPalette = (
   const leaderTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const leaderActiveRef = useRef(false)
   const isEnabledRef = useRef(isEnabled)
-  const originalThemeIdRef = useRef<string | null>(null)
+  const originalThemeIdRef = useRef<ThemeId | null>(null)
 
   isEnabledRef.current = isEnabled
 
@@ -322,7 +322,9 @@ export const useCommandPalette = (
           : parsedQuery.args
 
       selected.execute(executionArgs)
-      originalThemeIdRef.current = null
+      if (selected.preview != null) {
+        originalThemeIdRef.current = null
+      }
       close()
     }
   }, [

--- a/src/features/command-palette/registry/types.ts
+++ b/src/features/command-palette/registry/types.ts
@@ -5,6 +5,7 @@ export interface Command {
   icon: string
   children?: Command[]
   execute?: (args: string) => void
+  preview?: () => void
   match?: (query: string) => number
 }
 

--- a/src/features/workspace/commands/buildWorkspaceCommands.test.ts
+++ b/src/features/workspace/commands/buildWorkspaceCommands.test.ts
@@ -70,13 +70,13 @@ describe('buildWorkspaceCommands - happy paths', () => {
     expect(themeService.current().id).toBe('gruvbox-light')
 
     themeCmd?.children?.find((c) => c.id === 'theme-tokyo-night')?.preview?.()
-    expect(themeService.current().id).toBe('tokyo-night')
+    expect(themeService.current().id).toBe('gruvbox-light')
 
     themeCmd?.children?.find((c) => c.id === 'theme-tokyo-night')?.execute?.('')
     expect(themeService.current().id).toBe('tokyo-night')
 
     themeCmd?.children?.find((c) => c.id === 'theme-dracula')?.preview?.()
-    expect(themeService.current().id).toBe('dracula')
+    expect(themeService.current().id).toBe('tokyo-night')
 
     themeCmd?.children?.find((c) => c.id === 'theme-dracula')?.execute?.('')
     expect(themeService.current().id).toBe('dracula')

--- a/src/features/workspace/commands/buildWorkspaceCommands.test.ts
+++ b/src/features/workspace/commands/buildWorkspaceCommands.test.ts
@@ -69,8 +69,14 @@ describe('buildWorkspaceCommands - happy paths', () => {
       ?.execute?.('')
     expect(themeService.current().id).toBe('gruvbox-light')
 
+    themeCmd?.children?.find((c) => c.id === 'theme-tokyo-night')?.preview?.()
+    expect(themeService.current().id).toBe('tokyo-night')
+
     themeCmd?.children?.find((c) => c.id === 'theme-tokyo-night')?.execute?.('')
     expect(themeService.current().id).toBe('tokyo-night')
+
+    themeCmd?.children?.find((c) => c.id === 'theme-dracula')?.preview?.()
+    expect(themeService.current().id).toBe('dracula')
 
     themeCmd?.children?.find((c) => c.id === 'theme-dracula')?.execute?.('')
     expect(themeService.current().id).toBe('dracula')

--- a/src/features/workspace/commands/buildWorkspaceCommands.ts
+++ b/src/features/workspace/commands/buildWorkspaceCommands.ts
@@ -172,6 +172,9 @@ export const buildWorkspaceCommands = (
         label: theme.label,
         description: `Switch to ${theme.label}`,
         icon: 'palette',
+        preview: (): void => {
+          themeService.apply(theme.id)
+        },
         execute: (): void => {
           themeService.apply(theme.id)
         },

--- a/src/features/workspace/commands/buildWorkspaceCommands.ts
+++ b/src/features/workspace/commands/buildWorkspaceCommands.ts
@@ -173,7 +173,7 @@ export const buildWorkspaceCommands = (
         description: `Switch to ${theme.label}`,
         icon: 'palette',
         preview: (): void => {
-          themeService.apply(theme.id)
+          themeService.preview(theme.id)
         },
         execute: (): void => {
           themeService.apply(theme.id)

--- a/src/theme/service.test.ts
+++ b/src/theme/service.test.ts
@@ -42,7 +42,7 @@ test('preview updates the displayed theme and subscribers without persisting', (
 
   themeService.preview('flexoki')
 
-  expect(themeService.current().id).toBe('flexoki')
+  expect(themeService.current().id).toBe('obsidian-lens')
   expect(document.documentElement.dataset.theme).toBe('flexoki')
   expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('obsidian-lens')
   expect(seen).toHaveBeenCalledTimes(1)

--- a/src/theme/service.test.ts
+++ b/src/theme/service.test.ts
@@ -34,6 +34,22 @@ test('subscribers are notified once per apply with the new theme', () => {
   expect(seen).toHaveBeenCalledTimes(1)
 })
 
+test('preview updates the displayed theme and subscribers without persisting', () => {
+  const seen = vi.fn()
+  const unsubscribe = themeService.subscribe(seen)
+  themeService.apply('obsidian-lens')
+  seen.mockClear()
+
+  themeService.preview('flexoki')
+
+  expect(themeService.current().id).toBe('flexoki')
+  expect(document.documentElement.dataset.theme).toBe('flexoki')
+  expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('obsidian-lens')
+  expect(seen).toHaveBeenCalledTimes(1)
+  expect((seen.mock.calls[0][0] as ThemeDefinition).id).toBe('flexoki')
+  unsubscribe()
+})
+
 test('init falls back to obsidian-lens for unknown stored ids', () => {
   window.localStorage.setItem(THEME_STORAGE_KEY, 'no-such-theme')
   themeService.init()

--- a/src/theme/service.ts
+++ b/src/theme/service.ts
@@ -69,8 +69,15 @@ const apply = (id: ThemeId): void => {
   listeners.forEach((listener) => listener(next))
 }
 
+const preview = (id: ThemeId): void => {
+  const next = themes.find((t) => t.id === id) ?? DEFAULT_THEME
+
+  writeDom(next)
+}
+
 export const themeService = {
   apply,
+  preview,
   current: (): ThemeDefinition => active,
   list: (): readonly ThemeDefinition[] => themes,
   subscribe: (listener: Listener): (() => void) => {

--- a/src/theme/service.ts
+++ b/src/theme/service.ts
@@ -72,7 +72,9 @@ const apply = (id: ThemeId): void => {
 const preview = (id: ThemeId): void => {
   const next = themes.find((t) => t.id === id) ?? DEFAULT_THEME
 
+  active = next
   writeDom(next)
+  listeners.forEach((listener) => listener(next))
 }
 
 export const themeService = {

--- a/src/theme/service.ts
+++ b/src/theme/service.ts
@@ -72,7 +72,6 @@ const apply = (id: ThemeId): void => {
 const preview = (id: ThemeId): void => {
   const next = themes.find((t) => t.id === id) ?? DEFAULT_THEME
 
-  active = next
   writeDom(next)
   listeners.forEach((listener) => listener(next))
 }


### PR DESCRIPTION
## Summary
- Preview theme commands as the command-palette highlight moves
- Apply theme preview behavior to both workspace and default theme command trees

## Test plan
- [x] npm run test -- src/features/command-palette/hooks/useCommandPalette.test.ts src/features/workspace/commands/buildWorkspaceCommands.test.ts src/features/command-palette/data/defaultCommands.test.ts src/theme/service.test.ts
- [x] npm run type-check
- [x] npx eslint --max-warnings=0 src/features/command-palette/hooks/useCommandPalette.ts src/features/command-palette/hooks/useCommandPalette.test.ts src/features/command-palette/registry/types.ts src/features/command-palette/data/defaultCommands.ts src/features/command-palette/data/defaultCommands.test.ts src/features/workspace/commands/buildWorkspaceCommands.ts src/features/workspace/commands/buildWorkspaceCommands.test.ts


Refs VIM-185