### PR TITLE
refactor(settings): extract reusable settings content

### DIFF
--- a/src/features/settings/SettingsContent.test.tsx
+++ b/src/features/settings/SettingsContent.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest'
+import { render as rtlRender, screen } from '@testing-library/react'
+import { type ReactElement } from 'react'
+import { SettingsContent } from './SettingsContent'
+import { SettingsProvider } from './SettingsProvider'
+import { DEFAULT_SETTINGS } from './store/settingsDefaults'
+
+const render = (ui: ReactElement): ReturnType<typeof rtlRender> =>
+  rtlRender(ui, { wrapper: SettingsProvider })
+
+describe('SettingsContent', () => {
+  beforeEach(() => {
+    window.vimeflow = {
+      settings: {
+        load: vi.fn().mockResolvedValue(DEFAULT_SETTINGS),
+        save: vi.fn().mockResolvedValue(undefined),
+        openFile: vi.fn(),
+      },
+    } as unknown as Window['vimeflow']
+  })
+
+  afterEach(() => {
+    delete window.vimeflow
+  })
+
+  test('renders the settings body without modal chrome', () => {
+    render(<SettingsContent />)
+
+    expect(screen.queryByRole('dialog')).toBeNull()
+    expect(screen.queryByTestId('settings-dialog-backdrop')).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Close' })).toBeNull()
+    expect(
+      screen.getByRole('heading', { name: 'Appearance' })
+    ).toBeInTheDocument()
+
+    expect(screen.getByRole('option', { name: 'Appearance' })).toHaveClass(
+      'text-primary'
+    )
+  })
+})

