### PR TITLE
test(terminal): add Ghostty native runtime smoke

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -76,7 +76,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Error Surfacing](patterns/error-surfacing.md)                                                       | error-handling     | 40       | 13   | 2026-06-13   |
 | [File Tree Paths](patterns/file-tree-paths.md)                                                       | files              | 4        | 0    | 2026-04-10   |
 | [Scope Boundary](patterns/scope-boundary.md)                                                         | review-process     | 8        | 3    | 2026-06-01   |
-| [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 21       | 9    | 2026-06-20   |
+| [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 22       | 9    | 2026-06-20   |
 | [Module Boundaries](patterns/module-boundaries.md)                                                   | code-quality       | 15       | 3    | 2026-06-12   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 11       | 3    | 2026-06-12   |
 | [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 19       | 1    | 2026-06-06   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -54,11 +54,11 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 1        | 0    | 2026-06-09   |
-| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 65       | 32   | 2026-06-18   |
+| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 66       | 33   | 2026-06-20   |
 | [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 24       | 7    | 2026-06-19   |
 | [Terminal DOM Rendering](patterns/terminal-dom-rendering.md)                                         | terminal           | 3        | 0    | 2026-06-19   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
-| [Terminal Render-State Driver Contract](patterns/terminal-render-state-driver-contract.md)           | terminal           | 19       | 3    | 2026-06-20   |
+| [Terminal Render-State Driver Contract](patterns/terminal-render-state-driver-contract.md)           | terminal           | 20       | 4    | 2026-06-20   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 85       | 25   | 2026-06-08   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 51       | 24   | 2026-06-18   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
@@ -76,7 +76,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Error Surfacing](patterns/error-surfacing.md)                                                       | error-handling     | 40       | 13   | 2026-06-13   |
 | [File Tree Paths](patterns/file-tree-paths.md)                                                       | files              | 4        | 0    | 2026-04-10   |
 | [Scope Boundary](patterns/scope-boundary.md)                                                         | review-process     | 8        | 3    | 2026-06-01   |
-| [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 20       | 8    | 2026-06-19   |
+| [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 21       | 9    | 2026-06-20   |
 | [Module Boundaries](patterns/module-boundaries.md)                                                   | code-quality       | 15       | 3    | 2026-06-12   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 11       | 3    | 2026-06-12   |
 | [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 19       | 1    | 2026-06-06   |
@@ -91,4 +91,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Prototype Handoff Artifacts](patterns/prototype-handoff-artifacts.md)                               | review-process     | 2        | 0    | 2026-06-12   |
 | [CloudFormation Environment Prefix Coupling](patterns/cloudformation-environment-prefix-coupling.md) | infrastructure     | 1        | 0    | 2026-06-12   |
 | [CloudFormation Stale References](patterns/cloudformation-stale-references.md)                       | infrastructure     | 2        | 1    | 2026-06-12   |
-| [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 3        | 1    | 2026-06-20   |
+| [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 4        | 2    | 2026-06-20   |

--- a/docs/reviews/patterns/dead-code.md
+++ b/docs/reviews/patterns/dead-code.md
@@ -3,7 +3,7 @@ id: dead-code
 category: code-quality
 created: 2026-06-13
 last_updated: 2026-06-20
-ref_count: 1
+ref_count: 2
 ---
 
 # Dead Code
@@ -42,4 +42,13 @@ code and should be removed.
 - **File:** `src/features/terminal/components/TerminalPane/terminalTextSurface.ts` L810-822
 - **Finding:** `applyScrollMode` reset `root.scrollTop` to `0` before calling `scrollCursorRowIntoView`, so the helper's `cursorTop < viewportTop` branch could never execute. The extra branch suggested a bidirectional scroll contract the only caller did not provide.
 - **Fix:** Simplified the helper to the actual caller contract: return when the cursor already fits in the top viewport, otherwise scroll down to reveal the cursor bottom.
+- **Commit:** same commit as this entry
+
+### 4. Vite build-time variables in an E2E run script are no-ops
+
+- **Source:** github-claude | PR #578 round 1 | 2026-06-20
+- **Severity:** LOW
+- **File:** `package.json`
+- **Finding:** `test:e2e:ghostty:native:run` set `VITE_E2E`, `VITE_TERMINAL_RENDERER`, and `VITE_GHOSTTY_RENDER_STATE_DRIVER_PROVIDER` even though the Electron bundle had already been built. The runtime assignments could mislead developers into thinking renderer mode changes apply without rebuilding.
+- **Fix:** Removed the build-time `VITE_*` variables from the native Ghostty run script; the build script remains the place where Vite consumes those values.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/e2e-testing.md
+++ b/docs/reviews/patterns/e2e-testing.md
@@ -236,3 +236,12 @@ completely different root causes. The generic fast-failure modes:
 - **Finding:** The native Ghostty smoke suite's `before()` hook chained several `waitUntil` helpers whose cumulative maximum wait could exceed the 60-second Mocha timeout. On a cold CI runner, Mocha could kill the hook before the helper-specific diagnostics surfaced.
 - **Fix:** Raised the native Ghostty WDIO Mocha timeout to 120 seconds so the bounded setup helpers can reach their own failure messages under slow CI conditions.
 - **Commit:** same commit as this entry
+
+### 22. Fitted viewport row assertions must accept the max valid row gap
+
+- **Source:** github-claude | PR #578 round 2 | 2026-06-20
+- **Severity:** MEDIUM
+- **File:** `tests/e2e/ghostty-native/specs/native-render-state-smoke.spec.ts`
+- **Finding:** The native Ghostty smoke suite compared `root.clientHeight` against `ptyViewportHeight + lineHeight - overflowTolerance`. With an 18 px line height and 1 px tolerance, that excluded the valid case where the visible pane has exactly 17 px of extra height after the fitted PTY rows.
+- **Fix:** Kept the lower tolerance for minor rounding below the PTY viewport height, but changed the upper exclusive bound to `ptyViewportHeight + lineHeight` so every fitted-row remainder below one full line is accepted.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/e2e-testing.md
+++ b/docs/reviews/patterns/e2e-testing.md
@@ -2,8 +2,8 @@
 id: e2e-testing
 category: e2e-testing
 created: 2026-04-19
-last_updated: 2026-06-19
-ref_count: 8
+last_updated: 2026-06-20
+ref_count: 9
 ---
 
 # E2E Testing
@@ -227,3 +227,12 @@ completely different root causes. The generic fast-failure modes:
 - **Finding:** The new `eventContainsInvalidBytePair` helper decoded each recorded PTY event independently and only reported the probe bytes found when `0xff` was immediately followed by `0xfe` within a single event. OS PTY reads can split the two-byte probe across adjacent events, so the test could time out even though Ghostty had correctly received and preserved both bytes. The false negative would surface as a flaky CI failure rather than a product bug.
 - **Fix:** Replaced the per-event predicate with `recordedEventsContainInvalidBytePair(events)`, which concatenates decoded `bytesBase64` payloads from every recorded event in order (skipping events without byte metadata) and scans the resulting byte stream for the adjacent `0xff 0xfe` sequence. Post-wait assertions were moved to stream-level checks: at least one event carries `bytesBase64`, the total decoded byte length is at least 2, the stream contains `0xff` followed by `0xfe`, and at least one event's decoded `data` contains the Unicode replacement character.
 - **Commit:** _(this cycle)_
+
+### 21. Native Ghostty setup waits can exceed the WDIO Mocha hook timeout
+
+- **Source:** github-claude | PR #578 round 1 | 2026-06-20
+- **Severity:** HIGH
+- **File:** `tests/e2e/ghostty-native/wdio.conf.ts`
+- **Finding:** The native Ghostty smoke suite's `before()` hook chained several `waitUntil` helpers whose cumulative maximum wait could exceed the 60-second Mocha timeout. On a cold CI runner, Mocha could kill the hook before the helper-specific diagnostics surfaced.
+- **Fix:** Raised the native Ghostty WDIO Mocha timeout to 120 seconds so the bounded setup helpers can reach their own failure messages under slow CI conditions.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/terminal-render-state-driver-contract.md
+++ b/docs/reviews/patterns/terminal-render-state-driver-contract.md
@@ -3,7 +3,7 @@ id: terminal-render-state-driver-contract
 category: terminal
 created: 2026-06-19
 last_updated: 2026-06-20
-ref_count: 3
+ref_count: 4
 ---
 
 # Terminal Render-State Driver Contract
@@ -190,4 +190,13 @@ documented explicitly: effect callbacks must be invoked synchronously inside the
 - **File:** `electron/ghostty-render-state-main.ts` L708-721
 - **Finding:** After reset was changed to allocate a replacement before disposing the old terminal, a failed old-terminal `dispose()` path was easy to misread as leaking the new terminal because the failure was caught only by the outer native-binding wrapper.
 - **Fix:** Catch old-terminal disposal failures inside `reset()` and return the IPC failure directly after the replacement has been published. Regression coverage now asserts the replacement remains active and is not disposed on that path.
+- **Commit:** same commit as this entry
+
+### 20. Native package resolution must require an actual native payload
+
+- **Source:** github-codex-connector | PR #578 round 1 | 2026-06-20
+- **Severity:** P2 / MEDIUM
+- **File:** `electron/ghostty-render-state-main.ts`
+- **Finding:** `resolveGhosttyNativePackageRoot()` accepted an app-root package when it had `package.json` plus a `prebuilds/` directory, even if that directory contained no loadable `.node` file. A stale copied package could therefore win over a valid fallback install and fail later inside `node-gyp-build`.
+- **Fix:** Changed native package detection to recursively require a `.node` file under `prebuilds` or the build output directories before selecting a package root.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -2,8 +2,8 @@
 id: testing-gaps
 category: testing
 created: 2026-04-09
-last_updated: 2026-06-18
-ref_count: 32
+last_updated: 2026-06-20
+ref_count: 33
 ---
 
 # Testing Gaps
@@ -647,4 +647,13 @@ filesystem scope restrictions).
 - **File:** `src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts` L171-177
 - **Finding:** The `continues stripping controls after renderer handle disposal` test hardcoded `byteLen: 15` for a payload that encodes to 16 UTF-8 bytes (`before ESC[0mafter`). The test passed only because `byteLen` was treated as opaque metadata, so it would silently assert the wrong length if the router ever validated it.
 - **Fix:** Replaced the hardcoded value with `new TextEncoder().encode(...).length` so the fixture is consistent with the surrounding tests and proof against future payload edits.
+- **Commit:** same commit as this entry
+
+### 65. Resolver fallback tests depended on an optional native dependency
+
+- **Source:** github-claude | PR #578 round 1 | 2026-06-20
+- **Severity:** MEDIUM
+- **File:** `electron/ghostty-render-state-main.test.ts`
+- **Finding:** Native package resolver tests asserted fallback to `process.cwd()/node_modules/@coder/libghostty-vt-node`, which only works when the optional native package is installed in the checkout. Clean or unsupported-platform installs could fail with a misleading path mismatch.
+- **Fix:** Made the resolver tests create their own temporary valid fallback package, including a manifest and `.node` file under `prebuilds`, so they no longer depend on local optional dependency installation.
 - **Commit:** same commit as this entry

--- a/electron/ghostty-render-state-main.test.ts
+++ b/electron/ghostty-render-state-main.test.ts
@@ -1,7 +1,11 @@
-// cspell:ignore ghostty
+// cspell:ignore ghostty libghostty prebuilds
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 import { describe, expect, test, vi } from 'vitest'
 import {
   GhosttyRenderStateMainBridge,
+  resolveGhosttyNativePackageRoot,
   setupGhosttyRenderStateIpc,
   type GhosttyNativeBindings,
   type IpcMainEventLike,
@@ -134,6 +138,18 @@ const requireResult = <T>(
   return value.result
 }
 
+const withTempDir = (callback: (tempDir: string) => void): void => {
+  const tempDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'vimeflow-ghostty-native-')
+  )
+
+  try {
+    callback(tempDir)
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  }
+}
+
 const createIpcMain = (): TestIpcMain => {
   const handlers = new Map<
     string,
@@ -152,6 +168,59 @@ const createIpcMain = (): TestIpcMain => {
     }),
   }
 }
+
+describe('ghostty render-state native package resolver', () => {
+  test('prefers a package copied under the Electron app root', () => {
+    withTempDir((appRoot) => {
+      const packageRoot = path.join(
+        appRoot,
+        'node_modules',
+        '@coder',
+        'libghostty-vt-node'
+      )
+      fs.mkdirSync(packageRoot, { recursive: true })
+      fs.writeFileSync(path.join(packageRoot, 'package.json'), '{}')
+      fs.mkdirSync(path.join(packageRoot, 'prebuilds'), { recursive: true })
+
+      expect(resolveGhosttyNativePackageRoot(appRoot)).toBe(packageRoot)
+    })
+  })
+
+  test('skips a partial app-root package without native payloads', () => {
+    withTempDir((appRoot) => {
+      const packageRoot = path.join(
+        appRoot,
+        'node_modules',
+        '@coder',
+        'libghostty-vt-node'
+      )
+
+      const expectedPackageRoot = path.join(
+        process.cwd(),
+        'node_modules',
+        '@coder',
+        'libghostty-vt-node'
+      )
+      fs.mkdirSync(packageRoot, { recursive: true })
+      fs.writeFileSync(path.join(packageRoot, 'package.json'), '{}')
+
+      expect(resolveGhosttyNativePackageRoot(appRoot)).toBe(expectedPackageRoot)
+    })
+  })
+
+  test('falls back to Node resolution when the app root has no copied package', () => {
+    withTempDir((appRoot) => {
+      const expectedPackageRoot = path.join(
+        process.cwd(),
+        'node_modules',
+        '@coder',
+        'libghostty-vt-node'
+      )
+
+      expect(resolveGhosttyNativePackageRoot(appRoot)).toBe(expectedPackageRoot)
+    })
+  })
+})
 
 describe('ghostty render-state main bridge', () => {
   test('feeds bytes into the native terminal and normalizes snapshots', () => {

--- a/electron/ghostty-render-state-main.test.ts
+++ b/electron/ghostty-render-state-main.test.ts
@@ -150,6 +150,20 @@ const withTempDir = (callback: (tempDir: string) => void): void => {
   }
 }
 
+const nativePackageRootUnder = (basePath: string): string =>
+  path.join(basePath, 'node_modules', '@coder', 'libghostty-vt-node')
+
+const createNativePackage = (packageRoot: string): void => {
+  fs.mkdirSync(path.join(packageRoot, 'prebuilds', 'linux-x64'), {
+    recursive: true,
+  })
+  fs.writeFileSync(path.join(packageRoot, 'package.json'), '{}')
+  fs.writeFileSync(
+    path.join(packageRoot, 'prebuilds', 'linux-x64', 'ghostty.node'),
+    ''
+  )
+}
+
 const createIpcMain = (): TestIpcMain => {
   const handlers = new Map<
     string,
@@ -172,50 +186,34 @@ const createIpcMain = (): TestIpcMain => {
 describe('ghostty render-state native package resolver', () => {
   test('prefers a package copied under the Electron app root', () => {
     withTempDir((appRoot) => {
-      const packageRoot = path.join(
-        appRoot,
-        'node_modules',
-        '@coder',
-        'libghostty-vt-node'
-      )
-      fs.mkdirSync(packageRoot, { recursive: true })
-      fs.writeFileSync(path.join(packageRoot, 'package.json'), '{}')
-      fs.mkdirSync(path.join(packageRoot, 'prebuilds'), { recursive: true })
+      const packageRoot = nativePackageRootUnder(appRoot)
+      createNativePackage(packageRoot)
 
       expect(resolveGhosttyNativePackageRoot(appRoot)).toBe(packageRoot)
     })
   })
 
   test('skips a partial app-root package without native payloads', () => {
-    withTempDir((appRoot) => {
-      const packageRoot = path.join(
-        appRoot,
-        'node_modules',
-        '@coder',
-        'libghostty-vt-node'
-      )
+    withTempDir((tempDir) => {
+      const appRoot = path.join(tempDir, 'app')
+      const packageRoot = nativePackageRootUnder(appRoot)
+      const expectedPackageRoot = nativePackageRootUnder(tempDir)
 
-      const expectedPackageRoot = path.join(
-        process.cwd(),
-        'node_modules',
-        '@coder',
-        'libghostty-vt-node'
-      )
       fs.mkdirSync(packageRoot, { recursive: true })
       fs.writeFileSync(path.join(packageRoot, 'package.json'), '{}')
+      fs.mkdirSync(path.join(packageRoot, 'prebuilds'), { recursive: true })
+      createNativePackage(expectedPackageRoot)
 
       expect(resolveGhosttyNativePackageRoot(appRoot)).toBe(expectedPackageRoot)
     })
   })
 
   test('falls back to Node resolution when the app root has no copied package', () => {
-    withTempDir((appRoot) => {
-      const expectedPackageRoot = path.join(
-        process.cwd(),
-        'node_modules',
-        '@coder',
-        'libghostty-vt-node'
-      )
+    withTempDir((tempDir) => {
+      const appRoot = path.join(tempDir, 'app')
+      const expectedPackageRoot = nativePackageRootUnder(tempDir)
+
+      createNativePackage(expectedPackageRoot)
 
       expect(resolveGhosttyNativePackageRoot(appRoot)).toBe(expectedPackageRoot)
     })

--- a/electron/ghostty-render-state-main.ts
+++ b/electron/ghostty-render-state-main.ts
@@ -1,7 +1,9 @@
 // cspell:ignore ghostty libghostty prebuilds
+import fs from 'node:fs'
 import path from 'node:path'
 import { createRequire } from 'node:module'
 import { TextDecoder } from 'node:util'
+import { fileURLToPath } from 'node:url'
 import {
   GHOSTTY_RENDER_STATE_CREATE,
   GHOSTTY_RENDER_STATE_DISPOSE,
@@ -24,6 +26,7 @@ const OSC_ST_TERMINATOR = '\u001b\\'
 const OSC_BUFFER_LIMIT = 8192
 
 const nodeRequire = createRequire(import.meta.url)
+const electronModuleDir = path.dirname(fileURLToPath(import.meta.url))
 
 export interface GhosttyRenderStateBridgeSize {
   cols: number
@@ -174,12 +177,69 @@ const fail = (error: string): IpcResult<never> => ({ ok: false, error })
 const packageNameToPathSegments = (packageName: string): string[] =>
   packageName.split('/').filter((segment) => segment.length > 0)
 
-export const resolveGhosttyNativePackageRoot = (appRoot: string): string =>
-  path.join(
-    appRoot,
-    'node_modules',
-    ...packageNameToPathSegments(GHOSTTY_NATIVE_PACKAGE_ID)
-  )
+const GHOSTTY_NATIVE_PACKAGE_PATH_SEGMENTS = packageNameToPathSegments(
+  GHOSTTY_NATIVE_PACKAGE_ID
+)
+
+const hasPackageManifest = (packageRoot: string): boolean =>
+  fs.existsSync(path.join(packageRoot, 'package.json'))
+
+const hasNativeBuildFile = (dirPath: string): boolean => {
+  try {
+    return fs
+      .readdirSync(dirPath, { withFileTypes: true })
+      .some((entry) => entry.isFile() && entry.name.endsWith('.node'))
+  } catch {
+    return false
+  }
+}
+
+const hasNativeBuildCandidate = (packageRoot: string): boolean =>
+  fs.existsSync(path.join(packageRoot, 'prebuilds')) ||
+  hasNativeBuildFile(path.join(packageRoot, 'build', 'Release')) ||
+  hasNativeBuildFile(path.join(packageRoot, 'build', 'Debug'))
+
+const isLoadablePackageRoot = (packageRoot: string): boolean =>
+  hasPackageManifest(packageRoot) && hasNativeBuildCandidate(packageRoot)
+
+const resolvePackageRootUnder = (basePath: string): string =>
+  path.join(basePath, 'node_modules', ...GHOSTTY_NATIVE_PACKAGE_PATH_SEGMENTS)
+
+const findPackageRootInAncestors = (startPath: string): string | null => {
+  let currentDir = path.resolve(startPath)
+
+  while (currentDir !== path.dirname(currentDir)) {
+    const packageRoot = resolvePackageRootUnder(currentDir)
+
+    if (isLoadablePackageRoot(packageRoot)) {
+      return packageRoot
+    }
+
+    currentDir = path.dirname(currentDir)
+  }
+
+  return null
+}
+
+export const resolveGhosttyNativePackageRoot = (appRoot: string): string => {
+  const appRootPackageRoot = resolvePackageRootUnder(appRoot)
+
+  if (isLoadablePackageRoot(appRootPackageRoot)) {
+    return appRootPackageRoot
+  }
+
+  const searchRoots = new Set([appRoot, electronModuleDir, process.cwd()])
+
+  for (const searchRoot of searchRoots) {
+    const packageRoot = findPackageRootInAncestors(searchRoot)
+
+    if (packageRoot) {
+      return packageRoot
+    }
+  }
+
+  return appRootPackageRoot
+}
 
 const isGhosttyNativeBindings = (
   value: unknown

--- a/electron/ghostty-render-state-main.ts
+++ b/electron/ghostty-render-state-main.ts
@@ -186,16 +186,23 @@ const hasPackageManifest = (packageRoot: string): boolean =>
 
 const hasNativeBuildFile = (dirPath: string): boolean => {
   try {
-    return fs
-      .readdirSync(dirPath, { withFileTypes: true })
-      .some((entry) => entry.isFile() && entry.name.endsWith('.node'))
+    return fs.readdirSync(dirPath, { withFileTypes: true }).some((entry) => {
+      if (entry.isFile()) {
+        return entry.name.endsWith('.node')
+      }
+
+      return (
+        entry.isDirectory() &&
+        hasNativeBuildFile(path.join(dirPath, entry.name))
+      )
+    })
   } catch {
     return false
   }
 }
 
 const hasNativeBuildCandidate = (packageRoot: string): boolean =>
-  fs.existsSync(path.join(packageRoot, 'prebuilds')) ||
+  hasNativeBuildFile(path.join(packageRoot, 'prebuilds')) ||
   hasNativeBuildFile(path.join(packageRoot, 'build', 'Release')) ||
   hasNativeBuildFile(path.join(packageRoot, 'build', 'Debug'))
 

--- a/package.json
+++ b/package.json
@@ -38,10 +38,14 @@
     "test:e2e:ghostty:build": "npm run generate:bindings && npm run test:e2e:ghostty:build:generated",
     "test:e2e:ghostty:build:generated": "tsc -b && cross-env VITE_E2E=1 VITE_TERMINAL_RENDERER=ghostty vite build --mode electron && cargo build --bin vimeflow-backend --features e2e-test",
     "test:e2e:ghostty:run": "cross-env VITE_E2E=1 VITE_TERMINAL_RENDERER=ghostty wdio tests/e2e/ghostty/wdio.conf.ts",
+    "test:e2e:ghostty:native:build": "npm run generate:bindings && npm run test:e2e:ghostty:native:build:generated",
+    "test:e2e:ghostty:native:build:generated": "tsc -b && cross-env VITE_E2E=1 VITE_TERMINAL_RENDERER=ghostty VITE_GHOSTTY_RENDER_STATE_DRIVER_PROVIDER=native vite build --mode electron && cargo build --bin vimeflow-backend --features e2e-test",
+    "test:e2e:ghostty:native:run": "cross-env VITE_E2E=1 VITE_TERMINAL_RENDERER=ghostty VITE_GHOSTTY_RENDER_STATE_DRIVER_PROVIDER=native wdio tests/e2e/ghostty-native/wdio.conf.ts",
     "test:e2e": "npm run test:e2e:build && npm run test:e2e:core:run",
     "test:e2e:terminal": "npm run test:e2e:build && npm run test:e2e:terminal:run",
     "test:e2e:agent": "npm run test:e2e:build && npm run test:e2e:agent:run",
     "test:e2e:ghostty": "npm run test:e2e:ghostty:build && npm run test:e2e:ghostty:run",
+    "test:e2e:ghostty:native": "npm run test:e2e:ghostty:native:build && npm run test:e2e:ghostty:native:run",
     "test:e2e:all": "npm run test:e2e:build && npm run test:e2e:core:run && npm run test:e2e:terminal:run && npm run test:e2e:agent:run"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test:e2e:ghostty:run": "cross-env VITE_E2E=1 VITE_TERMINAL_RENDERER=ghostty wdio tests/e2e/ghostty/wdio.conf.ts",
     "test:e2e:ghostty:native:build": "npm run generate:bindings && npm run test:e2e:ghostty:native:build:generated",
     "test:e2e:ghostty:native:build:generated": "tsc -b && cross-env VITE_E2E=1 VITE_TERMINAL_RENDERER=ghostty VITE_GHOSTTY_RENDER_STATE_DRIVER_PROVIDER=native vite build --mode electron && cargo build --bin vimeflow-backend --features e2e-test",
-    "test:e2e:ghostty:native:run": "cross-env VITE_E2E=1 VITE_TERMINAL_RENDERER=ghostty VITE_GHOSTTY_RENDER_STATE_DRIVER_PROVIDER=native wdio tests/e2e/ghostty-native/wdio.conf.ts",
+    "test:e2e:ghostty:native:run": "wdio tests/e2e/ghostty-native/wdio.conf.ts",
     "test:e2e": "npm run test:e2e:build && npm run test:e2e:core:run",
     "test:e2e:terminal": "npm run test:e2e:build && npm run test:e2e:terminal:run",
     "test:e2e:agent": "npm run test:e2e:build && npm run test:e2e:agent:run",

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
@@ -53,6 +53,19 @@ const setScrollMetrics = (
   })
 }
 
+const createRect = (top: number, bottom: number): DOMRect =>
+  ({
+    bottom,
+    height: bottom - top,
+    left: 0,
+    right: 0,
+    toJSON: (): Record<string, number> => ({}),
+    top,
+    width: 0,
+    x: 0,
+    y: top,
+  }) as DOMRect
+
 const encodeBase64 = (bytes: Uint8Array): string => {
   let binary = ''
 
@@ -274,6 +287,29 @@ describe('ghosttyInstance', () => {
     expect(reset).toHaveBeenCalledOnce()
     expect(resize).toHaveBeenLastCalledWith({ cols: 40, rows: 11 })
     expect(resize).toHaveBeenCalledTimes(4)
+  })
+
+  test('syncs fitted PTY rows into the rendered viewport geometry', () => {
+    const container = document.createElement('div')
+    const created = createTrackedGhosttyTerminal()
+
+    setElementSize(container, 256, 180)
+    created.terminal.open(container)
+
+    const element = created.terminal.element
+    const output = element?.querySelector<HTMLElement>('pre')
+
+    expect(created.terminal.cols).toBe(30)
+    expect(created.terminal.rows).toBe(9)
+    expect(element?.dataset.terminalCols).toBe('30')
+    expect(element?.dataset.terminalRows).toBe('9')
+    expect(
+      element?.style.getPropertyValue('--terminal-pty-viewport-height')
+    ).toBe('178px')
+
+    expect(output?.style.minHeight).toBe(
+      'max(100%, var(--terminal-pty-viewport-height))'
+    )
   })
 
   test('keeps VT render-state driver cwd effects on the terminal parser event path', () => {
@@ -536,6 +572,72 @@ describe('ghosttyInstance', () => {
 
     expect(element.scrollTop).toBeGreaterThan(0)
     expect(element.scrollTop).toBeLessThan(640)
+  })
+
+  test('scrolls parser display replace snapshots by rendered cursor bounds', () => {
+    const parser: TerminalParser = {
+      onEvent: (): TerminalDisposable => ({ dispose: vi.fn() }),
+    }
+
+    const parserEngine: TerminalParserEngine = {
+      inputMode: 'bytes',
+      capabilities: ghosttyTerminalRenderer.capabilities,
+      parser,
+      parseText: (text): TerminalParserEngineOutput => ({
+        visibleText: text,
+      }),
+      parseInput: (input): TerminalParserEngineOutput => ({
+        visibleText: input.text,
+      }),
+      parseOutput: (): TerminalParserEngineOutput =>
+        createGhosttyVtRenderSnapshotOutput({
+          rows: ['prompt', '', '', '', 'ready'],
+          cursor: {
+            rowIndex: 4,
+            columnOffset: 5,
+          },
+        }),
+    }
+
+    const created = createTrackedGhosttyTerminal({
+      createParserEngine: () => parserEngine,
+    })
+
+    const element = created.terminal.element
+
+    if (!element) {
+      throw new Error('Expected terminal element')
+    }
+
+    setScrollMetrics(element, 54, 640)
+    element.scrollTop = 0
+
+    const getBoundingClientRectSpy = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: HTMLElement): DOMRect {
+        if (this.dataset.terminalCursorMarker === 'true') {
+          return createRect(90, 108)
+        }
+
+        if (this.dataset.terminalRenderer === GHOSTTY_TERMINAL_RENDERER_ID) {
+          return createRect(0, 54)
+        }
+
+        return createRect(0, 0)
+      })
+
+    try {
+      created.output.writeOutput({
+        text: 'snapshot',
+        offsetStart: 0,
+        byteLen: 8,
+        phase: 'live',
+      })
+    } finally {
+      getBoundingClientRectSpy.mockRestore()
+    }
+
+    expect(element.scrollTop).toBe(62)
   })
 
   test('renders the cursor from parser display snapshot coordinates', () => {

--- a/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
+++ b/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
@@ -176,10 +176,10 @@ export class TerminalTextSurface implements TerminalSurface {
       display: 'block',
       fontFamily: TERMINAL_FONT_FAMILY,
       fontSize: `${TERMINAL_FONT_SIZE}px`,
-      lineHeight: `${APPROXIMATE_LINE_HEIGHT}px`,
+      lineHeight: 'var(--terminal-line-height)',
       margin: '0',
       maxWidth: '100%',
-      minHeight: '100%',
+      minHeight: 'max(100%, var(--terminal-pty-viewport-height))',
       overflowX: 'hidden',
       padding: '8px',
       whiteSpace: 'normal',
@@ -198,6 +198,7 @@ export class TerminalTextSurface implements TerminalSurface {
     })
 
     this.input.setAttribute('aria-label', 'Terminal input')
+    this.syncPtyViewportGeometry()
     this.root.addEventListener('mousedown', this.handlePointerDown)
     document.addEventListener('selectionchange', this.handleSelectionChange)
     this.input.addEventListener('keydown', this.handleKeyDown)
@@ -423,24 +424,25 @@ export class TerminalTextSurface implements TerminalSurface {
 
     const contentWidth = Math.max(0, width - this.readOutputHorizontalPadding())
     const contentHeight = Math.max(0, height - this.readOutputVerticalPadding())
+    const lineHeight = this.readLineHeight()
 
     const nextCols = Math.max(
       MIN_COLS,
       Math.floor(contentWidth / this.measureCharacterWidth())
     )
 
-    const nextRows = Math.max(
-      MIN_ROWS,
-      Math.floor(contentHeight / APPROXIMATE_LINE_HEIGHT)
-    )
+    const nextRows = Math.max(MIN_ROWS, Math.floor(contentHeight / lineHeight))
 
     if (nextCols === this.colsValue && nextRows === this.rowsValue) {
+      this.syncPtyViewportGeometry()
+
       return
     }
 
     this.colsValue = nextCols
     this.rowsValue = nextRows
     this.outputBuffer.setColumns(nextCols)
+    this.syncPtyViewportGeometry()
     this.notifyResize()
   }
 
@@ -516,6 +518,31 @@ export class TerminalTextSurface implements TerminalSurface {
     )
   }
 
+  private readLineHeight(): number {
+    const parsed = parseCssPixels(
+      window.getComputedStyle(this.output).lineHeight
+    )
+
+    return parsed > 0 ? parsed : APPROXIMATE_LINE_HEIGHT
+  }
+
+  private syncPtyViewportGeometry(): void {
+    const viewportHeight =
+      this.rowsValue * this.readLineHeight() + this.readOutputVerticalPadding()
+
+    this.root.dataset.terminalCols = String(this.colsValue)
+    this.root.dataset.terminalRows = String(this.rowsValue)
+    this.root.style.setProperty(
+      '--terminal-line-height',
+      `${APPROXIMATE_LINE_HEIGHT}px`
+    )
+
+    this.root.style.setProperty(
+      '--terminal-pty-viewport-height',
+      `${viewportHeight}px`
+    )
+  }
+
   private measureCharacterWidth(): number {
     if (this.cachedCharacterWidth !== null) {
       return this.cachedCharacterWidth
@@ -527,7 +554,7 @@ export class TerminalTextSurface implements TerminalSurface {
     Object.assign(probe.style, {
       fontFamily: TERMINAL_FONT_FAMILY,
       fontSize: `${TERMINAL_FONT_SIZE}px`,
-      lineHeight: `${APPROXIMATE_LINE_HEIGHT}px`,
+      lineHeight: 'var(--terminal-line-height)',
       pointerEvents: 'none',
       position: 'absolute',
       visibility: 'hidden',
@@ -656,7 +683,7 @@ export class TerminalTextSurface implements TerminalSurface {
     Object.assign(row.style, {
       display: 'block',
       maxWidth: '100%',
-      minHeight: `${APPROXIMATE_LINE_HEIGHT}px`,
+      minHeight: 'var(--terminal-line-height)',
       overflowX: 'hidden',
       whiteSpace: 'pre',
       width: '100%',
@@ -789,7 +816,7 @@ export class TerminalTextSurface implements TerminalSurface {
     this.root.scrollTop = 0
 
     if (scrollMode === 'cursor') {
-      this.scrollCursorRowIntoView(cursorRowIndex)
+      this.scrollCursorMarkerIntoView(cursorRowIndex)
     }
   }
 
@@ -804,9 +831,9 @@ export class TerminalTextSurface implements TerminalSurface {
     const paddingTop = parseCssPixels(outputStyle.paddingTop)
     const paddingBottom = parseCssPixels(outputStyle.paddingBottom)
 
-    const cursorTop = paddingTop + cursorRowIndex * APPROXIMATE_LINE_HEIGHT
+    const cursorTop = paddingTop + cursorRowIndex * this.readLineHeight()
 
-    const cursorBottom = cursorTop + APPROXIMATE_LINE_HEIGHT
+    const cursorBottom = cursorTop + this.readLineHeight()
     const viewportBottom = Math.max(0, viewportHeight - paddingBottom)
 
     if (cursorBottom <= viewportBottom) {
@@ -817,6 +844,56 @@ export class TerminalTextSurface implements TerminalSurface {
     const nextScrollTop = cursorBottom - viewportHeight
 
     this.root.scrollTop = Math.min(Math.max(0, nextScrollTop), maxScrollTop)
+  }
+
+  private scrollCursorMarkerIntoView(cursorRowIndex: number): void {
+    const cursorMarker = this.root.querySelector<HTMLElement>(
+      '[data-terminal-cursor-marker="true"]'
+    )
+
+    if (!cursorMarker) {
+      this.scrollCursorRowIntoView(cursorRowIndex)
+
+      return
+    }
+
+    const rootRect = this.root.getBoundingClientRect()
+    const cursorRect = cursorMarker.getBoundingClientRect()
+
+    if (rootRect.height <= 0 || cursorRect.height <= 0) {
+      this.scrollCursorRowIntoView(cursorRowIndex)
+
+      return
+    }
+
+    const outputStyle = window.getComputedStyle(this.output)
+    const paddingTop = parseCssPixels(outputStyle.paddingTop)
+    const paddingBottom = parseCssPixels(outputStyle.paddingBottom)
+    const topOverflow = cursorRect.top - rootRect.top
+    const bottomOverflow = cursorRect.bottom - rootRect.bottom
+
+    if (topOverflow < 0) {
+      this.root.scrollTop = Math.max(
+        0,
+        this.root.scrollTop + Math.floor(topOverflow - paddingTop)
+      )
+
+      return
+    }
+
+    if (bottomOverflow <= 0) {
+      return
+    }
+
+    const maxScrollTop = Math.max(
+      0,
+      this.root.scrollHeight - this.root.clientHeight
+    )
+
+    this.root.scrollTop = Math.min(
+      maxScrollTop,
+      this.root.scrollTop + Math.ceil(bottomOverflow + paddingBottom)
+    )
   }
 
   private notifyResize(): void {

--- a/src/lib/e2e-bridge.ts
+++ b/src/lib/e2e-bridge.ts
@@ -1,3 +1,4 @@
+// cspell:ignore ghostty GHOSTTY
 import { invoke, listen, type UnlistenFn } from './backend'
 import { getAllPtySessionIds } from '../features/terminal/ptySessionMap'
 import { terminalCache } from '../features/terminal/terminalRegistry'
@@ -186,6 +187,15 @@ export const getVisibleTerminalSize = (): {
   }
 }
 
+export const getTerminalRendererConfig = (): {
+  readonly terminalRenderer: string | null
+  readonly ghosttyRenderStateDriverProvider: string | null
+} => ({
+  terminalRenderer: import.meta.env.VITE_TERMINAL_RENDERER ?? null,
+  ghosttyRenderStateDriverProvider:
+    import.meta.env.VITE_GHOSTTY_RENDER_STATE_DRIVER_PROVIDER ?? null,
+})
+
 export const writeOutputToVisibleTerminal = (data: string): boolean => {
   const pane = findActivePane()
   if (!pane) {
@@ -269,6 +279,7 @@ if (import.meta.env.VITE_E2E) {
     getRecordedPtyDataEvents,
     getTerminalBuffer: readVisibleTerminalBuffer,
     getTerminalBufferForSession: readTerminalBufferForSession,
+    getTerminalRendererConfig,
     getVisibleTerminalSize,
     getVisibleSessionId,
     getActiveSessionIds: getAllPtySessionIds,

--- a/src/types/e2e.d.ts
+++ b/src/types/e2e.d.ts
@@ -15,6 +15,10 @@ declare global {
       getRecordedPtyDataEvents(): readonly VimeflowE2ePtyDataEvent[]
       getTerminalBuffer(): string
       getTerminalBufferForSession(sessionId: string): string
+      getTerminalRendererConfig(): {
+        readonly terminalRenderer: string | null
+        readonly ghosttyRenderStateDriverProvider: string | null
+      }
       getVisibleTerminalSize(): { readonly cols: number; readonly rows: number } | null
       getVisibleSessionId(): string | null
       getActiveSessionIds(): string[]

--- a/tests/e2e/ghostty-native/specs/native-render-state-smoke.spec.ts
+++ b/tests/e2e/ghostty-native/specs/native-render-state-smoke.spec.ts
@@ -1,0 +1,372 @@
+// cspell:ignore ghostty
+export {}
+
+const ESCAPE_SEQUENCE_TIMEOUT_MS = 15_000
+const NARROW_TERMINAL_WIDTH_PX = 360
+const MAX_NARROW_PROMPT_COLS = 60
+
+interface GhosttyViewportMetrics {
+  readonly cursorVisible: boolean
+  readonly firstNonEmptyRowIndex: number | null
+  readonly firstNonEmptyRowText: string
+  readonly hasHorizontalOverflow: boolean
+  readonly rootScrollTop: number
+  readonly viewportRowsMatchPty: boolean
+}
+
+const waitForE2eBridge = async (): Promise<void> => {
+  await browser
+    .waitUntil(
+      async () =>
+        await browser.execute(
+          () => typeof window.__VIMEFLOW_E2E__ !== 'undefined'
+        ),
+      { timeout: 20_000, interval: 250 }
+    )
+    .catch(() => {
+      throw new Error(
+        'window.__VIMEFLOW_E2E__ missing; rebuild with VITE_E2E=1'
+      )
+    })
+}
+
+const assertNativeGhosttyBuild = async (): Promise<void> => {
+  const config = await browser.execute(
+    () => window.__VIMEFLOW_E2E__?.getTerminalRendererConfig() ?? null
+  )
+
+  expect(config).toEqual({
+    terminalRenderer: 'ghostty',
+    ghosttyRenderStateDriverProvider: 'native',
+  })
+}
+
+const writeOutputToVisibleTerminal = async (data: string): Promise<void> => {
+  const didWrite = await browser.execute(
+    (payload: string) =>
+      window.__VIMEFLOW_E2E__?.writeOutputToVisibleTerminal(payload) ?? false,
+    data
+  )
+
+  if (!didWrite) {
+    throw new Error('visible terminal renderer was unavailable for e2e output')
+  }
+}
+
+const readTerminalBuffer = async (): Promise<string> =>
+  browser.execute(() => window.__VIMEFLOW_E2E__?.getTerminalBuffer() ?? '')
+
+const readTerminalSize = async (): Promise<{
+  readonly cols: number
+  readonly rows: number
+} | null> =>
+  browser.execute(
+    () => window.__VIMEFLOW_E2E__?.getVisibleTerminalSize() ?? null
+  )
+
+const waitForGhosttyRenderer = async (): Promise<void> => {
+  const pane = await $('[data-testid="terminal-pane"]')
+  await pane.waitForDisplayed({ timeout: 20_000 })
+
+  await browser
+    .waitUntil(
+      async () =>
+        await browser.execute(
+          () =>
+            document.querySelector('[data-terminal-renderer="ghostty"]') !==
+            null
+        ),
+      {
+        timeout: 20_000,
+        timeoutMsg:
+          'Ghostty renderer root was not mounted; rebuild with VITE_TERMINAL_RENDERER=ghostty',
+      }
+    )
+    .catch(async () => {
+      const diagnostic = await browser.execute(() => {
+        const visiblePane = Array.from(
+          document.querySelectorAll<HTMLElement>(
+            '[data-testid="terminal-pane"]'
+          )
+        ).find((element) => {
+          const rect = element.getBoundingClientRect()
+
+          return rect.width > 0 && rect.height > 0
+        })
+
+        return visiblePane?.textContent?.replace(/\s+/g, ' ').trim() ?? ''
+      })
+
+      throw new Error(
+        `Ghostty renderer root was not mounted; terminal pane text: ${diagnostic}`
+      )
+    })
+}
+
+const waitForGhosttyPrompt = async (): Promise<void> => {
+  await browser.waitUntil(
+    async () => (await readTerminalBuffer()).trim().length > 0,
+    { timeout: 20_000, timeoutMsg: 'Ghostty PTY never produced a prompt' }
+  )
+}
+
+const setTerminalContentWidth = async (width: number | null): Promise<void> => {
+  await browser.execute((nextWidth: number | null) => {
+    const content = document.querySelector<HTMLElement>(
+      '[data-testid="terminal-content"]'
+    )
+
+    if (!content) {
+      return
+    }
+
+    content.style.width = nextWidth === null ? '' : `${nextWidth}px`
+  }, width)
+}
+
+const waitForTerminalColsAtMost = async (maxCols: number): Promise<number> => {
+  let cols = 0
+
+  await browser.waitUntil(
+    async () => {
+      cols = (await readTerminalSize())?.cols ?? 0
+
+      return cols > 3 && cols <= maxCols
+    },
+    {
+      timeout: 10_000,
+      interval: 250,
+      timeoutMsg: `Ghostty pane did not settle at or below ${maxCols} columns`,
+    }
+  )
+
+  return cols
+}
+
+const waitForTerminalBufferToSettle = async (): Promise<void> => {
+  let lastBuffer = await readTerminalBuffer()
+  let stableSince = Date.now()
+
+  await browser.waitUntil(
+    async () => {
+      const nextBuffer = await readTerminalBuffer()
+
+      if (nextBuffer !== lastBuffer) {
+        lastBuffer = nextBuffer
+        stableSince = Date.now()
+
+        return false
+      }
+
+      return Date.now() - stableSince >= 500
+    },
+    {
+      timeout: 5_000,
+      interval: 100,
+      timeoutMsg: 'Ghostty terminal buffer did not settle after resize',
+    }
+  )
+}
+
+const waitForTerminalBufferContaining = async (
+  marker: string,
+  description: string
+): Promise<void> => {
+  await browser
+    .waitUntil(
+      async () => {
+        const buffer = await readTerminalBuffer()
+
+        return buffer.includes(marker)
+      },
+      {
+        timeout: ESCAPE_SEQUENCE_TIMEOUT_MS,
+        interval: 100,
+      }
+    )
+    .catch(async () => {
+      const finalBuffer = await readTerminalBuffer()
+
+      throw new Error(
+        `${description}; final visible buffer: ${JSON.stringify(finalBuffer)}`
+      )
+    })
+}
+
+const readGhosttyViewportMetrics = async (): Promise<GhosttyViewportMetrics> =>
+  browser.execute(() => {
+    const root = document.querySelector<HTMLElement>(
+      '[data-terminal-renderer="ghostty"]'
+    )
+    const output = root?.querySelector<HTMLElement>('pre') ?? null
+    const cursorMarker =
+      root?.querySelector<HTMLElement>(
+        '[data-terminal-cursor-marker="true"]'
+      ) ?? null
+    const rows = Array.from(
+      root?.querySelectorAll<HTMLElement>('[data-terminal-row="true"]') ?? []
+    )
+    const firstNonEmptyRowIndex = rows.findIndex(
+      (row) => (row.textContent ?? '').trim().length > 0
+    )
+    const overflowTolerance = 1
+
+    if (!root || !output || !cursorMarker) {
+      return {
+        cursorVisible: false,
+        firstNonEmptyRowIndex:
+          firstNonEmptyRowIndex === -1 ? null : firstNonEmptyRowIndex,
+        firstNonEmptyRowText:
+          firstNonEmptyRowIndex === -1
+            ? ''
+            : (rows[firstNonEmptyRowIndex]?.textContent ?? ''),
+        hasHorizontalOverflow: true,
+        rootScrollTop: 0,
+        viewportRowsMatchPty: false,
+      }
+    }
+
+    const rootRect = root.getBoundingClientRect()
+    const cursorRect = cursorMarker.getBoundingClientRect()
+    const readPixels = (value: string): number => {
+      const parsed = Number.parseFloat(value)
+
+      return Number.isFinite(parsed) ? parsed : 0
+    }
+
+    const lineHeight = readPixels(
+      root.style.getPropertyValue('--terminal-line-height')
+    )
+    const ptyViewportHeight = readPixels(
+      root.style.getPropertyValue('--terminal-pty-viewport-height')
+    )
+    const viewportRowsMatchPty =
+      lineHeight > 0 &&
+      ptyViewportHeight > 0 &&
+      root.clientHeight + overflowTolerance >= ptyViewportHeight &&
+      root.clientHeight < ptyViewportHeight + lineHeight - overflowTolerance
+
+    return {
+      cursorVisible:
+        cursorRect.top >= rootRect.top && cursorRect.bottom <= rootRect.bottom,
+      firstNonEmptyRowIndex:
+        firstNonEmptyRowIndex === -1 ? null : firstNonEmptyRowIndex,
+      firstNonEmptyRowText:
+        firstNonEmptyRowIndex === -1
+          ? ''
+          : (rows[firstNonEmptyRowIndex]?.textContent ?? ''),
+      hasHorizontalOverflow:
+        root.scrollWidth - root.clientWidth > overflowTolerance ||
+        output.scrollWidth - output.clientWidth > overflowTolerance,
+      rootScrollTop: root.scrollTop,
+      viewportRowsMatchPty,
+    }
+  })
+
+const expectGhosttyViewportHealthy = (
+  metrics: GhosttyViewportMetrics
+): void => {
+  expect(metrics.cursorVisible).toBe(true)
+  expect(metrics.hasHorizontalOverflow).toBe(false)
+  expect(metrics.viewportRowsMatchPty).toBe(true)
+}
+
+describe('Ghostty native render-state smoke', () => {
+  let narrowTerminalCols = 0
+
+  before(async () => {
+    await waitForE2eBridge()
+    await assertNativeGhosttyBuild()
+    await waitForGhosttyRenderer()
+    await waitForGhosttyPrompt()
+    await setTerminalContentWidth(NARROW_TERMINAL_WIDTH_PX)
+    narrowTerminalCols = await waitForTerminalColsAtMost(MAX_NARROW_PROMPT_COLS)
+    await waitForTerminalBufferToSettle()
+  })
+
+  after(async () => {
+    await setTerminalContentWidth(null)
+  })
+
+  it('wraps native output without horizontal overflow', async () => {
+    await waitForTerminalBufferToSettle()
+    const marker = `gn-${Date.now().toString(36)}`
+    const prompt = 'native$ '
+    const longInput = 'x'.repeat(narrowTerminalCols * 2 + 3)
+
+    await writeOutputToVisibleTerminal(
+      `\x1b[2J\x1b[1;1H${prompt}${longInput}\n${marker}`
+    )
+
+    await waitForTerminalBufferContaining(
+      marker,
+      `Ghostty native marker ${marker} never appeared in the terminal buffer`
+    )
+
+    const buffer = await readTerminalBuffer()
+    const metrics = await readGhosttyViewportMetrics()
+
+    expect(buffer).toContain(
+      `${prompt}${'x'.repeat(narrowTerminalCols - prompt.length)}`
+    )
+    expect(buffer).toContain('\n')
+    expect(buffer).toContain(marker)
+    expect(buffer).not.toContain('\x1b')
+    expectGhosttyViewportHealthy(metrics)
+  })
+
+  it('keeps clear-screen output at the viewport top', async () => {
+    await waitForTerminalBufferToSettle()
+    const prompt = 'native-clear$ '
+
+    await writeOutputToVisibleTerminal(
+      `before clear\n\x1b[2J\x1b[1;1H${prompt}`
+    )
+
+    await waitForTerminalBufferContaining(prompt, 'Ghostty native prompt')
+
+    const metrics = await readGhosttyViewportMetrics()
+
+    expect(metrics.firstNonEmptyRowIndex).toBe(0)
+    expect(metrics.firstNonEmptyRowText).toContain(prompt)
+    expect(metrics.rootScrollTop).toBe(0)
+    expectGhosttyViewportHealthy(metrics)
+  })
+
+  it('keeps the cursor visible after blank-line scrolling', async () => {
+    await waitForTerminalBufferToSettle()
+    const rows = (await readTerminalSize())?.rows ?? 6
+    const marker = `bottom-${Date.now()}`
+
+    await writeOutputToVisibleTerminal(
+      `\x1b[2J\x1b[1;1Hnative-bottom$ ${'\n'.repeat(rows + 3)}${marker}`
+    )
+
+    await waitForTerminalBufferContaining(
+      marker,
+      'Ghostty native blank-line marker never became visible'
+    )
+
+    const metrics = await readGhosttyViewportMetrics()
+
+    expectGhosttyViewportHealthy(metrics)
+  })
+
+  it('keeps repeated prompt cursors inside the fitted PTY viewport', async () => {
+    await waitForTerminalBufferToSettle()
+    const rows = (await readTerminalSize())?.rows ?? 6
+    const prompt = 'native-active$ '
+
+    await writeOutputToVisibleTerminal(
+      `\x1b[2J\x1b[1;1H${Array.from({ length: rows + 4 }, () => prompt).join(
+        '\n'
+      )}`
+    )
+
+    await waitForTerminalBufferContaining(prompt, 'Ghostty native prompt rows')
+
+    const metrics = await readGhosttyViewportMetrics()
+
+    expectGhosttyViewportHealthy(metrics)
+  })
+})

--- a/tests/e2e/ghostty-native/specs/native-render-state-smoke.spec.ts
+++ b/tests/e2e/ghostty-native/specs/native-render-state-smoke.spec.ts
@@ -244,7 +244,7 @@ const readGhosttyViewportMetrics = async (): Promise<GhosttyViewportMetrics> =>
       lineHeight > 0 &&
       ptyViewportHeight > 0 &&
       root.clientHeight + overflowTolerance >= ptyViewportHeight &&
-      root.clientHeight < ptyViewportHeight + lineHeight - overflowTolerance
+      root.clientHeight < ptyViewportHeight + lineHeight
 
     return {
       cursorVisible:

--- a/tests/e2e/ghostty-native/wdio.conf.ts
+++ b/tests/e2e/ghostty-native/wdio.conf.ts
@@ -1,0 +1,54 @@
+// cspell:ignore ghostty
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  appArgs,
+  appEntryPoint,
+  cleanupUserDataDirs,
+  injectFreshUserDataDir,
+} from '../shared/electron-app.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const cacheDir = path.resolve(
+  process.env.RUNNER_TEMP ?? path.resolve(__dirname, '..', '.wdio-cache'),
+  'ghostty-native'
+)
+
+export const config: WebdriverIO.Config = {
+  runner: 'local',
+  framework: 'mocha',
+  reporters: ['spec'],
+  cacheDir,
+
+  specs: [path.resolve(__dirname, 'specs/**/*.spec.ts')],
+  maxInstances: 1,
+  maxInstancesPerCapability: 1,
+
+  tsConfigPath: path.resolve(__dirname, '../tsconfig.json'),
+
+  services: ['electron'],
+
+  onPrepare: () => {
+    process.env.VIMEFLOW_DISABLE_AGENT_DETECTION = '1'
+  },
+
+  beforeSession: (_config, capabilities) => {
+    injectFreshUserDataDir(capabilities as WebdriverIO.Capabilities)
+  },
+  afterSession: () => {
+    cleanupUserDataDirs()
+  },
+
+  capabilities: [
+    {
+      browserName: 'electron',
+      'wdio:electronServiceOptions': {
+        appEntryPoint,
+        appArgs,
+      },
+    },
+  ],
+
+  waitforTimeout: 20_000,
+  mochaOpts: { ui: 'bdd', timeout: 60_000 },
+}

--- a/tests/e2e/ghostty-native/wdio.conf.ts
+++ b/tests/e2e/ghostty-native/wdio.conf.ts
@@ -50,5 +50,5 @@ export const config: WebdriverIO.Config = {
   ],
 
   waitforTimeout: 20_000,
-  mochaOpts: { ui: 'bdd', timeout: 60_000 },
+  mochaOpts: { ui: 'bdd', timeout: 120_000 },
 }


### PR DESCRIPTION
## Summary

- Add a native Ghostty Electron smoke suite behind `VITE_TERMINAL_RENDERER=ghostty` and `VITE_GHOSTTY_RENDER_STATE_DRIVER_PROVIDER=native`.
- Harden Electron native package discovery so partial/stale app-root copies of `@coder/libghostty-vt-node` do not shadow the real workspace package.
- Expose renderer/provider config through the E2E bridge so native smoke fails if it runs against the wrong renderer.
- Add a terminal viewport invariant: fitted PTY cols/rows are published to the renderer and native smoke asserts the DOM viewport matches the fitted PTY height with less than one row of slack.
- Scroll snapshot/replace renders by the actual rendered cursor marker bounds before falling back to row math.

## Why

VIM-181 is the first M3 slice after the native render-state bridge landed. The recent cursor-hidden and native package startup failures came from two runtime parity risks: the native binding resolver could choose the wrong app-root path, and the renderer could drift between PTY rows and visible DOM viewport height.

## Manual testing

No manual smoke required for this slice. The PR adds automated native Electron smoke coverage for the behavior under the Ghostty native flags.

## Verification

- `npm run type-check:generated`
- `npx tsc -p tests/e2e/tsconfig.json`
- `npm run lint`
- `npm test -- --run src/lib/e2e-bridge.test.ts electron/ghostty-render-state-main.test.ts src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts`
- `npm run test:e2e:ghostty:native:build:generated`
- `npm run test:e2e:ghostty:native:run`
- pre-push `npm test`: 305 test files passed, 3957 tests passed, 3 skipped

Linear: VIM-181