### PR TITLE
feat(agent-status): codex watcher reattach UI + auto-recovery (VIM-192)

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -61,7 +61,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 88       | 25   | 2026-06-16   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 72       | 30   | 2026-06-20   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
-| [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 64       | 23   | 2026-06-17   |
+| [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 67       | 24   | 2026-06-20   |
 | [Canonical Path Dedupe](patterns/canonical-path-dedupe.md)                                           | correctness        | 2        | 0    | 2026-06-14   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)                                       | backend            | 4        | 2    | 2026-06-14   |
 | [Command Injection](patterns/command-injection.md)                                                   | security           | 8        | 3    | 2026-06-16   |
@@ -96,7 +96,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Unsafe Block Safety Comments](patterns/unsafe-block-safety-comments.md)                             | security           | 1        | 0    | 2026-06-14   |
 | [Type Contract Safety](patterns/type-contract-safety.md)                                             | code-quality       | 7        | 3    | 2026-06-19   |
 | [String Construction Hygiene](patterns/string-construction-hygiene.md)                               | code-quality       | 2        | 1    | 2026-06-19   |
-| [Agent-State Guards](patterns/agent-state-guards.md)                                                 | correctness        | 3        | 2    | 2026-06-15   |
+| [Agent-State Guards](patterns/agent-state-guards.md)                                                 | correctness        | 5        | 3    | 2026-06-20   |
 | [React Prop Contracts](patterns/react-prop-contracts.md)                                             | react-patterns     | 6        | 4    | 2026-06-19   |
 | [Stale Retained Interactions](patterns/stale-retained-interactions.md)                               | react-patterns     | 2        | 0    | 2026-06-15   |
 | [Retained State Identity](patterns/retained-state-identity.md)                                       | react-patterns     | 1        | 1    | 2026-06-15   |

--- a/docs/reviews/patterns/agent-state-guards.md
+++ b/docs/reviews/patterns/agent-state-guards.md
@@ -2,8 +2,8 @@
 id: agent-state-guards
 category: correctness
 created: 2026-06-15
-last_updated: 2026-06-15
-ref_count: 2
+last_updated: 2026-06-20
+ref_count: 3
 ---
 
 # Agent-State Guards
@@ -39,4 +39,22 @@ UI state that tracks an active agent session must validate the agent's identity 
 - **File:** `src/features/agent-status/hooks/useAgentStatus.ts` L197-200
 - **Finding:** A second `/clear` after the first reset committed saw `prev.agentSessionId === null` and overwrote `locallyResetAgentSessionIdRef` with null. That disabled the same-run staleness guard, so the next stale `agent-status` event could repopulate the cleared sidebar and clear the run-scoped suppression latch for old tool-call, turn, and test events.
 - **Fix:** Preserved the existing reset latch when `prev.agentSessionId` is already null, while still keeping run-scoped suppression active. Added a regression test that sends two reset generations across separate renders, then verifies same-run stale status, tool-call, and turn events remain suppressed until a fresh agent session ID arrives.
+- **Commit:** same commit as this entry
+
+### 4. Same-id reset hook cleared before status latch could recover
+
+- **Source:** github-codex-connector | PR #583 round 1 | 2026-06-20
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/agent-status/hooks/useAgentReattach.ts`
+- **Finding:** The reattach hook treated a zero-token same-id event as a successful recovery, but `useAgentStatus` still suppressed same-id reset events unless the token total dropped below the captured total. When `/clear` happened before any tokens accrued, the red reattach state disappeared while the status panel stayed reset.
+- **Fix:** Updated the status latch to accept zero-token same-id reset events and kept the reattach predicate aligned with that latch. Added regression coverage for the zero-token path in the reattach hook and retained status-hook coverage for same-id reset recovery.
+- **Commit:** same commit as this entry
+
+### 5. Unknown token baseline kept same-id reset recovery impossible
+
+- **Source:** github-claude | PR #583 round 1 | 2026-06-20
+- **Severity:** MEDIUM
+- **File:** `src/features/agent-status/hooks/useAgentReattach.ts`
+- **Finding:** When the pre-clear status had an `agentSessionId` but no `contextWindow`, `staleTotal` was null, so same-id relocated events with non-zero tokens could never satisfy the freshness predicate. The pane stayed in the red stale state until a pane switch or a different agent session ID arrived.
+- **Fix:** Treat a known post-reset token total as fresh when the captured baseline is unknown, and mirror that rule in `useAgentStatus` so the panel accepts the same event. Added hook and status tests for same-id recovery from a null token baseline.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/async-race-conditions.md
+++ b/docs/reviews/patterns/async-race-conditions.md
@@ -2,8 +2,8 @@
 id: async-race-conditions
 category: react-patterns
 created: 2026-04-09
-last_updated: 2026-06-08
-ref_count: 23
+last_updated: 2026-06-20
+ref_count: 24
 ---
 
 # Async Race Conditions
@@ -650,3 +650,30 @@ prevent showing previous data.
 - **Finding:** `selectedEditorFileExists` was never reset before a new existence check began. Switching from a deleted file to an existing file could make the new file momentarily read-only because `resolveEditorFileLifecycleStatus` saw the stale `false` value before the async check completed.
 - **Fix:** Set `selectedEditorFileExists(null)` synchronously at the start of the check, then update it with the async result.
 - **Commit:** see current commit
+
+### 65. Auto-reattach retry budget ignored non-inflight no-op rounds
+
+- **Source:** github-claude | PR #583 round 1 | 2026-06-20
+- **Severity:** MEDIUM
+- **File:** `src/features/agent-status/hooks/useAgentReattach.ts`
+- **Finding:** The auto-reattach loop only consumed retry budget when an IPC call was issued. If the PTY mapping was temporarily absent, `reattachAsync()` returned false and the loop kept scheduling 700 ms retries indefinitely instead of respecting the bounded retry contract.
+- **Fix:** Count false returns against the retry budget when no invoke is currently in flight, while preserving the manual-click/single-flight no-op behavior. Added a fake-timer regression test that removes the PTY mapping and verifies the timer queue drains without issuing IPC calls.
+- **Commit:** same commit as this entry
+
+### 66. Pane-switch stale identity was cleared before unresolved recovery
+
+- **Source:** github-codex-connector | PR #583 round 1 | 2026-06-20
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/agent-status/hooks/useAgentReattach.ts`
+- **Finding:** Switching away from an unresolved stale pane cleared the captured stale identity but left the capture-session guard in place. Returning after `useAgentStatus` reset the live id to null allowed an old watcher event to look fresh and resolve the stale key without a successful relocate.
+- **Fix:** Split non-stale pane transitions from resolved stale-key cleanup, so pane switches clear the visible red state without discarding the captured identity needed when the unresolved pane is selected again. Added regression coverage for switching away and back before the relocate lands.
+- **Commit:** same commit as this entry
+
+### 67. Late success event resolved the newest stale generation
+
+- **Source:** github-claude | PR #583 round 1 | 2026-06-20
+- **Severity:** MEDIUM
+- **File:** `src/features/agent-status/hooks/useAgentReattach.ts`
+- **Finding:** The success listener read the render-synchronized `staleKey` mirror at callback time. If a second `/clear` advanced the generation before the first reattach success event arrived, the late event marked the newer generation resolved and skipped recovery for the second clear.
+- **Fix:** Added an armed stale-key ref that records the key active when the red-state cycle was entered. A late event resolves only that armed key; if the current key has advanced, the newer key remains armed and still requires its own fresh event. Added regression tests for repeated `/clear` and the late-success generation race.
+- **Commit:** same commit as this entry

--- a/src/features/agent-status/components/AgentStatusPanel/Header.test.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/Header.test.tsx
@@ -101,3 +101,50 @@ test('does not add drag coverage when native controls are not reserved', () => {
     'vf-app-drag-region'
   )
 })
