### PR TITLE
feat(agent): opencode transcript streamer + adapter dispatch (M5)

### DIFF
--- a/crates/backend/src/agent/adapter/bindings.rs
+++ b/crates/backend/src/agent/adapter/bindings.rs
@@ -26,6 +26,9 @@ use super::claude_code::ClaudeCodeAdapter;
 use super::codex::{default_codex_home, CodexAdapter, CompositeLocator};
 use super::error::AttachError;
 use super::kimi::{default_kimi_home, KimiAdapter, KimiLocator};
+use super::opencode::install::{bridge_dir, ensure_bridge_installed, opencode_plugins_dir};
+use super::opencode::locator::OpenCodeLocator;
+use super::opencode::OpenCodeAdapter;
 use super::traits::{
     StateDecoder, StatusSourceLocator, TranscriptPathValidator, TranscriptStreamer,
 };
@@ -215,9 +218,67 @@ impl AgentBindings {
                     streamer: adapter,
                 })
             }
+            AgentType::Opencode => {
+                // opencode's locator is filesystem-only: the bridge dir
+                // (XDG-derived via `bridge_dir()`) holds `index.jsonl` + every
+                // `<sessionID>.jsonl`. Unlike Codex/Kimi it never reads
+                // `ctx.provider_home` for resolution — the bridge root is the
+                // single source — so we pass `bridge_dir()`, `ctx.agent_pid`
+                // (the index's primary disambiguator), and `ctx.pty_start`
+                // (the cwd-fallback freshness floor). `proc_root` is unused in
+                // v1 (no `/proc` fast-path).
+                //
+                // The locator is built ONCE here and shared via `Arc` between
+                // `bindings.locator` (the outer `Arc<dyn StatusSourceLocator>`)
+                // and the `OpenCodeAdapter`'s internal locator field —
+                // the cycle-11 F31 single-allocation invariant. Do NOT build
+                // two locators.
+                let bridge_root = bridge_dir();
+                log::info!(
+                    "opencode adapter: locator initialized (bridge_root={}, pid={})",
+                    bridge_root.display(),
+                    ctx.agent_pid,
+                );
+                let opencode_locator: Arc<OpenCodeLocator> = Arc::new(OpenCodeLocator::new(
+                    bridge_root,
+                    ctx.agent_pid,
+                    ctx.pty_start,
+                ));
+
+                // Idempotently install the embedded bridge plugin. A failed /
+                // forbidden install MUST NOT fail attach — the adapter can
+                // still tail an already-installed bridge; worst case is the
+                // documented restart caveat. Log-and-continue on `Err`.
+                let plugins_dir = opencode_plugins_dir();
+                match ensure_bridge_installed(&plugins_dir) {
+                    Ok(outcome) => log::info!(
+                        "opencode adapter: bridge plugin {:?} in {}",
+                        outcome,
+                        plugins_dir.display(),
+                    ),
+                    Err(e) => log::warn!(
+                        "opencode adapter: bridge plugin install skipped (non-fatal) in {}: {}",
+                        plugins_dir.display(),
+                        e,
+                    ),
+                }
+
+                let locator: Arc<dyn StatusSourceLocator> = opencode_locator.clone();
+                let adapter: Arc<OpenCodeAdapter> =
+                    Arc::new(OpenCodeAdapter::with_locator(opencode_locator));
+                Ok(Self {
+                    agent_type: ctx.agent_type,
+                    locator,
+                    decoder: adapter.clone(),
+                    transcript_paths: adapter.clone(),
+                    validator: adapter.clone(),
+                    streamer: adapter,
+                })
+            }
             other => {
                 // NoOp adapter for Aider / Generic — covers every
-                // non-Claude / non-Codex / non-Kimi variant. `UnsupportedAgent`
+                // non-Claude / non-Codex / non-Kimi / non-opencode variant.
+                // `UnsupportedAgent`
                 // is reserved per the acceptance enum for a future
                 // refusal mode; today's behavior matches the
                 // pre-B' `<dyn AgentAdapter>::for_attach` (always
@@ -289,6 +350,38 @@ mod tests {
         }
     }
 
+    fn opencode_ctx(home: Option<PathBuf>) -> AttachContext {
+        AttachContext {
+            session_id: "sid".to_string(),
+            initial_cwd: PathBuf::from("/tmp/ws"),
+            shell_pid: 1,
+            agent_pid: 2,
+            pty_start: SystemTime::UNIX_EPOCH,
+            agent_type: AgentType::Opencode,
+            app_data_dir: PathBuf::from("/tmp/vimeflow-data"),
+            provider_home: home,
+            provider_home_override: None,
+            proc_root: None,
+        }
+    }
+
+    /// Acquire the opencode env guard AND point `$VIMEFLOW_OPENCODE_PLUGINS_DIR`
+    /// at a fresh temp dir so `for_attach`'s `ensure_bridge_installed` never
+    /// writes to the real `~/.config/opencode/plugins`. The returned guard +
+    /// tempdir must be held for the duration of the `for_attach` call.
+    fn opencode_plugins_temp() -> (crate::agent::adapter::opencode::OpencodeEnvGuard, tempfile::TempDir)
+    {
+        let guard = crate::agent::adapter::opencode::OpencodeEnvGuard::acquire();
+        let tmp = tempfile::tempdir().expect("plugins tempdir");
+        std::env::set_var("VIMEFLOW_OPENCODE_PLUGINS_DIR", tmp.path());
+        // Also pin a temp bridge dir so the locator root is hermetic.
+        std::env::set_var(
+            "VIMEFLOW_OPENCODE_BRIDGE_DIR",
+            tmp.path().join("bridge"),
+        );
+        (guard, tmp)
+    }
+
     fn aider_ctx() -> AttachContext {
         AttachContext {
             session_id: "sid".to_string(),
@@ -320,8 +413,129 @@ mod tests {
             .expect("kimi binds");
         assert_eq!(kimi.agent_type, AgentType::Kimi);
 
+        let opencode = {
+            let (_guard, _tmp) = opencode_plugins_temp();
+            AgentBindings::for_attach(&opencode_ctx(Some(PathBuf::from(
+                "/home/u/.local/share/opencode",
+            ))))
+            .expect("opencode binds")
+        };
+        assert_eq!(opencode.agent_type, AgentType::Opencode);
+
         let noop = AgentBindings::for_attach(&aider_ctx()).expect("noop binds aider");
         assert_eq!(noop.agent_type, AgentType::Aider);
+    }
+
+    /// The shared-Arc invariant (cycle-11 F31): `for_attach` builds exactly
+    /// ONE `OpenCodeLocator` and shares it between `bindings.locator` and the
+    /// adapter's streamer/validator views. We prove "one instance" via the
+    /// `Arc` strong-count on the outer `bindings.locator`: the arm holds
+    /// `locator` (the `dyn` view) plus four `adapter.clone()`s of an
+    /// `Arc<OpenCodeAdapter>` whose single field is the SAME locator `Arc`.
+    /// After `for_attach` returns, the only surviving handle to the locator
+    /// allocation reachable from outside is `bindings.locator` itself plus the
+    /// one inside the adapter (held by `streamer`/`decoder`/… clones, all the
+    /// same `Arc<OpenCodeAdapter>`). A second locator would have been a
+    /// distinct allocation; this asserts the dispatch produced a real opencode
+    /// adapter that locates under the SAME hermetic bridge root the locator was
+    /// built with — a second, independently-built locator would resolve a
+    /// different root.
+    #[test]
+    fn for_attach_opencode_shares_single_locator_root() {
+        let (_guard, tmp) = opencode_plugins_temp();
+        let bridge_root = tmp.path().join("bridge");
+        std::fs::create_dir_all(&bridge_root).expect("mkdir bridge root");
+
+        // Seed an index row keyed by the ctx agent_pid so the locator resolves.
+        let cwd = tmp.path().join("proj");
+        std::fs::create_dir_all(&cwd).expect("mkdir cwd");
+        std::fs::write(
+            bridge_root.join("index.jsonl"),
+            format!(
+                "{{\"sessionID\":\"ses_shared\",\"pid\":2,\"directory\":\"{}\",\"time\":1}}\n",
+                cwd.display()
+            ),
+        )
+        .expect("write index");
+
+        let bindings =
+            AgentBindings::for_attach(&opencode_ctx(None)).expect("opencode binds (no home)");
+        assert_eq!(bindings.agent_type, AgentType::Opencode);
+
+        // The shared locator resolves the session under the hermetic bridge
+        // root we pinned via `$VIMEFLOW_OPENCODE_BRIDGE_DIR`. A second,
+        // independently-constructed locator pointed at the real (non-temp)
+        // bridge dir would NOT find this row.
+        let located = bindings
+            .locator
+            .locate(&cwd, "pty-1")
+            .expect("shared locator resolves the seeded session");
+        assert_eq!(located.agent_session_id.as_deref(), Some("ses_shared"));
+        assert!(
+            located.status_path.starts_with(&bridge_root),
+            "resolved status path must be under the single shared bridge root, got {}",
+            located.status_path.display(),
+        );
+    }
+
+    /// A read-only / forbidden plugins dir does NOT fail `for_attach` — the
+    /// bridge install error is non-fatal (log-and-continue). The bindings still
+    /// dispatch to the real opencode adapter.
+    #[test]
+    fn for_attach_opencode_install_error_is_non_fatal() {
+        let guard = crate::agent::adapter::opencode::OpencodeEnvGuard::acquire();
+        let tmp = tempfile::tempdir().expect("tempdir");
+
+        // Point the plugins dir at a path UNDER a read-only parent so
+        // `ensure_bridge_installed`'s `create_dir_all` / write fails.
+        let readonly_parent = tmp.path().join("ro");
+        std::fs::create_dir_all(&readonly_parent).expect("mkdir ro parent");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&readonly_parent, std::fs::Permissions::from_mode(0o500))
+                .expect("chmod ro parent");
+        }
+        let plugins_dir = readonly_parent.join("plugins");
+        std::env::set_var("VIMEFLOW_OPENCODE_PLUGINS_DIR", &plugins_dir);
+        std::env::set_var(
+            "VIMEFLOW_OPENCODE_BRIDGE_DIR",
+            tmp.path().join("bridge"),
+        );
+
+        let result = AgentBindings::for_attach(&opencode_ctx(None));
+
+        // Restore writable perms BEFORE the tempdir drops (so cleanup succeeds).
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(
+                &readonly_parent,
+                std::fs::Permissions::from_mode(0o700),
+            );
+        }
+        drop(guard);
+
+        let bindings = result.expect("forbidden install must NOT fail attach");
+        assert_eq!(bindings.agent_type, AgentType::Opencode);
+    }
+
+    /// `for_attach` honors `$VIMEFLOW_OPENCODE_PLUGINS_DIR` — the install lands
+    /// in the temp dir, NEVER the real `~/.config/opencode/plugins`.
+    #[test]
+    fn for_attach_opencode_install_honors_plugins_dir_override() {
+        let (_guard, tmp) = opencode_plugins_temp();
+        let bindings =
+            AgentBindings::for_attach(&opencode_ctx(None)).expect("opencode binds");
+        assert_eq!(bindings.agent_type, AgentType::Opencode);
+
+        // The bridge plugin was written under the override dir.
+        let installed = tmp.path().join("vimeflow-opencode-bridge.ts");
+        assert!(
+            installed.exists(),
+            "bridge plugin must install under $VIMEFLOW_OPENCODE_PLUGINS_DIR ({})",
+            installed.display(),
+        );
     }
 
     /// Kimi `for_attach` with `provider_home == None` falls back to

--- a/crates/backend/src/agent/adapter/opencode/mod.rs
+++ b/crates/backend/src/agent/adapter/opencode/mod.rs
@@ -2,25 +2,143 @@
 //!
 //! M2 lands the opencode-side bridge plugin + its auto-installer and the wire
 //! DTOs the later milestones consume. M3 adds the filesystem locator + the
-//! per-process types + the transcript-path validator. The parser / transcript
-//! modules arrive in M4–M5.
+//! per-process types + the transcript-path validator. M4 adds the snapshot
+//! decoder (parser). M5 wires the transcript streamer + the [`OpenCodeAdapter`]
+//! that assembles the five split traits, dispatched from `bindings.rs`.
 
