### PR TITLE
test(terminal): close Ghostty M4 native smoke

### DIFF
--- a/crates/backend/src/runtime/test_event_sink.rs
+++ b/crates/backend/src/runtime/test_event_sink.rs
@@ -62,6 +62,41 @@ impl RecordingEventSink {
             }
         }
     }
+
+    pub fn wait_for_event<F>(&self, event: &str, timeout: Duration, predicate: F) -> bool
+    where
+        F: Fn(&Value) -> bool,
+    {
+        let deadline = Instant::now() + timeout;
+        let mut recorded = self.recorded.lock().expect("RecordingEventSink poisoned");
+
+        loop {
+            if recorded
+                .iter()
+                .any(|(name, payload)| name == event && predicate(payload))
+            {
+                return true;
+            }
+
+            let now = Instant::now();
+            if now >= deadline {
+                return false;
+            }
+
+            let wait_for = deadline.saturating_duration_since(now);
+            let (next, wait_result) = self
+                .changed
+                .wait_timeout(recorded, wait_for)
+                .expect("RecordingEventSink poisoned");
+            recorded = next;
+
+            if wait_result.timed_out() {
+                return recorded
+                    .iter()
+                    .any(|(name, payload)| name == event && predicate(payload));
+            }
+        }
+    }
 }
 
 impl Default for RecordingEventSink {

--- a/crates/backend/src/terminal/commands.rs
+++ b/crates/backend/src/terminal/commands.rs
@@ -1742,16 +1742,11 @@ mod tests {
         .expect("write should succeed");
 
         let saw_marker =
-            events.wait_for_count("pty-data", 1, std::time::Duration::from_secs(5))
-                && events
-                    .recorded()
-                    .iter()
-                    .filter(|(event, _)| event == "pty-data")
-                    .any(|(_, payload)| {
-                        payload["data"]
-                            .as_str()
-                            .is_some_and(|data| data.contains(marker))
-                    });
+            events.wait_for_event("pty-data", std::time::Duration::from_secs(5), |payload| {
+                payload["data"]
+                    .as_str()
+                    .is_some_and(|data| data.contains(marker))
+            });
 
         assert!(saw_marker, "pty-data should contain the POSIX command output");
 

--- a/crates/backend/src/terminal/commands.rs
+++ b/crates/backend/src/terminal/commands.rs
@@ -1708,6 +1708,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn write_pty_emits_data_events_for_posix_command_output() {
+        let (state, cache, _events, _temp_dir) = create_test_state_with_cache();
+        let events = Arc::new(crate::runtime::FakeEventSink::new());
+        let marker = "vf-posix-pty-event";
+
+        spawn_pty_inner(
+            state.clone(),
+            cache.clone(),
+            events.clone() as Arc<dyn crate::runtime::EventSink>,
+            SpawnPtyRequest {
+                session_id: "test-posix-output".to_string(),
+                cwd: std::env::current_dir()
+                    .unwrap()
+                    .to_string_lossy()
+                    .to_string(),
+                shell: None,
+                env: None,
+                enable_agent_bridge: false,
+                ephemeral: false,
+            },
+        )
+        .await
+        .expect("spawn should succeed");
+
+        write_pty_inner(
+            &state,
+            WritePtyRequest {
+                session_id: "test-posix-output".to_string(),
+                data: format!("printf '{marker}\\n'\n"),
+            },
+        )
+        .expect("write should succeed");
+
+        let saw_marker =
+            events.wait_for_count("pty-data", 1, std::time::Duration::from_secs(5))
+                && events
+                    .recorded()
+                    .iter()
+                    .filter(|(event, _)| event == "pty-data")
+                    .any(|(_, payload)| {
+                        payload["data"]
+                            .as_str()
+                            .is_some_and(|data| data.contains(marker))
+                    });
+
+        assert!(saw_marker, "pty-data should contain the POSIX command output");
+
+        let _ = state.remove(&"test-posix-output".to_string());
+    }
+
+    #[tokio::test]
     async fn session_remains_accessible_during_reader_startup() {
         // This test verifies the fix for the race condition where session was
         // temporarily removed from state during reader cloning, causing concurrent

--- a/docs/explorations/ghostty-m4-native-vt-smoke.md
+++ b/docs/explorations/ghostty-m4-native-vt-smoke.md
@@ -1,0 +1,72 @@
+# Ghostty M4 Native VT Smoke Checklist
+
+Use this checklist to close M4 against the real native Ghostty VT provider.
+
+## Launch
+
+Run the Electron app with the native provider enabled:
+
+```sh
+VITE_TERMINAL_RENDERER=ghostty VITE_GHOSTTY_RENDER_STATE_DRIVER_PROVIDER=native npm run electron:dev
+```
+
+Expected startup result:
+
+- The terminal pane does not show `Terminal failed to start`.
+- Shell output appears without clicking another UI control first.
+- The prompt renders ANSI colors, powerline or Nerd Font symbols, and a blinking block cursor.
+- The terminal pane has no horizontal scrollbar after narrowing the pane.
+
+## Selection And Copy
+
+1. In the terminal, run:
+
+   ```sh
+   printf '\033[2J\033[1;1Hnative-select$ '
+   ```
+
+2. Right-click inside the terminal and choose `Select All`.
+3. Right-click again and choose `Copy`, or use the platform copy shortcut.
+4. Paste into a text editor.
+
+Expected result:
+
+```text
+native-select$
+```
+
+There should be no extra blank lines after the prompt.
+
+## Native Command IO
+
+Run:
+
+```sh
+printf 'native-m4:stdout\n'; printf 'native-m4:stderr\n' 1>&2; read vf_line; printf 'native-m4:stdin:%s\n' "$vf_line"
+```
+
+Then type:
+
+```text
+hello-from-ghostty
+```
+
+Expected result:
+
+- `stdout`, `stderr`, and `stdin:hello-from-ghostty` are visible.
+- The active cursor remains visible at the bottom of the viewport.
+- No escape-control text such as `[2J`, `[1;1H`, or `]7;` is rendered.
+
+## Wrapping And Cursor
+
+Narrow the terminal pane and run:
+
+```sh
+i=0; while [ "$i" -lt 240 ]; do printf x; i=$((i + 1)); done; printf '\nwrap-done\n'
+```
+
+Expected result:
+
+- Output wraps inside the pane width.
+- No horizontal scrollbar appears.
+- The cursor remains visible after the final prompt.

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -54,7 +54,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 1        | 0    | 2026-06-09   |
-| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 66       | 33   | 2026-06-20   |
+| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 66       | 34   | 2026-06-20   |
 | [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 24       | 7    | 2026-06-19   |
 | [Terminal DOM Rendering](patterns/terminal-dom-rendering.md)                                         | terminal           | 3        | 0    | 2026-06-19   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
@@ -62,7 +62,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 85       | 25   | 2026-06-08   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 51       | 24   | 2026-06-18   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
-| [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 63       | 22   | 2026-06-08   |
+| [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 63       | 23   | 2026-06-08   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)                                       | backend            | 2        | 1    | 2026-05-20   |
 | [Command Injection](patterns/command-injection.md)                                                   | security           | 7        | 3    | 2026-05-02   |
 | [Policy Judge Hygiene](patterns/policy-judge-hygiene.md)                                             | security           | 15       | 2    | 2026-04-20   |

--- a/docs/reviews/patterns/async-race-conditions.md
+++ b/docs/reviews/patterns/async-race-conditions.md
@@ -3,7 +3,7 @@ id: async-race-conditions
 category: react-patterns
 created: 2026-04-09
 last_updated: 2026-06-08
-ref_count: 22
+ref_count: 23
 ---
 
 # Async Race Conditions

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -3,7 +3,7 @@ id: testing-gaps
 category: testing
 created: 2026-04-09
 last_updated: 2026-06-20
-ref_count: 33
+ref_count: 34
 ---
 
 # Testing Gaps
@@ -656,4 +656,13 @@ filesystem scope restrictions).
 - **File:** `electron/ghostty-render-state-main.test.ts`
 - **Finding:** Native package resolver tests asserted fallback to `process.cwd()/node_modules/@coder/libghostty-vt-node`, which only works when the optional native package is installed in the checkout. Clean or unsupported-platform installs could fail with a misleading path mismatch.
 - **Fix:** Made the resolver tests create their own temporary valid fallback package, including a manifest and `.node` file under `prebuilds`, so they no longer depend on local optional dependency installation.
+- **Commit:** same commit as this entry
+
+### 66. PTY event test waited for any data instead of the command marker
+
+- **Source:** github-codex-connector | PR #582 round 1 | 2026-06-20
+- **Severity:** HIGH
+- **File:** `crates/backend/src/terminal/commands.rs`
+- **Finding:** The new PTY output regression test waited for the first `pty-data` event and then immediately inspected recorded events for the command marker. Shell startup prompts can emit PTY data before the `printf` output arrives, making the test intermittently fail in CI.
+- **Fix:** Added a predicate-based wait helper to the recording event sink and updated the test to wait until a `pty-data` payload contains the marker itself.
 - **Commit:** same commit as this entry

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test:e2e:ghostty:run": "cross-env VITE_E2E=1 VITE_TERMINAL_RENDERER=ghostty wdio tests/e2e/ghostty/wdio.conf.ts",
     "test:e2e:ghostty:native:build": "npm run generate:bindings && npm run test:e2e:ghostty:native:build:generated",
     "test:e2e:ghostty:native:build:generated": "tsc -b && cross-env VITE_E2E=1 VITE_TERMINAL_RENDERER=ghostty VITE_GHOSTTY_RENDER_STATE_DRIVER_PROVIDER=native vite build --mode electron && cargo build --bin vimeflow-backend --features e2e-test",
-    "test:e2e:ghostty:native:run": "wdio tests/e2e/ghostty-native/wdio.conf.ts",
+    "test:e2e:ghostty:native:run": "cross-env VITE_E2E=1 VITE_TERMINAL_RENDERER=ghostty VITE_GHOSTTY_RENDER_STATE_DRIVER_PROVIDER=native wdio tests/e2e/ghostty-native/wdio.conf.ts",
     "test:e2e": "npm run test:e2e:build && npm run test:e2e:core:run",
     "test:e2e:terminal": "npm run test:e2e:build && npm run test:e2e:terminal:run",
     "test:e2e:agent": "npm run test:e2e:build && npm run test:e2e:agent:run",

--- a/src/features/terminal/components/TerminalContextMenu.test.tsx
+++ b/src/features/terminal/components/TerminalContextMenu.test.tsx
@@ -7,6 +7,7 @@ const baseProps = {
   onClose: vi.fn(),
   onCopy: vi.fn(),
   onPaste: vi.fn(),
+  onSelectAll: vi.fn(),
   canCopy: true,
 }
 
@@ -21,7 +22,7 @@ test('renders null when isOpen is false', () => {
   expect(container).toBeEmptyDOMElement()
 })
 
-test('renders a menu with Copy and Paste items when isOpen and canCopy', () => {
+test('renders a menu with terminal action items when isOpen and canCopy', () => {
   render(
     <TerminalContextMenu {...baseProps} isOpen position={{ x: 50, y: 60 }} />
   )
@@ -29,11 +30,12 @@ test('renders a menu with Copy and Paste items when isOpen and canCopy', () => {
   expect(
     screen.getByRole('menu', { name: 'Terminal actions' })
   ).toBeInTheDocument()
+
+  expect(
+    screen.getByRole('menuitem', { name: 'Select All' })
+  ).toBeInTheDocument()
   expect(screen.getByRole('menuitem', { name: 'Copy' })).toBeInTheDocument()
   expect(screen.getByRole('menuitem', { name: 'Paste' })).toBeInTheDocument()
-  expect(
-    screen.queryByRole('menuitem', { name: 'Select All' })
-  ).not.toBeInTheDocument()
 
   expect(
     screen.queryByRole('menuitem', { name: 'Clear' })
@@ -90,6 +92,33 @@ test('clicking Copy with canCopy=true fires onCopy then onClose', async () => {
   await user.click(screen.getByRole('menuitem', { name: 'Copy' }))
 
   expect(order).toEqual(['copy', 'close'])
+})
+
+test('clicking Select All fires onSelectAll then onClose', async () => {
+  const user = userEvent.setup()
+  const order: string[] = []
+
+  const onSelectAll = vi.fn(() => {
+    order.push('select-all')
+  })
+
+  const onClose = vi.fn(() => {
+    order.push('close')
+  })
+
+  render(
+    <TerminalContextMenu
+      {...baseProps}
+      onClose={onClose}
+      onSelectAll={onSelectAll}
+      isOpen
+      position={{ x: 0, y: 0 }}
+    />
+  )
+
+  await user.click(screen.getByRole('menuitem', { name: 'Select All' }))
+
+  expect(order).toEqual(['select-all', 'close'])
 })
 
 test('clicking Copy when canCopy=false does not fire onCopy or onClose', async () => {
@@ -165,8 +194,11 @@ test('ArrowDown loops on Paste when disabled Copy is skipped', async () => {
     />
   )
 
-  expect(screen.getByRole('menuitem', { name: 'Paste' })).toHaveFocus()
+  expect(screen.getByRole('menuitem', { name: 'Select All' })).toHaveFocus()
 
   await user.keyboard('{ArrowDown}')
   expect(screen.getByRole('menuitem', { name: 'Paste' })).toHaveFocus()
+
+  await user.keyboard('{ArrowDown}')
+  expect(screen.getByRole('menuitem', { name: 'Select All' })).toHaveFocus()
 })

--- a/src/features/terminal/components/TerminalContextMenu.tsx
+++ b/src/features/terminal/components/TerminalContextMenu.tsx
@@ -6,6 +6,7 @@ export interface TerminalContextMenuProps {
   isOpen: boolean
   position: { x: number; y: number } | null
   onClose: () => void
+  onSelectAll: () => void
   onCopy: () => void
   onPaste: () => void
   canCopy: boolean
@@ -29,6 +30,7 @@ export const TerminalContextMenu = ({
   isOpen,
   position,
   onClose,
+  onSelectAll,
   onCopy,
   onPaste,
   canCopy,
@@ -48,6 +50,7 @@ export const TerminalContextMenu = ({
       }}
       aria-label="Terminal actions"
     >
+      <Menu.Item onSelect={onSelectAll}>Select All</Menu.Item>
       <Menu.Item disabled={!canCopy} shortcut={COPY_SHORTCUT} onSelect={onCopy}>
         Copy
       </Menu.Item>

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -979,6 +979,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
         isOpen={clipboard.isOpen}
         position={clipboard.openAt}
         onClose={clipboard.close}
+        onSelectAll={clipboard.selectAll}
         onCopy={(): void => {
           void clipboard.copy()
         }}

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
@@ -686,6 +686,52 @@ describe('ghosttyInstance', () => {
     expect(cursor?.nextSibling?.textContent).toBe('tput')
   })
 
+  test('copies interpreted text for full replace snapshot selections', () => {
+    const parser: TerminalParser = {
+      onEvent: (): TerminalDisposable => ({ dispose: vi.fn() }),
+    }
+
+    const parserEngine: TerminalParserEngine = {
+      inputMode: 'bytes',
+      capabilities: ghosttyTerminalRenderer.capabilities,
+      parser,
+      parseText: (text): TerminalParserEngineOutput => ({
+        visibleText: text,
+      }),
+      parseInput: (input): TerminalParserEngineOutput => ({
+        visibleText: input.text,
+      }),
+      parseOutput: (): TerminalParserEngineOutput =>
+        createGhosttyVtRenderSnapshotOutput({
+          rows: ['prompt', '', ''],
+          cursor: {
+            rowIndex: 0,
+            columnOffset: 6,
+          },
+        }),
+    }
+
+    const created = createTrackedGhosttyTerminal({
+      createParserEngine: () => parserEngine,
+    })
+    const container = document.createElement('div')
+
+    document.body.append(container)
+    created.terminal.open(container)
+    created.output.writeOutput({
+      text: 'snapshot',
+      offsetStart: 0,
+      byteLen: 8,
+      phase: 'live',
+    })
+
+    created.terminal.selectAll()
+
+    expect(created.viewportReader.readVisibleText()).toBe('prompt')
+    expect(created.terminal.hasSelection()).toBe(true)
+    expect(created.terminal.getSelection()).toBe('prompt')
+  })
+
   test('disposes the parser engine once through terminal disposal', () => {
     const parser: TerminalParser = {
       onEvent: (): TerminalDisposable => ({ dispose: vi.fn() }),

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
@@ -796,6 +796,7 @@ describe('plainTextInstance', () => {
       ...theme,
       background: theme.brightBlack,
       foreground: theme.brightWhite,
+      selectionForeground: theme.background,
     }
 
     created.terminal.applyTheme(terminalTheme)
@@ -807,5 +808,25 @@ describe('plainTextInstance', () => {
         '--terminal-cursor-color'
       )
     ).toBe(terminalTheme.cursor)
+
+    expect(
+      created.terminal.element?.style.getPropertyValue(
+        '--terminal-selection-background'
+      )
+    ).toBe(terminalTheme.selectionBackground)
+
+    expect(
+      created.terminal.element?.style.getPropertyValue(
+        '--terminal-selection-foreground'
+      )
+    ).toBe(terminalTheme.selectionForeground)
+
+    created.terminal.applyTheme(theme)
+
+    expect(
+      created.terminal.element?.style.getPropertyValue(
+        '--terminal-selection-foreground'
+      )
+    ).toBe('')
   })
 })

--- a/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
+++ b/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
@@ -65,7 +65,11 @@ const getControlKeyData = (key: string): string | null => {
   return String.fromCharCode(upperKey.charCodeAt(0) - 64)
 }
 
-const readContainedSelection = (root: HTMLElement): string => {
+const readContainedSelection = (
+  root: HTMLElement,
+  output: HTMLElement,
+  selectAllText: string
+): string => {
   const selection = window.getSelection()
 
   if (!selection || selection.rangeCount === 0) {
@@ -82,6 +86,18 @@ const readContainedSelection = (root: HTMLElement): string => {
     !root.contains(focusNode)
   ) {
     return ''
+  }
+
+  const range = selection.getRangeAt(0)
+  const outputRange = document.createRange()
+  outputRange.selectNodeContents(output)
+
+  const includesAllOutput =
+    range.compareBoundaryPoints(Range.START_TO_START, outputRange) <= 0 &&
+    range.compareBoundaryPoints(Range.END_TO_END, outputRange) >= 0
+
+  if (includesAllOutput) {
+    return selectAllText
   }
 
   return selection.toString()
@@ -154,6 +170,7 @@ export class TerminalTextSurface implements TerminalSurface {
   private rowsValue = DEFAULT_ROWS
   private cachedCharacterWidth: number | null = null
   private lastSelectionText = ''
+  private selectAllSelectionText: string | null = null
   private disposed = false
 
   constructor(private readonly options: TerminalTextSurfaceOptions) {
@@ -332,11 +349,11 @@ export class TerminalTextSurface implements TerminalSurface {
   }
 
   hasSelection(): boolean {
-    return readContainedSelection(this.root).length > 0
+    return this.readSelectionText().length > 0
   }
 
   getSelection(): string {
-    return readContainedSelection(this.root)
+    return this.readSelectionText()
   }
 
   paste(text: string): void {
@@ -348,13 +365,15 @@ export class TerminalTextSurface implements TerminalSurface {
       return
     }
 
+    this.selectAllSelectionText = this.outputBuffer.readVisibleText()
+
     const range = document.createRange()
     range.selectNodeContents(this.output)
 
     const selection = window.getSelection()
     selection?.removeAllRanges()
     selection?.addRange(range)
-    this.lastSelectionText = readContainedSelection(this.root)
+    this.lastSelectionText = this.readSelectionText()
     this.notifySelectionChange()
   }
 
@@ -412,6 +431,15 @@ export class TerminalTextSurface implements TerminalSurface {
       '--terminal-selection-background',
       theme.selectionBackground
     )
+
+    if (theme.selectionForeground) {
+      this.root.style.setProperty(
+        '--terminal-selection-foreground',
+        theme.selectionForeground
+      )
+    } else {
+      this.root.style.removeProperty('--terminal-selection-foreground')
+    }
   }
 
   fit(): void {
@@ -451,11 +479,13 @@ export class TerminalTextSurface implements TerminalSurface {
   }
 
   private readonly handlePointerDown = (): void => {
+    this.selectAllSelectionText = null
     this.focus()
   }
 
   private readonly handleSelectionChange = (): void => {
-    const selectionText = readContainedSelection(this.root)
+    this.selectAllSelectionText = null
+    const selectionText = this.readSelectionText()
 
     if (selectionText === this.lastSelectionText) {
       return
@@ -463,6 +493,20 @@ export class TerminalTextSurface implements TerminalSurface {
 
     this.lastSelectionText = selectionText
     this.notifySelectionChange()
+  }
+
+  private readSelectionText(): string {
+    const nativeSelectionText = readContainedSelection(
+      this.root,
+      this.output,
+      this.outputBuffer.readVisibleText()
+    )
+
+    if (nativeSelectionText.length > 0) {
+      return nativeSelectionText
+    }
+
+    return this.selectAllSelectionText ?? ''
   }
 
   private readonly handleKeyDown = (event: KeyboardEvent): void => {

--- a/src/lib/e2e-bridge.test.ts
+++ b/src/lib/e2e-bridge.test.ts
@@ -4,8 +4,10 @@ import { __resetBackendEventSubscriptions, type BackendApi } from './backend'
 import {
   clearRecordedPtyDataEvents,
   getRecordedPtyDataEvents,
+  getVisibleTerminalSelection,
   getVisibleTerminalSize,
   readPaneBuffer,
+  selectAllVisibleTerminal,
   startRecordingPtyDataEvents,
   stopRecordingPtyDataEvents,
   writeInputToVisibleTerminal,
@@ -28,6 +30,8 @@ interface MockViewportReader {
 }
 
 const makeMockEntry = (rows: readonly string[]): CacheEntry => {
+  let selectionText = ''
+
   const viewportReader: MockViewportReader = {
     readVisibleText: (): string => {
       const visibleRows = rows.map((row) => row.replace(/\s+$/, ''))
@@ -37,7 +41,16 @@ const makeMockEntry = (rows: readonly string[]): CacheEntry => {
   }
 
   return {
-    terminal: { cols: 80, dispose: (): void => undefined, rows: 24 },
+    terminal: {
+      cols: 80,
+      dispose: (): void => undefined,
+      getSelection: (): string => selectionText,
+      hasSelection: (): boolean => selectionText.length > 0,
+      rows: 24,
+      selectAll: (): void => {
+        selectionText = viewportReader.readVisibleText()
+      },
+    },
     output: { writeOutput: vi.fn() },
     fitController: { fit: (): void => undefined },
     viewportReader,
@@ -333,6 +346,22 @@ describe('readPaneBuffer', () => {
     document.body.append(wrapper)
 
     expect(getVisibleTerminalSize()).toEqual({ cols: 80, rows: 24 })
+  })
+
+  test('selects all text from the active cached renderer', () => {
+    const wrapper = buildSessionWrapper([''], 0)
+    wrapper.getBoundingClientRect = visibleDomRect
+
+    terminalCache.set('pty-0', makeMockEntry(['visible', '', ''])!)
+    document.body.append(wrapper)
+
+    expect(selectAllVisibleTerminal()).toBe(true)
+    expect(getVisibleTerminalSelection()).toBe('visible')
+  })
+
+  test('does not select terminal text when no visible renderer is mounted', () => {
+    expect(selectAllVisibleTerminal()).toBe(false)
+    expect(getVisibleTerminalSelection()).toBe('')
   })
 
   test('does not write output when no visible terminal is mounted', () => {

--- a/src/lib/e2e-bridge.ts
+++ b/src/lib/e2e-bridge.ts
@@ -134,6 +134,28 @@ const readVisibleTerminalBuffer = (): string => {
   return pane ? readPaneBuffer(pane) : ''
 }
 
+const readVisibleTerminalEntry = (): {
+  readonly sessionId: string
+  readonly entry: NonNullable<ReturnType<typeof terminalCache.get>>
+} | null => {
+  const pane = findActivePane()
+  if (!pane) {
+    return null
+  }
+
+  const sessionId = resolveCacheKey(pane)
+  if (!sessionId) {
+    return null
+  }
+
+  const entry = terminalCache.get(sessionId)
+  if (!entry) {
+    return null
+  }
+
+  return { sessionId, entry }
+}
+
 // Callers may pass either a React `Session.id` (the workspace UUID) or a
 // `pane.ptyId` (the Rust PTY handle). Post-5a these are distinct values;
 // post-5b SplitView refactor (PR #199) the pane-level data-attrs moved
@@ -166,24 +188,14 @@ export const getVisibleTerminalSize = (): {
   readonly cols: number
   readonly rows: number
 } | null => {
-  const pane = findActivePane()
-  if (!pane) {
-    return null
-  }
-
-  const sessionId = resolveCacheKey(pane)
-  if (!sessionId) {
-    return null
-  }
-
-  const entry = terminalCache.get(sessionId)
-  if (!entry) {
+  const active = readVisibleTerminalEntry()
+  if (!active) {
     return null
   }
 
   return {
-    cols: entry.terminal.cols,
-    rows: entry.terminal.rows,
+    cols: active.entry.terminal.cols,
+    rows: active.entry.terminal.rows,
   }
 }
 
@@ -197,18 +209,8 @@ export const getTerminalRendererConfig = (): {
 })
 
 export const writeOutputToVisibleTerminal = (data: string): boolean => {
-  const pane = findActivePane()
-  if (!pane) {
-    return false
-  }
-
-  const sessionId = resolveCacheKey(pane)
-  if (!sessionId) {
-    return false
-  }
-
-  const entry = terminalCache.get(sessionId)
-  if (!entry) {
+  const active = readVisibleTerminalEntry()
+  if (!active) {
     return false
   }
 
@@ -216,7 +218,7 @@ export const writeOutputToVisibleTerminal = (data: string): boolean => {
   const offsetStart = e2eOutputOffset
   e2eOutputOffset += bytes.length
 
-  entry.output.writeOutput({
+  active.entry.output.writeOutput({
     text: data,
     bytesBase64: encodeBase64(bytes),
     offsetStart,
@@ -230,19 +232,14 @@ export const writeOutputToVisibleTerminal = (data: string): boolean => {
 export const writeInputToVisibleTerminal = async (
   data: string
 ): Promise<boolean> => {
-  const pane = findActivePane()
-  if (!pane) {
-    return false
-  }
-
-  const sessionId = resolveCacheKey(pane)
-  if (!sessionId) {
+  const active = readVisibleTerminalEntry()
+  if (!active) {
     return false
   }
 
   await invoke<null>('write_pty', {
     request: {
-      sessionId,
+      sessionId: active.sessionId,
       data,
     },
   })
@@ -273,6 +270,20 @@ export const clearRecordedPtyDataEvents = (): void => {
 export const getRecordedPtyDataEvents = (): readonly RecordedPtyDataEvent[] =>
   recordedPtyDataEvents
 
+export const selectAllVisibleTerminal = (): boolean => {
+  const active = readVisibleTerminalEntry()
+  if (!active) {
+    return false
+  }
+
+  active.entry.terminal.selectAll()
+
+  return active.entry.terminal.hasSelection()
+}
+
+export const getVisibleTerminalSelection = (): string =>
+  readVisibleTerminalEntry()?.entry.terminal.getSelection() ?? ''
+
 if (import.meta.env.VITE_E2E) {
   window.__VIMEFLOW_E2E__ = {
     clearRecordedPtyDataEvents,
@@ -280,11 +291,13 @@ if (import.meta.env.VITE_E2E) {
     getTerminalBuffer: readVisibleTerminalBuffer,
     getTerminalBufferForSession: readTerminalBufferForSession,
     getTerminalRendererConfig,
+    getVisibleTerminalSelection,
     getVisibleTerminalSize,
     getVisibleSessionId,
     getActiveSessionIds: getAllPtySessionIds,
     listActivePtySessions: async (): Promise<string[]> =>
       invoke<string[]>('list_active_pty_sessions'),
+    selectAllVisibleTerminal,
     startRecordingPtyDataEvents,
     writeInputToVisibleTerminal,
     writeOutputToVisibleTerminal,

--- a/src/theme/base.css
+++ b/src/theme/base.css
@@ -39,6 +39,11 @@
   color: var(--color-on-surface);
 }
 
+[data-terminal-renderer] ::selection {
+  background: var(--terminal-selection-background);
+  color: var(--terminal-selection-foreground, inherit);
+}
+
 @layer base {
   /* Global default: every scroll container — current and future, including
    * xterm's viewport and CodeMirror's scroller — gets the thin themed

--- a/src/types/e2e.d.ts
+++ b/src/types/e2e.d.ts
@@ -19,10 +19,12 @@ declare global {
         readonly terminalRenderer: string | null
         readonly ghosttyRenderStateDriverProvider: string | null
       }
+      getVisibleTerminalSelection(): string
       getVisibleTerminalSize(): { readonly cols: number; readonly rows: number } | null
       getVisibleSessionId(): string | null
       getActiveSessionIds(): string[]
       listActivePtySessions(): Promise<string[]>
+      selectAllVisibleTerminal(): boolean
       startRecordingPtyDataEvents(): Promise<void>
       writeInputToVisibleTerminal(data: string): Promise<boolean>
       writeOutputToVisibleTerminal(data: string): boolean

--- a/tests/e2e/ghostty-native/specs/native-render-state-smoke.spec.ts
+++ b/tests/e2e/ghostty-native/specs/native-render-state-smoke.spec.ts
@@ -4,14 +4,46 @@ export {}
 const ESCAPE_SEQUENCE_TIMEOUT_MS = 15_000
 const NARROW_TERMINAL_WIDTH_PX = 360
 const MAX_NARROW_PROMPT_COLS = 60
+const TRUE_COLOR_PINK = ['rgb', '(243, 139, 168)'].join('')
+const NERD_FONT_PROMPT_ICON = String.fromCodePoint(0xf0954)
 
 interface GhosttyViewportMetrics {
+  readonly cursorAnimationName: string
+  readonly cursorHeight: number
   readonly cursorVisible: boolean
+  readonly cursorWidth: number
   readonly firstNonEmptyRowIndex: number | null
   readonly firstNonEmptyRowText: string
   readonly hasHorizontalOverflow: boolean
   readonly rootScrollTop: number
+  readonly symbolFontReady: boolean
   readonly viewportRowsMatchPty: boolean
+}
+
+interface GhosttyStyleRun {
+  readonly color: string
+  readonly text: string
+}
+
+interface BackendPtyEventBridgeProbeResult {
+  readonly error?: string
+  readonly events: readonly string[]
+  readonly sessionId: string
+}
+
+interface E2eBackendBridge {
+  readonly invoke: (
+    command: string,
+    args?: Record<string, unknown>
+  ) => Promise<unknown>
+  readonly listen: <TPayload>(
+    event: string,
+    callback: (payload: TPayload) => void
+  ) => Promise<() => void>
+}
+
+interface E2eBackendWindow extends Window {
+  readonly vimeflow?: E2eBackendBridge
 }
 
 const waitForE2eBridge = async (): Promise<void> => {
@@ -53,8 +85,104 @@ const writeOutputToVisibleTerminal = async (data: string): Promise<void> => {
   }
 }
 
+const startRecordingPtyDataEvents = async (): Promise<void> => {
+  await browser.execute(
+    async () => await window.__VIMEFLOW_E2E__?.startRecordingPtyDataEvents()
+  )
+}
+
+const clearRecordedPtyDataEvents = async (): Promise<void> => {
+  await browser.execute(() =>
+    window.__VIMEFLOW_E2E__?.clearRecordedPtyDataEvents()
+  )
+}
+
+const readRecordedPtyDataEvents = async (): Promise<
+  readonly VimeflowE2ePtyDataEvent[]
+> =>
+  browser.execute(
+    () => window.__VIMEFLOW_E2E__?.getRecordedPtyDataEvents() ?? []
+  )
+
+const probeBackendPtyEventBridge =
+  async (): Promise<BackendPtyEventBridgeProbeResult> =>
+    browser.execute(async () => {
+      const bridge = (window as E2eBackendWindow).vimeflow
+      const sessionId = `native-probe-${Date.now().toString(36)}`
+      const marker = `${sessionId}-ok`
+      const events: string[] = []
+      let unlisten: (() => void) | null = null
+
+      if (!bridge) {
+        return {
+          error: 'window.vimeflow bridge was unavailable',
+          events,
+          sessionId,
+        }
+      }
+
+      try {
+        unlisten = await bridge.listen<{
+          readonly data: string
+          readonly sessionId: string
+        }>('pty-data', (payload) => {
+          if (payload.sessionId === sessionId) {
+            events.push(payload.data)
+          }
+        })
+
+        await bridge.invoke('spawn_pty', {
+          request: {
+            cwd: '~',
+            enableAgentBridge: false,
+            env: null,
+            ephemeral: true,
+            sessionId,
+            shell: null,
+          },
+        })
+
+        await bridge.invoke('write_pty', {
+          request: {
+            data: `printf '${marker}\\n'\n`,
+            sessionId,
+          },
+        })
+
+        const deadline = Date.now() + 5_000
+        while (
+          Date.now() < deadline &&
+          !events.some((event) => event.includes(marker))
+        ) {
+          await new Promise((resolve) => {
+            window.setTimeout(resolve, 50)
+          })
+        }
+      } catch (error) {
+        return {
+          error: error instanceof Error ? error.message : String(error),
+          events,
+          sessionId,
+        }
+      } finally {
+        unlisten?.()
+        await bridge
+          .invoke('kill_pty', {
+            request: {
+              sessionId,
+            },
+          })
+          .catch(() => undefined)
+      }
+
+      return { events, sessionId }
+    })
+
 const readTerminalBuffer = async (): Promise<string> =>
   browser.execute(() => window.__VIMEFLOW_E2E__?.getTerminalBuffer() ?? '')
+
+const withoutVisualRowBreaks = (buffer: string): string =>
+  buffer.replace(/\n/g, '')
 
 const readTerminalSize = async (): Promise<{
   readonly cols: number
@@ -103,11 +231,57 @@ const waitForGhosttyRenderer = async (): Promise<void> => {
     })
 }
 
-const waitForGhosttyPrompt = async (): Promise<void> => {
+const focusGhosttyRenderer = async (): Promise<void> => {
+  const renderer = await $('[data-terminal-renderer="ghostty"]')
+
+  await renderer.click()
   await browser.waitUntil(
-    async () => (await readTerminalBuffer()).trim().length > 0,
-    { timeout: 20_000, timeoutMsg: 'Ghostty PTY never produced a prompt' }
+    async () =>
+      await browser.execute(() => {
+        const activeElement = document.activeElement
+
+        return (
+          activeElement instanceof HTMLTextAreaElement &&
+          activeElement.getAttribute('aria-label') === 'Terminal input'
+        )
+      }),
+    {
+      timeout: 5_000,
+      interval: 100,
+      timeoutMsg: 'Ghostty terminal input did not receive focus after click',
+    }
   )
+}
+
+const sendInputThroughGhosttyInput = async (text: string): Promise<void> => {
+  const didSend = await browser.execute((payload: string) => {
+    const input = document.querySelector<HTMLTextAreaElement>(
+      '[data-terminal-renderer="ghostty"] textarea[aria-label="Terminal input"]'
+    )
+
+    if (!input) {
+      return false
+    }
+
+    input.focus()
+
+    const clipboardData = new DataTransfer()
+    clipboardData.setData('text/plain', payload)
+
+    input.dispatchEvent(
+      new ClipboardEvent('paste', {
+        bubbles: true,
+        cancelable: true,
+        clipboardData,
+      })
+    )
+
+    return true
+  }, text)
+
+  if (!didSend) {
+    throw new Error('Ghostty terminal input textarea was unavailable')
+  }
 }
 
 const setTerminalContentWidth = async (width: number | null): Promise<void> => {
@@ -193,6 +367,79 @@ const waitForTerminalBufferContaining = async (
     })
 }
 
+const waitForGhosttyShellReady = async (): Promise<void> => {
+  const marker = `native-ready-${Date.now().toString(36)}`
+  let lastProbeAt = 0
+
+  await startRecordingPtyDataEvents()
+  await clearRecordedPtyDataEvents()
+
+  await browser
+    .waitUntil(
+      async () => {
+        if ((await readTerminalBuffer()).includes(marker)) {
+          return true
+        }
+
+        const now = Date.now()
+        if (now - lastProbeAt < 500) {
+          return false
+        }
+
+        lastProbeAt = now
+        await sendInputThroughGhosttyInput(
+          `printf '\\033[2J\\033[1;1H${marker}\\n'\r`
+        )
+
+        return false
+      },
+      {
+        timeout: 20_000,
+        interval: 100,
+      }
+    )
+    .catch(async () => {
+      const finalBuffer = await readTerminalBuffer()
+      const activePtys = await browser.execute(
+        async () => await window.__VIMEFLOW_E2E__?.listActivePtySessions()
+      )
+      const registeredPtys = await browser.execute(
+        () => window.__VIMEFLOW_E2E__?.getActiveSessionIds() ?? []
+      )
+      const ptyEvents = await readRecordedPtyDataEvents()
+      const eventSummary = ptyEvents.map((event) => ({
+        byteLen: event.byteLen,
+        data: event.data,
+        offsetStart: event.offsetStart,
+        sessionId: event.sessionId,
+      }))
+      const backendProbe = await probeBackendPtyEventBridge()
+
+      throw new Error(
+        'Ghostty PTY did not echo the startup readiness probe; ' +
+          `backend PTYs: ${JSON.stringify(activePtys ?? [])}; ` +
+          `registered PTYs: ${JSON.stringify(registeredPtys)}; ` +
+          `pty events: ${JSON.stringify(eventSummary)}; ` +
+          `backend probe: ${JSON.stringify(backendProbe)}; ` +
+          `final visible buffer: ${JSON.stringify(finalBuffer)}`
+      )
+    })
+}
+
+const pasteTextIntoGhosttyInput = sendInputThroughGhosttyInput
+
+const readGhosttyStyleRuns = async (): Promise<readonly GhosttyStyleRun[]> =>
+  browser.execute(() =>
+    Array.from(
+      document.querySelectorAll(
+        '[data-terminal-renderer="ghostty"] [data-terminal-style-run="true"]'
+      )
+    ).map((element) => ({
+      color: (element as HTMLElement).style.color,
+      text: element.textContent ?? '',
+    }))
+  )
+
 const readGhosttyViewportMetrics = async (): Promise<GhosttyViewportMetrics> =>
   browser.execute(() => {
     const root = document.querySelector<HTMLElement>(
@@ -213,7 +460,10 @@ const readGhosttyViewportMetrics = async (): Promise<GhosttyViewportMetrics> =>
 
     if (!root || !output || !cursorMarker) {
       return {
+        cursorAnimationName: '',
+        cursorHeight: 0,
         cursorVisible: false,
+        cursorWidth: 0,
         firstNonEmptyRowIndex:
           firstNonEmptyRowIndex === -1 ? null : firstNonEmptyRowIndex,
         firstNonEmptyRowText:
@@ -222,12 +472,14 @@ const readGhosttyViewportMetrics = async (): Promise<GhosttyViewportMetrics> =>
             : (rows[firstNonEmptyRowIndex]?.textContent ?? ''),
         hasHorizontalOverflow: true,
         rootScrollTop: 0,
+        symbolFontReady: false,
         viewportRowsMatchPty: false,
       }
     }
 
     const rootRect = root.getBoundingClientRect()
     const cursorRect = cursorMarker.getBoundingClientRect()
+    const cursorStyle = window.getComputedStyle(cursorMarker)
     const readPixels = (value: string): number => {
       const parsed = Number.parseFloat(value)
 
@@ -246,9 +498,18 @@ const readGhosttyViewportMetrics = async (): Promise<GhosttyViewportMetrics> =>
       root.clientHeight + overflowTolerance >= ptyViewportHeight &&
       root.clientHeight < ptyViewportHeight + lineHeight
 
+    const symbolFontReady =
+      document.fonts?.check(
+        '14px "Vimeflow Nerd Symbols"',
+        String.fromCodePoint(0xf0954)
+      ) ?? true
+
     return {
+      cursorAnimationName: cursorStyle.animationName,
+      cursorHeight: cursorRect.height,
       cursorVisible:
         cursorRect.top >= rootRect.top && cursorRect.bottom <= rootRect.bottom,
+      cursorWidth: cursorRect.width,
       firstNonEmptyRowIndex:
         firstNonEmptyRowIndex === -1 ? null : firstNonEmptyRowIndex,
       firstNonEmptyRowText:
@@ -259,6 +520,7 @@ const readGhosttyViewportMetrics = async (): Promise<GhosttyViewportMetrics> =>
         root.scrollWidth - root.clientWidth > overflowTolerance ||
         output.scrollWidth - output.clientWidth > overflowTolerance,
       rootScrollTop: root.scrollTop,
+      symbolFontReady,
       viewportRowsMatchPty,
     }
   })
@@ -278,7 +540,8 @@ describe('Ghostty native render-state smoke', () => {
     await waitForE2eBridge()
     await assertNativeGhosttyBuild()
     await waitForGhosttyRenderer()
-    await waitForGhosttyPrompt()
+    await focusGhosttyRenderer()
+    await waitForGhosttyShellReady()
     await setTerminalContentWidth(NARROW_TERMINAL_WIDTH_PX)
     narrowTerminalCols = await waitForTerminalColsAtMost(MAX_NARROW_PROMPT_COLS)
     await waitForTerminalBufferToSettle()
@@ -367,6 +630,140 @@ describe('Ghostty native render-state smoke', () => {
 
     const metrics = await readGhosttyViewportMetrics()
 
+    expectGhosttyViewportHealthy(metrics)
+  })
+
+  it('renders ANSI color, Nerd Font glyphs, and a block cursor with native snapshots', async () => {
+    await waitForTerminalBufferToSettle()
+    const marker = `native-style-${Date.now().toString(36)}`
+    const prompt = `${'x'.repeat(
+      Math.max(1, narrowTerminalCols - marker.length - 6)
+    )}${NERD_FONT_PROMPT_ICON}> `
+
+    await writeOutputToVisibleTerminal(
+      `\x1b[2J\x1b[1;1H\x1b[38;2;243;139;168m${marker}\x1b[0m ${prompt}`
+    )
+
+    await waitForTerminalBufferContaining(
+      NERD_FONT_PROMPT_ICON,
+      'Ghostty native Nerd Font prompt icon never appeared'
+    )
+
+    const buffer = await readTerminalBuffer()
+    const styleRuns = await readGhosttyStyleRuns()
+    const metrics = await readGhosttyViewportMetrics()
+
+    expect(buffer).toContain(marker)
+    expect(buffer).toContain(NERD_FONT_PROMPT_ICON)
+    expect(buffer).not.toContain('\x1b')
+    expect(
+      styleRuns.some(
+        (run) => run.text.includes(marker) && run.color === TRUE_COLOR_PINK
+      )
+    ).toBe(true)
+    expect(metrics.cursorAnimationName).toBe('vfTerminalCursorBlink')
+    expect(metrics.cursorWidth).toBeGreaterThan(4)
+    expect(metrics.cursorHeight).toBeGreaterThan(10)
+    expect(metrics.symbolFontReady).toBe(true)
+    expectGhosttyViewportHealthy(metrics)
+  })
+
+  it('runs common POSIX commands through native stdin, stdout, and stderr', async () => {
+    await waitForTerminalBufferToSettle()
+    const marker = `native-posix-${Date.now().toString(36)}`
+    const stdinPayload = `stdin-${marker}`
+
+    await sendInputThroughGhosttyInput(
+      [
+        "printf '\\033[2J\\033[1;1H'",
+        `printf '${marker}:pwd:%s\\n' "$(pwd)"`,
+        `printf '${marker}:uname:%s\\n' "$(uname -s)"`,
+        `printf '${marker}:stdout\\n'`,
+        `printf '${marker}:stderr\\n' 1>&2`,
+        'read vf_m4_line',
+        `printf '${marker}:stdin:%s\\n' "$vf_m4_line"`,
+        `printf '${marker}:done\\n'`,
+      ].join('; ') + '\r'
+    )
+    await sendInputThroughGhosttyInput(`${stdinPayload}\r`)
+
+    await waitForTerminalBufferContaining(
+      `${marker}:done`,
+      'Ghostty native POSIX command sequence did not finish'
+    )
+
+    const buffer = await readTerminalBuffer()
+    const unwrappedBuffer = withoutVisualRowBreaks(buffer)
+    const metrics = await readGhosttyViewportMetrics()
+
+    expect(unwrappedBuffer).toContain(`${marker}:pwd:/`)
+    expect(unwrappedBuffer).toMatch(
+      new RegExp(`${marker}:uname:(Darwin|Linux)`)
+    )
+    expect(unwrappedBuffer).toContain(`${marker}:stdout`)
+    expect(unwrappedBuffer).toContain(`${marker}:stderr`)
+    expect(unwrappedBuffer).toContain(`${marker}:stdin:${stdinPayload}`)
+    expect(buffer).not.toContain('\x1b')
+    expect(metrics.firstNonEmptyRowIndex).toBe(0)
+    expect(metrics.firstNonEmptyRowText).toContain(`${marker}:pwd:`)
+    expectGhosttyViewportHealthy(metrics)
+  })
+
+  it('keeps POSIX command output soft-wrapped inside the native pane width', async () => {
+    await waitForTerminalBufferToSettle()
+    const marker = `native-wrap-${Date.now().toString(36)}`
+    const repeatedCells = narrowTerminalCols * 4 + 7
+
+    await sendInputThroughGhosttyInput(
+      [
+        "printf '\\033[2J\\033[1;1H'",
+        `printf '${marker}:wrap:'`,
+        'i=0',
+        `while [ "$i" -lt ${repeatedCells} ]; do printf x; i=$((i + 1)); done`,
+        `printf '\\n${marker}:done\\n'`,
+      ].join('; ') + '\r'
+    )
+
+    await waitForTerminalBufferContaining(
+      `${marker}:done`,
+      'Ghostty native wrapping command did not finish'
+    )
+
+    const buffer = await readTerminalBuffer()
+    const metrics = await readGhosttyViewportMetrics()
+
+    expect(buffer).toContain(`${marker}:wrap:`)
+    expect(buffer).toContain(`${marker}:done`)
+    expect(buffer).toContain('x'.repeat(narrowTerminalCols))
+    expectGhosttyViewportHealthy(metrics)
+  })
+
+  it('routes paste events into shell stdin on the native renderer', async () => {
+    await waitForTerminalBufferToSettle()
+    const marker = `native-paste-${Date.now().toString(36)}`
+    const pastePayload = `paste-${marker}`
+
+    await sendInputThroughGhosttyInput(
+      [
+        "printf '\\033[2J\\033[1;1H'",
+        'read vf_m4_paste',
+        `printf '${marker}:paste:%s\\n' "$vf_m4_paste"`,
+        `printf '${marker}:done\\n'`,
+      ].join('; ') + '\r'
+    )
+
+    await pasteTextIntoGhosttyInput(`${pastePayload}\r`)
+
+    await waitForTerminalBufferContaining(
+      `${marker}:done`,
+      'Ghostty native paste command did not finish'
+    )
+
+    const buffer = await readTerminalBuffer()
+    const unwrappedBuffer = withoutVisualRowBreaks(buffer)
+    const metrics = await readGhosttyViewportMetrics()
+
+    expect(unwrappedBuffer).toContain(`${marker}:paste:${pastePayload}`)
     expectGhosttyViewportHealthy(metrics)
   })
 })

--- a/tests/e2e/ghostty-native/specs/native-render-state-smoke.spec.ts
+++ b/tests/e2e/ghostty-native/specs/native-render-state-smoke.spec.ts
@@ -181,6 +181,21 @@ const probeBackendPtyEventBridge =
 const readTerminalBuffer = async (): Promise<string> =>
   browser.execute(() => window.__VIMEFLOW_E2E__?.getTerminalBuffer() ?? '')
 
+const selectAllVisibleTerminal = async (): Promise<void> => {
+  const didSelect = await browser.execute(
+    () => window.__VIMEFLOW_E2E__?.selectAllVisibleTerminal() ?? false
+  )
+
+  if (!didSelect) {
+    throw new Error('visible terminal selection was unavailable for e2e')
+  }
+}
+
+const readVisibleTerminalSelection = async (): Promise<string> =>
+  browser.execute(
+    () => window.__VIMEFLOW_E2E__?.getVisibleTerminalSelection() ?? ''
+  )
+
 const withoutVisualRowBreaks = (buffer: string): string =>
   buffer.replace(/\n/g, '')
 
@@ -665,6 +680,28 @@ describe('Ghostty native render-state smoke', () => {
     expect(metrics.cursorWidth).toBeGreaterThan(4)
     expect(metrics.cursorHeight).toBeGreaterThan(10)
     expect(metrics.symbolFontReady).toBe(true)
+    expectGhosttyViewportHealthy(metrics)
+  })
+
+  it('copies interpreted native snapshot text without viewport filler rows', async () => {
+    await waitForTerminalBufferToSettle()
+    const prompt = `native-select-${Date.now().toString(36)}$ `
+
+    await writeOutputToVisibleTerminal(`\x1b[2J\x1b[1;1H${prompt}`)
+
+    await waitForTerminalBufferContaining(
+      prompt,
+      'Ghostty native selectable prompt never appeared'
+    )
+    await selectAllVisibleTerminal()
+
+    const buffer = await readTerminalBuffer()
+    const selection = await readVisibleTerminalSelection()
+    const metrics = await readGhosttyViewportMetrics()
+
+    expect(buffer).toBe(prompt)
+    expect(selection).toBe(prompt)
+    expect(selection).not.toContain('\n')
     expectGhosttyViewportHealthy(metrics)
   })
 


### PR DESCRIPTION
## Summary

- Extend the Ghostty native Electron smoke suite so M4 can close against the real native render-state provider.
- Add native select-all/copy coverage proving full-screen Ghostty replacement snapshots copy interpreted terminal text, not viewport filler rows.
- Add test-only e2e bridge helpers for selecting and reading the active terminal selection.
- Add a terminal context-menu `Select All` action wired to the existing clipboard/select-all controller, so manual verification can exercise the same Electron UI path.
- Add `docs/explorations/ghostty-m4-native-vt-smoke.md` as the manual real-Ghostty-VT smoke checklist.

## Why

VIM-182 is the M4 fidelity and ergonomics hardening milestone. Earlier M4 work made native Ghostty startup, focus, stdin/stdout/stderr, wrapping, colors, glyphs, and cursor behavior testable. This close-out adds the missing selection/copy path and gives the user a concrete real-VT checklist before closing M4.

The key regression being guarded: native Ghostty `displayDelta.replace` can include empty viewport filler rows after real content. Copy/select-all should return the interpreted terminal text, not those filler rows.

## Manual testing

Manual real-Ghostty-VT smoke passed on 2026-06-21 for basic interaction across:

- Codex
- Kimi
- Claude Code

Known non-blocking follow-up:

- Kimi and Claude Code logo/icon glyphs are incomplete; some line/glyph fragments appear between symbols.
- Input text is visible, but the input box/background area is generally missing.
- Some box-drawing lines and UI borders are missing.

Tracked as VIM-200: Ghostty follow-up: agent TUI glyph and box-drawing fidelity.

Keep `auto-review` only on this PR because it required manual verification.

## Verification

- `npm test -- src/lib/e2e-bridge.test.ts src/features/terminal/components/TerminalContextMenu.test.tsx src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts src/features/terminal/components/TerminalPane/plainTextInstance.test.ts` -> 107 tests passing
- `npx tsc -p tests/e2e/tsconfig.json`
- `npm run lint`
- `npm run type-check:generated`
- `npx prettier --check src/lib/e2e-bridge.ts src/lib/e2e-bridge.test.ts src/types/e2e.d.ts src/features/terminal/components/TerminalContextMenu.tsx src/features/terminal/components/TerminalContextMenu.test.tsx src/features/terminal/components/TerminalPane/Body.tsx tests/e2e/ghostty-native/specs/native-render-state-smoke.spec.ts docs/explorations/ghostty-m4-native-vt-smoke.md`
- `npm run test:e2e:ghostty:native:build`
- `npm run test:e2e:ghostty:native:run` -> 9/9 native Ghostty smoke tests passing
- pre-push `npm test`: 305 test files passed, 3961 tests passed, 3 skipped
- GitHub checks green: Unit Tests, Code Quality Check, Generate TypeScript Bindings, Rust Tests, Claude Code Review

Linear: VIM-182, VIM-200