+
+test('shows the red needs-reattach state when stale', () => {
+  render(
+    <AgentStatusPanelHeader
+      agent={AGENTS.codex}
+      needsReattach
+      onReattach={() => undefined}
+      onCollapse={() => undefined}
+    />
+  )
+
+  expect(screen.getByTestId('agent-glyph-chip')).toHaveAttribute(
+    'data-stale',
+    'true'
+  )
+  expect(screen.getByText('reattach needed')).toBeInTheDocument()
+  expect(screen.getByText('link_off')).toBeInTheDocument()
+})
+
+test('renders a Reattach button that fires onReattach', async () => {
+  const onReattach = vi.fn()
+  render(
+    <AgentStatusPanelHeader
+      agent={AGENTS.codex}
+      onReattach={onReattach}
+      onCollapse={() => undefined}
+    />
+  )
+
+  await userEvent.click(
+    screen.getByRole('button', { name: /reattach agent session/i })
+  )
+  expect(onReattach).toHaveBeenCalledTimes(1)
+})
+
+test('omits the Reattach button when no handler is provided', () => {
+  render(
+    <AgentStatusPanelHeader
+      agent={AGENTS.claude}
+      onCollapse={() => undefined}
+    />
+  )
+
+  expect(
+    screen.queryByRole('button', { name: /reattach agent session/i })
+  ).not.toBeInTheDocument()
+})

--- a/src/features/agent-status/components/AgentStatusPanel/Header.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/Header.tsx
@@ -6,6 +6,10 @@ import type { Agent } from '../../../../agents/registry'
 export interface AgentStatusPanelHeaderProps {
   agent: Agent
   isRefreshing?: boolean
+  /** Session is known-stale (codex `/clear`/`resume`): show the red state. */
+  needsReattach?: boolean
+  /** When provided, render the Reattach button (the universal recovery). */
+  onReattach?: () => void
   onCollapse: () => void
   reserveWindowControls?: boolean
 }