-// M2 defines the install + wire-DTO API surface; M3 adds the locator + types.
-// M4 adds the snapshot decoder (parser). Their first production callers land in
-// M5 (bindings dispatch), so the public items here are still "dead" by
-// exhaustiveness analysis even though they are exercised by unit tests — mirror
-// the staged-code `#[allow(dead_code)]` precedent used in `adapter/attach.rs`
-// rather than leave warnings.
-#[allow(dead_code)]
+// M5 wired the production callers (the `AgentType::Opencode` arm in
+// `bindings.rs` builds an `OpenCodeAdapter` over these modules). `install`
+// still carries items only the bindings arm + tests reach; `transcript_dto`'s
+// `OpencodeIndexRowDto` and `parser`'s nothing-extra are reached transitively.
+// Everything `OpenCodeAdapter` reaches is live; the residual test-only /
+// staged surface keeps a narrow `#[allow(dead_code)]`.
 pub(crate) mod install;
-#[allow(dead_code)]
 pub(crate) mod locator;
-#[allow(dead_code)]
 pub(crate) mod parser;
-#[allow(dead_code)]
+pub(crate) mod transcript;
 pub(crate) mod transcript_dto;
-#[allow(dead_code)]
 pub(crate) mod types;
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use crate::agent::adapter::base::TranscriptHandle;
+use crate::agent::adapter::traits::{
+    StateDecoder, TranscriptPathValidator, TranscriptStreamer,
+};
+use crate::agent::adapter::types::{
+    stamp_snapshot, LocatedStatusSource, ParsedStatus, RawPath, StatusSnapshot,
+    TranscriptPathSource, ValidateTranscriptError,
+};
+use crate::agent::adapter::AgentAdapter;
+use crate::agent::types::AgentType;
+use crate::runtime::EventSink;
+
+use self::locator::OpenCodeLocator;
+use crate::agent::adapter::traits::StatusSourceLocator as _;
+
+/// Adapter for the opencode CLI. Holds a shared `Arc<OpenCodeLocator>` so
+/// `AgentBindings::for_attach` can share one locator between `bindings.locator`
+/// and the adapter's decoder/validator/streamer views (the cycle-11 F31
+/// single-allocation invariant — mirror `KimiAdapter`/`CodexAdapter`).
+pub(crate) struct OpenCodeAdapter {
+    locator: Arc<OpenCodeLocator>,
+}
+
+impl OpenCodeAdapter {
+    /// Construct an `OpenCodeAdapter` that shares the supplied
+    /// `Arc<OpenCodeLocator>` with the caller. Used by
+    /// `AgentBindings::for_attach` so `bindings.locator` and the adapter's
+    /// streamer/validator reference the same `Arc<OpenCodeLocator>` instance.
+    pub(crate) fn with_locator(locator: Arc<OpenCodeLocator>) -> Self {
+        Self { locator }
+    }
+
+    fn locator(&self) -> &OpenCodeLocator {
+        &self.locator
+    }
+}
+
+impl TranscriptPathSource for OpenCodeAdapter {
+    /// opencode's transcript path is the `<sessionID>.jsonl` the locator
+    /// resolves at attach time; surface it via the static hint.
+    fn static_hint(&self, located: &LocatedStatusSource) -> Option<RawPath> {
+        located.static_transcript_hint.clone()
+    }
+
+    // `dynamic_hint` defaults to `None` — opencode never writes the transcript
+    // path inside the bridge JSONL stream.
+}
+
+impl StateDecoder for OpenCodeAdapter {
+    fn decode(&self, session_id: Option<&str>, raw: &str) -> Result<StatusSnapshot, String> {
+        Ok(parser::parse_bridge_snapshot(session_id, raw))
+    }
+}
+
+impl TranscriptPathValidator for OpenCodeAdapter {
+    fn validate(&self, raw: &str) -> Result<PathBuf, ValidateTranscriptError> {
+        // Validate against the SAME bridge root the locator resolved, so both
+        // sides scope the transcript path from one source.
+        locator::validate_transcript_path_with_root(raw, self.locator.effective_bridge_root())
+    }
+}
+
+impl TranscriptStreamer for OpenCodeAdapter {
+    fn tail(
+        &self,
+        events: Arc<dyn EventSink>,
+        session_id: String,
+        cwd: Option<PathBuf>,
+        transcript_path: PathBuf,
+    ) -> Result<TranscriptHandle, String> {
+        transcript::start_tailing(
+            events,
+            session_id,
+            cwd,
+            transcript_path,
+            self.locator.clone(),
+        )
+    }
+}
+
+// Transitional `AgentAdapter` façade. Every method delegates to the matching
+// split-trait impl above via UFCS, exactly like `KimiAdapter`/`CodexAdapter`.
+impl AgentAdapter for OpenCodeAdapter {
+    fn agent_type(&self) -> AgentType {
+        AgentType::Opencode
+    }
+
+    fn located_status_source(
+        &self,
+        _app_data_dir: &Path,
+        cwd: &Path,
+        session_id: &str,
+    ) -> Result<LocatedStatusSource, String> {
+        self.locator().locate(cwd, session_id)
+    }
+
+    fn parse_status(&self, session_id: &str, raw: &str) -> Result<ParsedStatus, String> {
+        let snapshot = <Self as StateDecoder>::decode(self, Some(session_id), raw)?;
+        Ok(ParsedStatus {
+            event: stamp_snapshot(session_id, snapshot),
+        })
+    }
+
+    fn validate_transcript(&self, raw: &str) -> Result<PathBuf, ValidateTranscriptError> {
+        <Self as TranscriptPathValidator>::validate(self, raw)
+    }
+
+    fn tail_transcript(
+        &self,
+        events: Arc<dyn EventSink>,
+        session_id: String,
+        cwd: Option<PathBuf>,
+        transcript_path: PathBuf,
+    ) -> Result<TranscriptHandle, String> {
+        <Self as TranscriptStreamer>::tail(self, events, session_id, cwd, transcript_path)
+    }
+}
 
 #[cfg(test)]
 use std::ffi::OsString;
