### PR TITLE
feat(settings): open settings in native window

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -59,7 +59,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 93       | 26   | 2026-06-16   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 76       | 28   | 2026-06-19   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
-| [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 68       | 22   | 2026-06-20   |
+| [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 70       | 22   | 2026-06-20   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)                                       | backend            | 2        | 1    | 2026-05-20   |
 | [Command Injection](patterns/command-injection.md)                                                   | security           | 8        | 4    | 2026-06-14   |
 | [Policy Judge Hygiene](patterns/policy-judge-hygiene.md)                                             | security           | 15       | 2    | 2026-04-20   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -44,7 +44,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | Pattern                                                                                              | Category           | Findings | Refs | Last Updated |
 | ---------------------------------------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md)                                                     | security           | 23       | 4    | 2026-06-15   |
-| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 39       | 17   | 2026-06-19   |
+| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 40       | 17   | 2026-06-20   |
 | [React Key Stability](patterns/react-key-stability.md)                                               | react-patterns     | 3        | 1    | 2026-06-19   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 14       | 12   | 2026-06-13   |
@@ -59,7 +59,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 93       | 26   | 2026-06-16   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 76       | 28   | 2026-06-19   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
-| [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 67       | 22   | 2026-06-14   |
+| [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 68       | 22   | 2026-06-20   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)                                       | backend            | 2        | 1    | 2026-05-20   |
 | [Command Injection](patterns/command-injection.md)                                                   | security           | 8        | 4    | 2026-06-14   |
 | [Policy Judge Hygiene](patterns/policy-judge-hygiene.md)                                             | security           | 15       | 2    | 2026-04-20   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -50,7 +50,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 14       | 12   | 2026-06-13   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)                                             | cross-platform     | 7        | 3    | 2026-06-15   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                                                       | code-quality       | 7        | 0    | 2026-06-11   |
