### PR TITLE
feat(agent): register opencode agent type (M1)

### DIFF
--- a/crates/backend/src/agent/config.rs
+++ b/crates/backend/src/agent/config.rs
@@ -78,7 +78,11 @@ pub(crate) const AGENT_SPECS: &[AgentSpec] = &[
         agent_type: AgentType::Opencode,
         display_name: "opencode",
         binary_names: &["opencode"],
-        home_subdir: Some(".local/share/opencode"),
+        // TODO(M6): opencode uses the platform data directory
+        // (`dirs::data_dir().join("opencode")`), not a home-relative
+        // dotdir. Leave this unresolved until the opencode adapter consumes
+        // provider_home so non-Linux builds do not receive a bad path.
+        home_subdir: None,
     },
     AgentSpec {
         agent_type: AgentType::Aider,
@@ -233,6 +237,9 @@ mod tests {
 
     #[test]
     fn provider_home_is_none_when_subdir_missing() {
+        let opencode = spec_for(AgentType::Opencode);
+        assert_eq!(opencode.provider_home(), None);
+
         let aider = spec_for(AgentType::Aider);
         assert_eq!(aider.provider_home(), None);
 

--- a/crates/backend/src/agent/config.rs
+++ b/crates/backend/src/agent/config.rs
@@ -75,6 +75,12 @@ pub(crate) const AGENT_SPECS: &[AgentSpec] = &[
         home_subdir: Some(".kimi-code"),
     },
     AgentSpec {
+        agent_type: AgentType::Opencode,
+        display_name: "opencode",
+        binary_names: &["opencode"],
+        home_subdir: Some(".local/share/opencode"),
+    },
+    AgentSpec {
         agent_type: AgentType::Aider,
         display_name: "Aider",
         binary_names: &["aider"],
@@ -162,6 +168,7 @@ mod tests {
             AgentType::ClaudeCode
             | AgentType::Codex
             | AgentType::Kimi
+            | AgentType::Opencode
             | AgentType::Aider
             | AgentType::Generic => spec_for(at),
         };
@@ -173,6 +180,7 @@ mod tests {
             AgentType::ClaudeCode,
             AgentType::Codex,
             AgentType::Kimi,
+            AgentType::Opencode,
             AgentType::Aider,
             AgentType::Generic,
         ] {
@@ -197,6 +205,10 @@ mod tests {
         assert_eq!(agent_type_for_binary("codex"), Some(AgentType::Codex));
         assert_eq!(agent_type_for_binary("kimi"), Some(AgentType::Kimi));
         assert_eq!(agent_type_for_binary("kimi-code"), Some(AgentType::Kimi));
+        assert_eq!(
+            agent_type_for_binary("opencode"),
+            Some(AgentType::Opencode)
+        );
         assert_eq!(agent_type_for_binary("aider"), Some(AgentType::Aider));
     }
 

--- a/crates/backend/src/agent/detector.rs
+++ b/crates/backend/src/agent/detector.rs
@@ -445,6 +445,25 @@ mod tests {
     }
 
     #[test]
+    fn detects_opencode_agent() {
+        let source = MockProcessSource {
+            children: HashMap::from([(10, vec![11])]),
+            cmdlines: HashMap::from([
+                (10, vec!["bash".to_string()]),
+                (11, vec!["opencode".to_string()]),
+            ]),
+        };
+
+        let detected = detect_agent_with_source(10, &source);
+
+        assert!(
+            matches!(detected, Some((AgentType::Opencode, 11))),
+            "expected opencode detection, got {:?}",
+            detected,
+        );
+    }
+
+    #[test]
     fn detects_aider_agent() {
         let cmdline = vec!["aider".to_string(), "--model".to_string()];
         let binary = extract_binary_name(&cmdline).unwrap();

--- a/crates/backend/src/agent/types.rs
+++ b/crates/backend/src/agent/types.rs
@@ -14,6 +14,8 @@ pub enum AgentType {
     Codex,
     /// Kimi Code (Moonshot kimi-code CLI)
     Kimi,
+    /// opencode (AI coding agent by SST)
+    Opencode,
     /// Aider (AI pair programming tool)
     Aider,
     /// Generic/unknown agent

--- a/crates/backend/src/terminal/workspace_layout.rs
+++ b/crates/backend/src/terminal/workspace_layout.rs
@@ -162,7 +162,14 @@ const MAX_TABS: usize = 50;
 const MAX_HISTORY: usize = 100;
 const MAX_URL_LEN: usize = 4096;
 const MAX_TITLE_LEN: usize = 1024;
-const KNOWN_AGENTS: [&str; 5] = ["claude-code", "codex", "kimi", "aider", "generic"];
+const KNOWN_AGENTS: [&str; 6] = [
+    "claude-code",
+    "codex",
+    "kimi",
+    "opencode",
+    "aider",
+    "generic",
+];
 const PANE_KINDS: [&str; 2] = ["shell", "browser"];
 
 fn builtin_layout_capacity(layout: &str) -> Option<usize> {
@@ -1148,6 +1155,21 @@ mod tests {
         );
         let s = shell(&store.sessions[0].panes[0]);
         assert_eq!(s.agent_type, "kimi"); // kimi is a known agent, not coerced to generic
+    }
+
+    #[test]
+    fn preserves_known_opencode_agent_type() {
+        let store = repair_workspace_layout(
+            json!({ "version": 1, "sessions": [{
+                "id": "s", "layout": "single", "active": true,
+                "panes": [
+                    { "kind": "shell", "paneId": "p0", "paneIndex": 0, "active": true,
+                      "ptyId": "x", "cwd": "/", "agentType": "opencode", "agentSessionId": null } ] }] }),
+            "proj",
+            "/",
+        );
+        let s = shell(&store.sessions[0].panes[0]);
+        assert_eq!(s.agent_type, "opencode");
     }
 
     #[test]

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -65,6 +65,10 @@ words:
   - kimi
   - Kimi
 
+  # opencode (SST coding agent)
+  - opencode
+  - Opencode
+
   # Design / UI
   - glassmorphism
   - catppuccin

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -50,7 +50,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Fixed-Position Portals](patterns/fixed-position-portals.md)                                         | react-patterns     | 1        | 0    | 2026-06-12   |
 | [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 15       | 12   | 2026-06-16   |
-| [Cross-Platform Paths](patterns/cross-platform-paths.md)                                             | cross-platform     | 8        | 4    | 2026-06-20   |
+| [Cross-Platform Paths](patterns/cross-platform-paths.md)                                             | cross-platform     | 10       | 4    | 2026-06-20   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                                                       | code-quality       | 7        | 0    | 2026-06-11   |
 | [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 12       | 9    | 2026-06-19   |
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
@@ -85,7 +85,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [UI Visual Regression](patterns/ui-visual-regression.md)                                             | code-quality       | 15       | 8    | 2026-06-20   |
 | [Status Indicator Display](patterns/status-indicator-display.md)                                     | code-quality       | 3        | 0    | 2026-05-26   |
 | [Parser Resilience](patterns/parser-resilience.md)                                                   | code-quality       | 11       | 8    | 2026-06-12   |
-| [Persisted State Invariants](patterns/persisted-state-invariants.md)                                 | correctness        | 11       | 5    | 2026-06-19   |
+| [Persisted State Invariants](patterns/persisted-state-invariants.md)                                 | correctness        | 12       | 5    | 2026-06-20   |
 | [macOS Window Chrome](patterns/macos-window-chrome.md)                                               | cross-platform     | 9        | 2    | 2026-06-15   |
 | [Guard Branch Correctness](patterns/guard-branch-correctness.md)                                     | correctness        | 2        | 0    | 2026-06-19   |
 | [Identifier Prefix Matching](patterns/identifier-prefix-matching.md)                                 | correctness        | 4        | 2    | 2026-06-17   |

--- a/docs/reviews/patterns/cross-platform-paths.md
+++ b/docs/reviews/patterns/cross-platform-paths.md
@@ -97,3 +97,12 @@ consider using path libraries for cross-platform code.
 - **Finding:** The pre-push Vitest hook failed on macOS because `parentPathForGitStatus('~/repo/src/new.ts')` intentionally lowercases the expanded path on case-insensitive platforms, while the test expected the raw `$HOME` casing (`/Users/...`). The production behavior was correct, but the platform-sensitive expectation made the local gate fail and encouraged a `git push --no-verify` bypass.
 - **Fix:** Keep the direct `expandTildePath` assertion for raw home expansion, but compare the git-status parent path with `normalizePathForComparison(`${home}/repo/src`)` so the expected value follows the same case-folding contract as the API under test.
 - **Commit:** same commit as this entry
+
+### 9. opencode provider home used a Linux XDG path as a home-relative subdir
+
+- **Source:** github-claude | PR #584 round 1 | 2026-06-20
+- **Severity:** MEDIUM
+- **File:** `crates/backend/src/agent/config.rs`
+- **Finding:** The opencode registry entry set `home_subdir` to `.local/share/opencode`, which made `provider_home()` resolve a Linux XDG data path through `dirs::home_dir().join(...)` on every platform. macOS and Windows would receive nonexistent home-relative paths instead of their platform data directories once the opencode adapter starts consuming `provider_home`.
+- **Fix:** Cleared opencode's `home_subdir` for the scaffold milestone and documented the M6 follow-up to resolve it through `dirs::data_dir().join("opencode")` when the adapter needs the value.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/persisted-state-invariants.md
+++ b/docs/reviews/patterns/persisted-state-invariants.md
@@ -2,7 +2,7 @@
 id: persisted-state-invariants
 category: correctness
 created: 2026-06-08
-last_updated: 2026-06-19
+last_updated: 2026-06-20
 ref_count: 5
 ---
 
@@ -111,4 +111,13 @@ Durable user-facing state (workspace shapes, caches, settings files) can be malf
 - **File:** `crates/backend/src/terminal/cache.rs` L87-89 (original)
 - **Finding:** `SessionCache::app_data_dir()` derived the Vimeflow data root by calling `.parent()` on `self.path` (`sessions.json`). The invariant that the cache file is always a direct child of `app_data_dir` was established by convention in `BackendState::new` and not enforced by the type system. Moving the cache path (e.g., `db/sessions.json`) would silently write bridge/status files under the wrong parent with no compile-time or runtime warning.
 - **Fix:** Stored `app_data_dir: PathBuf` explicitly in `SessionCache`, initialized it in `SessionCache::new`/`with_path`, and added `BackendState::with_app_data_dir` so the root is pinned once at construction rather than inferred from the cache path. `spawn_pty_inner` now uses the explicit field instead of `cache.app_data_dir()`.
+- **Commit:** same commit as this entry
+
+### 12. Durable layout repair coerced opencode panes to generic
+
+- **Source:** github-codex-connector | PR #584 round 1 | 2026-06-20
+- **Severity:** P2 / MEDIUM
+- **File:** `crates/backend/src/terminal/workspace_layout.rs`
+- **Finding:** The frontend type contract allowed `agentType: "opencode"` and workspace-shape persistence could write that value, but Rust layout repair still treated only the older agent set as known. Restarting from a durable layout would coerce opencode panes to `generic` until detection ran again.
+- **Fix:** Added `opencode` to the repair allowlist and added a regression test proving `repair_workspace_layout` preserves the opencode agent type.
 - **Commit:** same commit as this entry

--- a/src/features/agent-status/types/index.ts
+++ b/src/features/agent-status/types/index.ts
@@ -48,7 +48,14 @@ export interface AgentStatus {
    * metrics during its exit window.
    */
   agentExited: boolean
-  agentType: 'claude-code' | 'codex' | 'kimi' | 'aider' | 'generic' | null
+  agentType:
+    | 'claude-code'
+    | 'codex'
+    | 'kimi'
+    | 'opencode'
+    | 'aider'
+    | 'generic'
+    | null
   modelId: string | null
   modelDisplayName: string | null
   version: string | null

--- a/src/features/agent-status/utils/agentStatusModel.test.ts
+++ b/src/features/agent-status/utils/agentStatusModel.test.ts
@@ -9,6 +9,7 @@ describe('agentStatusModel', () => {
     expect(mapDetectedAgentType('claudeCode')).toBe('claude-code')
     expect(mapDetectedAgentType('codex')).toBe('codex')
     expect(mapDetectedAgentType('aider')).toBe('aider')
+    expect(mapDetectedAgentType('opencode')).toBe('opencode')
     expect(mapDetectedAgentType('unknown')).toBe('generic')
   })
 

--- a/src/features/agent-status/utils/agentStatusModel.ts
+++ b/src/features/agent-status/utils/agentStatusModel.ts
@@ -4,6 +4,7 @@ const AGENT_TYPE_MAP = {
   claudeCode: 'claude-code',
   codex: 'codex',
   kimi: 'kimi',
+  opencode: 'opencode',
   aider: 'aider',
   generic: 'generic',
 } as const

--- a/src/features/sessions/types/index.ts
+++ b/src/features/sessions/types/index.ts
@@ -50,7 +50,7 @@ export interface Pane {
   shell?: string
 
   /** Detected agent CLI for this pane. */
-  agentType: 'claude-code' | 'codex' | 'kimi' | 'aider' | 'generic'
+  agentType: 'claude-code' | 'codex' | 'kimi' | 'opencode' | 'aider' | 'generic'
 
   /**
    * Title emitted by the agent for the agent session bound to this PTY.
@@ -118,7 +118,7 @@ export interface Session {
   /** Stable session/project cwd used as the baseline for new panes. */
   workingDirectory: string
   /** Derived from `getActivePane(session).agentType`; retained for existing chrome. */
-  agentType: 'claude-code' | 'codex' | 'kimi' | 'aider' | 'generic'
+  agentType: 'claude-code' | 'codex' | 'kimi' | 'opencode' | 'aider' | 'generic'
   /** Per-session canvas layout. Builtin ids or validated workspace custom ids. */
   layout: PaneLayoutId
   /** Session-scoped collapse state for the right agent activity panel.

--- a/src/features/sessions/utils/agentForSession.test.ts
+++ b/src/features/sessions/utils/agentForSession.test.ts
@@ -50,6 +50,12 @@ describe('agentForSession', () => {
     )
   })
 
+  test('opencode falls back to AGENTS.shell (M1 temporary)', () => {
+    expect(agentForSession({ ...baseSession, agentType: 'opencode' })).toBe(
+      AGENTS.shell
+    )
+  })
+
   test('aider falls back to AGENTS.shell', () => {
     expect(agentForSession({ ...baseSession, agentType: 'aider' })).toBe(
       AGENTS.shell
@@ -80,6 +86,12 @@ describe('agentForPane', () => {
 
   test('codex maps to AGENTS.codex', () => {
     expect(agentForPane({ ...basePane, agentType: 'codex' })).toBe(AGENTS.codex)
+  })
+
+  test('opencode falls back to AGENTS.shell (M1 temporary)', () => {
+    expect(agentForPane({ ...basePane, agentType: 'opencode' })).toBe(
+      AGENTS.shell
+    )
   })
 
   test('aider falls back to AGENTS.shell', () => {

--- a/src/features/sessions/utils/agentForSession.ts
+++ b/src/features/sessions/utils/agentForSession.ts
@@ -5,6 +5,8 @@ const AGENT_BY_SESSION_TYPE: Record<Session['agentType'], AgentId> = {
   'claude-code': 'claude',
   codex: 'codex',
   kimi: 'kimi',
+  // TEMPORARY (M1): opencode mapped to 'shell' until M6 adds the registry entry
+  opencode: 'shell',
   aider: 'shell',
   generic: 'shell',
 }

--- a/src/features/sessions/utils/groupSessionsFromInfos.ts
+++ b/src/features/sessions/utils/groupSessionsFromInfos.ts
@@ -39,6 +39,7 @@ const KNOWN_AGENT_TYPES: readonly AgentType[] = [
   'claude-code',
   'codex',
   'kimi',
+  'opencode',
   'aider',
   'generic',
 ]


### PR DESCRIPTION
## M1 — opencode agent-type registration

Part of VIM-193. Closes VIM-194.

First milestone of opencode observability support (codex-reviewed spec + plan live on this branch under `docs/superpowers/`). Pure registration scaffold — **no adapter behavior yet**: opencode is detected and routed to `NoOpAdapter` via the existing `other =>` fallback.

### Changes
- `AgentType::Opencode` + `AGENT_SPECS` entry (`binary_names: ["opencode"]`, `home_subdir: ".local/share/opencode"`); exhaustiveness, binary-map, and detector tests.
- Frontend type unions + maps (`AGENT_TYPE_MAP`, `KNOWN_AGENT_TYPES`, `AGENT_BY_SESSION_TYPE` → `shell` temporarily until M6).
- Generated `src/bindings/AgentType.ts` wire string verified as `"opencode"`.
- `cspell` word-list updated.

### Verification (local; CI re-runs the full suite)
- Backend: `registry_covers_every_agent_type`, `agent_type_for_binary*`, `detects_opencode_agent` pass.
- `type-check` / `lint` / `format:check` green; touched frontend tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)