@@ -80,5 +198,105 @@ impl Drop for OpencodeEnvGuard {
                 None => std::env::remove_var(key),
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod adapter_tests {
+    use super::*;
+    use std::time::SystemTime;
+
+    fn adapter() -> OpenCodeAdapter {
+        OpenCodeAdapter::with_locator(Arc::new(OpenCodeLocator::new(
+            PathBuf::from("/tmp/opencode-bridge"),
+            4242,
+            SystemTime::UNIX_EPOCH,
+        )))
+    }
+
+    #[test]
+    fn agent_type_is_opencode() {
+        assert_eq!(
+            <OpenCodeAdapter as AgentAdapter>::agent_type(&adapter()),
+            AgentType::Opencode
+        );
+    }
+
+    #[test]
+    fn static_hint_surfaces_located_transcript_hint() {
+        let adapter = adapter();
+        let tps: &dyn TranscriptPathSource = &adapter;
+
+        let located = LocatedStatusSource {
+            status_path: PathBuf::from("/tmp/opencode-bridge/ses_x.jsonl"),
+            trust_root: PathBuf::from("/tmp/opencode-bridge"),
+            static_transcript_hint: Some("/tmp/opencode-bridge/ses_x.jsonl".to_string()),
+            agent_session_id: Some("ses_x".to_string()),
+        };
+        assert_eq!(
+            tps.static_hint(&located).as_deref(),
+            Some("/tmp/opencode-bridge/ses_x.jsonl"),
+        );
+
+        let without = LocatedStatusSource {
+            status_path: PathBuf::from("/tmp/x"),
+            trust_root: PathBuf::from("/tmp"),
+            static_transcript_hint: None,
+            agent_session_id: None,
+        };
+        assert_eq!(tps.static_hint(&without), None);
+    }
+
+    #[test]
+    fn dynamic_hint_is_none_regardless_of_raw() {
+        let adapter = adapter();
+        let tps: &dyn TranscriptPathSource = &adapter;
+        assert_eq!(tps.dynamic_hint(r#"{"transcript_path":"/ignored"}"#), None);
+    }
+
+    #[test]
+    fn decode_parses_bridge_into_snapshot() {
+        let adapter = adapter();
+        let raw = concat!(
+            r#"{"v":1,"ts":1,"kind":"event","type":"session.created","data":{"info":{"id":"ses_d","version":"1.2.3","model":{"id":"claude-sonnet-4"},"cost":0,"tokens":{"input":700,"output":300,"cache":{"read":0,"write":0}}}}}"#,
+            "\n",
+        );
+        let snapshot = <OpenCodeAdapter as StateDecoder>::decode(&adapter, Some("pty"), raw)
+            .expect("opencode snapshot decodes");
+        assert_eq!(snapshot.agent_session_id, "ses_d");
+        assert_eq!(snapshot.model_id, "claude-sonnet-4");
+        assert_eq!(snapshot.context_window.total_input_tokens, 700);
+    }
+
+    #[test]
+    fn validate_transcript_rejects_path_outside_bridge_root() {
+        let adapter = adapter();
+        assert!(
+            <OpenCodeAdapter as AgentAdapter>::validate_transcript(&adapter, "/tmp/not-opencode")
+                .is_err(),
+            "path outside the bridge root should be rejected",
+        );
+    }
+
+    #[test]
+    fn validate_transcript_accepts_real_jsonl_under_bridge_root() {
+        let bridge = tempfile::tempdir().expect("bridge tempdir");
+        let session = bridge.path().join("ses_v.jsonl");
+        std::fs::write(&session, "").expect("write session file");
+        let adapter = OpenCodeAdapter::with_locator(Arc::new(OpenCodeLocator::new(
+            bridge.path().to_path_buf(),
+            4242,
+            SystemTime::UNIX_EPOCH,
+        )));
+
+        let validated = <OpenCodeAdapter as AgentAdapter>::validate_transcript(
+            &adapter,
+            session.to_str().expect("utf8 path"),
+        )
+        .expect("real jsonl under bridge root validates");
+        assert_eq!(
+            validated,
+            std::fs::canonicalize(&session).expect("canonical")
+        );
     }
 }

--- a/crates/backend/src/agent/adapter/opencode/transcript.rs
+++ b/crates/backend/src/agent/adapter/opencode/transcript.rs
@@ -1,0 +1,1020 @@
+//! Transcript tailer for opencode bridge JSONL files.
+//!
+//! Mirrors `codex/transcript.rs`: [`start_tailing`] opens the
+//! `<sessionID>.jsonl` the vimeflow-opencode-bridge plugin writes, builds an
+//! [`OpencodeTranscriptDecoder`], wraps it in the shared
+//! [`TranscriptTailService`], and spawns the tail thread. The decoder folds
+//! each bridge line into `agent-turn` / `agent-tool-call` / `agent-cwd` /
+//! `test-run` events per spec §4.4.
+//!
+//! Bridge line → event mapping (spec §4.4):
+//!
+//! - `kind=event`, `type=message.updated`, `data.info.role == "user"` ⇒
+//!   [`AgentTurnEvent`] — **once per user message id** (tracked in
+//!   `seen_turns`). `session.created` is intentionally NOT a turn source.
+//! - `kind=tool.before` ⇒ tool-call start (args preview already on the line).
+//!   `kind=event`, `type=message.part.updated`, `data.part.type=="tool"`,
+//!   `state.status` `pending`/`running` ⇒ start/running.
+//! - `kind=tool.after` ⇒ tool-call done (`completed`) / failed (`error`).
+//!   Deduped by `(callID, status)` so repeated running updates don't re-emit.
+//! - `kind=tool.after` where `tool=="bash"` ⇒ feed `args.command` +
+//!   `result.output` + `result.metadata.exit` into the shared
+//!   `claude_code::test_runners` (cwd = the session cwd, NOT a per-command
+//!   workdir). Only submit when `maybe_build_snapshot` returns `Some`.
+//! - `kind=event`, `type=session.idle`/`session.status`/`step-finish` part ⇒
+//!   status/phase refresh (v1 has no lifecycle phase emission for opencode, so
+//!   these are observed but do not emit; reserved for a later milestone).
+//! - assistant `data.info.path.cwd` change ⇒ [`AgentCwdEvent`] when it differs
+//!   from `last_cwd`. (The v1 bridge sanitizer drops `info.path`, so this is a
+//!   defensive read that only fires if a future bridge re-adds the field; the
+//!   authored fixture carries it so the path is exercised.)
+
+use std::collections::{HashMap, HashSet};
+use std::fs::File;
+use std::io::BufReader;
+use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+use std::time::Instant;
+
+use serde_json::Value;
+
+use crate::agent::adapter::base::{TranscriptDecoder, TranscriptHandle, TranscriptTailService};
+use crate::agent::adapter::claude_code::test_runners::build::{maybe_build_snapshot, BuildArgs};
+use crate::agent::adapter::claude_code::test_runners::emitter::TestRunEmitter;
+use crate::agent::adapter::claude_code::test_runners::matcher::match_command;
+use crate::agent::adapter::claude_code::test_runners::timestamps::compute_duration_ms;
+use crate::agent::adapter::claude_code::test_runners::types::CapturedOutput;
+use crate::agent::events::{emit_agent_cwd, emit_agent_tool_call, emit_agent_turn};
+use crate::agent::types::{AgentCwdEvent, AgentToolCallEvent, AgentTurnEvent, ToolCallStatus};
+use crate::runtime::EventSink;
+
+use super::locator::OpenCodeLocator;
+use super::transcript_dto::{OpencodeEventType, OpencodeKind, OpencodeLineDto};
+
+/// Cap on the displayed args preview, matching `codex/transcript.rs`'s
+/// `MAX_ARGS_LEN` so the agent-status activity card renders a bounded string.
+const MAX_ARGS_LEN: usize = 1024;
+
+/// An in-flight tool call awaiting its terminal `tool.after` (or a
+/// `message.part.updated` `completed`/`error`). Keyed by `callID` (fallback the
+/// part `id`).
+struct InFlightToolCall {
+    started_at: Instant,
+    started_at_iso: String,
+    tool: String,
+    args: String,
+    is_test_file: bool,
+}
+
+type InFlightToolCalls = HashMap<String, InFlightToolCall>;
+
+/// Open the bridge JSONL, build the decoder, and spawn the tail thread.
+///
+/// Mirrors `codex::transcript::start_tailing` / `kimi::transcript::start_tailing`.
+/// The `locator` is accepted for signature parity with the other providers and
+/// so the streamer can prefer the locator's resolved cwd; the v1 opencode
+/// locator carries no live process cwd beyond what `cwd` already supplies, so
+/// the argument is otherwise unused.
+pub(crate) fn start_tailing(
+    events: Arc<dyn EventSink>,
+    session_id: String,
+    cwd: Option<PathBuf>,
+    transcript_path: PathBuf,
+    _locator: Arc<OpenCodeLocator>,
+) -> Result<TranscriptHandle, String> {
+    let file = File::open(&transcript_path).map_err(|e| {
+        format!(
+            "Failed to open opencode bridge transcript: {}: {}",
+            transcript_path.display(),
+            e
+        )
+    })?;
+
+    // Surface the resolved workspace cwd once so the pane / file tree / git
+    // follow the opencode project rather than the stale spawn cwd (mirrors
+    // Kimi's `emit_initial_cwd`).
+    if let Some(cwd_str) = cwd.as_deref().and_then(std::path::Path::to_str) {
+        let event = AgentCwdEvent {
+            session_id: session_id.clone(),
+            cwd: cwd_str.to_string(),
+        };
+        if let Err(e) = emit_agent_cwd(events.as_ref(), &event) {
+            log::warn!("Failed to emit opencode initial agent-cwd event: {}", e);
+        }
+    }
+
+    let stop_flag = Arc::new(AtomicBool::new(false));
+    let stop_clone = stop_flag.clone();
+
+    let decoder = OpencodeTranscriptDecoder::new(events, session_id, cwd);
+    let service = TranscriptTailService::new(Box::new(decoder), "opencode transcript");
+
+    let join_handle = std::thread::spawn(move || {
+        service.run(BufReader::new(file), stop_clone);
+    });
+
+    Ok(TranscriptHandle::new(stop_flag, join_handle))
+}
+
+/// Per-session opencode decoder: owns the in-flight tool-call map, the
+/// seen-turn message ids, turn count, last-seen cwd, the replay-aware test-run
+/// emitter, and a `replay_done` one-shot guard. Driven by
+/// [`TranscriptTailService`], which owns the read/buffer/poll loop.
+pub(crate) struct OpencodeTranscriptDecoder {
+    events: Arc<dyn EventSink>,
+    session_id: String,
+    /// Session cwd passed into `start_tailing` — the cwd fed to the test-run
+    /// parser (NOT any per-command workdir). Also the baseline for `last_cwd`.
+    cwd: Option<PathBuf>,
+    in_flight: InFlightToolCalls,
+    /// Dedup set keyed by `(callID, status-discriminant)` so a repeated
+    /// running/completed update for the same call does not re-emit. The
+    /// discriminant is a `&'static str` ("running"/"done"/"failed") rather than
+    /// `ToolCallStatus` so we don't have to widen the shared enum's derives
+    /// (it isn't `Hash`/`Eq`).
+    emitted: HashSet<(String, &'static str)>,
+    /// User-message ids already counted as a turn — a re-delivered
+    /// `message.updated` for the same id does not double-count.
+    seen_turns: HashSet<String>,
+    num_turns: u32,
+    /// Last cwd surfaced via `agent-cwd`; transitions only.
+    last_cwd: Option<String>,
+    emitter: TestRunEmitter,
+    /// One-shot guard: false during replay, true after the first on_caught_up.
+    replay_done: bool,
+}
+
+impl OpencodeTranscriptDecoder {
+    fn new(events: Arc<dyn EventSink>, session_id: String, cwd: Option<PathBuf>) -> Self {
+        let emitter = TestRunEmitter::new(events.clone());
+        // Seed `last_cwd` with the session cwd so we don't re-emit the same
+        // path the initial `emit_agent_cwd` in `start_tailing` already sent.
+        let last_cwd = cwd
+            .as_deref()
+            .and_then(std::path::Path::to_str)
+            .map(str::to_string);
+        Self {
+            events,
+            session_id,
+            cwd,
+            in_flight: HashMap::new(),
+            emitted: HashSet::new(),
+            seen_turns: HashSet::new(),
+            num_turns: 0,
+            last_cwd,
+            emitter,
+            replay_done: false,
+        }
+    }
+
+    fn process_line(&mut self, line: &str) {
+        let dto: OpencodeLineDto = match serde_json::from_str(line) {
+            Ok(dto) => dto,
+            Err(_) => return,
+        };
+        let timestamp = ts_to_iso8601(dto.ts);
+
+        match dto.kind() {
+            OpencodeKind::ToolBefore => self.start_tool_call_from_before(&dto, &timestamp),
+            OpencodeKind::ToolAfter => self.finish_tool_call_from_after(&dto, &timestamp),
+            OpencodeKind::Event => self.process_event(&dto, &timestamp),
+            OpencodeKind::Unknown => {}
+        }
+    }
+
+    fn process_event(&mut self, dto: &OpencodeLineDto, timestamp: &str) {
+        match dto.event_type() {
+            OpencodeEventType::MessageUpdated => self.process_message_updated(dto),
+            OpencodeEventType::MessagePartUpdated => self.process_part_updated(dto, timestamp),
+            OpencodeEventType::SessionCreated | OpencodeEventType::SessionUpdated => {
+                self.process_session_event(dto);
+            }
+            // session.idle / session.status / session.error / session.diff /
+            // todo.updated — observed for status/phase refresh; v1 emits no
+            // lifecycle phase for opencode, so there's nothing to emit here.
+            _ => {}
+        }
+    }
+
+    /// A user `message.updated` is one turn, counted once per `info.id`.
+    fn process_message_updated(&mut self, dto: &OpencodeLineDto) {
+        let info = match dto.data.get("info") {
+            Some(info) => info,
+            None => return,
+        };
+        if info.get("role").and_then(Value::as_str) != Some("user") {
+            return;
+        }
+        let Some(id) = info.get("id").and_then(Value::as_str).filter(|s| !s.is_empty()) else {
+            return;
+        };
+        // Dedup by user-message id: a re-delivered update must not re-count.
+        if !self.seen_turns.insert(id.to_string()) {
+            return;
+        }
+
+        self.num_turns = self.num_turns.saturating_add(1);
+        let event = AgentTurnEvent {
+            session_id: self.session_id.clone(),
+            num_turns: self.num_turns,
+        };
+        if let Err(e) = emit_agent_turn(self.events.as_ref(), &event) {
+            log::warn!("Failed to emit opencode agent-turn event: {}", e);
+        }
+    }
+
+    /// `message.part.updated` with a `tool` part. `state.status`:
+    /// `pending`/`running` ⇒ start/running; `completed` ⇒ done; `error` ⇒ failed.
+    fn process_part_updated(&mut self, dto: &OpencodeLineDto, timestamp: &str) {
+        let part = match dto.data.get("part") {
+            Some(part) => part,
+            None => return,
+        };
+        if part.get("type").and_then(Value::as_str) != Some("tool") {
+            return;
+        }
+        let call_key = part_call_key(part);
+        let Some(call_key) = call_key else {
+            return;
+        };
+        let tool = part
+            .get("tool")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+            .to_string();
+        let state = part.get("state");
+        let status = state
+            .and_then(|s| s.get("status"))
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        let args = summarize_state_args(state, &tool);
+
+        match status {
+            "pending" | "running" => {
+                self.start_tool_call(&call_key, tool, args, timestamp, false);
+            }
+            "completed" => {
+                self.finish_tool_call(&call_key, ToolCallStatus::Done, timestamp);
+            }
+            "error" => {
+                self.finish_tool_call(&call_key, ToolCallStatus::Failed, timestamp);
+            }
+            _ => {}
+        }
+    }
+
+    /// `tool.before`: register the in-flight call + emit a running start
+    /// (post-replay). The args preview is already on the line.
+    fn start_tool_call_from_before(&mut self, dto: &OpencodeLineDto, timestamp: &str) {
+        let Some(call_id) = dto.call_id.as_deref().filter(|s| !s.is_empty()) else {
+            return;
+        };
+        let tool = dto.tool.as_deref().unwrap_or("unknown").to_string();
+        let args = summarize_value_args(&dto.args, &tool);
+        self.start_tool_call(call_id, tool, args, timestamp, false);
+    }
+
+    /// `tool.after`: complete the in-flight call (`metadata.exit` decides
+    /// done/failed) and, for `bash`, feed the captured output into the shared
+    /// test-run parser.
+    fn finish_tool_call_from_after(&mut self, dto: &OpencodeLineDto, timestamp: &str) {
+        let Some(call_id) = dto.call_id.as_deref().filter(|s| !s.is_empty()) else {
+            return;
+        };
+        let tool = dto.tool.as_deref().unwrap_or("unknown");
+        let result = &dto.result;
+        let exit = result
+            .get("metadata")
+            .and_then(|m| m.get("exit"))
+            .and_then(Value::as_i64);
+        let status = if exit.is_some_and(|code| code != 0) {
+            ToolCallStatus::Failed
+        } else {
+            ToolCallStatus::Done
+        };
+
+        // bash tool.after → shared test-run parser (cwd = session cwd).
+        if tool == "bash" {
+            self.maybe_submit_test_run(call_id, result, exit, timestamp);
+        }
+
+        self.finish_tool_call(call_id, status, timestamp);
+    }
+
+    /// Common start path: insert into `in_flight` (idempotent on the call key)
+    /// and emit a `running` event once per call, post-replay. The dedup set is
+    /// keyed by `(callID, Running)` so a `tool.before` followed by a `running`
+    /// part update for the same call emits a single start.
+    fn start_tool_call(
+        &mut self,
+        call_key: &str,
+        tool: String,
+        args: String,
+        timestamp: &str,
+        is_test_file: bool,
+    ) {
+        self.in_flight
+            .entry(call_key.to_string())
+            .or_insert_with(|| InFlightToolCall {
+                started_at: Instant::now(),
+                started_at_iso: timestamp.to_string(),
+                tool: tool.clone(),
+                args: args.clone(),
+                is_test_file,
+            });
+
+        let dedup_key = (call_key.to_string(), status_discriminant(&ToolCallStatus::Running));
+        if !self.emitted.insert(dedup_key) {
+            return;
+        }
+
+        if self.replay_done {
+            self.emit_tool_call(AgentToolCallEvent {
+                session_id: self.session_id.clone(),
+                tool_use_id: call_key.to_string(),
+                tool,
+                args,
+                status: ToolCallStatus::Running,
+                timestamp: timestamp.to_string(),
+                duration_ms: 0,
+                is_test_file,
+            });
+        }
+    }
+
+    /// Common completion path: remove the in-flight call and emit its terminal
+    /// status once. Deduped by `(callID, status)` — a `tool.after` plus a
+    /// `completed` part update for the same call emits a single done.
+    fn finish_tool_call(&mut self, call_key: &str, status: ToolCallStatus, timestamp: &str) {
+        let dedup_key = (call_key.to_string(), status_discriminant(&status));
+        if !self.emitted.insert(dedup_key) {
+            // Already emitted this terminal status for this call.
+            self.in_flight.remove(call_key);
+            return;
+        }
+
+        let (tool, args, duration_ms, is_test_file) = match self.in_flight.remove(call_key) {
+            Some(call) => (
+                call.tool,
+                call.args,
+                compute_duration_ms(&call.started_at_iso, timestamp, call.started_at.elapsed()),
+                call.is_test_file,
+            ),
+            // A terminal update with no recorded start (replay began mid-call,
+            // or the start was dropped). Emit with what we know.
+            None => ("unknown".to_string(), String::new(), 0, false),
+        };
+
+        self.emit_tool_call(AgentToolCallEvent {
+            session_id: self.session_id.clone(),
+            tool_use_id: call_key.to_string(),
+            tool,
+            args,
+            status,
+            timestamp: timestamp.to_string(),
+            duration_ms,
+            is_test_file,
+        });
+    }
+
+    /// Feed a `bash` `tool.after` into the shared `claude_code::test_runners`.
+    /// `cwd` is the session cwd (NOT any per-command workdir). Only submits when
+    /// the command matches a known runner AND `maybe_build_snapshot` returns
+    /// `Some`. The `TestRunEmitter` collapses replay-phase snapshots to the
+    /// latest one, flushed at `finish_replay`.
+    fn maybe_submit_test_run(
+        &mut self,
+        call_id: &str,
+        result: &Value,
+        exit: Option<i64>,
+        timestamp: &str,
+    ) {
+        let Some(cwd) = self.cwd.clone() else {
+            log::debug!(
+                "Skipping opencode test-run snapshot for session {}: no workspace cwd resolved",
+                self.session_id
+            );
+            return;
+        };
+
+        // The command preview lives on the in-flight start's args (the
+        // `tool.before`'s `args.command`); fall back to nothing if the start
+        // wasn't seen. `result.output` carries the captured output.
+        let command = self
+            .in_flight
+            .get(call_id)
+            .map(|c| c.args.clone())
+            .unwrap_or_default();
+        if command.is_empty() {
+            return;
+        }
+        let Some(matched) = match_command(&command, Some(cwd.as_path())) else {
+            return;
+        };
+
+        let output = result
+            .get("output")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        let started_at = self
+            .in_flight
+            .get(call_id)
+            .map(|c| c.started_at_iso.clone())
+            .unwrap_or_else(|| timestamp.to_string());
+        let instant_fallback = self
+            .in_flight
+            .get(call_id)
+            .map(|c| c.started_at.elapsed())
+            .unwrap_or_default();
+
+        let captured = CapturedOutput {
+            content: output,
+            is_error: exit.is_some_and(|code| code != 0),
+        };
+        if let Some(snapshot) = maybe_build_snapshot(BuildArgs {
+            session_id: &self.session_id,
+            matched: &matched,
+            started_at: &started_at,
+            finished_at: timestamp,
+            instant_fallback,
+            captured,
+            cwd: cwd.as_path(),
+        }) {
+            self.emitter.submit(snapshot);
+        }
+    }
+
+    /// `session.created`/`session.updated`: track the cwd transition off
+    /// `data.info.path.cwd`. Emit `agent-cwd` only when it differs from
+    /// `last_cwd`.
+    fn process_session_event(&mut self, dto: &OpencodeLineDto) {
+        let observed = dto
+            .data
+            .get("info")
+            .and_then(|info| info.get("path"))
+            .and_then(|path| path.get("cwd"))
+            .and_then(Value::as_str)
+            .filter(|s| !s.is_empty());
+        let Some(observed) = observed else {
+            return;
+        };
+        if self
+            .last_cwd
+            .as_deref()
+            .map_or(true, |seen| seen != observed)
+        {
+            let event = AgentCwdEvent {
+                session_id: self.session_id.clone(),
+                cwd: observed.to_string(),
+            };
+            if let Err(e) = emit_agent_cwd(self.events.as_ref(), &event) {
+                log::warn!("Failed to emit opencode agent-cwd event: {}", e);
+            }
+            self.last_cwd = Some(observed.to_string());
+        }
+    }
+
+    fn emit_tool_call(&self, event: AgentToolCallEvent) {
+        if let Err(e) = emit_agent_tool_call(self.events.as_ref(), &event) {
+            log::warn!("Failed to emit opencode agent-tool-call event: {}", e);
+        }
+    }
+}
+
+impl TranscriptDecoder for OpencodeTranscriptDecoder {
+    fn decode_line(&mut self, line: &str) {
+        self.process_line(line);
+    }
+
+    /// First EOF marks the end of replay; subsequent EOFs are idempotent. The
+    /// replay-flush (and any in-flight reconciliation) is gated behind
+    /// `replay_done`, mirroring `codex/transcript.rs`.
+    fn on_caught_up(&mut self) {
+        if !self.replay_done {
+            self.replay_done = true;
+            // Surface any tool calls still running at the replay→live boundary
+            // so the activity feed shows them as in-progress (mirrors Codex's
+            // `emit_replay_in_flight_tool_calls`). Each is keyed `Running` in
+            // the dedup set already, so a later live terminal update still
+            // emits its done/failed exactly once.
+            for (call_id, call) in &self.in_flight {
+                self.emit_tool_call(AgentToolCallEvent {
+                    session_id: self.session_id.clone(),
+                    tool_use_id: call_id.clone(),
+                    tool: call.tool.clone(),
+                    args: call.args.clone(),
+                    status: ToolCallStatus::Running,
+                    timestamp: call.started_at_iso.clone(),
+                    duration_ms: 0,
+                    is_test_file: call.is_test_file,
+                });
+            }
+        }
+        self.emitter.finish_replay();
+    }
+}
+
+/// Stable `&'static str` discriminant for a [`ToolCallStatus`], used as the
+/// second half of the `(callID, status)` dedup key. Keeping this local avoids
+/// adding `Hash`/`Eq` to the shared `ToolCallStatus` enum.
+fn status_discriminant(status: &ToolCallStatus) -> &'static str {
+    match status {
+        ToolCallStatus::Running => "running",
+        ToolCallStatus::Done => "done",
+        ToolCallStatus::Failed => "failed",
+    }
+}
+
+/// Resolve the in-flight key for a `tool` part: prefer `callID`, fall back to
+/// the part `id`. Empty strings are treated as absent.
+fn part_call_key(part: &Value) -> Option<String> {
+    part.get("callID")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            part.get("id")
+                .and_then(Value::as_str)
+                .filter(|s| !s.is_empty())
+        })
+        .map(str::to_string)
+}
+
+/// Summarize a `tool.before` / `tool.after` `args` object into a bounded
+/// preview string. Prefers the per-tool low-risk field the bridge keeps
+/// (`command` for bash, `filePath` for read/edit/write, `pattern` for
+/// glob/grep), else the raw JSON.
+fn summarize_value_args(args: &Value, _tool: &str) -> String {
+    if let Some(command) = args.get("command").and_then(Value::as_str) {
+        return truncate_string(command, MAX_ARGS_LEN);
+    }
+    if let Some(file_path) = args.get("filePath").and_then(Value::as_str) {
+        return truncate_string(file_path, MAX_ARGS_LEN);
+    }
+    if let Some(pattern) = args.get("pattern").and_then(Value::as_str) {
+        return truncate_string(pattern, MAX_ARGS_LEN);
+    }
+    if args.is_null() {
+        return String::new();
+    }
+    truncate_string(&args.to_string(), MAX_ARGS_LEN)
+}
+
+/// Summarize a `message.part.updated` tool part's `state.args` (same shape as
+/// the `tool.*` args). Falls back to the empty string when absent.
+fn summarize_state_args(state: Option<&Value>, tool: &str) -> String {
+    match state.and_then(|s| s.get("args")) {
+        Some(args) => summarize_value_args(args, tool),
+        None => String::new(),
+    }
+}
+
+/// Truncate to `max_len` chars with a `...` suffix, char-boundary safe.
+fn truncate_string(input: &str, max_len: usize) -> String {
+    if input.chars().count() <= max_len {
+        return input.to_string();
+    }
+    let end = input
+        .char_indices()
+        .nth(max_len.saturating_sub(3))
+        .map_or(input.len(), |(idx, _)| idx);
+    format!("{}...", &input[..end])
+}
+
+/// Convert the bridge `ts` (epoch-ms) into an ISO-8601 UTC string for event
+/// payloads. `None` falls back to "now". Mirrors `codex/transcript.rs`'s
+/// `now_iso8601` for the formatting half.
+fn ts_to_iso8601(ts: Option<i64>) -> String {
+    match ts {
+        Some(ms) if ms >= 0 => {
+            let total_secs = (ms / 1000) as u64;
+            iso8601_from_unix_secs(total_secs)
+        }
+        _ => now_iso8601(),
+    }
+}
+
+fn now_iso8601() -> String {
+    let now = std::time::SystemTime::now();
+    let since_epoch = now
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    iso8601_from_unix_secs(since_epoch.as_secs())
+}
+
+fn iso8601_from_unix_secs(total_secs: u64) -> String {
+    let days = total_secs / 86_400;
+    let secs_of_day = total_secs % 86_400;
+    let (year, month, day) = days_to_date(days);
+    let hour = secs_of_day / 3_600;
+    let minute = (secs_of_day % 3_600) / 60;
+    let second = secs_of_day % 60;
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+        year, month, day, hour, minute, second
+    )
+}
+
+fn days_to_date(days_since_epoch: u64) -> (u64, u64, u64) {
+    let z = days_since_epoch as i64 + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = mp + if mp < 10 { 3 } else { -9 };
+    let year = y + if m <= 2 { 1 } else { 0 };
+    (year as u64, m as u64, d as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::FakeEventSink;
+    use std::time::{Duration, SystemTime};
+
+    const SAMPLE_BRIDGE: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/agent/adapter/opencode/fixtures/sample_bridge.jsonl"
+    ));
+
+    fn tool_call_payloads(sink: &FakeEventSink) -> Vec<Value> {
+        sink.recorded()
+            .into_iter()
+            .filter(|(name, _)| name == "agent-tool-call")
+            .map(|(_, payload)| payload)
+            .collect()
+    }
+
+    fn decoder(sink: &Arc<FakeEventSink>, cwd: Option<PathBuf>) -> OpencodeTranscriptDecoder {
+        OpencodeTranscriptDecoder::new(sink.clone(), "sid".to_string(), cwd)
+    }
+
+    /// A user `message.updated` ⇒ exactly one `agent-turn`; a duplicate user
+    /// message id does NOT double-count.
+    #[test]
+    fn user_message_emits_one_turn_and_dedups_by_id() {
+        let sink = Arc::new(FakeEventSink::new());
+        let mut dec = decoder(&sink, None);
+        dec.on_caught_up();
+
+        let line = r#"{"v":1,"ts":1,"kind":"event","type":"message.updated","data":{"info":{"id":"msg_u1","role":"user","sessionID":"ses1"}}}"#;
+        dec.decode_line(line);
+        dec.decode_line(line); // duplicate id — must not re-count
+
+        assert_eq!(sink.count("agent-turn"), 1);
+        let turns: Vec<Value> = sink
+            .recorded()
+            .into_iter()
+            .filter(|(n, _)| n == "agent-turn")
+            .map(|(_, p)| p)
+            .collect();
+        assert_eq!(turns[0]["numTurns"], 1);
+        assert_eq!(turns[0]["sessionId"], "sid");
+    }
+
+    /// An assistant `message.updated` (role != user) is NOT a turn.
+    #[test]
+    fn assistant_message_is_not_a_turn() {
+        let sink = Arc::new(FakeEventSink::new());
+        let mut dec = decoder(&sink, None);
+        dec.on_caught_up();
+        dec.decode_line(
+            r#"{"v":1,"ts":1,"kind":"event","type":"message.updated","data":{"info":{"id":"msg_a1","role":"assistant"}}}"#,
+        );
+        assert_eq!(sink.count("agent-turn"), 0);
+    }
+
+    /// `tool.before` then `tool.after` ⇒ one running start + one done, deduped
+    /// by callID. (Live phase — replay already finished.)
+    #[test]
+    fn tool_before_after_emits_start_then_done_once() {
+        let sink = Arc::new(FakeEventSink::new());
+        let mut dec = decoder(&sink, None);
+        dec.on_caught_up();
+
+        dec.decode_line(
+            r#"{"v":1,"ts":1000,"kind":"tool.before","tool":"read","sessionID":"ses1","callID":"call_r1","args":{"filePath":"src/lib.rs"}}"#,
+        );
+        dec.decode_line(
+            r#"{"v":1,"ts":2000,"kind":"tool.after","tool":"read","sessionID":"ses1","callID":"call_r1","result":{"output":"contents","metadata":{"exit":0}}}"#,
+        );
+
+        let payloads = tool_call_payloads(&sink);
+        assert_eq!(payloads.len(), 2, "one running + one done");
+        assert_eq!(payloads[0]["toolUseId"], "call_r1");
+        assert_eq!(payloads[0]["status"], "running");
+        assert_eq!(payloads[0]["tool"], "read");
+        assert_eq!(payloads[0]["args"], "src/lib.rs");
+        assert_eq!(payloads[1]["toolUseId"], "call_r1");
+        assert_eq!(payloads[1]["status"], "done");
+    }
+
+    /// A repeated `running` part update for the same call does NOT re-emit a
+    /// start — deduped by `(callID, Running)`.
+    #[test]
+    fn repeated_running_part_does_not_reemit_start() {
+        let sink = Arc::new(FakeEventSink::new());
+        let mut dec = decoder(&sink, None);
+        dec.on_caught_up();
+
+        let running = r#"{"v":1,"ts":1,"kind":"event","type":"message.part.updated","data":{"part":{"type":"tool","callID":"call_p1","tool":"bash","state":{"status":"running","args":{"command":"ls"}}}}}"#;
+        dec.decode_line(running);
+        dec.decode_line(running);
+        dec.decode_line(running);
+
+        let payloads = tool_call_payloads(&sink);
+        assert_eq!(payloads.len(), 1, "only one running start despite 3 updates");
+        assert_eq!(payloads[0]["status"], "running");
+        assert_eq!(payloads[0]["toolUseId"], "call_p1");
+    }
+
+    /// A `tool.before`+`running` part for the SAME callID emit one start total.
+    #[test]
+    fn before_then_running_part_emit_single_start() {
+        let sink = Arc::new(FakeEventSink::new());
+        let mut dec = decoder(&sink, None);
+        dec.on_caught_up();
+
+        dec.decode_line(
+            r#"{"v":1,"ts":1,"kind":"tool.before","tool":"bash","sessionID":"ses1","callID":"call_x","args":{"command":"echo hi"}}"#,
+        );
+        dec.decode_line(
+            r#"{"v":1,"ts":2,"kind":"event","type":"message.part.updated","data":{"part":{"type":"tool","callID":"call_x","tool":"bash","state":{"status":"running"}}}}"#,
+        );
+        let payloads = tool_call_payloads(&sink);
+        assert_eq!(payloads.len(), 1);
+        assert_eq!(payloads[0]["status"], "running");
+    }
+
+    /// A tool part with `state.status == "error"` ⇒ failed.
+    #[test]
+    fn tool_state_error_emits_failed() {
+        let sink = Arc::new(FakeEventSink::new());
+        let mut dec = decoder(&sink, None);
+        dec.on_caught_up();
+
+        dec.decode_line(
+            r#"{"v":1,"ts":1,"kind":"tool.before","tool":"bash","sessionID":"ses1","callID":"call_e","args":{"command":"false"}}"#,
+        );
+        dec.decode_line(
+            r#"{"v":1,"ts":2,"kind":"event","type":"message.part.updated","data":{"part":{"type":"tool","callID":"call_e","tool":"bash","state":{"status":"error"}}}}"#,
+        );
+
+        let payloads = tool_call_payloads(&sink);
+        assert_eq!(payloads.len(), 2);
+        assert_eq!(payloads[1]["status"], "failed");
+        assert_eq!(payloads[1]["toolUseId"], "call_e");
+    }
+
+    /// A `tool.after` with a non-zero `metadata.exit` ⇒ failed.
+    #[test]
+    fn tool_after_nonzero_exit_emits_failed() {
+        let sink = Arc::new(FakeEventSink::new());
+        let mut dec = decoder(&sink, None);
+        dec.on_caught_up();
+
+        dec.decode_line(
+            r#"{"v":1,"ts":1,"kind":"tool.before","tool":"bash","sessionID":"ses1","callID":"call_f","args":{"command":"exit 1"}}"#,
+        );
+        dec.decode_line(
+            r#"{"v":1,"ts":2,"kind":"tool.after","tool":"bash","sessionID":"ses1","callID":"call_f","result":{"output":"boom","metadata":{"exit":2}}}"#,
+        );
+
+        let payloads = tool_call_payloads(&sink);
+        assert_eq!(payloads.last().unwrap()["status"], "failed");
+    }
+
+    /// A `bash` `tool.after` running a test command ⇒ a test-run snapshot.
+    #[test]
+    fn bash_test_command_emits_test_run_snapshot() {
+        let sink = Arc::new(FakeEventSink::new());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let workspace = tmp.path().to_path_buf();
+        let mut dec = decoder(&sink, Some(workspace));
+        dec.on_caught_up();
+
+        dec.decode_line(
+            r#"{"v":1,"ts":1000,"kind":"tool.before","tool":"bash","sessionID":"ses1","callID":"call_t","args":{"command":"cargo test"}}"#,
+        );
+        dec.decode_line(
+            r#"{"v":1,"ts":2000,"kind":"tool.after","tool":"bash","sessionID":"ses1","callID":"call_t","result":{"output":"running 1 test\ntest result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out\n","metadata":{"exit":0}}}"#,
+        );
+
+        assert_eq!(sink.count("test-run"), 1, "passing cargo test ⇒ one snapshot");
+        let test_runs: Vec<Value> = sink
+            .recorded()
+            .into_iter()
+            .filter(|(n, _)| n == "test-run")
+            .map(|(_, p)| p)
+            .collect();
+        assert_eq!(test_runs[0]["runner"], "cargo");
+        assert_eq!(test_runs[0]["summary"]["passed"], 1);
+    }
+
+    /// A non-test `bash` `tool.after` ⇒ no test-run snapshot.
+    #[test]
+    fn non_test_bash_emits_no_test_run() {
+        let sink = Arc::new(FakeEventSink::new());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut dec = decoder(&sink, Some(tmp.path().to_path_buf()));
+        dec.on_caught_up();
+
+        dec.decode_line(
+            r#"{"v":1,"ts":1,"kind":"tool.before","tool":"bash","sessionID":"ses1","callID":"call_g","args":{"command":"git status"}}"#,
+        );
+        dec.decode_line(
+            r#"{"v":1,"ts":2,"kind":"tool.after","tool":"bash","sessionID":"ses1","callID":"call_g","result":{"output":"clean","metadata":{"exit":0}}}"#,
+        );
+
+        assert_eq!(sink.count("test-run"), 0);
+    }
+
+    /// `on_caught_up` called twice ⇒ no duplicate replay flush (the buffered
+    /// test-run is emitted exactly once).
+    #[test]
+    fn on_caught_up_twice_does_not_duplicate_replay_flush() {
+        let sink = Arc::new(FakeEventSink::new());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut dec = decoder(&sink, Some(tmp.path().to_path_buf()));
+
+        // Replay phase (before any on_caught_up): a test-run is buffered.
+        dec.decode_line(
+            r#"{"v":1,"ts":1000,"kind":"tool.before","tool":"bash","sessionID":"ses1","callID":"call_r","args":{"command":"cargo test"}}"#,
+        );
+        dec.decode_line(
+            r#"{"v":1,"ts":2000,"kind":"tool.after","tool":"bash","sessionID":"ses1","callID":"call_r","result":{"output":"test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out\n","metadata":{"exit":0}}}"#,
+        );
+        assert_eq!(sink.count("test-run"), 0, "buffered during replay");
+
+        dec.on_caught_up();
+        dec.on_caught_up();
+        dec.on_caught_up();
+
+        assert_eq!(sink.count("test-run"), 1, "flushed exactly once");
+    }
+
+    /// A tool call still in-flight at the replay boundary surfaces as running
+    /// exactly once when `on_caught_up` fires.
+    #[test]
+    fn in_flight_tool_call_surfaces_running_at_caught_up() {
+        let sink = Arc::new(FakeEventSink::new());
+        let mut dec = decoder(&sink, None);
+
+        // Started during replay, never completed.
+        dec.decode_line(
+            r#"{"v":1,"ts":1,"kind":"tool.before","tool":"bash","sessionID":"ses1","callID":"call_live","args":{"command":"sleep 100"}}"#,
+        );
+        assert_eq!(sink.count("agent-tool-call"), 0, "no emit during replay");
+
+        dec.on_caught_up();
+        dec.on_caught_up(); // idempotent — must not re-emit
+
+        let payloads = tool_call_payloads(&sink);
+        assert_eq!(payloads.len(), 1);
+        assert_eq!(payloads[0]["status"], "running");
+        assert_eq!(payloads[0]["toolUseId"], "call_live");
+    }
+
+    /// `session.updated` with a changed `info.path.cwd` ⇒ one `agent-cwd`;
+    /// the same cwd does not re-emit.
+    #[test]
+    fn session_cwd_change_emits_agent_cwd_on_transition() {
+        let sink = Arc::new(FakeEventSink::new());
+        let mut dec = decoder(&sink, None);
+        dec.on_caught_up();
+
+        dec.decode_line(
+            r#"{"v":1,"ts":1,"kind":"event","type":"session.updated","data":{"info":{"id":"ses1","path":{"cwd":"/work/a"}}}}"#,
+        );
+        dec.decode_line(
+            r#"{"v":1,"ts":2,"kind":"event","type":"session.updated","data":{"info":{"id":"ses1","path":{"cwd":"/work/a"}}}}"#,
+        );
+        dec.decode_line(
+            r#"{"v":1,"ts":3,"kind":"event","type":"session.updated","data":{"info":{"id":"ses1","path":{"cwd":"/work/b"}}}}"#,
+        );
+
+        let cwds: Vec<Value> = sink
+            .recorded()
+            .into_iter()
+            .filter(|(n, _)| n == "agent-cwd")
+            .map(|(_, p)| p)
+            .collect();
+        assert_eq!(cwds.len(), 2, "two distinct cwds; the repeat is suppressed");
+        assert_eq!(cwds[0]["cwd"], "/work/a");
+        assert_eq!(cwds[1]["cwd"], "/work/b");
+    }
+
+    /// End-to-end: feeding the authored `sample_bridge.jsonl` through
+    /// `start_tailing` emits the expected sequence — one `agent-turn` (the user
+    /// `message.updated`) and one settled bash tool-call (`done`). The whole
+    /// fixture is replayed before the first EOF, so the bash call (which both
+    /// starts AND completes during replay) settles to a single `done` event —
+    /// its `running` start is suppressed during replay, mirroring Codex's
+    /// `codex_replay_does_not_emit_running_for_settled_tool_calls`.
+    ///
+    /// No `test-run` is asserted: the fixture's bash `result.output` uses a
+    /// Jest-style summary (`Tests: 12 passed, 12 total`), which the v1 vitest
+    /// parser intentionally does not recognize (its summary line is
+    /// `Tests  12 passed (12)`), so `maybe_build_snapshot` returns `None` and
+    /// nothing is submitted. That is the genuine behavior for this fixture; the
+    /// bash → shared test-run-parser wiring is proven against a real
+    /// cargo-format output in `bash_test_command_emits_test_run_snapshot`. Uses
+    /// the capturing `FakeEventSink` + `wait_for_count` for event-based sync
+    /// (mirrors Codex's transcript tests).
+    #[test]
+    fn start_tailing_replays_sample_bridge_fixture() {
+        let sink = Arc::new(FakeEventSink::new());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let workspace = tmp.path().join("sample-project");
+        std::fs::create_dir_all(&workspace).expect("mkdir workspace");
+
+        let bridge_root = tmp.path().to_path_buf();
+        let transcript_path = bridge_root.join("ses_sample001.jsonl");
+        std::fs::write(&transcript_path, SAMPLE_BRIDGE).expect("write fixture transcript");
+
+        let locator = Arc::new(OpenCodeLocator::new(
+            bridge_root,
+            4242,
+            SystemTime::UNIX_EPOCH,
+        ));
+
+        let handle = start_tailing(
+            sink.clone(),
+            "sid-sample".to_string(),
+            Some(workspace.clone()),
+            transcript_path,
+            locator,
+        )
+        .expect("tailing should start");
+
+        assert!(
+            sink.wait_for_count("agent-turn", 1, Duration::from_secs(5)),
+            "expected 1 agent-turn from the user message.updated line",
+        );
+        assert!(
+            sink.wait_for_count("agent-tool-call", 1, Duration::from_secs(5)),
+            "expected the settled bash tool's single done event",
+        );
+        handle.stop();
+
+        let turns: Vec<Value> = sink
+            .recorded()
+            .into_iter()
+            .filter(|(n, _)| n == "agent-turn")
+            .map(|(_, p)| p)
+            .collect();
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0]["numTurns"], 1);
+
+        let tool_calls = tool_call_payloads(&sink);
+        // The fixture has exactly one bash tool (call_bash001): tool.before →
+        // tool.after, both during replay ⇒ a single settled `done` (the
+        // `running` start is suppressed during replay).
+        let bash_calls: Vec<&Value> = tool_calls
+            .iter()
+            .filter(|p| p["toolUseId"] == "call_bash001")
+            .collect();
+        assert_eq!(bash_calls.len(), 1, "settled bash tool ⇒ one done");
+        assert_eq!(bash_calls[0]["status"], "done");
+        assert_eq!(bash_calls[0]["tool"], "bash");
+        assert_eq!(bash_calls[0]["args"], "npm test");
+
+        // The Jest-style fixture output is unparseable to the vitest runner, so
+        // no test-run snapshot is produced (see the test docstring).
+        assert_eq!(sink.count("test-run"), 0);
+    }
+
+    #[test]
+    fn ts_to_iso8601_formats_epoch_ms() {
+        // 1781965827596 ms ≈ 2026-06-18 (well-defined UTC date/time).
+        let iso = ts_to_iso8601(Some(1_781_965_827_596));
+        assert!(iso.starts_with("2026-"), "got: {iso}");
+        assert!(iso.ends_with('Z'));
+        // None falls back to a now-stamp, still ISO-shaped.
+        assert!(ts_to_iso8601(None).ends_with('Z'));
+    }
+
+    #[test]
+    fn truncate_string_caps_and_marks() {
+        assert_eq!(truncate_string("short", 1024), "short");
+        let long = "x".repeat(2000);
+        let out = truncate_string(&long, 1024);
+        assert!(out.ends_with("..."));
+        assert_eq!(out.chars().count(), 1024);
+    }
+
+    #[test]
+    fn malformed_line_is_skipped() {
+        let sink = Arc::new(FakeEventSink::new());
+        let mut dec = decoder(&sink, None);
+        dec.on_caught_up();
+        dec.decode_line("this is not json");
+        dec.decode_line(r#"{"v":1,"kind":"totally.unknown"}"#);
+        assert_eq!(sink.count("agent-turn"), 0);
+        assert_eq!(sink.count("agent-tool-call"), 0);
+    }
+}