-| [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 11       | 8    | 2026-06-15   |
+| [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 12       | 8    | 2026-06-20   |
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 1        | 0    | 2026-06-09   |
@@ -76,7 +76,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 20       | 7    | 2026-06-15   |
 | [Module Boundaries](patterns/module-boundaries.md)                                                   | code-quality       | 18       | 3    | 2026-06-18   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 11       | 3    | 2026-06-12   |
-| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 36       | 5    | 2026-06-19   |
+| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 37       | 5    | 2026-06-20   |
 | [Verify Render Target](patterns/verify-render-target.md)                                             | code-quality       | 2        | 0    | 2026-05-24   |
 | [UI Visual Regression](patterns/ui-visual-regression.md)                                             | code-quality       | 9        | 4    | 2026-06-13   |
 | [Status Indicator Display](patterns/status-indicator-display.md)                                     | code-quality       | 3        | 0    | 2026-05-26   |

--- a/docs/reviews/patterns/async-race-conditions.md
+++ b/docs/reviews/patterns/async-race-conditions.md
@@ -2,7 +2,7 @@
 id: async-race-conditions
 category: react-patterns
 created: 2026-04-09
-last_updated: 2026-06-14
+last_updated: 2026-06-20
 ref_count: 22
 ---
 
@@ -677,3 +677,12 @@ prevent showing previous data.
 - **Finding:** The component initialized `aliases` with `DEFAULT_ALIASES`, but the backend returns `[]` when `aliases.toml` is missing. First-launch users saw defaults briefly before the list collapsed to empty; returning users also saw defaults before their real aliases arrived.
 - **Fix:** Initialize `aliases` to `[]` with an explicit `isInitializing` loading state. Defaults are now used only as an intentional fallback when the aliases bridge is absent or when the backend load fails. Added tests verifying no default flash during a slow load and that controls remain disabled until hydration completes.
 - **Commit:** same commit as this entry
+
+### 67. Hydrated settings snapshot rebroadcasts stale disk state as a renderer edit
+
+- **Source:** github-codex-connector | PR #577 round 1 | 2026-06-20
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/settings/SettingsProvider.tsx`
+- **Finding:** A newly mounted settings renderer loaded settings from disk and immediately synced that hydration snapshot back to the main process. The main process broadcast that snapshot as `settings:changed`, so a stale disk value could overwrite a newer in-memory edit in another renderer while the async save queue was still pending.
+- **Fix:** Stopped syncing load hydration snapshots to the main process. Explicit user updates still sync the in-memory snapshot immediately before the queued save, preserving the last-window-close race guard without treating disk hydration as an authoritative cross-renderer edit.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/async-race-conditions.md
+++ b/docs/reviews/patterns/async-race-conditions.md
@@ -686,3 +686,21 @@ prevent showing previous data.
 - **Finding:** A newly mounted settings renderer loaded settings from disk and immediately synced that hydration snapshot back to the main process. The main process broadcast that snapshot as `settings:changed`, so a stale disk value could overwrite a newer in-memory edit in another renderer while the async save queue was still pending.
 - **Fix:** Stopped syncing load hydration snapshots to the main process. Explicit user updates still sync the in-memory snapshot immediately before the queued save, preserving the last-window-close race guard without treating disk hydration as an authoritative cross-renderer edit.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 69. Settings snapshot echo can overwrite the sender's newer local merge base
+
+- **Source:** github-claude | PR #577 round 2 | 2026-06-20
+- **Severity:** HIGH
+- **File:** `electron/main.ts`
+- **Finding:** The settings sync handler broadcast every valid settings snapshot to all windows, including the renderer that just submitted it. A stale IPC echo could write an older snapshot back into the sender's `settingsRef.current`, making the next rapid settings update merge on the wrong base and drop an intermediate change.
+- **Fix:** Pass the originating `WebContents` from the IPC event into the settings broadcast helper and skip that sender when publishing `settings:changed`. Other windows still receive the live update, but the local renderer keeps its current in-memory edit sequence.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 70. Pre-ready singleton window reopen bypasses hidden-until-ready loading guard
+
+- **Source:** github-claude | PR #577 round 2 | 2026-06-20
+- **Severity:** MEDIUM
+- **File:** `electron/settings-window.ts`
+- **Finding:** The settings window singleton was assigned before `ready-to-show`, but repeated `open()` calls unconditionally called `show()` and `focus()` on the existing window. A rapid second open could therefore reveal the still-loading BrowserWindow despite the initial `show: false` guard.
+- **Fix:** Track whether the singleton has reached `ready-to-show`; repeated opens only restore/show/focus once that flag is true, while the original `ready-to-show` handler remains responsible for the first reveal. Regression coverage now asserts a second pre-ready `open()` does not call `show()`.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/derived-state-consistency.md
+++ b/docs/reviews/patterns/derived-state-consistency.md
@@ -2,7 +2,7 @@
 id: derived-state-consistency
 category: code-quality
 created: 2026-06-07
-last_updated: 2026-06-15
+last_updated: 2026-06-20
 ref_count: 8
 ---
 
@@ -148,4 +148,13 @@ base data is technically "correct."
 - **File:** `src/features/command-palette/hooks/useVimLeaderChords.ts` L79-93
 - **Finding:** `cycleNextPane` advanced through `session.panes` directly. In an over-capacity layout (e.g. three panes in a two-slot `vsplit`), pressing the leader `w` chord could focus a hidden pane. `selectVisiblePanes` would then rescue that pane into the last visible slot, evicting the pane that was already there and causing a visible layout jump. This also made `w` inconsistent with the directional `h`/`j`/`k`/`l` chords, which already resolved against the visible-slot subset.
 - **Fix:** Derived the current layout shape from `LAYOUTS[session.layout]`, guarded the `undefined` case, computed `visiblePanes = selectVisiblePanes(session.panes, shape.capacity)`, and cycled within the visible array before activating `visiblePanes[next].id`. Added an over-capacity regression test verifying that `w` wraps within the visible subset rather than jumping to a hidden pane.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 12. Native settings window updates did not refresh workspace settings state
+
+- **Source:** github-codex-connector | PR #577 round 1 | 2026-06-20
+- **Severity:** P2 / MEDIUM
+- **File:** `src/App.tsx`
+- **Finding:** The workspace and native settings window each mounted their own `SettingsProvider`. Updates made in the native window saved to disk and changed that renderer's context, but the workspace provider kept its old in-memory settings until reload, leaving live keymap and command-palette behavior stale.
+- **Fix:** Added a `settings:changed` Electron broadcast from the existing settings snapshot sync path, exposed `settings.onDidChange` through preload, and subscribed `SettingsProvider` to apply remote snapshots without re-saving them. Added provider/preload coverage for the cross-renderer update path.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/keyboard-shortcut-guards.md
+++ b/docs/reviews/patterns/keyboard-shortcut-guards.md
@@ -2,7 +2,7 @@
 id: keyboard-shortcut-guards
 category: keyboard-shortcuts
 created: 2026-05-18
-last_updated: 2026-06-19
+last_updated: 2026-06-20
 ref_count: 11
 ---
 
@@ -460,4 +460,13 @@ against three classes of false-fire:
 - **File:** `src/features/settings/components/SettingsSidebar.tsx` L43-43
 - **Finding:** The search input's ArrowDown/ArrowUp/Enter handlers always called `preventDefault()` and repurposed those keys for settings navigation. When a user types with a CJK/IME input method active, those same keys are used to choose or commit composition candidates, so the custom handlers interrupted composing text.
 - **Fix:** Added an early return in `handleSearchKeyDown` when `event.nativeEvent.isComposing` is true, before the Arrow/Enter branches. Added a co-located test firing composing keydown events to confirm navigation/confirmation callbacks are not invoked during composition.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 37. Settings toggle shortcut could not close the fallback modal after native IPC failed
+
+- **Source:** github-claude | PR #577 round 1 | 2026-06-20
+- **Severity:** MEDIUM
+- **File:** `src/features/settings/hooks/useSettingsDialog.ts`
+- **Finding:** `toggle()` always delegated to `openNativeWindow()` when the Electron bridge existed, even while the fallback modal was already open because a previous native-window open failed. A second Cmd/Ctrl+Comma press retried the failing IPC path and returned early instead of closing the modal.
+- **Fix:** Guarded native-window delegation with `!isOpenRef.current` so the shortcut only opens through Electron when closed, then falls through to the normal state toggle when the fallback modal is open. Added a hook regression test that verifies the second toggle closes the fallback modal without another IPC call.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/react-lifecycle.md
+++ b/docs/reviews/patterns/react-lifecycle.md
@@ -2,7 +2,7 @@
 id: react-lifecycle
 category: react-patterns
 created: 2026-04-09
-last_updated: 2026-06-19
+last_updated: 2026-06-20
 ref_count: 17
 ---
 
@@ -364,4 +364,13 @@ to avoid unintended re-runs (e.g., PTY respawning on every cwd change).
 - **File:** `src/features/settings/SettingsDialog.tsx` L96-103
 - **Finding:** `SettingsDialog` called `searchSettings({ sections: SETTINGS_SECTIONS, targets: SETTINGS_TARGETS, query })` directly in the render body, so navigation, focus state, and selection updates reran the full scoring, sorting, and map construction even when `query` was unchanged.
 - **Fix:** Wrapped the `searchSettings` call in `useMemo` with `[query]` as its dependency so the search model is only recomputed when the query changes.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 37. Settings toggle callback reads a ref declared later in the component body
+
+- **Source:** github-claude | PR #577 round 1 | 2026-06-20
+- **Severity:** LOW
+- **File:** `src/features/settings/hooks/useSettingsDialog.ts`
+- **Finding:** The `toggle` callback closed over `isOpenRef` before the `const isOpenRef = useRef(isOpen)` declaration appeared in the component body. Runtime behavior was safe because the callback is not invoked during render, but the forward reference creates a temporal-dead-zone footgun for future synchronous invocation changes.
+- **Fix:** Moved the `isOpenRef` declaration above the callbacks that read it so hook-local refs are declared before dependent closures.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/electron/ipc-channels.ts
+++ b/electron/ipc-channels.ts
@@ -13,4 +13,6 @@ export const KEYMAP_CAPTURE_ACTIVE = 'keymap:capture-active'
 
 export const SETTINGS_OPEN_FILE = 'settings:open-file'
 
+export const SETTINGS_OPEN_WINDOW = 'settings:open-window'
+
 export const SETTINGS_SYNC_SNAPSHOT = 'settings:sync-snapshot'

--- a/electron/ipc-channels.ts
+++ b/electron/ipc-channels.ts
@@ -16,3 +16,5 @@ export const SETTINGS_OPEN_FILE = 'settings:open-file'
 export const SETTINGS_OPEN_WINDOW = 'settings:open-window'
 
 export const SETTINGS_SYNC_SNAPSHOT = 'settings:sync-snapshot'
+
+export const SETTINGS_CHANGED = 'settings:changed'

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -6,6 +6,7 @@ import {
   protocol,
   session,
   shell,
+  type WebContents,
 } from 'electron'
 import { readFileSync } from 'node:fs'
 import { access } from 'node:fs/promises'
@@ -275,8 +276,15 @@ const isAppSettings = (value: unknown): value is AppSettings =>
   typeof value.agentShimEnabled === 'boolean' &&
   isStringRecord(value.customKeybindings)
 
-const broadcastSettingsChanged = (settings: AppSettings): void => {
+const broadcastSettingsChanged = (
+  settings: AppSettings,
+  senderWebContents: WebContents
+): void => {
   for (const win of BrowserWindow.getAllWindows()) {
+    if (win.webContents === senderWebContents) {
+      continue
+    }
+
     win.webContents.send(SETTINGS_CHANGED, settings)
   }
 }
@@ -601,7 +609,7 @@ const setupApp = async (): Promise<void> => {
 
   ipcMain.handle(
     SETTINGS_SYNC_SNAPSHOT,
-    (_ipcEvent, settings: unknown): void => {
+    (ipcEvent, settings: unknown): void => {
       if (
         isRecord(settings) &&
         typeof settings.onLastWindowClosed === 'string'
@@ -610,7 +618,7 @@ const setupApp = async (): Promise<void> => {
       }
 
       if (isAppSettings(settings)) {
-        broadcastSettingsChanged(settings)
+        broadcastSettingsChanged(settings, ipcEvent.sender)
       }
     }
   )

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -31,10 +31,12 @@ import {
   COMMAND_PALETTE_BINDING,
   KEYMAP_CAPTURE_ACTIVE,
   SETTINGS_OPEN_FILE,
+  SETTINGS_OPEN_WINDOW,
   SETTINGS_SYNC_SNAPSHOT,
 } from './ipc-channels'
 import { spawnSidecar, type Sidecar } from './sidecar'
 import { setupBrowserPaneIpc, type BrowserPaneController } from './browser-pane'
+import { SettingsWindowController } from './settings-window'
 import {
   setupWorkspaceLayoutController,
   type WorkspaceLayoutController,
@@ -237,6 +239,8 @@ let sidecar: Sidecar | null = null
 let browserPaneController: BrowserPaneController | null = null
 let workspaceLayoutController: WorkspaceLayoutController | null = null
 let workspaceTeardown: WorkspaceTeardown | null = null
+let workspaceWindow: BrowserWindow | null = null
+let settingsWindowController: SettingsWindowController | null = null
 let quitting = false
 let lastKnownOnLastWindowClosed: string | undefined
 
@@ -314,7 +318,20 @@ const isBackendInvokePayload = (
   return payload.args === undefined || isRecord(payload.args)
 }
 
-const createWindow = (): void => {
+const openExternalUrl = (url: string): void => {
+  const open = async (): Promise<void> => {
+    try {
+      await shell.openExternal(url)
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.warn('Failed to open external URL', url, error)
+    }
+  }
+
+  void open()
+}
+
+const createWindow = (): BrowserWindow => {
   const win = new BrowserWindow({
     width: 1400,
     height: 900,
@@ -330,6 +347,7 @@ const createWindow = (): void => {
       preload: path.join(__dirname, 'preload.mjs'),
     },
   })
+  workspaceWindow = win
 
   // Re-arm the teardown flush for this window's lifecycle (spec §3.2).
   workspaceTeardown?.reset()
@@ -355,36 +373,33 @@ const createWindow = (): void => {
     })()
   })
 
+  win.on('closed', () => {
+    if (workspaceWindow === win) {
+      workspaceWindow = null
+    }
+  })
+
   installRendererDiagnosticLogging(win)
   installCommandPaletteShortcutOverride(win)
-  installNavigationGuard(win, (url) => {
-    const openExternalUrl = async (): Promise<void> => {
-      try {
-        await shell.openExternal(url)
-      } catch (error) {
-        // eslint-disable-next-line no-console
-        console.warn('Failed to open external URL', url, error)
-      }
-    }
-
-    void openExternalUrl()
-  })
+  installNavigationGuard(win, openExternalUrl)
 
   const devUrl = process.env.VITE_DEV_SERVER_URL
 
   if (app.isPackaged) {
     void win.loadURL(`${APP_ORIGIN}/index.html`)
 
-    return
+    return win
   }
 
   if (devUrl !== undefined && devUrl.length > 0) {
     void win.loadURL(devUrl)
 
-    return
+    return win
   }
 
   void win.loadFile(path.join(__dirname, '..', 'dist', 'index.html'))
+
+  return win
 }
 
 const setupApp = async (): Promise<void> => {
@@ -430,8 +445,8 @@ const setupApp = async (): Promise<void> => {
 
   workspaceTeardown = new WorkspaceTeardown({
     drainFinalShape: async (): Promise<void> => {
-      const win = BrowserWindow.getAllWindows().at(0)
-      if (win && !win.webContents.isDestroyed()) {
+      const win = workspaceWindow
+      if (win && !win.isDestroyed() && !win.webContents.isDestroyed()) {
         await workspaceLayoutController?.requestFinalShape(win.webContents)
       }
     },
@@ -537,6 +552,23 @@ const setupApp = async (): Promise<void> => {
     }
   })
 
+  settingsWindowController = new SettingsWindowController({
+    createWindow: (options): BrowserWindow => new BrowserWindow(options),
+    location: {
+      appOrigin: APP_ORIGIN,
+      isPackaged: app.isPackaged,
+      rendererDistDir: path.resolve(__dirname, '..', 'dist'),
+      devServerUrl: process.env.VITE_DEV_SERVER_URL,
+    },
+    preloadPath: path.join(__dirname, 'preload.mjs'),
+    openExternalUrl,
+    onRendererDiagnostics: installRendererDiagnosticLogging,
+  })
+
+  ipcMain.handle(SETTINGS_OPEN_WINDOW, (): void => {
+    settingsWindowController?.open()
+  })
+
   ipcMain.handle(
     SETTINGS_SYNC_SNAPSHOT,
     (_ipcEvent, settings: unknown): void => {
@@ -631,7 +663,12 @@ app.on('window-all-closed', () => {
 })
 
 app.on('activate', () => {
-  if (BrowserWindow.getAllWindows().length === 0) {
+  if (workspaceWindow === null || workspaceWindow.isDestroyed()) {
     createWindow()
+
+    return
   }
+
+  workspaceWindow.show()
+  workspaceWindow.focus()
 })

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -30,6 +30,7 @@ import {
   BACKEND_INVOKE,
   COMMAND_PALETTE_BINDING,
   KEYMAP_CAPTURE_ACTIVE,
+  SETTINGS_CHANGED,
   SETTINGS_OPEN_FILE,
   SETTINGS_OPEN_WINDOW,
   SETTINGS_SYNC_SNAPSHOT,
@@ -251,6 +252,34 @@ const RENDERER_DIAGNOSTIC_PREFIXES = [
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const isStringRecord = (value: unknown): value is Record<string, string> =>
+  isRecord(value) &&
+  Object.values(value).every((entry) => typeof entry === 'string')
+
+const isAppSettings = (value: unknown): value is AppSettings =>
+  isRecord(value) &&
+  typeof value.version === 'number' &&
+  typeof value.closeWithNoTabs === 'string' &&
+  typeof value.onLastWindowClosed === 'string' &&
+  typeof value.useSystemPathPrompts === 'boolean' &&
+  typeof value.useSystemPrompts === 'boolean' &&
+  typeof value.redactPrivateValues === 'boolean' &&
+  typeof value.cliOpenBehavior === 'string' &&
+  typeof value.aesthetic === 'string' &&
+  typeof value.accentHue === 'number' &&
+  typeof value.density === 'string' &&
+  typeof value.uiFont === 'string' &&
+  typeof value.monoFont === 'string' &&
+  typeof value.keymapPreset === 'string' &&
+  typeof value.agentShimEnabled === 'boolean' &&
+  isStringRecord(value.customKeybindings)
+
+const broadcastSettingsChanged = (settings: AppSettings): void => {
+  for (const win of BrowserWindow.getAllWindows()) {
+    win.webContents.send(SETTINGS_CHANGED, settings)
+  }
+}
 
 // Mirrors isStructuredBackendError in src/lib/backend.ts; keep in sync manually.
 const isStructuredBackendError = (
@@ -578,6 +607,10 @@ const setupApp = async (): Promise<void> => {
         typeof settings.onLastWindowClosed === 'string'
       ) {
         lastKnownOnLastWindowClosed = settings.onLastWindowClosed
+      }
+
+      if (isAppSettings(settings)) {
+        broadcastSettingsChanged(settings)
       }
     }
   )

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -563,6 +563,7 @@ const setupApp = async (): Promise<void> => {
     preloadPath: path.join(__dirname, 'preload.mjs'),
     openExternalUrl,
     onRendererDiagnostics: installRendererDiagnosticLogging,
+    windowChromeOptions: macosWindowChromeOptions,
   })
 
   ipcMain.handle(SETTINGS_OPEN_WINDOW, (): void => {

--- a/electron/preload.test.ts
+++ b/electron/preload.test.ts
@@ -17,7 +17,11 @@ import {
   BROWSER_PANE_TABS_CHANGED,
   BROWSER_PANE_URL_CHANGED,
 } from './browser-pane-channels'
-import { COMMAND_PALETTE_BINDING, COMMAND_PALETTE_TOGGLE } from './ipc-channels'
+import {
+  COMMAND_PALETTE_BINDING,
+  COMMAND_PALETTE_TOGGLE,
+  SETTINGS_OPEN_WINDOW,
+} from './ipc-channels'
 import './preload'
 
 const electronMock = vi.hoisted(() => {
@@ -117,6 +121,18 @@ describe('preload browserPane wiring', () => {
         palette: 'Mod+KeyP',
         leader: 'Mod+KeyK',
       }
+    )
+  })
+
+  test('settings.openWindow invokes the native settings window channel', async () => {
+    const settings = preloadApi().settings as {
+      openWindow: () => Promise<void>
+    }
+
+    await settings.openWindow()
+
+    expect(electronMock.ipcRenderer.invoke).toHaveBeenCalledWith(
+      SETTINGS_OPEN_WINDOW
     )
   })
 

--- a/electron/preload.test.ts
+++ b/electron/preload.test.ts
@@ -20,6 +20,7 @@ import {
 import {
   COMMAND_PALETTE_BINDING,
   COMMAND_PALETTE_TOGGLE,
+  SETTINGS_CHANGED,
   SETTINGS_OPEN_WINDOW,
 } from './ipc-channels'
 import './preload'
@@ -133,6 +134,33 @@ describe('preload browserPane wiring', () => {
 
     expect(electronMock.ipcRenderer.invoke).toHaveBeenCalledWith(
       SETTINGS_OPEN_WINDOW
+    )
+  })
+
+  test('settings.onDidChange forwards settings broadcasts', () => {
+    const settings = preloadApi().settings as {
+      onDidChange: (callback: (settings: unknown) => void) => () => void
+    }
+    const callback = vi.fn()
+
+    const unlisten = settings.onDidChange(callback)
+
+    const handler = electronMock.ipcRenderer.on.mock.calls.find(
+      ([channel]) => channel === SETTINGS_CHANGED
+    )?.[1] as ((event: unknown, settings: unknown) => void) | undefined
+
+    if (handler === undefined) {
+      throw new Error('settings listener was not registered')
+    }
+
+    const next = { version: 1, onLastWindowClosed: 'quit' }
+    handler({}, next)
+    unlisten()
+
+    expect(callback).toHaveBeenCalledWith(next)
+    expect(electronMock.ipcRenderer.off).toHaveBeenCalledWith(
+      SETTINGS_CHANGED,
+      handler
     )
   })
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -6,6 +6,7 @@ import {
   COMMAND_PALETTE_TOGGLE,
   KEYMAP_CAPTURE_ACTIVE,
   SETTINGS_OPEN_FILE,
+  SETTINGS_OPEN_WINDOW,
   SETTINGS_SYNC_SNAPSHOT,
 } from './ipc-channels'
 import type { AgentAlias } from '../src/bindings/AgentAlias'
@@ -243,6 +244,7 @@ contextBridge.exposeInMainWorld('vimeflow', {
     save: (settings: AppSettings): Promise<void> =>
       invoke('save_app_settings', { settings }),
     openFile: (): Promise<void> => ipcRenderer.invoke(SETTINGS_OPEN_FILE),
+    openWindow: (): Promise<void> => ipcRenderer.invoke(SETTINGS_OPEN_WINDOW),
     syncSnapshot: (settings: AppSettings): Promise<void> =>
       ipcRenderer.invoke(SETTINGS_SYNC_SNAPSHOT, settings),
   },

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -5,6 +5,7 @@ import {
   COMMAND_PALETTE_BINDING,
   COMMAND_PALETTE_TOGGLE,
   KEYMAP_CAPTURE_ACTIVE,
+  SETTINGS_CHANGED,
   SETTINGS_OPEN_FILE,
   SETTINGS_OPEN_WINDOW,
   SETTINGS_SYNC_SNAPSHOT,
@@ -247,6 +248,20 @@ contextBridge.exposeInMainWorld('vimeflow', {
     openWindow: (): Promise<void> => ipcRenderer.invoke(SETTINGS_OPEN_WINDOW),
     syncSnapshot: (settings: AppSettings): Promise<void> =>
       ipcRenderer.invoke(SETTINGS_SYNC_SNAPSHOT, settings),
+    onDidChange: (callback: (settings: AppSettings) => void): (() => void) => {
+      const handler = (
+        _event: IpcRendererEvent,
+        settings: AppSettings
+      ): void => {
+        callback(settings)
+      }
+
+      ipcRenderer.on(SETTINGS_CHANGED, handler)
+
+      return (): void => {
+        ipcRenderer.off(SETTINGS_CHANGED, handler)
+      }
+    },
   },
   aliases: {
     load: (): Promise<AgentAlias[]> => invoke('load_agent_aliases'),

--- a/electron/settings-window.test.ts
+++ b/electron/settings-window.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, test, vi } from 'vitest'
+import type { BrowserWindow, BrowserWindowConstructorOptions } from 'electron'
+import { SettingsWindowController, settingsWindowUrl } from './settings-window'
+
+type WindowEventName = 'closed' | 'ready-to-show'
+
+class FakeSettingsWindow {
+  readonly webContents = {
+    getURL: vi.fn(() => 'vimeflow://app/index.html?window=settings'),
+    on: vi.fn(),
+    setWindowOpenHandler: vi.fn(),
+  }
+
+  readonly focus = vi.fn()
+  readonly loadURL = vi.fn(() => Promise.resolve())
+  readonly restore = vi.fn()
+  readonly show = vi.fn()
+
+  private readonly handlers = new Map<WindowEventName, (() => void)[]>()
+  private destroyed = false
+  private minimized = false
+
+  constructor(readonly options: BrowserWindowConstructorOptions) {}
+
+  isDestroyed(): boolean {
+    return this.destroyed
+  }
+
+  isMinimized(): boolean {
+    return this.minimized
+  }
+
+  markDestroyed(): void {
+    this.destroyed = true
+  }
+
+  markMinimized(): void {
+    this.minimized = true
+  }
+
+  on(event: WindowEventName, handler: () => void): void {
+    this.handlers.set(event, [...(this.handlers.get(event) ?? []), handler])
+  }
+
+  once(event: WindowEventName, handler: () => void): void {
+    const onceHandler = (): void => {
+      this.handlers.set(
+        event,
+        (this.handlers.get(event) ?? []).filter((h) => h !== onceHandler)
+      )
+      handler()
+    }
+
+    this.on(event, onceHandler)
+  }
+
+  emit(event: WindowEventName): void {
+    for (const handler of this.handlers.get(event) ?? []) {
+      handler()
+    }
+  }
+}
+
+const location = {
+  appOrigin: 'vimeflow://app',
+  isPackaged: false,
+  rendererDistDir: '/app/dist',
+}
+
+describe('settingsWindowUrl', () => {
+  test('targets the custom app protocol in packaged builds', () => {
+    expect(
+      settingsWindowUrl({
+        ...location,
+        isPackaged: true,
+      })
+    ).toBe('vimeflow://app/index.html?window=settings')
+  })
+
+  test('preserves dev server URL params while selecting the settings window', () => {
+    expect(
+      settingsWindowUrl({
+        ...location,
+        devServerUrl: 'http://localhost:5173/?foo=bar',
+      })
+    ).toBe('http://localhost:5173/?foo=bar&window=settings')
+  })
+
+  test('falls back to the built renderer file when no dev server is present', () => {
+    expect(settingsWindowUrl(location)).toBe(
+      'file:///app/dist/index.html?window=settings'
+    )
+  })
+})
+
+describe('SettingsWindowController', () => {
+  test('creates a native settings window and loads the settings renderer', () => {
+    const windows: FakeSettingsWindow[] = []
+
+    const controller = new SettingsWindowController({
+      createWindow: (options): BrowserWindow => {
+        const win = new FakeSettingsWindow(options)
+        windows.push(win)
+
+        return win as unknown as BrowserWindow
+      },
+      location,
+      preloadPath: '/dist-electron/preload.mjs',
+      openExternalUrl: vi.fn(),
+    })
+
+    controller.open()
+
+    expect(windows).toHaveLength(1)
+    expect(windows[0].options).toMatchObject({
+      title: 'Settings',
+      show: false,
+      width: 960,
+      height: 680,
+      minWidth: 720,
+      minHeight: 520,
+      webPreferences: {
+        contextIsolation: true,
+        nodeIntegration: false,
+        preload: '/dist-electron/preload.mjs',
+        sandbox: true,
+      },
+    })
+
+    expect(windows[0].loadURL).toHaveBeenCalledWith(
+      'file:///app/dist/index.html?window=settings'
+    )
+
+    windows[0].emit('ready-to-show')
+
+    expect(windows[0].show).toHaveBeenCalledTimes(1)
+  })
+
+  test('focuses the existing settings window instead of creating another one', () => {
+    const windows: FakeSettingsWindow[] = []
+
+    const controller = new SettingsWindowController({
+      createWindow: (options): BrowserWindow => {
+        const win = new FakeSettingsWindow(options)
+        windows.push(win)
+
+        return win as unknown as BrowserWindow
+      },
+      location,
+      preloadPath: '/dist-electron/preload.mjs',
+      openExternalUrl: vi.fn(),
+    })
+
+    controller.open()
+    windows[0].markMinimized()
+    controller.open()
+
+    expect(windows).toHaveLength(1)
+    expect(windows[0].restore).toHaveBeenCalledTimes(1)
+    expect(windows[0].show).toHaveBeenCalledTimes(1)
+    expect(windows[0].focus).toHaveBeenCalledTimes(1)
+  })
+
+  test('allows a new settings window after the previous one closes', () => {
+    const windows: FakeSettingsWindow[] = []
+
+    const controller = new SettingsWindowController({
+      createWindow: (options): BrowserWindow => {
+        const win = new FakeSettingsWindow(options)
+        windows.push(win)
+
+        return win as unknown as BrowserWindow
+      },
+      location,
+      preloadPath: '/dist-electron/preload.mjs',
+      openExternalUrl: vi.fn(),
+    })
+
+    controller.open()
+    windows[0].emit('closed')
+    windows[0].markDestroyed()
+    controller.open()
+
+    expect(windows).toHaveLength(2)
+  })
+})

--- a/electron/settings-window.test.ts
+++ b/electron/settings-window.test.ts
@@ -107,6 +107,10 @@ describe('SettingsWindowController', () => {
       location,
       preloadPath: '/dist-electron/preload.mjs',
       openExternalUrl: vi.fn(),
+      windowChromeOptions: {
+        titleBarStyle: 'hiddenInset',
+        trafficLightPosition: { x: 16, y: 13 },
+      },
     })
 
     controller.open()
@@ -119,6 +123,8 @@ describe('SettingsWindowController', () => {
       height: 680,
       minWidth: 720,
       minHeight: 520,
+      titleBarStyle: 'hiddenInset',
+      trafficLightPosition: { x: 16, y: 13 },
       webPreferences: {
         contextIsolation: true,
         nodeIntegration: false,

--- a/electron/settings-window.test.ts
+++ b/electron/settings-window.test.ts
@@ -158,13 +158,41 @@ describe('SettingsWindowController', () => {
     })
 
     controller.open()
+    windows[0].emit('ready-to-show')
     windows[0].markMinimized()
     controller.open()
 
     expect(windows).toHaveLength(1)
     expect(windows[0].restore).toHaveBeenCalledTimes(1)
-    expect(windows[0].show).toHaveBeenCalledTimes(1)
+    expect(windows[0].show).toHaveBeenCalledTimes(2)
     expect(windows[0].focus).toHaveBeenCalledTimes(1)
+  })
+
+  test('does not show an existing settings window before it is ready', () => {
+    const windows: FakeSettingsWindow[] = []
+
+    const controller = new SettingsWindowController({
+      createWindow: (options): BrowserWindow => {
+        const win = new FakeSettingsWindow(options)
+        windows.push(win)
+
+        return win as unknown as BrowserWindow
+      },
+      location,
+      preloadPath: '/dist-electron/preload.mjs',
+      openExternalUrl: vi.fn(),
+    })
+
+    controller.open()
+    controller.open()
+
+    expect(windows).toHaveLength(1)
+    expect(windows[0].show).not.toHaveBeenCalled()
+    expect(windows[0].focus).not.toHaveBeenCalled()
+
+    windows[0].emit('ready-to-show')
+
+    expect(windows[0].show).toHaveBeenCalledTimes(1)
   })
 
   test('allows a new settings window after the previous one closes', () => {

--- a/electron/settings-window.ts
+++ b/electron/settings-window.ts
@@ -10,6 +10,11 @@ const SETTINGS_WINDOW_MIN_HEIGHT = 520
 const SETTINGS_WINDOW_QUERY_KEY = 'window'
 const SETTINGS_WINDOW_QUERY_VALUE = 'settings'
 
+type SettingsWindowChromeOptions = Pick<
+  BrowserWindowConstructorOptions,
+  'backgroundColor' | 'titleBarStyle' | 'trafficLightPosition'
+>
+
 export interface SettingsWindowLocation {
   appOrigin: string
   isPackaged: boolean
@@ -23,6 +28,7 @@ export interface SettingsWindowControllerOptions {
   preloadPath: string
   openExternalUrl: (url: string) => void
   onRendererDiagnostics?: (win: BrowserWindow) => void
+  windowChromeOptions?: SettingsWindowChromeOptions
 }
 
 export const settingsWindowUrl = ({
@@ -79,6 +85,7 @@ export class SettingsWindowController {
       show: false,
       resizable: true,
       backgroundColor: '#121221',
+      ...this.options.windowChromeOptions,
       webPreferences: {
         contextIsolation: true,
         nodeIntegration: false,

--- a/electron/settings-window.ts
+++ b/electron/settings-window.ts
@@ -1,0 +1,108 @@
+import type { BrowserWindow, BrowserWindowConstructorOptions } from 'electron'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { installNavigationGuard } from './navigation-guard'
+
+const SETTINGS_WINDOW_WIDTH = 960
+const SETTINGS_WINDOW_HEIGHT = 680
+const SETTINGS_WINDOW_MIN_WIDTH = 720
+const SETTINGS_WINDOW_MIN_HEIGHT = 520
+const SETTINGS_WINDOW_QUERY_KEY = 'window'
+const SETTINGS_WINDOW_QUERY_VALUE = 'settings'
+
+export interface SettingsWindowLocation {
+  appOrigin: string
+  isPackaged: boolean
+  rendererDistDir: string
+  devServerUrl?: string
+}
+
+export interface SettingsWindowControllerOptions {
+  createWindow: (options: BrowserWindowConstructorOptions) => BrowserWindow
+  location: SettingsWindowLocation
+  preloadPath: string
+  openExternalUrl: (url: string) => void
+  onRendererDiagnostics?: (win: BrowserWindow) => void
+}
+
+export const settingsWindowUrl = ({
+  appOrigin,
+  isPackaged,
+  rendererDistDir,
+  devServerUrl,
+}: SettingsWindowLocation): string => {
+  if (isPackaged) {
+    const url = new URL('/index.html', appOrigin)
+    url.searchParams.set(SETTINGS_WINDOW_QUERY_KEY, SETTINGS_WINDOW_QUERY_VALUE)
+
+    return url.toString()
+  }
+
+  if (devServerUrl !== undefined && devServerUrl.length > 0) {
+    const url = new URL(devServerUrl)
+    url.searchParams.set(SETTINGS_WINDOW_QUERY_KEY, SETTINGS_WINDOW_QUERY_VALUE)
+
+    return url.toString()
+  }
+
+  const url = pathToFileURL(path.join(rendererDistDir, 'index.html'))
+  url.searchParams.set(SETTINGS_WINDOW_QUERY_KEY, SETTINGS_WINDOW_QUERY_VALUE)
+
+  return url.toString()
+}
+
+export class SettingsWindowController {
+  private settingsWindow: BrowserWindow | null = null
+
+  constructor(private readonly options: SettingsWindowControllerOptions) {}
+
+  open(): void {
+    const existing = this.settingsWindow
+
+    if (existing !== null && !existing.isDestroyed()) {
+      if (existing.isMinimized()) {
+        existing.restore()
+      }
+
+      existing.show()
+      existing.focus()
+
+      return
+    }
+
+    const win = this.options.createWindow({
+      width: SETTINGS_WINDOW_WIDTH,
+      height: SETTINGS_WINDOW_HEIGHT,
+      minWidth: SETTINGS_WINDOW_MIN_WIDTH,
+      minHeight: SETTINGS_WINDOW_MIN_HEIGHT,
+      title: 'Settings',
+      show: false,
+      resizable: true,
+      backgroundColor: '#121221',
+      webPreferences: {
+        contextIsolation: true,
+        nodeIntegration: false,
+        sandbox: true,
+        preload: this.options.preloadPath,
+      },
+    })
+
+    this.settingsWindow = win
+    this.options.onRendererDiagnostics?.(win)
+    installNavigationGuard(win, this.options.openExternalUrl)
+
+    win.once('ready-to-show', () => {
+      if (!win.isDestroyed()) {
+        win.show()
+      }
+    })
+
+    win.on('closed', () => {
+      if (this.settingsWindow === win) {
+        this.settingsWindow = null
+      }
+    })
+
+    void win.loadURL(settingsWindowUrl(this.options.location))
+  }
+}

--- a/electron/settings-window.ts
+++ b/electron/settings-window.ts
@@ -59,6 +59,7 @@ export const settingsWindowUrl = ({
 
 export class SettingsWindowController {
   private settingsWindow: BrowserWindow | null = null
+  private isReady = false
 
   constructor(private readonly options: SettingsWindowControllerOptions) {}
 
@@ -70,8 +71,10 @@ export class SettingsWindowController {
         existing.restore()
       }
 
-      existing.show()
-      existing.focus()
+      if (this.isReady) {
+        existing.show()
+        existing.focus()
+      }
 
       return
     }
@@ -95,10 +98,13 @@ export class SettingsWindowController {
     })
 
     this.settingsWindow = win
+    this.isReady = false
     this.options.onRendererDiagnostics?.(win)
     installNavigationGuard(win, this.options.openExternalUrl)
 
     win.once('ready-to-show', () => {
+      this.isReady = true
+
       if (!win.isDestroyed()) {
         win.show()
       }
@@ -107,6 +113,7 @@ export class SettingsWindowController {
     win.on('closed', () => {
       if (this.settingsWindow === win) {
         this.settingsWindow = null
+        this.isReady = false
       }
     })
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -90,6 +90,18 @@ describe('App', () => {
     expect(screen.getByTestId('workspace-view')).toBeInTheDocument()
   })
 
+  test('renders settings content for the native settings window route', () => {
+    window.history.replaceState(null, '', '/?window=settings')
+
+    render(<App />)
+
+    expect(screen.getByRole('main', { name: 'Settings' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Appearance' })
+    ).toBeInTheDocument()
+    expect(screen.queryByTestId('workspace-view')).not.toBeInTheDocument()
+  })
+
   test('is an arrow-function component', () => {
     expect(typeof App).toBe('function')
     expect(App.prototype).toBeUndefined()

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -146,6 +146,19 @@ describe('App', () => {
       expect(screen.getByTestId('settings-window-drag-region')).toHaveClass(
         'vf-app-drag-region'
       )
+
+      expect(
+        screen.getByTestId('settings-window-sidebar-drag-region')
+      ).toHaveClass(
+        'w-[220px]',
+        'border-r',
+        'border-outline-variant/25',
+        'bg-surface-container'
+      )
+
+      expect(
+        screen.getByTestId('settings-window-content-drag-region')
+      ).toHaveClass('flex-1', 'bg-surface')
     })
   })
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -67,6 +67,41 @@ class TestWorker {
   }
 }
 
+const withNavigatorPlatform = (
+  platform: string,
+  callback: () => void
+): void => {
+  const originalNavigator = globalThis.navigator
+
+  const mockedNavigator = Object.create(originalNavigator) as Navigator & {
+    userAgentData?: { platform?: string }
+  }
+
+  Object.defineProperty(mockedNavigator, 'platform', {
+    configurable: true,
+    value: platform,
+  })
+
+  Object.defineProperty(mockedNavigator, 'userAgentData', {
+    configurable: true,
+    value: { platform },
+  })
+
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: mockedNavigator,
+  })
+
+  try {
+    callback()
+  } finally {
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: originalNavigator,
+    })
+  }
+}
+
 describe('App', () => {
   beforeAll(() => {
     vi.stubGlobal('Worker', TestWorker)
@@ -100,6 +135,18 @@ describe('App', () => {
       screen.getByRole('heading', { name: 'Appearance' })
     ).toBeInTheDocument()
     expect(screen.queryByTestId('workspace-view')).not.toBeInTheDocument()
+  })
+
+  test('reserves native macOS traffic light space in the settings window route', () => {
+    withNavigatorPlatform('MacIntel', () => {
+      window.history.replaceState(null, '', '/?window=settings')
+
+      render(<App />)
+
+      expect(screen.getByTestId('settings-window-drag-region')).toHaveClass(
+        'vf-app-drag-region'
+      )
+    })
   })
 
   test('is an arrow-function component', () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { WorkspaceView } from './features/workspace/WorkspaceView'
 import { InlineCommentDemo } from './features/diff/demo/InlineCommentDemo'
 import { ReorderMotionDemo } from './features/sessions/demo/ReorderMotionDemo'
 import { SettingsProvider } from './features/settings/SettingsProvider'
+import { SettingsContent } from './features/settings/SettingsContent'
 
 // Pierre's worker entry is exposed as a dedicated package export so Vite
 // bundles it via `new Worker(url, ...)` with the worker config in
@@ -43,13 +44,32 @@ const renderDemo = (demoName: string | null): ReactElement => {
   return <WorkspaceView />
 }
 
-const App = (): ReactElement => (
-  <WorkerPoolContextProvider
-    poolOptions={poolOptions}
-    highlighterOptions={highlighterOptions}
-  >
-    <SettingsProvider>{renderDemo(devDemoName())}</SettingsProvider>
-  </WorkerPoolContextProvider>
-)
+const isSettingsWindow = (): boolean =>
+  typeof window !== 'undefined' &&
+  new URLSearchParams(window.location.search).get('window') === 'settings'
+
+const App = (): ReactElement => {
+  if (isSettingsWindow()) {
+    return (
+      <SettingsProvider>
+        <main
+          aria-label="Settings"
+          className="flex h-screen min-h-0 bg-surface text-on-surface"
+        >
+          <SettingsContent />
+        </main>
+      </SettingsProvider>
+    )
+  }
+
+  return (
+    <WorkerPoolContextProvider
+      poolOptions={poolOptions}
+      highlighterOptions={highlighterOptions}
+    >
+      <SettingsProvider>{renderDemo(devDemoName())}</SettingsProvider>
+    </WorkerPoolContextProvider>
+  )
+}
 
 export default App

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,9 +61,18 @@ const SettingsWindowShell = (): ReactElement => {
         {reserveWindowControls && (
           <div
             aria-hidden="true"
-            className="vf-app-drag-region h-[44px] shrink-0"
+            className="vf-app-drag-region flex h-[44px] shrink-0"
             data-testid="settings-window-drag-region"
-          />
+          >
+            <div
+              className="w-[220px] shrink-0 border-r border-outline-variant/25 bg-surface-container"
+              data-testid="settings-window-sidebar-drag-region"
+            />
+            <div
+              className="min-w-0 flex-1 bg-surface"
+              data-testid="settings-window-content-drag-region"
+            />
+          </div>
         )}
         <div className="flex min-h-0 flex-1">
           <SettingsContent />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { InlineCommentDemo } from './features/diff/demo/InlineCommentDemo'
 import { ReorderMotionDemo } from './features/sessions/demo/ReorderMotionDemo'
 import { SettingsProvider } from './features/settings/SettingsProvider'
 import { SettingsContent } from './features/settings/SettingsContent'
+import { isMacPlatform } from './lib/formatShortcut'
 
 // Pierre's worker entry is exposed as a dedicated package export so Vite
 // bundles it via `new Worker(url, ...)` with the worker config in
@@ -48,18 +49,33 @@ const isSettingsWindow = (): boolean =>
   typeof window !== 'undefined' &&
   new URLSearchParams(window.location.search).get('window') === 'settings'
 
+const SettingsWindowShell = (): ReactElement => {
+  const reserveWindowControls = isMacPlatform()
+
+  return (
+    <SettingsProvider>
+      <main
+        aria-label="Settings"
+        className="flex h-screen min-h-0 flex-col bg-surface text-on-surface"
+      >
+        {reserveWindowControls && (
+          <div
+            aria-hidden="true"
+            className="vf-app-drag-region h-[44px] shrink-0"
+            data-testid="settings-window-drag-region"
+          />
+        )}
+        <div className="flex min-h-0 flex-1">
+          <SettingsContent />
+        </div>
+      </main>
+    </SettingsProvider>
+  )
+}
+
 const App = (): ReactElement => {
   if (isSettingsWindow()) {
-    return (
-      <SettingsProvider>
-        <main
-          aria-label="Settings"
-          className="flex h-screen min-h-0 bg-surface text-on-surface"
-        >
-          <SettingsContent />
-        </main>
-      </SettingsProvider>
-    )
+    return <SettingsWindowShell />
   }
 
   return (

--- a/src/features/settings/SettingsProvider.test.tsx
+++ b/src/features/settings/SettingsProvider.test.tsx
@@ -100,7 +100,7 @@ describe('SettingsProvider', () => {
     )
   })
 
-  test('syncs an in-memory snapshot to the main process on load and update', async () => {
+  test('syncs an in-memory snapshot to the main process only on update', async () => {
     const loaded = createLoadedSettings()
     const load = vi.fn().mockResolvedValue(loaded)
     const save = vi.fn().mockResolvedValue(undefined)
@@ -120,7 +120,7 @@ describe('SettingsProvider', () => {
       expect(screen.getByTestId('closeWithNoTabs').textContent).toBe('close')
     })
 
-    expect(syncSnapshot).toHaveBeenCalledWith(loaded)
+    expect(syncSnapshot).not.toHaveBeenCalled()
 
     const user = userEvent.setup()
     await user.click(screen.getByRole('button', { name: 'Update' }))
@@ -130,7 +130,7 @@ describe('SettingsProvider', () => {
     })
 
     await waitFor(() => {
-      expect(syncSnapshot).toHaveBeenLastCalledWith(
+      expect(syncSnapshot).toHaveBeenCalledWith(
         expect.objectContaining({ closeWithNoTabs: 'nothing' })
       )
     })

--- a/src/features/settings/SettingsProvider.test.tsx
+++ b/src/features/settings/SettingsProvider.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi, afterEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ReactElement } from 'react'
 import type { AppSettings } from '../../bindings/AppSettings'
@@ -134,6 +134,53 @@ describe('SettingsProvider', () => {
         expect.objectContaining({ closeWithNoTabs: 'nothing' })
       )
     })
+  })
+
+  test('applies settings broadcasts from another renderer', async () => {
+    const loaded = createLoadedSettings()
+    const next = { ...loaded, keymapPreset: 'vim' as const }
+    const load = vi.fn().mockResolvedValue(loaded)
+    const save = vi.fn().mockResolvedValue(undefined)
+    let changeCallback: ((settings: AppSettings) => void) | undefined
+
+    window.vimeflow = {
+      settings: {
+        load,
+        save,
+        openFile: vi.fn(),
+        onDidChange: vi.fn((callback: (settings: AppSettings) => void) => {
+          changeCallback = callback
+
+          return vi.fn()
+        }),
+      },
+    } as unknown as Window['vimeflow']
+
+    const KeymapConsumer = (): ReactElement => {
+      const { settings } = useSettings()
+
+      return <span data-testid="keymapPreset">{settings.keymapPreset}</span>
+    }
+
+    render(
+      <SettingsProvider>
+        <KeymapConsumer />
+      </SettingsProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('keymapPreset').textContent).toBe('vscode')
+    })
+
+    act(() => {
+      changeCallback?.(next)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('keymapPreset').textContent).toBe('vim')
+    })
+
+    expect(save).not.toHaveBeenCalled()
   })
 
   test('falls back to DEFAULT_SETTINGS when the bridge is absent', () => {

--- a/src/features/settings/SettingsProvider.tsx
+++ b/src/features/settings/SettingsProvider.tsx
@@ -67,14 +67,13 @@ export const SettingsProvider = ({
         const loaded = await bridge.load()
         setSettings(loaded)
         settingsRef.current = loaded
-        await syncSnapshotToMain(loaded)
       } catch {
         // Fall back to defaults if the backend load fails.
       }
     }
 
     void load()
-  }, [syncSnapshotToMain])
+  }, [])
 
   useEffect(() => {
     const bridge =

--- a/src/features/settings/SettingsProvider.tsx
+++ b/src/features/settings/SettingsProvider.tsx
@@ -76,6 +76,17 @@ export const SettingsProvider = ({
     void load()
   }, [syncSnapshotToMain])
 
+  useEffect(() => {
+    const bridge =
+      typeof window !== 'undefined' ? window.vimeflow?.settings : undefined
+
+    return bridge?.onDidChange?.((next) => {
+      settingsRef.current = next
+      setSettings(next)
+      setSaveError(null)
+    })
+  }, [])
+
   const saveNext = useCallback(
     async (previous: Promise<void>, next: AppSettings): Promise<void> => {
       try {

--- a/src/features/settings/hooks/useSettingsDialog.test.ts
+++ b/src/features/settings/hooks/useSettingsDialog.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, test, vi } from 'vitest'
-import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import { KEYMAP_CAPTURE_TARGET_ATTRIBUTE } from '../../keymap/capture'
+import type { BackendApi } from '../../../lib/backend'
 import { useSettingsDialog } from './useSettingsDialog'
 
 const dispatchFromRecorder = (init: KeyboardEventInit): void => {
@@ -22,6 +23,11 @@ const dispatchFromRecorder = (init: KeyboardEventInit): void => {
 }
 
 describe('useSettingsDialog', () => {
+  afterEach(() => {
+    delete window.vimeflow
+    vi.unstubAllGlobals()
+  })
+
   test('initial state is closed', () => {
     const { result } = renderHook(() => useSettingsDialog())
 
@@ -69,7 +75,6 @@ describe('useSettingsDialog', () => {
     })
 
     expect(result.current.isOpen).toBe(true)
-    vi.unstubAllGlobals()
   })
 
   test('Ctrl+, toggles the dialog open on non-macOS', () => {
@@ -89,7 +94,62 @@ describe('useSettingsDialog', () => {
     })
 
     expect(result.current.isOpen).toBe(true)
-    vi.unstubAllGlobals()
+  })
+
+  test('open requests the native settings window when the bridge is present', () => {
+    const openWindow = vi.fn().mockResolvedValue(undefined)
+    window.vimeflow = {
+      settings: {
+        openWindow,
+      },
+    } as unknown as BackendApi
+    const { result } = renderHook(() => useSettingsDialog())
+
+    act(() => result.current.open())
+
+    expect(openWindow).toHaveBeenCalledTimes(1)
+    expect(result.current.isOpen).toBe(false)
+  })
+
+  test('shortcut requests the native settings window when the bridge is present', () => {
+    vi.stubGlobal('navigator', {
+      userAgent: 'test-linux',
+      platform: 'Linux x86_64',
+    })
+    const openWindow = vi.fn().mockResolvedValue(undefined)
+    window.vimeflow = {
+      settings: {
+        openWindow,
+      },
+    } as unknown as BackendApi
+    const { result } = renderHook(() => useSettingsDialog())
+
+    act(() => {
+      const event = new KeyboardEvent('keydown', {
+        ctrlKey: true,
+        key: ',',
+        bubbles: true,
+      })
+      document.dispatchEvent(event)
+    })
+
+    expect(openWindow).toHaveBeenCalledTimes(1)
+    expect(result.current.isOpen).toBe(false)
+  })
+
+  test('falls back to the dialog if native settings window opening fails', async () => {
+    window.vimeflow = {
+      settings: {
+        openWindow: vi.fn().mockRejectedValue(new Error('failed')),
+      },
+    } as unknown as BackendApi
+    const { result } = renderHook(() => useSettingsDialog())
+
+    act(() => result.current.open())
+
+    await waitFor(() => {
+      expect(result.current.isOpen).toBe(true)
+    })
   })
 
   test('Escape closes the dialog when open', () => {

--- a/src/features/settings/hooks/useSettingsDialog.test.ts
+++ b/src/features/settings/hooks/useSettingsDialog.test.ts
@@ -152,6 +152,27 @@ describe('useSettingsDialog', () => {
     })
   })
 
+  test('toggle closes the fallback dialog after native window opening fails', async () => {
+    const openWindow = vi.fn().mockRejectedValue(new Error('failed'))
+    window.vimeflow = {
+      settings: {
+        openWindow,
+      },
+    } as unknown as BackendApi
+    const { result } = renderHook(() => useSettingsDialog())
+
+    act(() => result.current.toggle())
+
+    await waitFor(() => {
+      expect(result.current.isOpen).toBe(true)
+    })
+
+    act(() => result.current.toggle())
+
+    expect(result.current.isOpen).toBe(false)
+    expect(openWindow).toHaveBeenCalledTimes(1)
+  })
+
   test('Escape closes the dialog when open', () => {
     const { result } = renderHook(() => useSettingsDialog())
 

--- a/src/features/settings/hooks/useSettingsDialog.ts
+++ b/src/features/settings/hooks/useSettingsDialog.ts
@@ -5,6 +5,7 @@ import type { UseSettingsDialogReturn } from '../types'
 
 export const useSettingsDialog = (): UseSettingsDialogReturn => {
   const [isOpen, setIsOpen] = useState(false)
+  const isOpenRef = useRef(isOpen)
 
   const openNativeWindow = useCallback((): boolean => {
     const openWindow =
@@ -45,7 +46,6 @@ export const useSettingsDialog = (): UseSettingsDialogReturn => {
     setIsOpen((prev) => !prev)
   }, [openNativeWindow])
 
-  const isOpenRef = useRef(isOpen)
   const handlersRef = useRef({ close, toggle })
 
   isOpenRef.current = isOpen

--- a/src/features/settings/hooks/useSettingsDialog.ts
+++ b/src/features/settings/hooks/useSettingsDialog.ts
@@ -6,9 +6,44 @@ import type { UseSettingsDialogReturn } from '../types'
 export const useSettingsDialog = (): UseSettingsDialogReturn => {
   const [isOpen, setIsOpen] = useState(false)
 
-  const open = useCallback(() => setIsOpen(true), [])
+  const openNativeWindow = useCallback((): boolean => {
+    const openWindow =
+      typeof window !== 'undefined'
+        ? window.vimeflow?.settings?.openWindow
+        : undefined
+
+    if (openWindow === undefined) {
+      return false
+    }
+
+    void (async (): Promise<void> => {
+      try {
+        await openWindow()
+      } catch {
+        setIsOpen(true)
+      }
+    })()
+
+    return true
+  }, [])
+
+  const open = useCallback(() => {
+    if (openNativeWindow()) {
+      return
+    }
+
+    setIsOpen(true)
+  }, [openNativeWindow])
+
   const close = useCallback(() => setIsOpen(false), [])
-  const toggle = useCallback(() => setIsOpen((prev) => !prev), [])
+
+  const toggle = useCallback(() => {
+    if (openNativeWindow()) {
+      return
+    }
+
+    setIsOpen((prev) => !prev)
+  }, [openNativeWindow])
 
   const isOpenRef = useRef(isOpen)
   const handlersRef = useRef({ close, toggle })

--- a/src/features/settings/hooks/useSettingsDialog.ts
+++ b/src/features/settings/hooks/useSettingsDialog.ts
@@ -38,7 +38,7 @@ export const useSettingsDialog = (): UseSettingsDialogReturn => {
   const close = useCallback(() => setIsOpen(false), [])
 
   const toggle = useCallback(() => {
-    if (openNativeWindow()) {
+    if (!isOpenRef.current && openNativeWindow()) {
       return
     }
 

--- a/src/lib/backend.ts
+++ b/src/lib/backend.ts
@@ -27,6 +27,7 @@ export interface SettingsBridge {
   openFile: () => Promise<void>
   openWindow?: () => Promise<void>
   syncSnapshot: (settings: AppSettings) => Promise<void>
+  onDidChange?: (callback: (settings: AppSettings) => void) => UnlistenFn
 }
 
 export interface AliasesBridge {

--- a/src/lib/backend.ts
+++ b/src/lib/backend.ts
@@ -25,6 +25,7 @@ export interface SettingsBridge {
   load: () => Promise<AppSettings>
   save: (settings: AppSettings) => Promise<void>
   openFile: () => Promise<void>
+  openWindow?: () => Promise<void>
   syncSnapshot: (settings: AppSettings) => Promise<void>
 }
 


### PR DESCRIPTION
## Summary
- Add a singleton Electron settings BrowserWindow that loads the reusable settings content with native window chrome
- Expose settings.openWindow through preload and route ?window=settings to the settings-only renderer surface
- Keep the modal fallback for browser/test contexts while desktop shortcuts/sidebar open the native window
- Track the workspace BrowserWindow explicitly so layout teardown does not target the settings window

## Test plan
- [x] npm test -- electron/settings-window.test.ts electron/preload.test.ts src/App.test.tsx src/features/settings/hooks/useSettingsDialog.test.ts
- [x] npm run lint
- [x] npm run type-check

Refs VIM-105