--- a/src/features/settings/SettingsContent.tsx
+++ b/src/features/settings/SettingsContent.tsx
@@ -1,0 +1,255 @@
+import { useEffect, useMemo, useRef, useState, type ReactElement } from 'react'
+import type {
+  SettingsSearchNavigationDirection,
+  SettingsSectionId,
+  SettingsSubsection,
+  SettingsTarget,
+  SettingsTargetId,
+} from './types'
+import {
+  SETTINGS_SECTIONS,
+  SETTINGS_SUBSECTIONS,
+  SETTINGS_TARGETS,
+} from './sections'
+import {
+  searchSettings,
+  settingsSectionResultKey,
+  settingsTargetResultKey,
+  type SettingsSearchResult,
+} from './search'
+import { SettingsSidebar } from './components/SettingsSidebar'
+import { AgentsPane } from './components/panes/AgentsPane'
+import { AppearancePane } from './components/panes/AppearancePane'
+import { GeneralPane } from './components/panes/GeneralPane'
+import { KeymapPane } from './components/panes/KeymapPane'
+import { PlaceholderPane } from './components/panes/PlaceholderPane'
+
+const REAL_PANES: readonly SettingsSectionId[] = [
+  'general',
+  'appearance',
+  'keymap',
+  'agents',
+]
+
+type TargetFocusMode = 'focus-target' | 'preserve-search-focus'
+
+export const SettingsContent = (): ReactElement => {
+  const [section, setSection] = useState<SettingsSectionId>('appearance')
+  const [query, setQuery] = useState('')
+
+  const [activeTargetId, setActiveTargetId] = useState<SettingsTargetId | null>(
+    null
+  )
+
+  const [selectedSearchResultKey, setSelectedSearchResultKey] = useState<
+    string | null
+  >(null)
+
+  const [targetNavigationKey, setTargetNavigationKey] = useState(0)
+
+  const [targetFocusMode, setTargetFocusMode] =
+    useState<TargetFocusMode>('focus-target')
+
+  const contentRef = useRef<HTMLDivElement>(null)
+
+  const searchModel = useMemo(
+    () =>
+      searchSettings({
+        sections: SETTINGS_SECTIONS,
+        targets: SETTINGS_TARGETS,
+        query,
+      }),
+    [query]
+  )
+  const filtered = searchModel.sections
+  const targetMatches = searchModel.targets
+  const searchResults = searchModel.results
+
+  const activeSearchResultKey =
+    selectedSearchResultKey !== null &&
+    searchResults.some((result) => result.key === selectedSearchResultKey)
+      ? selectedSearchResultKey
+      : query.trim() !== '' && searchResults.length > 0
+        ? searchResults[0].key
+        : null
+
+  const activeSection = SETTINGS_SECTIONS.find((s) => s.id === section)
+
+  const handlePickSection = (id: SettingsSectionId): void => {
+    setSection(id)
+    setActiveTargetId(null)
+    setSelectedSearchResultKey(settingsSectionResultKey(id))
+  }
+
+  const handleQuery = (nextQuery: string): void => {
+    setQuery(nextQuery)
+    setActiveTargetId(null)
+    setSelectedSearchResultKey(null)
+  }
+
+  const handleClearQuery = (): void => {
+    setQuery('')
+    setActiveTargetId(null)
+    setSelectedSearchResultKey(null)
+    setTargetFocusMode('focus-target')
+  }
+
+  const applySearchResult = (
+    result: SettingsSearchResult,
+    focusMode: TargetFocusMode
+  ): void => {
+    setTargetFocusMode(focusMode)
+    setSelectedSearchResultKey(result.key)
+
+    if (result.kind === 'section') {
+      handlePickSection(result.section.id)
+
+      return
+    }
+
+    const { target } = result
+    setSection(target.section)
+    setActiveTargetId(target.id)
+    setTargetNavigationKey((key) => key + 1)
+  }
+
+  const handlePickTarget = (target: SettingsTarget): void => {
+    const owningSection = SETTINGS_SECTIONS.find((s) => s.id === target.section)
+    if (owningSection === undefined) {
+      return
+    }
+
+    applySearchResult(
+      {
+        key: settingsTargetResultKey(target),
+        kind: 'target',
+        section: owningSection,
+        target,
+        score: 0,
+      },
+      'focus-target'
+    )
+  }
+
+  const handlePickSubsection = (subsection: SettingsSubsection): void => {
+    const target = SETTINGS_TARGETS.find(
+      (candidate) => candidate.id === subsection.targetId
+    )
+
+    if (target === undefined) {
+      return
+    }
+
+    handlePickTarget(target)
+  }
+
+  const handleNavigateSearchResult = (
+    direction: SettingsSearchNavigationDirection
+  ): void => {
+    if (searchResults.length === 0) {
+      return
+    }
+
+    const currentIndex =
+      activeSearchResultKey === null
+        ? -1
+        : searchResults.findIndex(
+            (result) => result.key === activeSearchResultKey
+          )
+    const delta = direction === 'next' ? 1 : -1
+    let nextIndex: number
+    if (currentIndex === -1) {
+      nextIndex = direction === 'next' ? 0 : searchResults.length - 1
+    } else {
+      nextIndex =
+        (currentIndex + delta + searchResults.length) % searchResults.length
+    }
+
+    const nextResult = searchResults[nextIndex]
+
+    applySearchResult(nextResult, 'preserve-search-focus')
+  }
+
+  const handleConfirmSearchResult = (): void => {
+    if (searchResults.length === 0) {
+      return
+    }
+
+    const currentResult =
+      activeSearchResultKey === null
+        ? undefined
+        : searchResults.find((result) => result.key === activeSearchResultKey)
+
+    const resultToConfirm =
+      currentResult ?? (query.trim() ? searchResults[0] : undefined)
+
+    if (!resultToConfirm) {
+      return
+    }
+
+    applySearchResult(resultToConfirm, 'focus-target')
+  }
+
+  useEffect(() => {
+    if (activeTargetId === null) {
+      return
+    }
+
+    const target = contentRef.current?.querySelector<HTMLElement>(
+      `[data-settings-target="${activeTargetId}"]`
+    )
+
+    if (!target) {
+      return
+    }
+
+    target.scrollIntoView({ block: 'center', behavior: 'smooth' })
+    if (targetFocusMode === 'focus-target') {
+      target.focus({ preventScroll: true })
+    }
+  }, [activeTargetId, section, targetFocusMode, targetNavigationKey])
+
+  return (
+    <div className="flex min-h-0 flex-1">
+      <SettingsSidebar
+        sections={filtered}
+        targets={targetMatches}
+        subsections={SETTINGS_SUBSECTIONS}
+        active={section}
+        activeTargetId={activeTargetId}
+        activeSearchResultKey={activeSearchResultKey}
+        onPick={handlePickSection}
+        onPickTarget={handlePickTarget}
+        onPickSubsection={handlePickSubsection}
+        onClearQuery={handleClearQuery}
+        onNavigateSearchResult={handleNavigateSearchResult}
+        onConfirmSearchResult={handleConfirmSearchResult}
+        query={query}
+        onQuery={handleQuery}
+      />
+
+      <div className="flex min-w-0 flex-1 flex-col">
+        <div
+          ref={contentRef}
+          className="thin-scrollbar flex-1 overflow-auto px-7 py-5"
+        >
+          {section === 'general' && (
+            <GeneralPane activeTargetId={activeTargetId} />
+          )}
+          {section === 'appearance' && (
+            <AppearancePane activeTargetId={activeTargetId} />
+          )}
+          {section === 'keymap' && (
+            <KeymapPane activeTargetId={activeTargetId} />
+          )}
+          {section === 'agents' && (
+            <AgentsPane activeTargetId={activeTargetId} />
+          )}
+          {!REAL_PANES.includes(section) && activeSection && (
+            <PlaceholderPane section={activeSection} />
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/features/settings/SettingsDialog.tsx
+++ b/src/features/settings/SettingsDialog.tsx
@@ -1,42 +1,10 @@
 import { AnimatePresence, motion } from 'framer-motion'
-import { useEffect, useMemo, useRef, useState, type ReactElement } from 'react'
-import type {
-  SettingsDialogProps,
-  SettingsSearchNavigationDirection,
-  SettingsSectionId,
-  SettingsSubsection,
-  SettingsTarget,
-  SettingsTargetId,
-} from './types'
-import {
-  SETTINGS_SECTIONS,
-  SETTINGS_SUBSECTIONS,
-  SETTINGS_TARGETS,
-} from './sections'
-import {
-  searchSettings,
-  settingsSectionResultKey,
-  settingsTargetResultKey,
-  type SettingsSearchResult,
-} from './search'
+import { useEffect, useRef, useState, type ReactElement } from 'react'
+import type { SettingsDialogProps } from './types'
 import { Icon } from './components/Icon'
 import { Tooltip } from '@/components/Tooltip'
 import { Kbd } from './components/Kbd'
-import { SettingsSidebar } from './components/SettingsSidebar'
-import { AgentsPane } from './components/panes/AgentsPane'
-import { AppearancePane } from './components/panes/AppearancePane'
-import { GeneralPane } from './components/panes/GeneralPane'
-import { KeymapPane } from './components/panes/KeymapPane'
-import { PlaceholderPane } from './components/panes/PlaceholderPane'
-
-const REAL_PANES: readonly SettingsSectionId[] = [
-  'general',
-  'appearance',
-  'keymap',
-  'agents',
-]
-
-type TargetFocusMode = 'focus-target' | 'preserve-search-focus'
+import { SettingsContent } from './SettingsContent'
 
 const FOCUSABLE_SELECTOR =
   'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
@@ -75,164 +43,10 @@ export const SettingsDialog = ({
   open,
   onClose,
 }: SettingsDialogProps): ReactElement | null => {
-  const [section, setSection] = useState<SettingsSectionId>('appearance')
-  const [query, setQuery] = useState('')
-
-  const [activeTargetId, setActiveTargetId] = useState<SettingsTargetId | null>(
-    null
-  )
-
-  const [selectedSearchResultKey, setSelectedSearchResultKey] = useState<
-    string | null
-  >(null)
-
-  const [targetNavigationKey, setTargetNavigationKey] = useState(0)
-
-  const [targetFocusMode, setTargetFocusMode] =
-    useState<TargetFocusMode>('focus-target')
-
+  const [contentSessionKey, setContentSessionKey] = useState(0)
   const dialogRef = useRef<HTMLDivElement>(null)
   const closeButtonRef = useRef<HTMLButtonElement>(null)
-  const contentRef = useRef<HTMLDivElement>(null)
   const previousFocusRef = useRef<HTMLElement | null>(null)
-
-  const searchModel = useMemo(
-    () =>
-      searchSettings({
-        sections: SETTINGS_SECTIONS,
-        targets: SETTINGS_TARGETS,
-        query,
-      }),
-    [query]
-  )
-  const filtered = searchModel.sections
-  const targetMatches = searchModel.targets
-  const searchResults = searchModel.results
-
-  const activeSearchResultKey =
-    selectedSearchResultKey !== null &&
-    searchResults.some((result) => result.key === selectedSearchResultKey)
-      ? selectedSearchResultKey
-      : query.trim() !== '' && searchResults.length > 0
-        ? searchResults[0].key
-        : null
-
-  const activeSection = SETTINGS_SECTIONS.find((s) => s.id === section)
-
-  const handlePickSection = (id: SettingsSectionId): void => {
-    setSection(id)
-    setActiveTargetId(null)
-    setSelectedSearchResultKey(settingsSectionResultKey(id))
-  }
-
-  const handleQuery = (nextQuery: string): void => {
-    setQuery(nextQuery)
-    setActiveTargetId(null)
-    setSelectedSearchResultKey(null)
-  }
-
-  const handleClearQuery = (): void => {
-    setQuery('')
-    setActiveTargetId(null)
-    setSelectedSearchResultKey(null)
-    setTargetFocusMode('focus-target')
-  }
-
-  const applySearchResult = (
-    result: SettingsSearchResult,
-    focusMode: TargetFocusMode
-  ): void => {
-    setTargetFocusMode(focusMode)
-    setSelectedSearchResultKey(result.key)
-
-    if (result.kind === 'section') {
-      handlePickSection(result.section.id)
-
-      return
-    }
-
-    const { target } = result
-    setSection(target.section)
-    setActiveTargetId(target.id)
-    setTargetNavigationKey((key) => key + 1)
-  }
-
-  const handlePickTarget = (target: SettingsTarget): void => {
-    const owningSection = SETTINGS_SECTIONS.find((s) => s.id === target.section)
-    if (owningSection === undefined) {
-      return
-    }
-
-    applySearchResult(
-      {
-        key: settingsTargetResultKey(target),
-        kind: 'target',
-        section: owningSection,
-        target,
-        score: 0,
-      },
-      'focus-target'
-    )
-  }
-
-  const handlePickSubsection = (subsection: SettingsSubsection): void => {
-    const target = SETTINGS_TARGETS.find(
-      (candidate) => candidate.id === subsection.targetId
-    )
-
-    if (target === undefined) {
-      return
-    }
-
-    handlePickTarget(target)
-  }
-
-  const handleNavigateSearchResult = (
-    direction: SettingsSearchNavigationDirection
-  ): void => {
-    if (searchResults.length === 0) {
-      return
-    }
-
-    const currentIndex =
-      activeSearchResultKey === null
-        ? -1
-        : searchResults.findIndex(
-            (result) => result.key === activeSearchResultKey
-          )
-    const delta = direction === 'next' ? 1 : -1
-    let nextIndex: number
-    if (currentIndex === -1) {
-      nextIndex = direction === 'next' ? 0 : searchResults.length - 1
-    } else {
-      nextIndex =
-        (currentIndex + delta + searchResults.length) % searchResults.length
-    }
-
-    const nextResult = searchResults[nextIndex]
-
-    applySearchResult(nextResult, 'preserve-search-focus')
-  }
-
-  const handleConfirmSearchResult = (): void => {
-    if (searchResults.length === 0) {
-      return
-    }
-
-    const currentResult =
-      activeSearchResultKey === null
-        ? undefined
-        : searchResults.find((result) => result.key === activeSearchResultKey)
-
-    const resultToConfirm =
-      currentResult ?? (query.trim() ? searchResults[0] : undefined)
-
-    if (!resultToConfirm) {
-      return
-    }
-
-    applySearchResult(resultToConfirm, 'focus-target')
-  }
 
   useEffect(() => {
     if (open) {
@@ -244,6 +58,12 @@ export const SettingsDialog = ({
     } else if (previousFocusRef.current) {
       previousFocusRef.current.focus()
       previousFocusRef.current = null
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (!open) {
+      setContentSessionKey((key) => key + 1)
     }
   }, [open])
 
@@ -293,33 +113,6 @@ export const SettingsDialog = ({
     }
   }, [open])
 
-  useEffect(() => {
-    if (!open) {
-      setQuery('')
-      setActiveTargetId(null)
-      setSelectedSearchResultKey(null)
-    }
-  }, [open])
-
-  useEffect(() => {
-    if (!open || activeTargetId === null) {
-      return
-    }
-
-    const target = contentRef.current?.querySelector<HTMLElement>(
-      `[data-settings-target="${activeTargetId}"]`
-    )
-
-    if (!target) {
-      return
-    }
-
-    target.scrollIntoView({ block: 'center', behavior: 'smooth' })
-    if (targetFocusMode === 'focus-target') {
-      target.focus({ preventScroll: true })
-    }
-  }, [activeTargetId, open, section, targetFocusMode, targetNavigationKey])
-
   return (
     <AnimatePresence>
       {open && (
@@ -367,47 +160,7 @@ export const SettingsDialog = ({
               </Tooltip>
             </div>
 
-            <div className="flex min-h-0 flex-1">
-              <SettingsSidebar
-                sections={filtered}
-                targets={targetMatches}
-                subsections={SETTINGS_SUBSECTIONS}
-                active={section}
-                activeTargetId={activeTargetId}
-                activeSearchResultKey={activeSearchResultKey}
-                onPick={handlePickSection}
-                onPickTarget={handlePickTarget}
-                onPickSubsection={handlePickSubsection}
-                onClearQuery={handleClearQuery}
-                onNavigateSearchResult={handleNavigateSearchResult}
-                onConfirmSearchResult={handleConfirmSearchResult}
-                query={query}
-                onQuery={handleQuery}
-              />
-
-              <div className="flex min-w-0 flex-1 flex-col">
-                <div
-                  ref={contentRef}
-                  className="thin-scrollbar flex-1 overflow-auto px-7 py-5"
-                >
-                  {section === 'general' && (
-                    <GeneralPane activeTargetId={activeTargetId} />
-                  )}
-                  {section === 'appearance' && (
-                    <AppearancePane activeTargetId={activeTargetId} />
-                  )}
-                  {section === 'keymap' && (
-                    <KeymapPane activeTargetId={activeTargetId} />
-                  )}
-                  {section === 'agents' && (
-                    <AgentsPane activeTargetId={activeTargetId} />
-                  )}
-                  {!REAL_PANES.includes(section) && activeSection && (
-                    <PlaceholderPane section={activeSection} />
-                  )}
-                </div>
-              </div>
-            </div>
+            <SettingsContent key={contentSessionKey} />
 
             {/* Footer */}
             <div className="flex h-7 shrink-0 items-center gap-2.5 border-t border-outline-variant/25 bg-surface-container-lowest px-3.5 font-mono text-[10px] text-on-surface-muted/80">

--- a/src/features/settings/index.test.ts
+++ b/src/features/settings/index.test.ts
@@ -5,6 +5,7 @@ import {
   KEYMAP_GROUPS,
   SETTINGS_SECTIONS,
   SETTINGS_SUBSECTIONS,
+  SettingsContent,
   SettingsDialog,
   VIM_KEYMAP_GROUPS,
   useSettingsDialog,
@@ -13,6 +14,10 @@ import {
 describe('settings feature barrel', () => {
   test('exports the SettingsDialog component', () => {
     expect(SettingsDialog).toBeInstanceOf(Function)
+  })
+
+  test('exports the SettingsContent component', () => {
+    expect(SettingsContent).toBeInstanceOf(Function)
   })
 
   test('exports the useSettingsDialog hook', () => {

--- a/src/features/settings/index.ts
+++ b/src/features/settings/index.ts
@@ -1,5 +1,7 @@
 export { SettingsDialog } from './SettingsDialog'
 
+export { SettingsContent } from './SettingsContent'
+
 export { useSettingsDialog } from './hooks/useSettingsDialog'
 
 export {


### PR DESCRIPTION
## Summary
- Extract Settings sidebar/search/pane rendering into a reusable SettingsContent component
- Keep SettingsDialog focused on modal-only chrome: overlay, close button, focus trap, and per-open reset
- Export SettingsContent for the future native Settings window host

## Test plan
- [x] npm test -- --run src/features/settings
- [x] npm run lint
- [x] npm run type-check:generated
- [x] npm run format:check && git diff --check

Refs VIM-184