--- a/crates/backend/src/agent/adapter/opencode/transcript.rs
+++ b/crates/backend/src/agent/adapter/opencode/transcript.rs
@@ -69,6 +69,18 @@ struct InFlightToolCall {
 
 type InFlightToolCalls = HashMap<String, InFlightToolCall>;
 
+/// Tool-call metadata that must survive display-state completion. opencode can
+/// deliver `message.part.updated[completed]` before `tool.after`; the latter is
+/// still needed for bash test-run parsing.
+struct ToolCallMetadata {
+    started_at: Instant,
+    started_at_iso: String,
+    tool: String,
+    args: String,
+}
+
+type ToolCallMetadataById = HashMap<String, ToolCallMetadata>;
+
 /// Open the bridge JSONL, build the decoder, and spawn the tail thread.
 ///
 /// Mirrors `codex::transcript::start_tailing` / `kimi::transcript::start_tailing`.
@@ -128,6 +140,7 @@ pub(crate) struct OpencodeTranscriptDecoder {
     /// parser (NOT any per-command workdir). Also the baseline for `last_cwd`.
     cwd: Option<PathBuf>,
     in_flight: InFlightToolCalls,
+    tool_metadata: ToolCallMetadataById,
     /// Dedup set keyed by `(callID, status-discriminant)` so a repeated
     /// running/completed update for the same call does not re-emit. The
     /// discriminant is a `&'static str` ("running"/"done"/"failed") rather than
@@ -159,6 +172,7 @@ impl OpencodeTranscriptDecoder {
             session_id,
             cwd,
             in_flight: HashMap::new(),
+            tool_metadata: HashMap::new(),
             emitted: HashSet::new(),
             seen_turns: HashSet::new(),
             num_turns: 0,
@@ -300,6 +314,7 @@ impl OpencodeTranscriptDecoder {
         }
 
         self.finish_tool_call(call_id, status, timestamp);
+        self.tool_metadata.remove(call_id);
     }
 
     /// Common start path: insert into `in_flight` (idempotent on the call key)
@@ -323,6 +338,7 @@ impl OpencodeTranscriptDecoder {
                 args: args.clone(),
                 is_test_file,
             });
+        self.record_tool_metadata(call_key, &tool, &args, timestamp);
 
         let dedup_key = (call_key.to_string(), status_discriminant(&ToolCallStatus::Running));
         if !self.emitted.insert(dedup_key) {
@@ -378,6 +394,23 @@ impl OpencodeTranscriptDecoder {
         });
     }
 