@@ -13,6 +17,8 @@ export interface AgentStatusPanelHeaderProps {
 export const AgentStatusPanelHeader = ({
   agent,
   isRefreshing = false,
+  needsReattach = false,
+  onReattach = undefined,
   onCollapse,
   reserveWindowControls = false,
 }: AgentStatusPanelHeaderProps): ReactElement => (
@@ -28,7 +34,10 @@ export const AgentStatusPanelHeader = ({
     <div
       data-testid="agent-glyph-chip"
       data-refreshing={isRefreshing ? 'true' : 'false'}
-      className={`grid h-6 w-6 shrink-0 place-items-center rounded-md font-mono text-xs font-bold ${isRefreshing ? 'vf-activity-glyph-refresh' : ''}`}
+      data-stale={needsReattach ? 'true' : 'false'}
+      className={`grid h-6 w-6 shrink-0 place-items-center rounded-md font-mono text-xs font-bold ${
+        needsReattach ? 'ring-1 ring-error' : ''
+      } ${isRefreshing ? 'vf-activity-glyph-refresh' : ''}`}
       style={{ background: agent.accentDim, color: agent.accent }}
     >
       <AgentGlyph agent={agent} size={14} />
@@ -38,19 +47,44 @@ export const AgentStatusPanelHeader = ({
         <span className="truncate font-headline text-[13px] font-semibold text-on-surface">
           {agent.short}
         </span>
-        {isRefreshing && (
+        {needsReattach ? (
           <span
-            className="material-symbols-outlined text-[11px] text-on-surface-muted motion-safe:animate-spin"
+            className="material-symbols-outlined text-[11px] text-error"
             aria-hidden="true"
           >
-            sync
+            link_off
           </span>
+        ) : (
+          isRefreshing && (
+            <span
+              className="material-symbols-outlined text-[11px] text-on-surface-muted motion-safe:animate-spin"
+              aria-hidden="true"
+            >
+              sync
+            </span>
+          )
         )}
       </div>
-      <span className="h-3 truncate font-mono text-[10px] leading-3 text-on-surface-muted">
-        {isRefreshing ? 'fetching latest' : 'updated now'}
+      <span
+        className={`h-3 truncate font-mono text-[10px] leading-3 ${
+          needsReattach ? 'text-error' : 'text-on-surface-muted'
+        }`}
+      >
+        {needsReattach
+          ? 'reattach needed'
+          : isRefreshing
+            ? 'fetching latest'
+            : 'updated now'}
       </span>
     </div>
+    {onReattach !== undefined && (
+      <IconButton
+        icon="refresh"
+        label="Reattach agent session"
+        onClick={onReattach}
+        className={`vf-app-no-drag shrink-0 ${needsReattach ? 'text-error' : ''}`}
+      />
+    )}
     <IconButton
       icon="chevron_right"
       label="Collapse activity panel"

--- a/src/features/agent-status/components/AgentStatusPanel/index.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/index.tsx
@@ -37,6 +37,8 @@ interface AgentStatusPanelProps {
   onOpenFile?: (path: string) => void
   gitStatus?: UseGitStatusReturn
   isRefreshing?: boolean
+  needsReattach?: boolean
+  onReattach?: () => void
   agent: Agent
   onCollapse: () => void
   cacheHistory: number[]
@@ -302,6 +304,8 @@ export const AgentStatusPanel = ({
   onOpenFile = undefined,
   gitStatus = undefined,
   isRefreshing = false,
+  needsReattach = false,
+  onReattach = undefined,
   agent,
   onCollapse,
   cacheHistory,
@@ -537,6 +541,8 @@ export const AgentStatusPanel = ({
       <AgentStatusPanelHeader
         agent={agent}
         isRefreshing={showsRefreshing}
+        needsReattach={needsReattach}
+        onReattach={onReattach}
         onCollapse={onCollapse}
         reserveWindowControls={reserveWindowControls}
       />

--- a/src/features/agent-status/hooks/useAgentReattach.test.ts
+++ b/src/features/agent-status/hooks/useAgentReattach.test.ts
@@ -182,6 +182,31 @@ test('stale state triggers a bounded, deferred auto-reattach', async () => {
   expect(invoke).toHaveBeenCalledTimes(5)
 })
 
+test('auto-reattach stops after bounded no-op rounds when pty is absent', async () => {
+  vi.mocked(getPtySessionId).mockReturnValue(undefined)
+
+  const { rerender } = renderHook(
+    ({ gen }) =>
+      useAgentReattach({
+        sessionId: 'session-1',
+        agentSessionId: null,
+        staleGeneration: gen,
+      }),
+    { initialProps: { gen: 0 } }
+  )
+
+  act(() => {
+    rerender({ gen: 1 })
+  })
+
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(400 + 700 * 6)
+  })
+
+  expect(invoke).not.toHaveBeenCalled()
+  expect(vi.getTimerCount()).toBe(0)
+})
+
 test('the stale session id is ignored; a new id clears needsReattach', () => {
   const { result, rerender } = renderHook(
     ({ aid, gen }) =>
@@ -243,9 +268,15 @@ test('repeated /clear preserves the original stale identity', () => {
   })
   expect(result.current.needsReattach).toBe(true)
 
-  // The relocated watcher emits a genuinely new id → resolved.
+  // A late success for the first clear must not resolve the newer generation.
   act(() => {
     emit('agent-status', makeEvent({ agentSessionId: 'codex-new' }))
+  })
+  expect(result.current.needsReattach).toBe(true)
+
+  // A subsequent fresh event resolves the still-armed second clear.
+  act(() => {
+    emit('agent-status', makeEvent({ agentSessionId: 'codex-newer' }))
   })
   expect(result.current.needsReattach).toBe(false)
 })
@@ -281,6 +312,41 @@ test('a same-session /clear from zero tokens clears on the reset event', () => {
       makeEvent({
         agentSessionId: 'codex-1',
         contextWindow: makeContextWindow(0),
+      })
+    )
+  })
+  expect(result.current.needsReattach).toBe(false)
+})
+
+test('a same-session /clear with unknown token baseline clears on known tokens', () => {
+  const { result, rerender } = renderHook(
+    ({ aid, tok, gen }) =>
+      useAgentReattach({
+        sessionId: 'session-1',
+        agentSessionId: aid,
+        agentTokenTotal: tok,
+        staleGeneration: gen,
+      }),
+    {
+      initialProps: {
+        aid: 'codex-1' as string | null,
+        tok: null as number | null,
+        gen: 0,
+      },
+    }
+  )
+
+  act(() => {
+    rerender({ aid: 'codex-1', tok: null, gen: 1 })
+  })
+  expect(result.current.needsReattach).toBe(true)
+
+  act(() => {
+    emit(
+      'agent-status',
+      makeEvent({
+        agentSessionId: 'codex-1',
+        contextWindow: makeContextWindow(100),
       })
     )
   })
@@ -392,6 +458,80 @@ test('switching to a non-stale pane drops carried-over stale state', () => {
   // must not leak onto it.
   act(() => {
     rerender({ sid: 'session-2', gen: 0 })
+  })
+  expect(result.current.needsReattach).toBe(false)
+})
+
+test('switching away from an unresolved stale pane preserves stale identity', () => {
+  const { result, rerender } = renderHook(
+    ({ sid, aid, gen }) =>
+      useAgentReattach({
+        sessionId: sid,
+        agentSessionId: aid,
+        staleGeneration: gen,
+      }),
+    {
+      initialProps: {
+        sid: 'session-1',
+        aid: 'codex-old' as string | null,
+        gen: 0,
+      },
+    }
+  )
+
+  act(() => {
+    rerender({ sid: 'session-1', aid: 'codex-old', gen: 1 })
+  })
+  expect(result.current.needsReattach).toBe(true)
+
+  act(() => {
+    rerender({ sid: 'session-2', aid: null, gen: 0 })
+  })
+  expect(result.current.needsReattach).toBe(false)
+
+  act(() => {
+    rerender({ sid: 'session-1', aid: null, gen: 1 })
+  })
+  expect(result.current.needsReattach).toBe(true)
+
+  act(() => {
+    emit('agent-status', makeEvent({ agentSessionId: 'codex-old' }))
+  })
+  expect(result.current.needsReattach).toBe(true)
+
+  act(() => {
+    emit('agent-status', makeEvent({ agentSessionId: 'codex-new' }))
+  })
+  expect(result.current.needsReattach).toBe(false)
+})
+
+test('a late success event does not resolve a newer stale generation', () => {
+  const { result, rerender } = renderHook(
+    ({ aid, gen }) =>
+      useAgentReattach({
+        sessionId: 'session-1',
+        agentSessionId: aid,
+        staleGeneration: gen,
+      }),
+    { initialProps: { aid: 'codex-old' as string | null, gen: 0 } }
+  )
+
+  act(() => {
+    rerender({ aid: 'codex-old', gen: 1 })
+  })
+  expect(result.current.needsReattach).toBe(true)
+
+  act(() => {
+    rerender({ aid: null, gen: 2 })
+  })
+
+  act(() => {
+    emit('agent-status', makeEvent({ agentSessionId: 'codex-new' }))
+  })
+  expect(result.current.needsReattach).toBe(true)
+
+  act(() => {
+    emit('agent-status', makeEvent({ agentSessionId: 'codex-newer' }))
   })
   expect(result.current.needsReattach).toBe(false)
 })

--- a/src/features/agent-status/hooks/useAgentReattach.test.ts
+++ b/src/features/agent-status/hooks/useAgentReattach.test.ts
@@ -1,0 +1,465 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
+import { invoke, listen } from '../../../lib/backend'
+import { getPtySessionId } from '../../terminal/ptySessionMap'
+import { useAgentReattach } from './useAgentReattach'
+import type { AgentStatusEvent } from '../types'
+
+vi.mock('../../../lib/backend', () => ({
+  invoke: vi.fn(),
+  listen: vi.fn(),
+}))
+
+vi.mock('../../terminal/ptySessionMap', () => ({
+  getPtySessionId: vi.fn(),
+}))
+
+type Listener = (payload: unknown) => void
+
+const listeners = new Map<string, Listener[]>()
+
+const emit = (event: string, payload: unknown): void => {
+  for (const cb of listeners.get(event) ?? []) {
+    cb(payload)
+  }
+}
+
+const makeEvent = (overrides: Partial<AgentStatusEvent>): AgentStatusEvent => ({
+  sessionId: 'pty-session-1',
+  agentSessionId: null,
+  modelId: null,
+  modelDisplayName: null,
+  version: null,
+  contextWindow: null,
+  cost: null,
+  rateLimits: null,
+  usageFetched: false,
+  ...overrides,
+})
+
+const makeContextWindow = (
+  total: number
+): AgentStatusEvent['contextWindow'] => ({
+  usedPercentage: 0,
+  remainingPercentage: 100,
+  contextWindowSize: BigInt(200000),
+  totalInputTokens: BigInt(total),
+  totalOutputTokens: BigInt(0),
+  currentUsage: {
+    inputTokens: BigInt(0),
+    outputTokens: BigInt(0),
+    cacheCreationInputTokens: BigInt(0),
+    cacheReadInputTokens: BigInt(0),
+  },
+})
+
+beforeEach(() => {
+  listeners.clear()
+  vi.useFakeTimers()
+  vi.mocked(getPtySessionId).mockImplementation((id) => `pty-${id}`)
+  vi.mocked(invoke).mockResolvedValue(null as never)
+  vi.mocked(listen).mockImplementation((event, handler) => {
+    const arr = listeners.get(event) ?? []
+    arr.push(handler as Listener)
+    listeners.set(event, arr)
+
+    return Promise.resolve((): void => {
+      listeners.set(
+        event,
+        (listeners.get(event) ?? []).filter((l) => l !== handler)
+      )
+    })
+  })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.clearAllMocks()
+})
+
+test('reattach re-invokes start_agent_watcher for the resolved pty', () => {
+  const { result } = renderHook(() =>
+    useAgentReattach({
+      sessionId: 'session-1',
+      agentSessionId: null,
+      staleGeneration: 0,
+    })
+  )
+
+  act(() => {
+    result.current.reattach()
+  })
+
+  expect(invoke).toHaveBeenCalledWith('start_agent_watcher', {
+    sessionId: 'pty-session-1',
+  })
+})
+
+test('reattach is a no-op without a session', () => {
+  const { result } = renderHook(() =>
+    useAgentReattach({
+      sessionId: null,
+      agentSessionId: null,
+      staleGeneration: 0,
+    })
+  )
+
+  act(() => {
+    result.current.reattach()
+  })
+
+  expect(invoke).not.toHaveBeenCalled()
+})
+
+test('reattach is single-flight while one is in progress', () => {
+  vi.mocked(invoke).mockImplementation(
+    () => new Promise<never>(() => undefined) // never resolves
+  )
+
+  const { result } = renderHook(() =>
+    useAgentReattach({
+      sessionId: 'session-1',
+      agentSessionId: null,
+      staleGeneration: 0,
+    })
+  )
+
+  act(() => {
+    result.current.reattach()
+    result.current.reattach()
+  })
+
+  expect(invoke).toHaveBeenCalledTimes(1)
+})
+
+test('a stale-generation bump marks needsReattach', () => {
+  const { result, rerender } = renderHook(
+    ({ gen }) =>
+      useAgentReattach({
+        sessionId: 'session-1',
+        agentSessionId: null,
+        staleGeneration: gen,
+      }),
+    { initialProps: { gen: 0 } }
+  )
+
+  expect(result.current.needsReattach).toBe(false)
+
+  act(() => {
+    rerender({ gen: 1 })
+  })
+
+  expect(result.current.needsReattach).toBe(true)
+})
+
+test('stale state triggers a bounded, deferred auto-reattach', async () => {
+  const { rerender } = renderHook(
+    ({ gen }) =>
+      useAgentReattach({
+        sessionId: 'session-1',
+        agentSessionId: null,
+        staleGeneration: gen,
+      }),
+    { initialProps: { gen: 0 } }
+  )
+
+  act(() => {
+    rerender({ gen: 1 })
+  })
+
+  // Deferred: nothing fires before the initial delay.
+  expect(invoke).not.toHaveBeenCalled()
+
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(400)
+  })
+  expect(invoke).toHaveBeenCalledTimes(1)
+
+  // Bounded: retries cap out (5 issued calls total) and then stop.
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(700 * 6)
+  })
+  expect(invoke).toHaveBeenCalledTimes(5)
+})
+
+test('the stale session id is ignored; a new id clears needsReattach', () => {
+  const { result, rerender } = renderHook(
+    ({ aid, gen }) =>
+      useAgentReattach({
+        sessionId: 'session-1',
+        agentSessionId: aid,
+        staleGeneration: gen,
+      }),
+    {
+      initialProps: { aid: 'codex-old' as string | null, gen: 0 },
+    }
+  )
+
+  // /clear captures the live id ('codex-old') from useAgentStatus.
+  act(() => {
+    rerender({ aid: 'codex-old', gen: 1 })
+  })
+  expect(result.current.needsReattach).toBe(true)
+
+  // The OLD watcher keeps emitting the stale id → must NOT clear (P2).
+  act(() => {
+    emit('agent-status', makeEvent({ agentSessionId: 'codex-old' }))
+  })
+  expect(result.current.needsReattach).toBe(true)
+
+  // The relocated watcher emits a NEW id → success.
+  act(() => {
+    emit('agent-status', makeEvent({ agentSessionId: 'codex-new' }))
+  })
+  expect(result.current.needsReattach).toBe(false)
+})
+
+test('repeated /clear preserves the original stale identity', () => {
+  const { result, rerender } = renderHook(
+    ({ aid, gen }) =>
+      useAgentReattach({
+        sessionId: 'session-1',
+        agentSessionId: aid,
+        staleGeneration: gen,
+      }),
+    { initialProps: { aid: 'codex-old' as string | null, gen: 0 } }
+  )
+
+  // First /clear captures 'codex-old' from the still-live status.
+  act(() => {
+    rerender({ aid: 'codex-old', gen: 1 })
+  })
+
+  // A second /clear arrives after useAgentStatus has reset the live id to null.
+  act(() => {
+    rerender({ aid: null, gen: 2 })
+  })
+  expect(result.current.needsReattach).toBe(true)
+
+  // The OLD watcher (still on the original rollout) keeps emitting 'codex-old'
+  // → it must NOT be treated as fresh just because the live id is now null.
+  act(() => {
+    emit('agent-status', makeEvent({ agentSessionId: 'codex-old' }))
+  })
+  expect(result.current.needsReattach).toBe(true)
+
+  // The relocated watcher emits a genuinely new id → resolved.
+  act(() => {
+    emit('agent-status', makeEvent({ agentSessionId: 'codex-new' }))
+  })
+  expect(result.current.needsReattach).toBe(false)
+})
+
+test('a same-session /clear from zero tokens clears on the reset event', () => {
+  const { result, rerender } = renderHook(
+    ({ aid, tok, gen }) =>
+      useAgentReattach({
+        sessionId: 'session-1',
+        agentSessionId: aid,
+        agentTokenTotal: tok,
+        staleGeneration: gen,
+      }),
+    {
+      initialProps: {
+        aid: 'codex-1' as string | null,
+        tok: 0 as number | null,
+        gen: 0,
+      },
+    }
+  )
+
+  // /clear keeps the same id; the pre-clear total was 0, so `< staleTotal` can
+  // never hold — the zero-token reset event must still count as fresh.
+  act(() => {
+    rerender({ aid: 'codex-1', tok: 0, gen: 1 })
+  })
+  expect(result.current.needsReattach).toBe(true)
+
+  act(() => {
+    emit(
+      'agent-status',
+      makeEvent({
+        agentSessionId: 'codex-1',
+        contextWindow: makeContextWindow(0),
+      })
+    )
+  })
+  expect(result.current.needsReattach).toBe(false)
+})
+
+test('a same-session /clear (lower token total) clears needsReattach', () => {
+  const { result, rerender } = renderHook(
+    ({ aid, tok, gen }) =>
+      useAgentReattach({
+        sessionId: 'session-1',
+        agentSessionId: aid,
+        agentTokenTotal: tok,
+        staleGeneration: gen,
+      }),
+    {
+      initialProps: {
+        aid: 'codex-1' as string | null,
+        tok: 5000 as number | null,
+        gen: 0,
+      },
+    }
+  )
+
+  // /clear keeps the same agentSessionId; the pre-clear total was 5000.
+  act(() => {
+    rerender({ aid: 'codex-1', tok: 5000, gen: 1 })
+  })
+  expect(result.current.needsReattach).toBe(true)
+
+  // The relocated run reuses the id but reset its tokens (lower) → fresh.
+  act(() => {
+    emit(
+      'agent-status',
+      makeEvent({
+        agentSessionId: 'codex-1',
+        contextWindow: makeContextWindow(100),
+      })
+    )
+  })
+  expect(result.current.needsReattach).toBe(false)
+})
+
+test('events for other ptys do not clear needsReattach', () => {
+  const { result, rerender } = renderHook(
+    ({ aid, gen }) =>
+      useAgentReattach({
+        sessionId: 'session-1',
+        agentSessionId: aid,
+        staleGeneration: gen,
+      }),
+    { initialProps: { aid: 'codex-old' as string | null, gen: 0 } }
+  )
+
+  act(() => {
+    rerender({ aid: 'codex-old', gen: 1 })
+  })
+
+  act(() => {
+    emit(
+      'agent-status',
+      makeEvent({ sessionId: 'pty-other', agentSessionId: 'codex-new' })
+    )
+  })
+
+  expect(result.current.needsReattach).toBe(true)
+})
+
+test('reaching the not-stale sentinel clears needsReattach', () => {
+  const { result, rerender } = renderHook(
+    ({ gen }) =>
+      useAgentReattach({
+        sessionId: 'session-1',
+        agentSessionId: null,
+        staleGeneration: gen,
+      }),
+    { initialProps: { gen: 0 } }
+  )
+
+  act(() => {
+    rerender({ gen: 1 })
+  })
+  expect(result.current.needsReattach).toBe(true)
+
+  // Active pane changed to one with no pending /clear (the `0` sentinel).
+  act(() => {
+    rerender({ gen: 0 })
+  })
+  expect(result.current.needsReattach).toBe(false)
+})
+
+test('switching to a non-stale pane drops carried-over stale state', () => {
+  const { result, rerender } = renderHook(
+    ({ sid, gen }) =>
+      useAgentReattach({
+        sessionId: sid,
+        agentSessionId: null,
+        staleGeneration: gen,
+      }),
+    { initialProps: { sid: 'session-1', gen: 0 } }
+  )
+
+  act(() => {
+    rerender({ sid: 'session-1', gen: 1 })
+  })
+  expect(result.current.needsReattach).toBe(true)
+
+  // A pane with no pending /clear reports staleGeneration 0 → the red state
+  // must not leak onto it.
+  act(() => {
+    rerender({ sid: 'session-2', gen: 0 })
+  })
+  expect(result.current.needsReattach).toBe(false)
+})
+
+test('auto-reattach keeps retrying after an IPC failure', async () => {
+  vi.mocked(invoke).mockRejectedValue(new Error('boom'))
+
+  const { rerender } = renderHook(
+    ({ gen }) =>
+      useAgentReattach({
+        sessionId: 'session-1',
+        agentSessionId: null,
+        staleGeneration: gen,
+      }),
+    { initialProps: { gen: 0 } }
+  )
+
+  act(() => {
+    rerender({ gen: 1 })
+  })
+
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(400)
+  })
+  expect(invoke).toHaveBeenCalledTimes(1)
+
+  // A rejecting invoke must not halt the bounded retry loop.
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(700 * 6)
+  })
+  expect(invoke).toHaveBeenCalledTimes(5)
+})
+
+test('a recovered pane does not re-arm when re-selected', () => {
+  const { result, rerender } = renderHook(
+    ({ sid, aid, gen }) =>
+      useAgentReattach({
+        sessionId: sid,
+        agentSessionId: aid,
+        staleGeneration: gen,
+      }),
+    {
+      initialProps: {
+        sid: 'session-1',
+        aid: 'codex-old' as string | null,
+        gen: 0,
+      },
+    }
+  )
+
+  // /clear on session-1, then the relocate lands (new id) → resolved.
+  act(() => {
+    rerender({ sid: 'session-1', aid: 'codex-old', gen: 1 })
+  })
+
+  act(() => {
+    emit('agent-status', makeEvent({ agentSessionId: 'codex-new' }))
+  })
+  expect(result.current.needsReattach).toBe(false)
+
+  // Switch away, then back: the same (now non-zero) generation reappears, but
+  // the key is already resolved → it must NOT flash red again.
+  act(() => {
+    rerender({ sid: 'session-2', aid: 'codex-new', gen: 0 })
+  })
+
+  act(() => {
+    rerender({ sid: 'session-1', aid: 'codex-new', gen: 1 })
+  })
+  expect(result.current.needsReattach).toBe(false)
+})

--- a/src/features/agent-status/hooks/useAgentReattach.ts
+++ b/src/features/agent-status/hooks/useAgentReattach.ts
@@ -1,0 +1,257 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { invoke, listen } from '../../../lib/backend'
+import { getPtySessionId } from '../../terminal/ptySessionMap'
+import type { AgentStatusEvent } from '../types'
+
+// `/clear` (and an in-session `resume`) point the codex agent at a NEW rollout
+// file on the SAME pid, but the backend transcript watcher was pinned to the
+// old rollout at attach time, so the panel silently stops updating (VIM-188).
+// Reattach re-invokes `start_agent_watcher`, whose `run_watch_sequence`
+// re-locates the rollout (now open-FD authoritative, VIM-191) and atomically
+// replaces the watcher — no stop-then-start.
+//
+// `/clear` is detectable but fires BEFORE codex opens the new rollout, so the
+// auto-reattach is deferred and bounded-retried until a fresh `agent-status`
+// with a new `agentSessionId` proves the relocate landed. The in-session
+// `resume` is undetectable, so the manual Reattach button is the universal
+// recovery.
+
+const REATTACH_AUTO_INITIAL_DELAY_MS = 400
+const REATTACH_AUTO_RETRY_INTERVAL_MS = 700
+const REATTACH_AUTO_MAX_ATTEMPTS = 5
+
+const eventTokenTotal = (
+  contextWindow: AgentStatusEvent['contextWindow']
+): number | null =>
+  contextWindow === null
+    ? null
+    : Number(contextWindow.totalInputTokens) +
+      Number(contextWindow.totalOutputTokens)
+
+interface UseAgentReattachOptions {
+  /** Workspace session id of the active pty-backed pane (or `null`). */
+  sessionId: string | null
+  /**
+   * The live agent session id (from `useAgentStatus`). Captured when the pane
+   * goes stale so the success predicate can tell the relocated watcher's events
+   * (a NEW id) from the old watcher's (the captured id).
+   */
+  agentSessionId: string | null
+  /**
+   * Total tokens (input + output) of the live session, from `useAgentStatus`,
+   * captured at stale time. A same-session `/clear` keeps the `agentSessionId`
+   * but resets the token total, so a later lower total also counts as "fresh".
+   */
+  agentTokenTotal?: number | null
+  /**
+   * Increments whenever the session becomes known-stale (a `/clear` was
+   * detected for the active pane). `0` means "not stale". The value is
+   * per-active-pane, so it reappears when that pane is re-selected — staleness
+   * is therefore keyed by `sessionId:staleGeneration` and tracked as resolved
+   * once the relocate lands, so a re-selected (already-recovered) pane does not
+   * flash red again.
+   */
+  staleGeneration: number
+}
+
+export interface AgentReattachControls {
+  /** The session is known-stale and the relocate has not yet landed. */
+  needsReattach: boolean
+  /** Manually re-invoke the watcher relocate (covers the undetectable resume). */
+  reattach: () => void
+}
+
+/**
+ * Recovery controls for a codex agent-status panel that froze after a `/clear`
+ * or in-session `resume`.
+ */
+export const useAgentReattach = ({
+  sessionId,
+  agentSessionId,
+  agentTokenTotal = null,
+  staleGeneration,
+}: UseAgentReattachOptions): AgentReattachControls => {
+  const [needsReattach, setNeedsReattach] = useState(false)
+
+  // Identity of the active pane's current staleness, or `null` when not stale.
+  const staleKey =
+    sessionId !== null && staleGeneration !== 0
+      ? `${sessionId}:${staleGeneration}`
+      : null
+
+  // Mirrors so the long-lived event listener reads current values without being
+  // torn down and re-subscribed on every change.
+  const needsReattachRef = useRef(false)
+  needsReattachRef.current = needsReattach
+  const agentSessionIdRef = useRef(agentSessionId)
+  agentSessionIdRef.current = agentSessionId
+  const agentTokenTotalRef = useRef(agentTokenTotal)
+  agentTokenTotalRef.current = agentTokenTotal
+  const staleKeyRef = useRef(staleKey)
+  staleKeyRef.current = staleKey
+
+  // Single-flight guard so a manual click and the auto-retry can't issue
+  // overlapping `start_agent_watcher` invokes.
+  const inFlightRef = useRef(false)
+  // The agent session id that was live when the pane went stale. The relocated
+  // watcher proves success by emitting a DIFFERENT id; the old watcher keeps
+  // emitting this one, so its events must not clear the red state.
+  const staleAgentSessionIdRef = useRef<string | null>(null)
+  const staleTokenTotalRef = useRef<number | null>(null)
+  // Session the stale identity was captured for, so a repeated `/clear` on the
+  // same pane keeps the original pre-clear identity (by then useAgentStatus has
+  // already reset the live id/total to null).
+  const staleCaptureSessionRef = useRef<string | null>(null)
+  // Stale keys whose relocate has succeeded — re-selecting that pane must not
+  // re-arm the red state (codex review VIM-192).
+  const resolvedKeysRef = useRef<Set<string>>(new Set())
+
+  // Returns whether it actually issued an invoke (vs skipped under
+  // single-flight) so the auto-retry budget only counts real calls.
+  const reattachAsync = useCallback(async (): Promise<boolean> => {
+    if (sessionId === null) {
+      return false
+    }
+    const ptyId = getPtySessionId(sessionId)
+    if (!ptyId || inFlightRef.current) {
+      return false
+    }
+    inFlightRef.current = true
+    // No stop-then-start: the backend re-locates and atomically replaces the
+    // watcher; a failed relocate leaves the old watcher intact (rollback-safe).
+    try {
+      await invoke('start_agent_watcher', { sessionId: ptyId })
+    } catch {
+      // Relocate failed (transient backend miss / bridge unavailable). Swallow
+      // so the bounded auto-retry keeps going and `void reattach()` never leaves
+      // an unhandled rejection; the old watcher stays intact and we try again.
+    } finally {
+      inFlightRef.current = false
+    }
+
+    return true
+  }, [sessionId])
+
+  const reattach = useCallback((): void => {
+    void reattachAsync()
+  }, [reattachAsync])
+
+  // Success predicate: a fresh `agent-status` carrying an `agentSessionId` that
+  // DIFFERS from the one live when we went stale means the relocated watcher is
+  // emitting → mark the key resolved and drop the red state. The old watcher
+  // keeps emitting the captured stale id, which is correctly ignored.
+  useEffect(() => {
+    if (sessionId === null) {
+      return
+    }
+
+    let cancelled = false
+    let unlisten: (() => void) | undefined
+
+    const subscribe = async (): Promise<void> => {
+      const fn = await listen<AgentStatusEvent>('agent-status', (payload) => {
+        if (cancelled || payload.sessionId !== getPtySessionId(sessionId)) {
+          return
+        }
+        const id = payload.agentSessionId
+        const staleId = staleAgentSessionIdRef.current
+        const staleTotal = staleTokenTotalRef.current
+        const eventTotal = eventTokenTotal(payload.contextWindow)
+
+        // Fresh when a relocated run is observed: a DIFFERENT agentSessionId, or
+        // the SAME id whose token total reset — either a drop below the captured
+        // total, or an explicit zero (covers a `/clear` whose pre-clear total
+        // was 0, where `< staleTotal` can never hold). Mirrors useAgentStatus's
+        // latch and additionally recognizes the zero reset (codex review
+        // VIM-192).
+        const tokensReset =
+          eventTotal !== null &&
+          (eventTotal === 0 || (staleTotal !== null && eventTotal < staleTotal))
+        const isFresh = id !== null && (id !== staleId || tokensReset)
+        if (needsReattachRef.current && isFresh) {
+          const key = staleKeyRef.current
+          if (key !== null) {
+            resolvedKeysRef.current.add(key)
+          }
+          setNeedsReattach(false)
+        }
+      })
+      if (cancelled) {
+        fn()
+      } else {
+        unlisten = fn
+      }
+    }
+
+    void subscribe()
+
+    return (): void => {
+      cancelled = true
+      unlisten?.()
+    }
+  }, [sessionId])
+
+  // Derive the red state from the active pane's stale key: armed when stale and
+  // not yet resolved, cleared otherwise. Keyed by `sessionId:staleGeneration`
+  // so switching to a non-stale (or already-recovered) pane clears it and a
+  // re-selected recovered pane never flashes red again.
+  useEffect(() => {
+    if (staleKey === null || resolvedKeysRef.current.has(staleKey)) {
+      staleAgentSessionIdRef.current = null
+      staleTokenTotalRef.current = null
+      setNeedsReattach(false)
+
+      return
+    }
+    // Preserve the original pre-clear identity across repeated `/clear` on the
+    // same session: by the second clear useAgentStatus has reset the live id to
+    // null, and overwriting with null would let the OLD watcher's events look
+    // fresh and falsely resolve (codex review VIM-192).
+    const sameSession = staleCaptureSessionRef.current === sessionId
+    if (!sameSession || agentSessionIdRef.current !== null) {
+      staleAgentSessionIdRef.current = agentSessionIdRef.current
+      staleTokenTotalRef.current = agentTokenTotalRef.current
+    }
+    staleCaptureSessionRef.current = sessionId
+    setNeedsReattach(true)
+  }, [staleKey, sessionId])
+
+  // Deferred, bounded auto-reattach: each attempt waits for its IPC to settle
+  // before scheduling the next, and the budget counts only issued calls — so a
+  // slow `start_agent_watcher` can't exhaust the retries with single-flight
+  // no-ops (codex review VIM-192). Stops as soon as the success predicate
+  // clears `needsReattach` (cleanup cancels the pending timer).
+  useEffect(() => {
+    if (!needsReattach) {
+      return
+    }
+
+    let cancelled = false
+    let attempts = 0
+    let timer: ReturnType<typeof setTimeout>
+
+    const run = async (): Promise<void> => {
+      if (cancelled || attempts >= REATTACH_AUTO_MAX_ATTEMPTS) {
+        return
+      }
+      const issued = await reattachAsync()
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- the effect cleanup sets `cancelled` across the await above
+      if (cancelled) {
+        return
+      }
+      if (issued) {
+        attempts += 1
+      }
+      timer = setTimeout(() => void run(), REATTACH_AUTO_RETRY_INTERVAL_MS)
+    }
+
+    timer = setTimeout(() => void run(), REATTACH_AUTO_INITIAL_DELAY_MS)
+
+    return (): void => {
+      cancelled = true
+      clearTimeout(timer)
+    }
+  }, [needsReattach, reattachAsync])
+
+  return { needsReattach, reattach }
+}

--- a/src/features/agent-status/hooks/useAgentReattach.ts
+++ b/src/features/agent-status/hooks/useAgentReattach.ts
@@ -87,9 +87,8 @@ export const useAgentReattach = ({
   agentSessionIdRef.current = agentSessionId
   const agentTokenTotalRef = useRef(agentTokenTotal)
   agentTokenTotalRef.current = agentTokenTotal
-  const staleKeyRef = useRef(staleKey)
-  staleKeyRef.current = staleKey
-
+  const currentStaleKeyRef = useRef(staleKey)
+  currentStaleKeyRef.current = staleKey
   // Single-flight guard so a manual click and the auto-retry can't issue
   // overlapping `start_agent_watcher` invokes.
   const inFlightRef = useRef(false)
@@ -105,6 +104,10 @@ export const useAgentReattach = ({
   // Stale keys whose relocate has succeeded — re-selecting that pane must not
   // re-arm the red state (codex review VIM-192).
   const resolvedKeysRef = useRef<Set<string>>(new Set())
+  // The stale key armed by the current red-state cycle. Unlike `staleKey`,
+  // this is not a render mirror, so an async success event cannot resolve a
+  // newer `/clear` generation that arrived while the event was in flight.
+  const armedStaleKeyRef = useRef<string | null>(null)
 
   // Returns whether it actually issued an invoke (vs skipped under
   // single-flight) so the auto-retry budget only counts real calls.
@@ -160,19 +163,30 @@ export const useAgentReattach = ({
 
         // Fresh when a relocated run is observed: a DIFFERENT agentSessionId, or
         // the SAME id whose token total reset — either a drop below the captured
-        // total, or an explicit zero (covers a `/clear` whose pre-clear total
-        // was 0, where `< staleTotal` can never hold). Mirrors useAgentStatus's
-        // latch and additionally recognizes the zero reset (codex review
-        // VIM-192).
+        // total, an explicit zero (covers a `/clear` whose pre-clear total was
+        // 0), or any known total when the pre-clear baseline was unknown.
+        // Mirrors useAgentStatus's local reset latch so the red state only
+        // clears when the status panel can accept the same event.
         const tokensReset =
           eventTotal !== null &&
-          (eventTotal === 0 || (staleTotal !== null && eventTotal < staleTotal))
+          (eventTotal === 0 || staleTotal === null || eventTotal < staleTotal)
         const isFresh = id !== null && (id !== staleId || tokensReset)
         if (needsReattachRef.current && isFresh) {
-          const key = staleKeyRef.current
+          const key = armedStaleKeyRef.current
           if (key !== null) {
             resolvedKeysRef.current.add(key)
           }
+          const currentKey = currentStaleKeyRef.current
+          if (
+            currentKey !== null &&
+            currentKey !== key &&
+            !resolvedKeysRef.current.has(currentKey)
+          ) {
+            armedStaleKeyRef.current = currentKey
+
+            return
+          }
+          armedStaleKeyRef.current = null
           setNeedsReattach(false)
         }
       })
@@ -196,9 +210,18 @@ export const useAgentReattach = ({
   // so switching to a non-stale (or already-recovered) pane clears it and a
   // re-selected recovered pane never flashes red again.
   useEffect(() => {
-    if (staleKey === null || resolvedKeysRef.current.has(staleKey)) {
+    if (staleKey === null) {
+      armedStaleKeyRef.current = null
+      setNeedsReattach(false)
+
+      return
+    }
+
+    if (resolvedKeysRef.current.has(staleKey)) {
       staleAgentSessionIdRef.current = null
       staleTokenTotalRef.current = null
+      staleCaptureSessionRef.current = null
+      armedStaleKeyRef.current = null
       setNeedsReattach(false)
 
       return
@@ -213,6 +236,9 @@ export const useAgentReattach = ({
       staleTokenTotalRef.current = agentTokenTotalRef.current
     }
     staleCaptureSessionRef.current = sessionId
+    if (!needsReattachRef.current || armedStaleKeyRef.current === null) {
+      armedStaleKeyRef.current = staleKey
+    }
     setNeedsReattach(true)
   }, [staleKey, sessionId])
 
@@ -240,6 +266,8 @@ export const useAgentReattach = ({
         return
       }
       if (issued) {
+        attempts += 1
+      } else if (!inFlightRef.current) {
         attempts += 1
       }
       timer = setTimeout(() => void run(), REATTACH_AUTO_RETRY_INTERVAL_MS)

--- a/src/features/agent-status/hooks/useAgentStatus.test.ts
+++ b/src/features/agent-status/hooks/useAgentStatus.test.ts
@@ -1429,7 +1429,7 @@ describe('useAgentStatus', () => {
     expect(result.current.toolCalls.active?.toolUseId).toBe('new-running-call')
   })
 
-  test('resetGeneration with null contextWindow suppresses same-run status until new session boundary', async () => {
+  test('resetGeneration with null contextWindow accepts same-run status once tokens are known', async () => {
     const { result, rerender } = renderHook(
       ({ resetGeneration }: { resetGeneration: number }) =>
         useAgentStatus('session-1', resetGeneration),
@@ -1465,9 +1465,8 @@ describe('useAgentStatus', () => {
     expect(result.current.agentSessionId).toBeNull()
     expect(result.current.contextWindow).toBeNull()
 
-    // A stale same-run status event with a non-null contextWindow must not
-    // repopulate the cleared sidebar, because freshness is undecidable when
-    // the pre-reset snapshot lacked a token total.
+    // Once the relocated watcher emits a known token total, the unknown
+    // pre-reset baseline no longer blocks same-id recovery.
     act(() => {
       emit('agent-status', {
         sessionId: 'pty-session-1',
@@ -1488,10 +1487,10 @@ describe('useAgentStatus', () => {
       })
     })
 
-    expect(result.current.agentSessionId).toBeNull()
-    expect(result.current.contextWindow).toBeNull()
+    expect(result.current.agentSessionId).toBe('codex-old')
+    expect(result.current.contextWindow?.usedPercentage).toBe(80)
 
-    // Run-scoped events must stay suppressed for the same session.
+    // Run-scoped events resume after the same-id status recovery.
     act(() => {
       emit('agent-tool-call', {
         sessionId: 'pty-session-1',
@@ -1509,9 +1508,11 @@ describe('useAgentStatus', () => {
       })
     })
 
-    expect(result.current.toolCalls.active).toBeNull()
+    expect(result.current.toolCalls.active?.toolUseId).toBe(
+      'stale-running-call'
+    )
     expect(result.current.toolCalls.total).toBe(0)
-    expect(result.current.numTurns).toBe(0)
+    expect(result.current.numTurns).toBe(9)
 
     // A fresh session boundary clears the suppression latch and allows updates.
     act(() => {

--- a/src/features/agent-status/hooks/useAgentStatus.ts
+++ b/src/features/agent-status/hooks/useAgentStatus.ts
@@ -504,12 +504,10 @@ export const useAgentStatus = (
             ) {
               const priorTokenTotal = locallyResetTokenTotalRef.current
               const nextTokenTotal = eventTokenTotal(p.contextWindow)
-              if (priorTokenTotal === null) {
-                return prev
-              }
-
               if (
                 nextTokenTotal !== null &&
+                nextTokenTotal !== 0 &&
+                priorTokenTotal !== null &&
                 nextTokenTotal >= priorTokenTotal
               ) {
                 return prev

--- a/src/features/workspace/WorkspaceView.command-palette.test.tsx
+++ b/src/features/workspace/WorkspaceView.command-palette.test.tsx
@@ -48,6 +48,14 @@ vi.mock('../../hooks/useElasticContainer', () => ({
 }))
 vi.mock('./hooks/useNotifyInfo')
 vi.mock('../agent-status/hooks/useAgentStatus')
+
+vi.mock('../agent-status/hooks/useAgentReattach', () => ({
+  useAgentReattach: (): { needsReattach: boolean; reattach: () => void } => ({
+    needsReattach: false,
+    reattach: (): void => undefined,
+  }),
+}))
+
 vi.mock('../diff/hooks/useGitStatus')
 vi.mock('../editor/hooks/useEditorBuffer')
 vi.mock('../files/services/fileSystemService')

--- a/src/features/workspace/WorkspaceView.elastic.test.tsx
+++ b/src/features/workspace/WorkspaceView.elastic.test.tsx
@@ -28,6 +28,13 @@ vi.mock('../agent-status/hooks/useAgentStatus', () => ({
   })),
 }))
 
+vi.mock('../agent-status/hooks/useAgentReattach', () => ({
+  useAgentReattach: (): { needsReattach: boolean; reattach: () => void } => ({
+    needsReattach: false,
+    reattach: (): void => undefined,
+  }),
+}))
+
 vi.mock('../terminal/services/terminalService', () => ({
   createTerminalService: vi.fn(() => ({
     spawn: vi.fn().mockResolvedValue({ sessionId: 'sess-1', pid: 1, cwd: '~' }),

--- a/src/features/workspace/WorkspaceView.integration.test.tsx
+++ b/src/features/workspace/WorkspaceView.integration.test.tsx
@@ -36,6 +36,13 @@ vi.mock('../agent-status/hooks/useAgentStatus', () => ({
   })),
 }))
 
+vi.mock('../agent-status/hooks/useAgentReattach', () => ({
+  useAgentReattach: (): { needsReattach: boolean; reattach: () => void } => ({
+    needsReattach: false,
+    reattach: (): void => undefined,
+  }),
+}))
+
 // Mock terminal service to return initial session data synchronously
 vi.mock('../terminal/services/terminalService', () => ({
   createTerminalService: vi.fn(() => ({

--- a/src/features/workspace/WorkspaceView.notifyInfo.test.tsx
+++ b/src/features/workspace/WorkspaceView.notifyInfo.test.tsx
@@ -22,6 +22,13 @@ vi.mock('../agent-status/hooks/useAgentStatus', () => ({
   })),
 }))
 
+vi.mock('../agent-status/hooks/useAgentReattach', () => ({
+  useAgentReattach: (): { needsReattach: boolean; reattach: () => void } => ({
+    needsReattach: false,
+    reattach: (): void => undefined,
+  }),
+}))
+
 vi.mock('../../hooks/useElasticContainer', () => ({
   useElasticContainer: vi.fn(() => ({
     size: 400,

--- a/src/features/workspace/WorkspaceView.subscription.test.tsx
+++ b/src/features/workspace/WorkspaceView.subscription.test.tsx
@@ -175,6 +175,13 @@ vi.mock('../agent-status/hooks/useAgentStatus', () => ({
   ),
 }))
 
+vi.mock('../agent-status/hooks/useAgentReattach', () => ({
+  useAgentReattach: (): { needsReattach: boolean; reattach: () => void } => ({
+    needsReattach: false,
+    reattach: (): void => undefined,
+  }),
+}))
+
 vi.mock('../agent-status/hooks/useAgentStatusHotLoading', () => ({
   useAgentStatusHotLoading: vi.fn(() => false),
 }))

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -139,6 +139,13 @@ vi.mock('../agent-status/hooks/useAgentStatus', () => ({
   })),
 }))
 
+vi.mock('../agent-status/hooks/useAgentReattach', () => ({
+  useAgentReattach: (): { needsReattach: boolean; reattach: () => void } => ({
+    needsReattach: false,
+    reattach: (): void => undefined,
+  }),
+}))
+
 // Mock useEditorBuffer so individual tests can flip isDirty without
 // having to drive the real hook through the editor. The default impl
 // (set in beforeEach below) returns a clean buffer so the bulk of

--- a/src/features/workspace/WorkspaceView.top-chrome.test.tsx
+++ b/src/features/workspace/WorkspaceView.top-chrome.test.tsx
@@ -38,6 +38,14 @@ vi.mock('../../hooks/useElasticContainer', () => ({
 }))
 vi.mock('./hooks/useNotifyInfo')
 vi.mock('../agent-status/hooks/useAgentStatus')
+
+vi.mock('../agent-status/hooks/useAgentReattach', () => ({
+  useAgentReattach: (): { needsReattach: boolean; reattach: () => void } => ({
+    needsReattach: false,
+    reattach: (): void => undefined,
+  }),
+}))
+
 vi.mock('../diff/hooks/useGitStatus')
 vi.mock('../editor/hooks/useEditorBuffer')
 vi.mock('../files/services/fileSystemService')

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -74,6 +74,7 @@ import { useNewSessionShortcut } from './hooks/useNewSessionShortcut'
 import { useSidebarCollapsed } from './hooks/useSidebarCollapsed'
 import { useEditorBuffer } from '../editor/hooks/useEditorBuffer'
 import { useAgentStatus } from '../agent-status/hooks/useAgentStatus'
+import { useAgentReattach } from '../agent-status/hooks/useAgentReattach'
 import { useAgentStatusHotLoading } from '../agent-status/hooks/useAgentStatusHotLoading'
 import { useGitStatus } from '../diff/hooks/useGitStatus'
 import { useFeedbackBatch } from '../diff/hooks/useFeedbackBatch'
@@ -519,6 +520,19 @@ const WorkspaceViewContent = (): ReactElement => {
     activePtyBackedPanePtyId ?? null,
     agentStatusResetGeneration
   )
+
+  // Codex watcher relocation recovery (VIM-188): `/clear` arms the red "needs
+  // reattach" state + a bounded auto-reattach; the manual button covers the
+  // undetectable in-session `resume`.
+  const agentReattach = useAgentReattach({
+    sessionId: activePtyBackedPanePtyId ?? null,
+    agentSessionId: agentStatus.agentSessionId,
+    agentTokenTotal: agentStatus.contextWindow
+      ? agentStatus.contextWindow.totalInputTokens +
+        agentStatus.contextWindow.totalOutputTokens
+      : null,
+    staleGeneration: agentStatusResetGeneration,
+  })
 
   const visibleAgentStatusPtyIds = useMemo(
     () =>
@@ -2507,6 +2521,12 @@ const WorkspaceViewContent = (): ReactElement => {
               cwd={activeCwd}
               gitStatus={gitStatus}
               isRefreshing={isAgentStatusRefreshing}
+              needsReattach={agentReattach.needsReattach}
+              onReattach={
+                agentStatus.agentType === 'codex'
+                  ? agentReattach.reattach
+                  : undefined
+              }
               onOpenDiff={handleOpenDiff}
               onOpenFile={handleOpenTestFile}
               agent={activityPanelAgent}

--- a/src/features/workspace/WorkspaceView.verification.test.tsx
+++ b/src/features/workspace/WorkspaceView.verification.test.tsx
@@ -36,6 +36,13 @@ vi.mock('../agent-status/hooks/useAgentStatus', () => ({
   })),
 }))
 
+vi.mock('../agent-status/hooks/useAgentReattach', () => ({
+  useAgentReattach: (): { needsReattach: boolean; reattach: () => void } => ({
+    needsReattach: false,
+    reattach: (): void => undefined,
+  }),
+}))
+
 // Mock terminal service to return initial session data synchronously
 vi.mock('../terminal/services/terminalService', () => ({
   createTerminalService: vi.fn(() => ({

--- a/src/features/workspace/WorkspaceView.visual.test.tsx
+++ b/src/features/workspace/WorkspaceView.visual.test.tsx
@@ -32,6 +32,13 @@ vi.mock('../agent-status/hooks/useAgentStatus', () => ({
   })),
 }))
 
+vi.mock('../agent-status/hooks/useAgentReattach', () => ({
+  useAgentReattach: (): { needsReattach: boolean; reattach: () => void } => ({
+    needsReattach: false,
+    reattach: (): void => undefined,
+  }),
+}))
+
 // Mock terminal service to return initial session data synchronously
 vi.mock('../terminal/services/terminalService', () => ({
   createTerminalService: vi.fn(() => ({


### PR DESCRIPTION
## What

The user-facing recovery for the codex agent-status freeze (VIM-188): after `/clear` or an in-session `resume`, the panel reattaches the watcher (which now relocates correctly via #581) instead of staying frozen.

- **`useAgentReattach`** — a self-contained hook (the fragile `useAgentStatus` is untouched). Reattach re-invokes `start_agent_watcher` directly: the backend's `run_watch_sequence` re-locates the rollout and **atomically replaces** the watcher — no stop-then-start.
- **Red "needs reattach" header state** + a **Reattach button** (codex panes), reusing the header's refreshing machinery.
- **`/clear`** (detected in `WorkspaceView`) arms the red state + a **deferred, bounded auto-reattach**; the undetectable in-session `resume` is covered by the manual button.

## Success predicate (mirrors `useAgentStatus`'s latch)

Cleared when a fresh `agent-status` arrives with a **new `agentSessionId`**, or a **same-id token-total reset** (lower, or zero). The old watcher keeps emitting the captured stale id, which is ignored — never a false success.

## Robustness (all regression-tested)

- Resolved `(session, generation)` keys tracked → a re-selected, already-recovered pane never re-flashes red.
- Auto-retry **awaits each IPC to settle**, counts **only issued calls** (slow `start_agent_watcher` can't burn the budget), and **survives transient failures** (no unhandled rejection).
- Stale identity **preserved across repeated `/clear`** (when `useAgentStatus` has already nulled the live id).
- Stale state never **leaks across panes** (per-pane `staleGeneration`, sentinel + session clearing).

## Tests

`useAgentReattach.test.ts` (14 tests) covers: reattach IPC, single-flight, deferred bounded auto-retry, IPC-failure resilience, all success predicates (new id / lower tokens / zero reset), stale-id ignored, repeated `/clear`, pane-switch clearing, recovered-pane no-re-arm. `Header.test.tsx` adds red-state + button tests. The 9 WorkspaceView suites mock the hook. Full frontend suite green (1142 tests); local codex review clean after iterating.

Part of VIM-188
Refs VIM-192

Spec: `docs/superpowers/specs/2026-06-20-codex-watcher-relocate-design.md` (§D3, §D4)