### PR TITLE
feat(agent-status): migrate collapsed-rail cache rate to a ring

### DIFF
--- a/src/features/agent-status/components/AgentStatusRail.test.tsx
+++ b/src/features/agent-status/components/AgentStatusRail.test.tsx
@@ -88,7 +88,7 @@ test('hides cache meter when cacheHitPercentage is null', () => {
   expect(screen.queryByRole('meter', { name: 'CACHE' })).not.toBeInTheDocument()
 })
 
-test('cache meter tone is mint at >=70%, lavender 40-70%, coral <40%', () => {
+test('cache ring tone is mint at >=70%, lavender 40-70%, coral <40%', () => {
   const { rerender } = render(
     <AgentStatusRail
       agent={AGENTS.claude}
@@ -98,9 +98,10 @@ test('cache meter tone is mint at >=70%, lavender 40-70%, coral <40%', () => {
     />
   )
 
-  expect(
-    within(screen.getByRole('meter', { name: 'CACHE' })).getByText('%')
-  ).toHaveStyle({ color: 'var(--color-success-muted)' })
+  expect(screen.getByTestId('cache-ring-arc')).toHaveAttribute(
+    'stroke',
+    'var(--color-success-muted)'
+  )
 
   rerender(
     <AgentStatusRail
@@ -111,9 +112,10 @@ test('cache meter tone is mint at >=70%, lavender 40-70%, coral <40%', () => {
     />
   )
 
-  expect(
-    within(screen.getByRole('meter', { name: 'CACHE' })).getByText('%')
-  ).toHaveStyle({ color: 'var(--color-primary)' })
+  expect(screen.getByTestId('cache-ring-arc')).toHaveAttribute(
+    'stroke',
+    'var(--color-primary)'
+  )
 
   rerender(
     <AgentStatusRail
@@ -124,9 +126,44 @@ test('cache meter tone is mint at >=70%, lavender 40-70%, coral <40%', () => {
     />
   )
 
+  expect(screen.getByTestId('cache-ring-arc')).toHaveAttribute(
+    'stroke',
+    'var(--color-tertiary)'
+  )
+})
+
+test('renders the cache rate as a ring, not the liquid bar', () => {
+  render(
+    <AgentStatusRail
+      agent={AGENTS.claude}
+      contextUsedPercentage={42}
+      cacheHitPercentage={75}
+      onExpand={() => undefined}
+    />
+  )
+
+  const cacheMeter = screen.getByRole('meter', { name: 'CACHE' })
+
+  expect(within(cacheMeter).getByTestId('cache-ring-arc')).toBeInTheDocument()
   expect(
-    within(screen.getByRole('meter', { name: 'CACHE' })).getByText('%')
-  ).toHaveStyle({ color: 'var(--color-tertiary)' })
+    within(cacheMeter).queryByTestId('liquid-base')
+  ).not.toBeInTheDocument()
+})
+
+test('drops the visible CACHE caption from the rail ring', () => {
+  render(
+    <AgentStatusRail
+      agent={AGENTS.claude}
+      contextUsedPercentage={null}
+      cacheHitPercentage={75}
+      onExpand={() => undefined}
+    />
+  )
+
+  // The label now lives only in the tooltip + accessible name, not on the ring.
+  expect(
+    within(screen.getByRole('meter', { name: 'CACHE' })).queryByText('CACHE')
+  ).not.toBeInTheDocument()
 })
 
 test('chevron expand button fires onExpand', async () => {

--- a/src/features/agent-status/components/AgentStatusRail.tsx
+++ b/src/features/agent-status/components/AgentStatusRail.tsx
@@ -3,6 +3,7 @@ import { IconButton } from '@/components/IconButton'
 import type { Agent } from '../../../agents/registry'
 import { AgentGlyph } from '@/components/AgentGlyph'
 import { RailMeter } from './RailMeter'
+import { CacheRing } from './CacheRing'
 import { ctxTone } from '../utils/contextTone'
 
 export interface AgentStatusRailProps {
@@ -90,12 +91,7 @@ export const AgentStatusRail = ({
 
       {cachePct !== null && (
         <div className="vf-app-no-drag mt-4">
-          <RailMeter
-            pct={cachePct}
-            color={cacheTone(cachePct)}
-            label="CACHE"
-            tooltip={`Cache hit rate: ${Math.round(cachePct)}%`}
-          />
+          <CacheRing pct={cachePct} color={cacheTone(cachePct)} />
         </div>
       )}
 

--- a/src/features/agent-status/components/CacheRing.test.tsx
+++ b/src/features/agent-status/components/CacheRing.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { test, expect } from 'vitest'
+import { CacheRing } from './CacheRing'
+
+test('renders the rounded rate in the center, without a percent sign', () => {
+  render(<CacheRing pct={73.4} color="var(--color-success-muted)" />)
+
+  const meter = screen.getByRole('meter', { name: 'CACHE' })
+
+  expect(within(meter).getByText('73')).toBeInTheDocument()
+  expect(within(meter).queryByText('%')).not.toBeInTheDocument()
+})
+
+test('exposes the rounded rate as the meter value', () => {
+  render(<CacheRing pct={73.6} color="var(--color-success-muted)" />)
+
+  const meter = screen.getByRole('meter', { name: 'CACHE' })
+
+  expect(meter).toHaveAttribute('aria-valuenow', '74')
+  expect(meter).toHaveAttribute('aria-valuemin', '0')
+  expect(meter).toHaveAttribute('aria-valuemax', '100')
+})
+
+test('clamps percent into [0, 100] without throwing', () => {
+  const { rerender } = render(
+    <CacheRing pct={-5} color="var(--color-tertiary)" />
+  )
+
+  expect(screen.getByRole('meter', { name: 'CACHE' })).toHaveAttribute(
+    'aria-valuenow',
+    '0'
+  )
+
+  rerender(<CacheRing pct={142} color="var(--color-success-muted)" />)
+
+  expect(screen.getByRole('meter', { name: 'CACHE' })).toHaveAttribute(
+    'aria-valuenow',
+    '100'
+  )
+})
+
+test('tints the progress arc with the provided tone color', () => {
+  render(<CacheRing pct={80} color="var(--color-success-muted)" />)
+
+  expect(screen.getByTestId('cache-ring-arc')).toHaveAttribute(
+    'stroke',
+    'var(--color-success-muted)'
+  )
+})
+
+test('draws a complete arc at 100% (zero dash offset)', () => {
+  render(<CacheRing pct={100} color="var(--color-success-muted)" />)
+
+  expect(screen.getByTestId('cache-ring-arc')).toHaveAttribute(
+    'stroke-dashoffset',
+    '0'
+  )
+})
+
+test('draws an empty arc at 0% (offset equals the full circumference)', () => {
+  render(<CacheRing pct={0} color="var(--color-tertiary)" />)
+
+  const arc = screen.getByTestId('cache-ring-arc')
+
+  expect(arc.getAttribute('stroke-dashoffset')).toBe(
+    arc.getAttribute('stroke-dasharray')
+  )
+})
+
+test('reveals the current cache rate in a tooltip on hover', async () => {
+  const user = userEvent.setup()
+
+  render(<CacheRing pct={73} color="var(--color-success-muted)" />)
+
+  await user.hover(screen.getByRole('meter', { name: 'CACHE' }))
+
+  expect(await screen.findByText('Current cache rate: 73%')).toBeInTheDocument()
+})

--- a/src/features/agent-status/components/CacheRing.tsx
+++ b/src/features/agent-status/components/CacheRing.tsx
@@ -1,0 +1,76 @@
+import type { ReactElement } from 'react'
+import { Tooltip } from '@/components/Tooltip'
+
+export interface CacheRingProps {
+  pct: number
+  color: string
+}
+
+const SIZE = 30
+const STROKE = 3.5
+const RADIUS = (SIZE - STROKE) / 2
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS
+
+// Collapsed-rail cache hit-rate gauge. Cache is a *ratio* (higher = better),
+// so it reads as a donut ring — a deliberately different shape from the CTX
+// liquid bar directly above it, which is a *level* (fuller = worse). The
+// rounded percent sits in the middle; the "%" sign is dropped because the ring
+// shape already signals "rate", and the meaning is carried by the tooltip.
+// Exposed to assistive tech as role="meter"; the SVG is decorative.
+export const CacheRing = ({ pct, color }: CacheRingProps): ReactElement => {
+  const clamped = Math.max(0, Math.min(100, pct))
+  const rounded = Math.round(clamped)
+  const offset = CIRCUMFERENCE - (clamped / 100) * CIRCUMFERENCE
+
+  return (
+    <Tooltip content={`Current cache rate: ${rounded}%`} placement="left">
+      <div
+        role="meter"
+        aria-label="CACHE"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={rounded}
+        className="relative"
+        style={{ width: SIZE, height: SIZE }}
+      >
+        <svg
+          width={SIZE}
+          height={SIZE}
+          viewBox={`0 0 ${SIZE} ${SIZE}`}
+          aria-hidden="true"
+          className="block"
+          style={{ transform: 'rotate(-90deg)' }}
+        >
+          <circle
+            cx={SIZE / 2}
+            cy={SIZE / 2}
+            r={RADIUS}
+            fill="none"
+            stroke="color-mix(in srgb, var(--color-outline-variant) 45%, transparent)"
+            strokeWidth={STROKE}
+          />
+          <circle
+            data-testid="cache-ring-arc"
+            cx={SIZE / 2}
+            cy={SIZE / 2}
+            r={RADIUS}
+            fill="none"
+            stroke={color}
+            strokeWidth={STROKE}
+            strokeLinecap="round"
+            strokeDasharray={CIRCUMFERENCE}
+            strokeDashoffset={offset}
+            style={{
+              filter: `drop-shadow(0 0 3px color-mix(in srgb, ${color} 53%, transparent))`,
+              transition: 'stroke-dashoffset 360ms ease',
+            }}
+          />
+        </svg>
+
+        <span className="absolute inset-0 grid place-items-center font-display text-[9.5px] font-semibold leading-none tracking-[-0.02em] tabular-nums text-on-surface">
+          {rounded}
+        </span>
+      </div>
+    </Tooltip>
+  )
+}


### PR DESCRIPTION
## What

Migrates the **collapsed activity rail's** cache hit-rate indicator from the liquid "tank" bar to a **donut ring** (`CacheRing`).

Cache hit rate is a *ratio* (higher = better), so a fill-level bar — sitting directly under the CTX *level* bar — read as the same kind of meter, making a near-full (good) cache look as alarming as a near-full (bad) context. A ring breaks that visual rhyme: different shape → different mental model. The rounded percent sits in the ring's center; the `%` sign is dropped because the shape already signals "rate".

Per the design discussion, the textual context lives in the **tooltip** (`Current cache rate: N%`) rather than a visible caption, so the rail ring stays clean.

## Changes

- **New `CacheRing.tsx`** — 30px SVG donut: muted track + tone arc filling clockwise from 12 o'clock, integer centered, `role="meter"` with `aria-value*` for parity with the old meter, wrapped in the shared `Tooltip`.
- **`AgentStatusRail.tsx`** — the cache branch renders `<CacheRing>` instead of `<RailMeter>`. Tone still flows through the existing rail `cacheTone` (`success-muted` / `primary` / `tertiary`).
- Visible `CACHE` caption dropped — the label now lives in the tooltip + the meter's accessible name.

## Intentionally untouched

- **CTX** stays a liquid bar — it *is* a level, so the bar metaphor is correct; the bar↔ring contrast is the whole point.
- The **expanded Token Cache card** is unchanged.

## Implementation notes

Adapted from a standalone prototype handoff; three things couldn't drop in verbatim and were translated to repo conventions:
- native `title=` → shared `Tooltip` (native `title` is banned by `react/forbid-dom-props`);
- glow `${color}88` (invalid with CSS-var colors + fails `no-hardcoded-colors`) → `color-mix(in srgb, ${color} 53%, transparent)` — the same pattern `LiquidFill` already uses;
- track `rgba(var(--vf-outline-rgb)…)` → `color-mix(… var(--color-outline-variant) 45% …)`.

## Test plan

- TDD: new `CacheRing.test.tsx` (centered integer / no `%`, meter value + clamping, arc tone, arc fill at 0% & 100%, tooltip-on-hover) + updated `AgentStatusRail.test.tsx` (tone via arc stroke, ring-not-bar, caption-dropped).
- `CacheRing` 7/7, `AgentStatusRail` 12/12, full agent-status feature **511/511**.
- Repo-wide gate green: `eslint .`, `tsc -b` (+ electron), `prettier --check`.
- Full `vitest run`: **4019 passed / 3 skipped / 1 failed** — the one failure is the pre-existing `editorFileLifecycleStatus` home-path casing test (unrelated, in `src/features/workspace/utils/`, macOS-local-only, green on CI).
- Visually verified the real component (rail in situ + tone strip) against live theme tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