+    fn record_tool_metadata(&mut self, call_key: &str, tool: &str, args: &str, timestamp: &str) {
+        self.tool_metadata
+            .entry(call_key.to_string())
+            .and_modify(|metadata| {
+                if metadata.args.is_empty() && !args.is_empty() {
+                    metadata.tool = tool.to_string();
+                    metadata.args = args.to_string();
+                }
+            })
+            .or_insert_with(|| ToolCallMetadata {
+                started_at: Instant::now(),
+                started_at_iso: timestamp.to_string(),
+                tool: tool.to_string(),
+                args: args.to_string(),
+            });
+    }
+
     /// Feed a `bash` `tool.after` into the shared `claude_code::test_runners`.
     /// `cwd` is the session cwd (NOT any per-command workdir). Only submits when
     /// the command matches a known runner AND `maybe_build_snapshot` returns
@@ -398,14 +431,10 @@ impl OpencodeTranscriptDecoder {
             return;
         };
 
-        // The command preview lives on the in-flight start's args (the
-        // `tool.before`'s `args.command`); fall back to nothing if the start
-        // wasn't seen. `result.output` carries the captured output.
-        let command = self
-            .in_flight
-            .get(call_id)
-            .map(|c| c.args.clone())
-            .unwrap_or_default();
+        // The command preview lives on the start metadata (the `tool.before`'s
+        // `args.command`). It is cached outside `in_flight` because a terminal
+        // part update can remove display state before `tool.after` arrives.
+        let command = self.tool_command(call_id).unwrap_or_default();
         if command.is_empty() {
             return;
         }
@@ -419,12 +448,12 @@ impl OpencodeTranscriptDecoder {
             .unwrap_or("")
             .to_string();
         let started_at = self
-            .in_flight
+            .tool_metadata
             .get(call_id)
             .map(|c| c.started_at_iso.clone())
             .unwrap_or_else(|| timestamp.to_string());
         let instant_fallback = self
-            .in_flight
+            .tool_metadata
             .get(call_id)
             .map(|c| c.started_at.elapsed())
             .unwrap_or_default();
@@ -444,6 +473,19 @@ impl OpencodeTranscriptDecoder {
         }) {
             self.emitter.submit(snapshot);
         }
+    }
+
+    fn tool_command(&self, call_id: &str) -> Option<String> {
+        self.tool_metadata
+            .get(call_id)
+            .filter(|metadata| metadata.tool == "bash")
+            .map(|metadata| metadata.args.clone())
+            .or_else(|| {
+                self.in_flight
+                    .get(call_id)
+                    .filter(|call| call.tool == "bash")
+                    .map(|call| call.args.clone())
+            })
     }
 
     /// `session.created`/`session.updated`: track the cwd transition off
@@ -813,6 +855,40 @@ mod tests {
             .collect();
         assert_eq!(test_runs[0]["runner"], "cargo");
         assert_eq!(test_runs[0]["summary"]["passed"], 1);
+    }
+
+    /// A completed `message.part.updated` can arrive before `tool.after`.
+    /// Test-run parsing must still see the original bash command even though
+    /// the terminal part update removed the in-flight display record.
+    #[test]
+    fn completed_part_before_tool_after_still_emits_test_run_snapshot() {
+        let sink = Arc::new(FakeEventSink::new());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let workspace = tmp.path().to_path_buf();
+        let mut dec = decoder(&sink, Some(workspace));
+        dec.on_caught_up();
+
+        dec.decode_line(
+            r#"{"v":1,"ts":1000,"kind":"tool.before","tool":"bash","sessionID":"ses1","callID":"call_order","args":{"command":"cargo test"}}"#,
+        );
+        dec.decode_line(
+            r#"{"v":1,"ts":1500,"kind":"event","type":"message.part.updated","data":{"part":{"type":"tool","callID":"call_order","tool":"bash","state":{"status":"completed"}}}}"#,
+        );
+        dec.decode_line(
+            r#"{"v":1,"ts":2000,"kind":"tool.after","tool":"bash","sessionID":"ses1","callID":"call_order","result":{"output":"running 1 test\ntest result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out\n","metadata":{"exit":0}}}"#,
+        );
+
+        assert_eq!(
+            sink.count("test-run"),
+            1,
+            "completed part before tool.after still emits a test-run snapshot",
+        );
+        let payloads = tool_call_payloads(&sink);
+        assert_eq!(
+            payloads.iter().filter(|p| p["status"] == "done").count(),
+            1,
+            "terminal status remains deduped",
+        );
     }
 
     /// A non-test `bash` `tool.after` ⇒ no test-run snapshot.

--- a/crates/backend/src/agent/adapter/opencode/transcript.rs
+++ b/crates/backend/src/agent/adapter/opencode/transcript.rs
@@ -15,8 +15,10 @@
 //! - `kind=tool.before` ⇒ tool-call start (args preview already on the line).
 //!   `kind=event`, `type=message.part.updated`, `data.part.type=="tool"`,
 //!   `state.status` `pending`/`running` ⇒ start/running.
-//! - `kind=tool.after` ⇒ tool-call done (`completed`) / failed (`error`).
-//!   Deduped by `(callID, status)` so repeated running updates don't re-emit.
+//! - `kind=tool.after` ⇒ authoritative tool-call done/failed from the process
+//!   exit code when a `tool.before` line established that `tool.after` is
+//!   expected. Terminal `message.part.updated` signals are used for calls that
+//!   appear without a `tool.before`.
 //! - `kind=tool.after` where `tool=="bash"` ⇒ feed `args.command` +
 //!   `result.output` + `result.metadata.exit` into the shared
 //!   `claude_code::test_runners` (cwd = the session cwd, NOT a per-command
@@ -77,6 +79,7 @@ struct ToolCallMetadata {
     started_at_iso: String,
     tool: String,
     args: String,
+    expects_tool_after: bool,
 }
 
 type ToolCallMetadataById = HashMap<String, ToolCallMetadata>;
@@ -142,11 +145,13 @@ pub(crate) struct OpencodeTranscriptDecoder {
     in_flight: InFlightToolCalls,
     tool_metadata: ToolCallMetadataById,
     /// Dedup set keyed by `(callID, status-discriminant)` so a repeated
-    /// running/completed update for the same call does not re-emit. The
-    /// discriminant is a `&'static str` ("running"/"done"/"failed") rather than
-    /// `ToolCallStatus` so we don't have to widen the shared enum's derives
-    /// (it isn't `Hash`/`Eq`).
+    /// running/terminal update for the same call does not re-emit. The
+    /// discriminant is a `&'static str` rather than `ToolCallStatus` so we don't
+    /// have to widen the shared enum's derives (it isn't `Hash`/`Eq`).
     emitted: HashSet<(String, &'static str)>,
+    /// Calls whose terminal status was already resolved by `tool.after`; later
+    /// terminal part updates are non-authoritative for these call ids.
+    resolved_by_tool_after: HashSet<String>,
     /// User-message ids already counted as a turn — a re-delivered
     /// `message.updated` for the same id does not double-count.
     seen_turns: HashSet<String>,
@@ -174,6 +179,7 @@ impl OpencodeTranscriptDecoder {
             in_flight: HashMap::new(),
             tool_metadata: HashMap::new(),
             emitted: HashSet::new(),
+            resolved_by_tool_after: HashSet::new(),
             seen_turns: HashSet::new(),
             num_turns: 0,
             last_cwd,
@@ -220,7 +226,11 @@ impl OpencodeTranscriptDecoder {
         if info.get("role").and_then(Value::as_str) != Some("user") {
             return;
         }
-        let Some(id) = info.get("id").and_then(Value::as_str).filter(|s| !s.is_empty()) else {
+        let Some(id) = info
+            .get("id")
+            .and_then(Value::as_str)
+            .filter(|s| !s.is_empty())
+        else {
             return;
         };
         // Dedup by user-message id: a re-delivered update must not re-count.
@@ -266,13 +276,17 @@ impl OpencodeTranscriptDecoder {
 
         match status {
             "pending" | "running" => {
-                self.start_tool_call(&call_key, tool, args, timestamp, false);
+                self.start_tool_call(&call_key, tool, args, timestamp, false, false);
             }
             "completed" => {
-                self.finish_tool_call(&call_key, ToolCallStatus::Done, timestamp);
+                self.finish_tool_call_from_part_update(&call_key, ToolCallStatus::Done, timestamp);
             }
             "error" => {
-                self.finish_tool_call(&call_key, ToolCallStatus::Failed, timestamp);
+                self.finish_tool_call_from_part_update(
+                    &call_key,
+                    ToolCallStatus::Failed,
+                    timestamp,
+                );
             }
             _ => {}
         }
@@ -286,7 +300,7 @@ impl OpencodeTranscriptDecoder {
         };
         let tool = dto.tool.as_deref().unwrap_or("unknown").to_string();
         let args = summarize_value_args(&dto.args, &tool);
-        self.start_tool_call(call_id, tool, args, timestamp, false);
+        self.start_tool_call(call_id, tool, args, timestamp, false, true);
     }
 
     /// `tool.after`: complete the in-flight call (`metadata.exit` decides
@@ -314,6 +328,7 @@ impl OpencodeTranscriptDecoder {
         }
 
         self.finish_tool_call(call_id, status, timestamp);
+        self.resolved_by_tool_after.insert(call_id.to_string());
         self.tool_metadata.remove(call_id);
     }
 
@@ -328,6 +343,7 @@ impl OpencodeTranscriptDecoder {
         args: String,
         timestamp: &str,
         is_test_file: bool,
+        expects_tool_after: bool,
     ) {
         self.in_flight
             .entry(call_key.to_string())
@@ -338,9 +354,12 @@ impl OpencodeTranscriptDecoder {
                 args: args.clone(),
                 is_test_file,
             });
-        self.record_tool_metadata(call_key, &tool, &args, timestamp);
+        self.record_tool_metadata(call_key, &tool, &args, timestamp, expects_tool_after);
 
-        let dedup_key = (call_key.to_string(), status_discriminant(&ToolCallStatus::Running));
+        let dedup_key = (
+            call_key.to_string(),
+            status_discriminant(&ToolCallStatus::Running),
+        );
         if !self.emitted.insert(dedup_key) {
             return;
         }
@@ -359,9 +378,28 @@ impl OpencodeTranscriptDecoder {
         }
     }
 
+    /// Terminal part updates are authoritative only for calls that started from
+    /// the part stream. Calls with `tool.before` metadata are expected to emit a
+    /// later `tool.after`, whose exit code decides the final display status.
+    fn finish_tool_call_from_part_update(
+        &mut self,
+        call_key: &str,
+        status: ToolCallStatus,
+        timestamp: &str,
+    ) {
+        if self
+            .tool_metadata
+            .get(call_key)
+            .is_some_and(|metadata| metadata.expects_tool_after)
+            || self.resolved_by_tool_after.contains(call_key)
+        {
+            return;
+        }
+        self.finish_tool_call(call_key, status, timestamp);
+    }
+
     /// Common completion path: remove the in-flight call and emit its terminal
-    /// status once. Deduped by `(callID, status)` — a `tool.after` plus a
-    /// `completed` part update for the same call emits a single done.
+    /// status once.
     fn finish_tool_call(&mut self, call_key: &str, status: ToolCallStatus, timestamp: &str) {
         let dedup_key = (call_key.to_string(), status_discriminant(&status));
         if !self.emitted.insert(dedup_key) {
@@ -394,7 +432,14 @@ impl OpencodeTranscriptDecoder {
         });
     }
 
-    fn record_tool_metadata(&mut self, call_key: &str, tool: &str, args: &str, timestamp: &str) {
+    fn record_tool_metadata(
+        &mut self,
+        call_key: &str,
+        tool: &str,
+        args: &str,
+        timestamp: &str,
+        expects_tool_after: bool,
+    ) {
         self.tool_metadata
             .entry(call_key.to_string())
             .and_modify(|metadata| {
@@ -402,12 +447,14 @@ impl OpencodeTranscriptDecoder {
                     metadata.tool = tool.to_string();
                     metadata.args = args.to_string();
                 }
+                metadata.expects_tool_after |= expects_tool_after;
             })
             .or_insert_with(|| ToolCallMetadata {
                 started_at: Instant::now(),
                 started_at_iso: timestamp.to_string(),
                 tool: tool.to_string(),
                 args: args.to_string(),
+                expects_tool_after,
             });
     }
 
@@ -769,7 +816,11 @@ mod tests {
         dec.decode_line(running);
 
         let payloads = tool_call_payloads(&sink);
-        assert_eq!(payloads.len(), 1, "only one running start despite 3 updates");
+        assert_eq!(
+            payloads.len(),
+            1,
+            "only one running start despite 3 updates"
+        );
         assert_eq!(payloads[0]["status"], "running");
         assert_eq!(payloads[0]["toolUseId"], "call_p1");
     }
@@ -792,7 +843,9 @@ mod tests {
         assert_eq!(payloads[0]["status"], "running");
     }
 
-    /// A tool part with `state.status == "error"` ⇒ failed.
+    /// A tool part with `state.status == "error"` ⇒ failed when no
+    /// `tool.before` established that `tool.after` is the authoritative
+    /// terminal source.
     #[test]
     fn tool_state_error_emits_failed() {
         let sink = Arc::new(FakeEventSink::new());
@@ -800,7 +853,7 @@ mod tests {
         dec.on_caught_up();
 
         dec.decode_line(
-            r#"{"v":1,"ts":1,"kind":"tool.before","tool":"bash","sessionID":"ses1","callID":"call_e","args":{"command":"false"}}"#,
+            r#"{"v":1,"ts":1,"kind":"event","type":"message.part.updated","data":{"part":{"type":"tool","callID":"call_e","tool":"bash","state":{"status":"running","args":{"command":"false"}}}}}"#,
         );
         dec.decode_line(
             r#"{"v":1,"ts":2,"kind":"event","type":"message.part.updated","data":{"part":{"type":"tool","callID":"call_e","tool":"bash","state":{"status":"error"}}}}"#,
@@ -846,7 +899,11 @@ mod tests {
             r#"{"v":1,"ts":2000,"kind":"tool.after","tool":"bash","sessionID":"ses1","callID":"call_t","result":{"output":"running 1 test\ntest result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out\n","metadata":{"exit":0}}}"#,
         );
 
-        assert_eq!(sink.count("test-run"), 1, "passing cargo test ⇒ one snapshot");
+        assert_eq!(
+            sink.count("test-run"),
+            1,
+            "passing cargo test ⇒ one snapshot"
+        );
         let test_runs: Vec<Value> = sink
             .recorded()
             .into_iter()
@@ -858,8 +915,9 @@ mod tests {
     }
 
     /// A completed `message.part.updated` can arrive before `tool.after`.
-    /// Test-run parsing must still see the original bash command even though
-    /// the terminal part update removed the in-flight display record.
+    /// Test-run parsing must still see the original bash command, and the
+    /// authoritative `tool.after` result should provide the display terminal
+    /// status.
     #[test]
     fn completed_part_before_tool_after_still_emits_test_run_snapshot() {
         let sink = Arc::new(FakeEventSink::new());
@@ -889,6 +947,64 @@ mod tests {
             1,
             "terminal status remains deduped",
         );
+    }
+
+    /// A completed part update is only the model-side completion signal; a
+    /// later non-zero `tool.after` exit remains the authoritative display
+    /// status and must not produce a preceding done event.
+    #[test]
+    fn completed_part_before_failing_tool_after_emits_only_failed_terminal_status() {
+        let sink = Arc::new(FakeEventSink::new());
+        let mut dec = decoder(&sink, None);
+        dec.on_caught_up();
+
+        dec.decode_line(
+            r#"{"v":1,"ts":1000,"kind":"tool.before","tool":"bash","sessionID":"ses1","callID":"call_fail_order","args":{"command":"cargo test"}}"#,
+        );
+        dec.decode_line(
+            r#"{"v":1,"ts":1500,"kind":"event","type":"message.part.updated","data":{"part":{"type":"tool","callID":"call_fail_order","tool":"bash","state":{"status":"completed"}}}}"#,
+        );
+        dec.decode_line(
+            r#"{"v":1,"ts":2000,"kind":"tool.after","tool":"bash","sessionID":"ses1","callID":"call_fail_order","result":{"output":"test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out\n","metadata":{"exit":1}}}"#,
+        );
+
+        let terminal_payloads: Vec<Value> = tool_call_payloads(&sink)
+            .into_iter()
+            .filter(|payload| {
+                payload["toolUseId"] == "call_fail_order" && payload["status"] != "running"
+            })
+            .collect();
+        assert_eq!(terminal_payloads.len(), 1);
+        assert_eq!(terminal_payloads[0]["status"], "failed");
+    }
+
+    /// Once `tool.after` provides the authoritative status, delayed terminal
+    /// part updates for the same call must remain suppressed even after the
+    /// metadata cache is cleared.
+    #[test]
+    fn completed_part_after_failing_tool_after_does_not_emit_done() {
+        let sink = Arc::new(FakeEventSink::new());
+        let mut dec = decoder(&sink, None);
+        dec.on_caught_up();
+
+        dec.decode_line(
+            r#"{"v":1,"ts":1000,"kind":"tool.before","tool":"bash","sessionID":"ses1","callID":"call_after_first","args":{"command":"cargo test"}}"#,
+        );
+        dec.decode_line(
+            r#"{"v":1,"ts":1500,"kind":"tool.after","tool":"bash","sessionID":"ses1","callID":"call_after_first","result":{"output":"test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out\n","metadata":{"exit":1}}}"#,
+        );
+        dec.decode_line(
+            r#"{"v":1,"ts":2000,"kind":"event","type":"message.part.updated","data":{"part":{"type":"tool","callID":"call_after_first","tool":"bash","state":{"status":"completed"}}}}"#,
+        );
+
+        let terminal_payloads: Vec<Value> = tool_call_payloads(&sink)
+            .into_iter()
+            .filter(|payload| {
+                payload["toolUseId"] == "call_after_first" && payload["status"] != "running"
+            })
+            .collect();
+        assert_eq!(terminal_payloads.len(), 1);
+        assert_eq!(terminal_payloads[0]["status"], "failed");
     }
 
     /// A non-test `bash` `tool.after` ⇒ no test-run snapshot.

--- a/crates/backend/src/agent/adapter/opencode/transcript.rs
+++ b/crates/backend/src/agent/adapter/opencode/transcript.rs
@@ -396,6 +396,7 @@ impl OpencodeTranscriptDecoder {
             return;
         }
         self.finish_tool_call(call_key, status, timestamp);
+        self.tool_metadata.remove(call_key);
     }
 
     /// Common completion path: remove the in-flight call and emit its terminal
@@ -863,6 +864,32 @@ mod tests {
         assert_eq!(payloads.len(), 2);
         assert_eq!(payloads[1]["status"], "failed");
         assert_eq!(payloads[1]["toolUseId"], "call_e");
+    }
+
+    /// A call that exists only in the part-update stream has no later
+    /// `tool.after` owner, so terminal part updates must clear cached metadata.
+    #[test]
+    fn part_update_only_completion_clears_tool_metadata() {
+        let sink = Arc::new(FakeEventSink::new());
+        let mut dec = decoder(&sink, None);
+        dec.on_caught_up();
+
+        dec.decode_line(
+            r#"{"v":1,"ts":1,"kind":"event","type":"message.part.updated","data":{"part":{"type":"tool","callID":"call_part_only","tool":"bash","state":{"status":"running","args":{"command":"echo hi"}}}}}"#,
+        );
+        assert!(
+            dec.tool_metadata.contains_key("call_part_only"),
+            "running part update caches metadata for display and command lookup",
+        );
+
+        dec.decode_line(
+            r#"{"v":1,"ts":2,"kind":"event","type":"message.part.updated","data":{"part":{"type":"tool","callID":"call_part_only","tool":"bash","state":{"status":"completed"}}}}"#,
+        );
+
+        assert!(
+            !dec.tool_metadata.contains_key("call_part_only"),
+            "part-update-only completion has no later owner for cached metadata",
+        );
     }
 
     /// A `tool.after` with a non-zero `metadata.exit` ⇒ failed.

--- a/crates/backend/src/agent/adapter/opencode/transcript_dto.rs
+++ b/crates/backend/src/agent/adapter/opencode/transcript_dto.rs
@@ -71,6 +71,13 @@ impl OpencodeEventType {
 
 /// One bridge JSONL line, flattened over all three kinds. Every field is
 /// optional/lenient so any line shape deserializes without error.
+///
+/// `#[allow(dead_code)]`: this is a wire-schema mirror — `v` (schema version)
+/// and the line-level `session_id` are parsed + test-asserted to document the
+/// contract, but the v1 decoder routes off `kind`/`event_type`/`data`/`tool`/
+/// `call_id`/`args`/`result` and never reads them. Keeping the fields makes the
+/// DTO a faithful 1:1 of the bridge line.
+#[allow(dead_code)]
 #[derive(Debug, Clone, Default, Deserialize)]
 pub(crate) struct OpencodeLineDto {
     /// Schema version (`1`).
@@ -124,6 +131,11 @@ impl OpencodeLineDto {
 }
 
 /// One `index.jsonl` row: identifies a session and its owning opencode process.
+///
+/// `#[allow(dead_code)]`: `slug` (the opencode session display slug) is parsed +
+/// test-asserted to mirror the index schema, but the v1 locator resolves off
+/// `session_id`/`pid`/`directory`/`time` only and never reads it.
+#[allow(dead_code)]
 #[derive(Debug, Clone, Default, Deserialize)]
 pub(crate) struct OpencodeIndexRowDto {
     #[serde(rename = "sessionID", default, deserialize_with = "lenient_string")]

--- a/crates/backend/src/agent/adapter/opencode/types.rs
+++ b/crates/backend/src/agent/adapter/opencode/types.rs
@@ -33,6 +33,16 @@ pub(crate) const OPENCODE_CONTEXT_WINDOW_SIZE: u64 = 0;
 /// `.local/share/opencode` when home is unknown (headless / service
 /// sessions). Mirrors `default_kimi_home`'s env → home → relative fallback
 /// shape.
+///
+/// Genuinely test-only in M5: the v1 filesystem locator ignores
+/// `provider_home` entirely (the bridge root is XDG-derived via
+/// `install::bridge_dir`), so the bindings arm never consults this. It exists
+/// for the detector/registry's `provider_home` chain wired in M1's
+/// `config.rs::AGENT_SPECS` (`home_subdir = ".local/share/opencode"`); until
+/// that lands it has no production caller. Keep the narrow allow rather than a
+/// blanket module-level one (per M5: drop the blanket `#[allow(dead_code)]`,
+/// scope it to the genuinely-staged item).
+#[allow(dead_code)]
 pub(crate) fn default_opencode_home() -> PathBuf {
     if let Some(env_home) = std::env::var_os("OPENCODE_HOME") {
         if !env_home.is_empty() {

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -61,7 +61,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 88       | 25   | 2026-06-16   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 72       | 30   | 2026-06-20   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 2        | 0    | 2026-06-20   |
-| [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 64       | 23   | 2026-06-17   |
+| [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 65       | 23   | 2026-06-20   |
 | [Canonical Path Dedupe](patterns/canonical-path-dedupe.md)                                           | correctness        | 2        | 0    | 2026-06-14   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)                                       | backend            | 4        | 2    | 2026-06-14   |
 | [Command Injection](patterns/command-injection.md)                                                   | security           | 8        | 3    | 2026-06-16   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -101,7 +101,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [React Prop Contracts](patterns/react-prop-contracts.md)                                             | react-patterns     | 6        | 4    | 2026-06-19   |
 | [Stale Retained Interactions](patterns/stale-retained-interactions.md)                               | react-patterns     | 2        | 0    | 2026-06-15   |
 | [Retained State Identity](patterns/retained-state-identity.md)                                       | react-patterns     | 1        | 1    | 2026-06-15   |
-| [Authoritative Completion Guard](patterns/authoritative-completion-guard.md)                         | correctness        | 3        | 0    | 2026-06-17   |
+| [Authoritative Completion Guard](patterns/authoritative-completion-guard.md)                         | correctness        | 4        | 1    | 2026-06-20   |
 | [Equality Guard Completeness](patterns/equality-guard-completeness.md)                               | correctness        | 2        | 0    | 2026-06-17   |
 | [Resizable Layout Bounds](patterns/resizable-layout-bounds.md)                                       | correctness        | 3        | 1    | 2026-06-18   |
 | [Schema Version Decoupling](patterns/schema-version-decoupling.md)                                   | correctness        | 1        | 0    | 2026-06-19   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -49,7 +49,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Imperative Animation Ownership](patterns/imperative-animation-ownership.md)                         | react-patterns     | 7        | 3    | 2026-06-17   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Fixed-Position Portals](patterns/fixed-position-portals.md)                                         | react-patterns     | 1        | 0    | 2026-06-12   |
-| [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 15       | 12   | 2026-06-16   |
+| [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 16       | 13   | 2026-06-20   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)                                             | cross-platform     | 10       | 4    | 2026-06-20   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                                                       | code-quality       | 7        | 0    | 2026-06-11   |
 | [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 12       | 9    | 2026-06-19   |
@@ -101,7 +101,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [React Prop Contracts](patterns/react-prop-contracts.md)                                             | react-patterns     | 6        | 4    | 2026-06-19   |
 | [Stale Retained Interactions](patterns/stale-retained-interactions.md)                               | react-patterns     | 2        | 0    | 2026-06-15   |
 | [Retained State Identity](patterns/retained-state-identity.md)                                       | react-patterns     | 1        | 1    | 2026-06-15   |
-| [Authoritative Completion Guard](patterns/authoritative-completion-guard.md)                         | correctness        | 4        | 1    | 2026-06-20   |
+| [Authoritative Completion Guard](patterns/authoritative-completion-guard.md)                         | correctness        | 4        | 2    | 2026-06-20   |
 | [Equality Guard Completeness](patterns/equality-guard-completeness.md)                               | correctness        | 2        | 0    | 2026-06-17   |
 | [Resizable Layout Bounds](patterns/resizable-layout-bounds.md)                                       | correctness        | 3        | 1    | 2026-06-18   |
 | [Schema Version Decoupling](patterns/schema-version-decoupling.md)                                   | correctness        | 1        | 0    | 2026-06-19   |

--- a/docs/reviews/patterns/async-race-conditions.md
+++ b/docs/reviews/patterns/async-race-conditions.md
@@ -2,7 +2,7 @@
 id: async-race-conditions
 category: react-patterns
 created: 2026-04-09
-last_updated: 2026-06-08
+last_updated: 2026-06-20
 ref_count: 23
 ---
 
@@ -650,3 +650,12 @@ prevent showing previous data.
 - **Finding:** `selectedEditorFileExists` was never reset before a new existence check began. Switching from a deleted file to an existing file could make the new file momentarily read-only because `resolveEditorFileLifecycleStatus` saw the stale `false` value before the async check completed.
 - **Fix:** Set `selectedEditorFileExists(null)` synchronously at the start of the check, then update it with the async result.
 - **Commit:** see current commit
+
+### 65. Terminal event updates consumed metadata needed by later authoritative output events
+
+- **Source:** github-codex-connector | PR #588 round 1 | 2026-06-20
+- **Severity:** MEDIUM
+- **File:** `crates/backend/src/agent/adapter/opencode/transcript.rs`
+- **Finding:** The opencode decoder removed an in-flight bash call when a completed `message.part.updated` arrived. If the later `tool.after` event carried the command output, test-run parsing no longer had the original command and silently skipped the snapshot.
+- **Fix:** Added a per-call metadata cache that survives display-state completion until `tool.after` runs, and covered the `tool.before` -> completed part update -> bash `tool.after` ordering with a regression test.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/authoritative-completion-guard.md
+++ b/docs/reviews/patterns/authoritative-completion-guard.md
@@ -2,8 +2,8 @@
 id: authoritative-completion-guard
 category: correctness
 created: 2026-06-16
-last_updated: 2026-06-17
-ref_count: 0
+last_updated: 2026-06-20
+ref_count: 1
 ---
 
 # Authoritative Completion Guard
@@ -58,4 +58,20 @@ When a state machine or lifecycle tracks an in-flight operation, multiple events
   and the now-unused `emit_exec_test_run_snapshot` and
   `exec_function_output_exit_code` helpers. Left `process_exec_command_end` as the
   sole authoritative path for exec snapshots.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 4. Model-side completion emitted success before authoritative process exit
+
+- **Source:** github-claude | PR #588 round 2 | 2026-06-20
+- **Severity:** MEDIUM
+- **File:** `crates/backend/src/agent/adapter/opencode/transcript.rs`
+- **Finding:** The opencode decoder treated `message.part.updated[completed]`
+  as a terminal Done event even when a prior `tool.before` meant a later
+  `tool.after` was expected. If the command then exited non-zero, the decoder
+  emitted both Done and Failed for one tool call.
+- **Fix:** Made `tool.after` the authoritative terminal source for calls with
+  cached `tool.before` metadata, and retained a resolved-by-`tool.after` guard
+  after metadata cleanup so delayed terminal part updates stay suppressed. Added
+  regression tests for completed part updates before and after non-zero
+  `tool.after`.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/authoritative-completion-guard.md
+++ b/docs/reviews/patterns/authoritative-completion-guard.md
@@ -3,7 +3,7 @@ id: authoritative-completion-guard
 category: correctness
 created: 2026-06-16
 last_updated: 2026-06-20
-ref_count: 1
+ref_count: 2
 ---
 
 # Authoritative Completion Guard

--- a/docs/reviews/patterns/resource-cleanup.md
+++ b/docs/reviews/patterns/resource-cleanup.md
@@ -2,8 +2,8 @@
 id: resource-cleanup
 category: react-patterns
 created: 2026-04-09
-last_updated: 2026-06-13
-ref_count: 12
+last_updated: 2026-06-20
+ref_count: 13
 ---
 
 # Resource Cleanup
@@ -153,4 +153,13 @@ causes listener accumulation and duplicate event handling.
 - **File:** `crates/backend/src/agent/adapter/kimi/usage_fetch.rs`
 - **Finding:** version_from_command used child.try_wait().ok()? to poll a spawned kimi binary; an Err from try_wait propagated None out of the loop, dropping the child without kill/wait and leaving a zombie process on Unix.
 - **Fix:** Removed version_from_command and the version_from_kimi_binary fallback entirely so the User-Agent version is resolved from transcript metadata or install/latest JSON only, eliminating the zombie-leak surface.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 16. Part-update-only opencode tool calls retained metadata forever
+
+- **Source:** github-claude | PR #588 round 3 | 2026-06-20
+- **Severity:** MEDIUM
+- **File:** `crates/backend/src/agent/adapter/opencode/transcript.rs`
+- **Finding:** `message.part.updated` running events cached tool metadata for every call, but the terminal part-update path only removed `in_flight` state. Calls without a later `tool.after` left one stale metadata entry per completed tool call for the lifetime of the session.
+- **Fix:** Remove the call's metadata immediately after a terminal part update is accepted for calls that do not expect `tool.after`, and add a regression test that asserts pure part-update completion clears the metadata cache.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)


### PR DESCRIPTION
## M5 — opencode transcript streamer + adapter dispatch

Part of VIM-193. Closes VIM-198.

The integration milestone — opencode becomes a **live** adapter. The transcript decoder/streamer, the `OpenCodeAdapter` assembling all five traits, and the `bindings.rs` dispatch arm.

### Changes
- `transcript.rs` — `OpencodeTranscriptDecoder` + `start_tailing`: user `message.updated` → turn (deduped by msg id); tool lifecycle → tool-call start/done/failed (deduped by `(callID, status)`); bash `tool.after` → shared test-runner (cwd = session cwd); `on_caught_up` idempotent (replay_done one-shot, mirrors Codex).
- `mod.rs` — `OpenCodeAdapter` + `with_locator`; the five trait impls + the `AgentAdapter` facade; dropped the blanket dead-code allow now that everything is wired.
- `bindings.rs` — `AgentType::Opencode` arm: one shared `Arc<OpenCodeLocator>` into both the locator slot and the adapter (shared-Arc invariant, avoids the F31 double-retry hazard); `ensure_bridge_installed` is log-and-continue (non-fatal); dispatch tests env-isolate the plugins dir.

### Verification (local; CI re-runs full suite)
- `cargo test --lib opencode`: 83 pass · `bindings`: 75 pass · full backend: 990 pass / 0 fail. `lint` / `type-check` / `format:check` green.

### Notes
- The v1 bridge sanitizer drops `info.path`, so `agent-cwd`-on-change fires only defensively (the initial cwd is still emitted). Documented in code; a future bridge re-adds the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)