### PR TITLE
fix(agent-status): follow codex /clear and in-session resume

### DIFF
--- a/crates/backend/src/agent/adapter/base/watcher_runtime.rs
+++ b/crates/backend/src/agent/adapter/base/watcher_runtime.rs
@@ -56,6 +56,12 @@ fn resolve_transcript_path(
 
 /// Handle to a running watcher — dropping it stops the watcher and polling thread
 pub struct WatcherHandle {
+    /// The status source (Codex: rollout) path this handle is watching.
+    /// Read via `AgentWatcherState::current_status_path` so the relocate
+    /// sequence can skip a no-op re-spawn when a fresh locate returns the
+    /// same path (the drift tick calls `start_agent_watcher` every few
+    /// seconds; re-tailing a 20-114MB rollout on every tick is wasteful).
+    status_path: PathBuf,
     _watcher: Option<RecommendedWatcher>,
     /// Signals the polling fallback thread to exit
     poll_stop: Arc<(Mutex<bool>, Condvar)>,
@@ -564,6 +570,20 @@ impl AgentWatcherState {
         watchers.get(pty_id).map(|handle| handle.agent_type)
     }
 
+    /// The status source path the live watcher for `session_id` is
+    /// currently tailing, or `None` when no watcher is registered. Reads
+    /// the same `watchers` mutex as `contains` / `agent_type_for_pty`, so
+    /// the relocate sequence sees a consistent (path, presence) pair. Used
+    /// by `run_watch_sequence` to skip a no-op re-spawn when a fresh locate
+    /// resolves the same path the handle already watches (drift-tick churn
+    /// guard, VIM-192).
+    pub(crate) fn current_status_path(&self, session_id: &str) -> Option<PathBuf> {
+        let watchers = self.watchers.lock().expect("failed to lock watchers");
+        watchers
+            .get(session_id)
+            .map(|handle| handle.status_path.clone())
+    }
+
     /// Test-only seam to set a pty's agent type without going through a
     /// real watcher startup. Builds a stub `WatcherHandle::new_for_test`
     /// with a fresh `TranscriptState` (whose `stop` is a no-op for an
@@ -770,6 +790,9 @@ pub(crate) fn start_watching(
 ) -> Result<WatcherHandle, String> {
     let located = located.into_inner();
     let status_file_path = located.status_path.clone();
+    // Retained for the `WatcherHandle` so the relocate sequence can compare a
+    // fresh locate against the path this handle is already watching.
+    let handle_status_path = status_file_path.clone();
     let target_path = status_file_path.clone();
     let sid = session_id.clone();
     let last_processed = Arc::new(Mutex::new(Instant::now()));
@@ -1291,6 +1314,7 @@ pub(crate) fn start_watching(
     );
 
     Ok(WatcherHandle {
+        status_path: handle_status_path,
         _watcher: Some(watcher),
         poll_stop,
         join_handle: poll_join_handle,
@@ -1330,6 +1354,7 @@ impl WatcherHandle {
         // overwrites this field — so the default only matters for
         // tests that never call `agent_type_for_pty` on the stub.
         WatcherHandle {
+            status_path: PathBuf::new(),
             _watcher: None,
             poll_stop: Arc::new((Mutex::new(false), Condvar::new())),
             join_handle: None,

--- a/crates/backend/src/agent/adapter/codex/locator.rs
+++ b/crates/backend/src/agent/adapter/codex/locator.rs
@@ -677,7 +677,7 @@ impl SqliteFirstLocator {
                 // argv/sqlite; surface as not-yet-ready so the bind retries and
                 // ultimately fails safe rather than reporting a false relocation.
                 log::debug!(
-                    "codex locator: open-fd provider failed pid={} err={}",
+                    "codex locator resolve: decision=provider-err pid={} err={} -> NotYetReady",
                     ctx.pid,
                     err
                 );
@@ -688,6 +688,10 @@ impl SqliteFirstLocator {
         if rollout_paths.is_empty() {
             // `Ok(∅)`: no open rollout FD — fall back to the early-window
             // strategies (resume-argv / logs / recency).
+            log::debug!(
+                "codex locator resolve: decision=empty-fallback pid={} (no open rollout FD)",
+                ctx.pid
+            );
             return Ok(None);
         }
 
@@ -696,28 +700,78 @@ impl SqliteFirstLocator {
             match self.query_thread_by_rollout_path(state_path, &rollout_path)? {
                 Some(location) => {
                     log::debug!(
-                        "codex locator: using open-fd fast-path pid={} rollout={}",
+                        "codex locator resolve: decision=single-fd pid={} picked_rollout={} picked_thread={} picked_updated_at_ms={}",
                         ctx.pid,
-                        rollout_path.display()
+                        location.rollout_path.display(),
+                        location.thread_id,
+                        location.state_updated_at_ms
                     );
                     Ok(Some(location))
                 }
                 // FD open but the thread row is not written yet — wait for it
                 // rather than falling back to a possibly-stale candidate.
-                None => Err(LocatorError::NotYetReady),
+                None => {
+                    log::debug!(
+                        "codex locator resolve: decision=single-fd-no-row pid={} open_fd={} -> NotYetReady",
+                        ctx.pid,
+                        rollout_path.display()
+                    );
+                    Err(LocatorError::NotYetReady)
+                }
             }
         } else {
+            // codex keeps OLD rollout FDs open after `/clear` and in-session
+            // `resume` (it does not close them), so a single pid can have
+            // several rollouts open at once. They share the same cwd, so cwd
+            // disambiguation cannot pick the active one — choose the MOST
+            // RECENTLY UPDATED open rollout (the live conversation is the one
+            // being written). Erroring on same-cwd ambiguity here (as
+            // `choose_state_candidate` does) strands the panel after every
+            // `/clear`/`resume` — the actual VIM-188 freeze, confirmed by `lsof`
+            // showing one codex pid holding 3 rollout files open.
             let rollout_path_strings: HashSet<String> = rollout_paths
                 .iter()
                 .map(|path| path.to_string_lossy().to_string())
                 .collect();
             let candidates =
                 self.query_candidate_rows(state_path, None, Some(&rollout_path_strings))?;
-            match choose_state_candidate(&candidates, ctx)? {
-                Some(candidate) => Ok(Some(candidate.into_rollout_location())),
-                // Open FDs present but none has a thread row yet — same as above.
-                None => Err(LocatorError::NotYetReady),
+
+            // One decision line per multi-FD resolve (debug, off by default) so
+            // `RUST_LOG=vimeflow_lib=debug` reveals which rollout was bound.
+            let Some(max_updated_at_ms) = candidates.iter().map(|c| c.updated_at_ms).max() else {
+                // Open FDs present but none has a thread row yet — wait for it.
+                log::debug!(
+                    "codex locator resolve: decision=no-rows pid={} open_fds={} -> NotYetReady",
+                    ctx.pid,
+                    rollout_paths.len()
+                );
+                return Err(LocatorError::NotYetReady);
+            };
+            let mut newest = candidates
+                .into_iter()
+                .filter(|c| c.updated_at_ms == max_updated_at_ms);
+            let candidate = newest.next().expect("a max implies at least one row");
+            if newest.next().is_some() {
+                // Two open rollouts share the newest `updated_at_ms` — we can't
+                // tell which is active (input order is non-deterministic), so
+                // fail safe rather than bind arbitrarily. The live rollout
+                // advances its row and breaks the tie on the next retry.
+                log::debug!(
+                    "codex locator resolve: decision=tie-not-yet-ready pid={} max_updated_at_ms={} -> NotYetReady",
+                    ctx.pid,
+                    max_updated_at_ms
+                );
+                return Err(LocatorError::NotYetReady);
             }
+            log::debug!(
+                "codex locator resolve: decision=unique-newest pid={} picked_thread={} picked_rollout={} picked_updated_at_ms={} open_fds={}",
+                ctx.pid,
+                candidate.thread_id,
+                candidate.rollout_path.display(),
+                max_updated_at_ms,
+                rollout_paths.len()
+            );
+            Ok(Some(candidate.into_rollout_location()))
         }
     }
 }
@@ -1543,6 +1597,15 @@ mod sqlite_first_tests {
         .expect("insert thread row");
     }
 
+    fn touch_thread(path: &Path, id: &str, updated_at_ms: i64) {
+        let conn = Connection::open(path).expect("open state db");
+        conn.execute(
+            "UPDATE threads SET updated_at_ms = ? WHERE id = ?",
+            rusqlite::params![updated_at_ms, id],
+        )
+        .expect("update thread row");
+    }
+
     fn ctx<'a>(cwd: &'a Path, pid: u32, pty_start: SystemTime) -> BindContext<'a> {
         BindContext {
             cwd,
@@ -2201,6 +2264,161 @@ mod sqlite_first_tests {
             .expect("multi-fd resolver must find the open rollout beyond the recency limit");
         assert_eq!(result.thread_id, "thread-OPEN");
         assert_eq!(result.rollout_path, rollout_open);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn open_fd_multi_picks_newest_when_codex_leaks_old_rollout_fds() {
+        // codex keeps OLD rollout FDs open across `/clear` and in-session
+        // `resume`, so a single pid holds several same-cwd rollouts open at once
+        // (confirmed by `lsof`). The resolver must pick the most recently updated
+        // (the active conversation) instead of erroring on same-cwd ambiguity —
+        // the latter strands the panel after every `/clear`/`resume` (VIM-188).
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state = dir.path().join("state_1.sqlite");
+        build_state_db(&state);
+        let sessions = dir.path().join("sessions");
+        std::fs::create_dir_all(&sessions).expect("sessions dir");
+
+        let rollout_old = sessions.join("rollout-OLD.jsonl");
+        let rollout_new = sessions.join("rollout-NEW.jsonl");
+        // Same cwd ('/tmp', from insert_thread) — only updated_at_ms differs.
+        insert_thread(
+            &state,
+            "thread-OLD",
+            rollout_old.to_str().expect("utf8"),
+            1000,
+        );
+        insert_thread(
+            &state,
+            "thread-NEW",
+            rollout_new.to_str().expect("utf8"),
+            5000,
+        );
+
+        let proc_root = fake_proc_root();
+        // Stale resume-argv points at the OLD thread — the authoritative open-FD
+        // (newest) must still win, since open-FD is consulted before argv.
+        write_cmdline(proc_root.path(), 8001, &["codex", "resume", "thread-OLD"]);
+        // The pid leaks BOTH rollouts open (the bug).
+        write_rollout_fd(proc_root.path(), 8001, "10", &rollout_old);
+        write_rollout_fd(proc_root.path(), 8001, "11", &rollout_new);
+
+        let locator = SqliteFirstLocator::with_proc_root(
+            dir.path().to_path_buf(),
+            Some(proc_root.path().to_path_buf()),
+        );
+        // ctx cwd matches the threads' cwd → the old resolver would error on
+        // same-cwd ambiguity; the recency pick must still bind the newest.
+        let result = locator
+            .resolve_rollout(&ctx(Path::new("/tmp"), 8001, SystemTime::now()))
+            .expect("same-cwd multi-fd must bind the newest open rollout, not error");
+        assert_eq!(result.thread_id, "thread-NEW");
+        assert_eq!(result.rollout_path, rollout_new);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn open_fd_multi_tied_updated_at_is_not_yet_ready() {
+        // Two open rollouts sharing the newest updated_at_ms are genuinely
+        // ambiguous (input order is non-deterministic) → fail safe with
+        // NotYetReady rather than bind one arbitrarily.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state = dir.path().join("state_1.sqlite");
+        build_state_db(&state);
+        let sessions = dir.path().join("sessions");
+        std::fs::create_dir_all(&sessions).expect("sessions dir");
+
+        let rollout_a = sessions.join("rollout-A.jsonl");
+        let rollout_b = sessions.join("rollout-B.jsonl");
+        insert_thread(&state, "thread-A", rollout_a.to_str().expect("utf8"), 3000);
+        insert_thread(&state, "thread-B", rollout_b.to_str().expect("utf8"), 3000);
+
+        let proc_root = fake_proc_root();
+        write_cmdline(proc_root.path(), 8002, &["codex"]);
+        write_rollout_fd(proc_root.path(), 8002, "10", &rollout_a);
+        write_rollout_fd(proc_root.path(), 8002, "11", &rollout_b);
+
+        let locator = SqliteFirstLocator::with_proc_root(
+            dir.path().to_path_buf(),
+            Some(proc_root.path().to_path_buf()),
+        );
+        let result = locator.resolve_rollout(&ctx(Path::new("/tmp"), 8002, SystemTime::now()));
+        assert!(
+            matches!(result, Err(LocatorError::NotYetReady)),
+            "a tie on the newest updated_at_ms must be NotYetReady, not an arbitrary bind"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn open_fd_multi_self_heals_when_resumed_idle_rollout_is_written() {
+        // The idle-resume signal gap: resuming an OLD conversation does not
+        // advance its `updated_at_ms` until the user interacts, so among leaked
+        // FDs the resolver structurally binds the previously-active (newest)
+        // rollout. There is NO resolver-side signal that can pick the resumed
+        // idle rollout earlier (confirmed: sqlite `updated_at` == file mtime,
+        // no active-thread column, `session_index.jsonl` is a stale title
+        // cache). Recovery is therefore "self-heal on first interaction": once
+        // the resumed rollout is written it becomes newest and the resolver
+        // binds it. This guards the backend half of that contract; the frontend
+        // persistent retry is what re-invokes the resolver until this flips.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state = dir.path().join("state_1.sqlite");
+        build_state_db(&state);
+        let sessions = dir.path().join("sessions");
+        std::fs::create_dir_all(&sessions).expect("sessions dir");
+
+        let rollout_active = sessions.join("rollout-ACTIVE.jsonl");
+        let rollout_resumed = sessions.join("rollout-RESUMED.jsonl");
+        // ACTIVE was the previously-live conversation (newest); RESUMED is the
+        // older conversation the user just resumed to but has not yet typed in.
+        insert_thread(
+            &state,
+            "thread-ACTIVE",
+            rollout_active.to_str().expect("utf8"),
+            5000,
+        );
+        insert_thread(
+            &state,
+            "thread-RESUMED",
+            rollout_resumed.to_str().expect("utf8"),
+            1000,
+        );
+
+        let proc_root = fake_proc_root();
+        write_cmdline(proc_root.path(), 8003, &["codex"]);
+        // The pid leaks BOTH rollouts open.
+        write_rollout_fd(proc_root.path(), 8003, "10", &rollout_active);
+        write_rollout_fd(proc_root.path(), 8003, "11", &rollout_resumed);
+
+        let locator = SqliteFirstLocator::with_proc_root(
+            dir.path().to_path_buf(),
+            Some(proc_root.path().to_path_buf()),
+        );
+
+        // Phase 1 — RESUMED is still idle (older): the resolver binds ACTIVE.
+        // This is the unavoidable signal-gap miss, not a bug.
+        let before = locator
+            .resolve_rollout(&ctx(Path::new("/tmp"), 8003, SystemTime::now()))
+            .expect("multi-fd binds the newest open rollout");
+        assert_eq!(
+            before.thread_id, "thread-ACTIVE",
+            "before interaction, the idle resumed rollout cannot be distinguished from the active one"
+        );
+
+        // Phase 2 — the user interacts with RESUMED, advancing its row past
+        // ACTIVE. A re-invoked resolve (what the persistent retry does) now
+        // binds RESUMED, so the panel recovers without a manual click.
+        touch_thread(&state, "thread-RESUMED", 9000);
+        let after = locator
+            .resolve_rollout(&ctx(Path::new("/tmp"), 8003, SystemTime::now()))
+            .expect("multi-fd re-resolve after the resumed rollout is written");
+        assert_eq!(
+            after.thread_id, "thread-RESUMED",
+            "once the resumed rollout is the newest, the resolver self-heals onto it"
+        );
+        assert_eq!(after.rollout_path, rollout_resumed);
     }
 }
 

--- a/crates/backend/src/agent/adapter/session_lifecycle.rs
+++ b/crates/backend/src/agent/adapter/session_lifecycle.rs
@@ -310,6 +310,54 @@ mod tests {
         }
     }
 
+    /// Locator that resolves a caller-chosen status path under a trust root,
+    /// for exercising the Codex no-op relocate (idempotency) branch.
+    struct StubPathLocator {
+        status_path: PathBuf,
+        trust_root: PathBuf,
+    }
+
+    impl StatusSourceLocator for StubPathLocator {
+        fn locate(
+            &self,
+            _cwd: &std::path::Path,
+            _session_id: &str,
+        ) -> Result<LocatedStatusSource, String> {
+            Ok(LocatedStatusSource {
+                status_path: self.status_path.clone(),
+                trust_root: self.trust_root.clone(),
+                static_transcript_hint: None,
+                agent_session_id: None,
+            })
+        }
+    }
+
+    fn write_stub_status(path: &Path) {
+        std::fs::create_dir_all(path.parent().expect("status path has parent"))
+            .expect("create status dir");
+        std::fs::write(path, r#"{"session_id":"sid","model":{}}"#).expect("write status");
+    }
+
+    fn stub_bindings(
+        agent_type: AgentType,
+        status_path: PathBuf,
+        trust_root: PathBuf,
+    ) -> AgentBindings {
+        let adapter: Arc<crate::agent::adapter::claude_code::ClaudeCodeAdapter> =
+            Arc::new(crate::agent::adapter::claude_code::ClaudeCodeAdapter);
+        AgentBindings {
+            agent_type,
+            locator: Arc::new(StubPathLocator {
+                status_path,
+                trust_root,
+            }),
+            decoder: adapter.clone(),
+            transcript_paths: adapter.clone(),
+            validator: adapter.clone(),
+            streamer: adapter,
+        }
+    }
+
     #[test]
     fn t_verb_locate_err_forwarding() {
         let adapter: Arc<crate::agent::adapter::claude_code::ClaudeCodeAdapter> =
@@ -575,6 +623,162 @@ mod tests {
 
         watcher_state.remove(&sid);
     }
+
+    #[tokio::test]
+    async fn codex_relocate_same_rollout_is_noop_changed_false() {
+        // Drift tick re-locates the active Codex pane every few seconds. When
+        // the locate resolves the SAME rollout already watched, the relocate
+        // must be a no-op (changed=false) so it neither re-tails the (large)
+        // rollout nor lets the frontend optimistic-clear red (VIM-192).
+        let tmp = TempDir::new().expect("tempdir");
+        let trust_root = tmp.path().to_path_buf();
+        let status_path = trust_root.join("sessions").join("a").join("status.json");
+        write_stub_status(&status_path);
+        let sid = "codex-sess".to_string();
+        let watcher_state = AgentWatcherState::new();
+        let transcript_state = TranscriptState::new();
+
+        let lifecycle = SessionLifecycle::new(
+            PtyState::new(),
+            watcher_state.clone(),
+            transcript_state,
+            Arc::new(FakeEventSink::new()),
+        );
+
+        // First attach: a real relocate.
+        let changed = lifecycle
+            .start_inner_for_test(
+                sid.clone(),
+                stub_bindings(AgentType::Codex, status_path.clone(), trust_root.clone()),
+                tmp.path().to_path_buf(),
+            )
+            .await
+            .expect("first codex attach");
+        assert!(changed, "first attach must report changed=true");
+        assert_eq!(
+            watcher_state.current_status_path(&sid).as_deref(),
+            Some(status_path.as_path()),
+            "handle records the rollout it watches"
+        );
+
+        // Second attach, same rollout: idempotent no-op.
+        let changed_again = lifecycle
+            .start_inner_for_test(
+                sid.clone(),
+                stub_bindings(AgentType::Codex, status_path.clone(), trust_root.clone()),
+                tmp.path().to_path_buf(),
+            )
+            .await
+            .expect("second codex attach (same rollout)");
+        assert!(
+            !changed_again,
+            "re-locating the SAME rollout must be a no-op (changed=false)"
+        );
+        assert_eq!(
+            watcher_state.current_status_path(&sid).as_deref(),
+            Some(status_path.as_path()),
+            "still watching the same rollout"
+        );
+
+        watcher_state.remove(&sid);
+    }
+
+    #[tokio::test]
+    async fn codex_relocate_changed_rollout_respawns_changed_true() {
+        // A genuine switch (resume -> different rollout becomes newest) must
+        // relocate and report changed=true so the panel follows it.
+        let tmp = TempDir::new().expect("tempdir");
+        let trust_root = tmp.path().to_path_buf();
+        let path1 = trust_root.join("sessions").join("a").join("status.json");
+        let path2 = trust_root.join("sessions").join("b").join("status.json");
+        write_stub_status(&path1);
+        write_stub_status(&path2);
+        let sid = "codex-sess".to_string();
+        let watcher_state = AgentWatcherState::new();
+
+        let lifecycle = SessionLifecycle::new(
+            PtyState::new(),
+            watcher_state.clone(),
+            TranscriptState::new(),
+            Arc::new(FakeEventSink::new()),
+        );
+
+        lifecycle
+            .start_inner_for_test(
+                sid.clone(),
+                stub_bindings(AgentType::Codex, path1.clone(), trust_root.clone()),
+                tmp.path().to_path_buf(),
+            )
+            .await
+            .expect("attach path1");
+
+        let changed = lifecycle
+            .start_inner_for_test(
+                sid.clone(),
+                stub_bindings(AgentType::Codex, path2.clone(), trust_root.clone()),
+                tmp.path().to_path_buf(),
+            )
+            .await
+            .expect("relocate to path2");
+        assert!(changed, "switching rollout must report changed=true");
+        assert_eq!(
+            watcher_state.current_status_path(&sid).as_deref(),
+            Some(path2.as_path()),
+            "now watching the new rollout"
+        );
+
+        watcher_state.remove(&sid);
+    }
+
+    #[tokio::test]
+    async fn non_codex_relocate_always_respawns_even_for_same_path() {
+        // The no-op is Codex-scoped: Claude/Kimi keep their always-respawn
+        // restart semantics, so a same-path re-locate still reports changed=true.
+        let tmp = TempDir::new().expect("tempdir");
+        let trust_root = tmp.path().to_path_buf();
+        let status_path = trust_root.join("sessions").join("a").join("status.json");
+        write_stub_status(&status_path);
+        let sid = "claude-sess".to_string();
+        let watcher_state = AgentWatcherState::new();
+
+        let lifecycle = SessionLifecycle::new(
+            PtyState::new(),
+            watcher_state.clone(),
+            TranscriptState::new(),
+            Arc::new(FakeEventSink::new()),
+        );
+
+        lifecycle
+            .start_inner_for_test(
+                sid.clone(),
+                stub_bindings(
+                    AgentType::ClaudeCode,
+                    status_path.clone(),
+                    trust_root.clone(),
+                ),
+                tmp.path().to_path_buf(),
+            )
+            .await
+            .expect("first claude attach");
+        let changed_again = lifecycle
+            .start_inner_for_test(
+                sid.clone(),
+                stub_bindings(
+                    AgentType::ClaudeCode,
+                    status_path.clone(),
+                    trust_root.clone(),
+                ),
+                tmp.path().to_path_buf(),
+            )
+            .await
+            .expect("second claude attach");
+        assert!(
+            changed_again,
+            "non-Codex agents always respawn (changed=true) even for the same path"
+        );
+
+        watcher_state.remove(&sid);
+    }
 }
 
 impl SessionLifecycle {
@@ -798,7 +1002,11 @@ impl SessionLifecycle {
         );
         let bindings = self.bind_services(&attach)?;
         let cwd = attach.initial_cwd.clone();
-        self.run_watch_sequence(session_id, bindings, cwd).await
+        // The Codex no-op `changed` flag is only consumed by tests (via
+        // `start_inner_for_test` -> `run_watch_sequence`); production callers
+        // don't read it, so discard it here.
+        self.run_watch_sequence(session_id, bindings, cwd).await?;
+        Ok(())
     }
 
     /// The post-bindings half of `start`: the verb sequence run on the
@@ -840,12 +1048,20 @@ impl SessionLifecycle {
     /// deleted the `evict_old` call: `insert` does the atomic replace
     /// it was designed for, and the spawn-failure-rollback property is
     /// preserved by the spawn-before-register ordering alone.
+    ///
+    /// Returns `Ok(true)` when the watcher was (re)spawned onto the located
+    /// path, and `Ok(false)` for a Codex no-op relocate — a fresh locate that
+    /// resolved the SAME rollout the live handle already watches. The drift
+    /// tick (VIM-192) calls this every few seconds for the active Codex pane, so
+    /// skipping the re-spawn avoids re-tailing a 20-114MB rollout on every tick.
+    /// The `bool` is observed only by tests (`start_inner_for_test`); production
+    /// callers discard it.
     async fn run_watch_sequence(
         &self,
         session_id: String,
         bindings: AgentBindings,
         cwd: std::path::PathBuf,
-    ) -> Result<(), String> {
+    ) -> Result<bool, String> {
         // Locate outside the long-running spawn_blocking closure so kimi's
         // retry delay can be an async `tokio::time::sleep` that yields the
         // task. The actual filesystem work still runs on the blocking pool
@@ -855,6 +1071,23 @@ impl SessionLifecycle {
         let lc = self.clone();
         tokio::task::spawn_blocking(move || {
             let trusted = lc.ensure_trust(located)?;
+
+            // Codex-only no-op: if the fresh locate resolved the SAME rollout
+            // the live handle already watches, skip spawn_watch + register
+            // entirely. Scoped to Codex because only its locator sets
+            // `status_path` to the rollout path (CompositeLocator); Claude /
+            // Kimi keep their existing always-respawn restart semantics.
+            if bindings.agent_type == AgentType::Codex
+                && lc.watcher_state.current_status_path(&session_id).as_deref()
+                    == Some(trusted.status_path())
+            {
+                log::debug!(
+                    "codex relocate: no-op (same rollout still watched) session={} path={}",
+                    session_id,
+                    trusted.status_path().display(),
+                );
+                return Ok::<bool, String>(false);
+            }
 
             log::debug!(
                 "Watcher startup detail: session={}, cwd={}, path={}",
@@ -903,7 +1136,7 @@ impl SessionLifecycle {
             // the full invariant statement (PR #302 cycle 3 deleted a
             // separate `evict_old` call that broke this property).
             lc.register(session_id, handle, agent_type);
-            Ok::<_, String>(())
+            Ok::<bool, String>(true)
         })
         .await
         .map_err(|e| format!("start_agent_watcher task panicked: {}", e))?
@@ -920,7 +1153,7 @@ impl SessionLifecycle {
         session_id: String,
         bindings: AgentBindings,
         cwd: std::path::PathBuf,
-    ) -> Result<(), String> {
+    ) -> Result<bool, String> {
         self.run_watch_sequence(session_id, bindings, cwd).await
     }
 

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -49,7 +49,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Imperative Animation Ownership](patterns/imperative-animation-ownership.md)                         | react-patterns     | 7        | 3    | 2026-06-17   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Fixed-Position Portals](patterns/fixed-position-portals.md)                                         | react-patterns     | 1        | 0    | 2026-06-12   |
-| [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 16       | 13   | 2026-06-20   |
+| [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 17       | 14   | 2026-06-21   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)                                             | cross-platform     | 8        | 4    | 2026-06-20   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                                                       | code-quality       | 7        | 0    | 2026-06-11   |
 | [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 12       | 9    | 2026-06-19   |
@@ -58,10 +58,10 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 3        | 0    | 2026-06-16   |
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 74       | 34   | 2026-06-18   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
-| [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 88       | 25   | 2026-06-16   |
+| [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 89       | 27   | 2026-06-21   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 72       | 30   | 2026-06-20   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
-| [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 67       | 24   | 2026-06-20   |
+| [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 67       | 25   | 2026-06-20   |
 | [Canonical Path Dedupe](patterns/canonical-path-dedupe.md)                                           | correctness        | 2        | 0    | 2026-06-14   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)                                       | backend            | 4        | 2    | 2026-06-14   |
 | [Command Injection](patterns/command-injection.md)                                                   | security           | 8        | 3    | 2026-06-16   |

--- a/docs/reviews/patterns/async-race-conditions.md
+++ b/docs/reviews/patterns/async-race-conditions.md
@@ -3,7 +3,7 @@ id: async-race-conditions
 category: react-patterns
 created: 2026-04-09
 last_updated: 2026-06-20
-ref_count: 24
+ref_count: 25
 ---
 
 # Async Race Conditions

--- a/docs/reviews/patterns/documentation-accuracy.md
+++ b/docs/reviews/patterns/documentation-accuracy.md
@@ -2,8 +2,8 @@
 id: documentation-accuracy
 category: code-quality
 created: 2026-04-09
-last_updated: 2026-06-16
-ref_count: 26
+last_updated: 2026-06-21
+ref_count: 27
 ---
 
 # Documentation Accuracy
@@ -827,4 +827,13 @@ Stale documentation misleads future contributors and review agents.
 - **File:** `README.zh-CN.md`
 - **Finding:** The line read `代理可观测性：Claude Code、Codex CLI 和 Kimi Code`; the reviewer requested the term be rendered as `agent可观测性` to keep the English product term consistent with the bilingual docs.
 - **Fix:** Replaced `代理可观测性` with `agent可观测性` on line 22.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 89. Reattach hook comment still references removed manual button
+
+- **Source:** github-claude | PR #592 round 1 | 2026-06-21
+- **Severity:** LOW
+- **File:** `src/features/agent-status/hooks/useAgentReattach.ts`
+- **Finding:** A comment on `resolveArmedReattach` still said the helper was shared by the success listener and the manual button, but this PR removed the manual reattach button.
+- **Fix:** Updated stale comments so they describe the current automatic success-listener and bounded-retry/drift behavior.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/resource-cleanup.md
+++ b/docs/reviews/patterns/resource-cleanup.md
@@ -3,7 +3,7 @@ id: resource-cleanup
 category: react-patterns
 created: 2026-04-09
 last_updated: 2026-06-20
-ref_count: 13
+ref_count: 14
 ---
 
 # Resource Cleanup
@@ -163,3 +163,12 @@ causes listener accumulation and duplicate event handling.
 - **Finding:** `RealLsofRunner::run` used `child.try_wait()?` inside its polling loop. A rare polling error returned before the timeout branch's cleanup sequence, so the spawned `lsof` child could remain running or unreaped and the stdout reader thread could be left detached in the long-lived sidecar.
 - **Fix:** Replaced the `?` with an explicit `match`. The `Err` arm now mirrors timeout cleanup by killing the child, waiting to reap it, joining the stdout reader, and then returning the original polling error.
 - **Commit:** same commit as this entry
+
+### 17. Drift reattach can leave a watcher running after pane switch
+
+- **Source:** github-codex-connector | PR #592 round 1 | 2026-06-21
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/agent-status/hooks/useAgentReattach.ts`
+- **Finding:** A periodic drift `start_agent_watcher` could still resolve after the active Codex pane switched away; cleanup cancelled the next timer but did not stop the backend watcher that the late IPC registered for the inactive PTY.
+- **Fix:** Captured the starting session, PTY id, and reattach generation, then stopped the captured PTY watcher if the start resolved after the hook no longer owned that generation. Added a regression test for switching panes while the drift start is in flight.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/src/features/agent-status/components/AgentStatusPanel/Header.test.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/Header.test.tsx
@@ -107,7 +107,6 @@ test('shows the red needs-reattach state when stale', () => {
     <AgentStatusPanelHeader
       agent={AGENTS.codex}
       needsReattach
-      onReattach={() => undefined}
       onCollapse={() => undefined}
     />
   )
@@ -116,30 +115,17 @@ test('shows the red needs-reattach state when stale', () => {
     'data-stale',
     'true'
   )
-  expect(screen.getByText('reattach needed')).toBeInTheDocument()
+  // The red state is an instruction (recovery is automatic once the user sends
+  // a prompt), not a clickable action.
+  expect(screen.getByText('send a prompt to reattach')).toBeInTheDocument()
   expect(screen.getByText('link_off')).toBeInTheDocument()
 })
 
-test('renders a Reattach button that fires onReattach', async () => {
-  const onReattach = vi.fn()
+test('never renders a manual reattach button (recovery is automatic)', () => {
   render(
     <AgentStatusPanelHeader
       agent={AGENTS.codex}
-      onReattach={onReattach}
-      onCollapse={() => undefined}
-    />
-  )
-
-  await userEvent.click(
-    screen.getByRole('button', { name: /reattach agent session/i })
-  )
-  expect(onReattach).toHaveBeenCalledTimes(1)
-})
-
-test('omits the Reattach button when no handler is provided', () => {
-  render(
-    <AgentStatusPanelHeader
-      agent={AGENTS.claude}
+      needsReattach
       onCollapse={() => undefined}
     />
   )

--- a/src/features/agent-status/components/AgentStatusPanel/Header.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/Header.tsx
@@ -6,10 +6,12 @@ import type { Agent } from '../../../../agents/registry'
 export interface AgentStatusPanelHeaderProps {
   agent: Agent
   isRefreshing?: boolean
-  /** Session is known-stale (codex `/clear`/`resume`): show the red state. */
+  /**
+   * Session is known-stale after a codex `/clear`: show the red state. Recovery
+   * is automatic — the watcher relocates once codex writes the conversation
+   * (i.e. when the user sends a prompt), so this is an instruction, not a button.
+   */
   needsReattach?: boolean
-  /** When provided, render the Reattach button (the universal recovery). */
-  onReattach?: () => void
   onCollapse: () => void
   reserveWindowControls?: boolean
 }
@@ -18,7 +20,6 @@ export const AgentStatusPanelHeader = ({
   agent,
   isRefreshing = false,
   needsReattach = false,
-  onReattach = undefined,
   onCollapse,
   reserveWindowControls = false,
 }: AgentStatusPanelHeaderProps): ReactElement => (
@@ -71,20 +72,12 @@ export const AgentStatusPanelHeader = ({
         }`}
       >
         {needsReattach
-          ? 'reattach needed'
+          ? 'send a prompt to reattach'
           : isRefreshing
             ? 'fetching latest'
             : 'updated now'}
       </span>
     </div>
-    {onReattach !== undefined && (
-      <IconButton
-        icon="refresh"
-        label="Reattach agent session"
-        onClick={onReattach}
-        className={`vf-app-no-drag shrink-0 ${needsReattach ? 'text-error' : ''}`}
-      />
-    )}
     <IconButton
       icon="chevron_right"
       label="Collapse activity panel"

--- a/src/features/agent-status/components/AgentStatusPanel/index.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/index.tsx
@@ -38,7 +38,6 @@ interface AgentStatusPanelProps {
   gitStatus?: UseGitStatusReturn
   isRefreshing?: boolean
   needsReattach?: boolean
-  onReattach?: () => void
   agent: Agent
   onCollapse: () => void
   cacheHistory: number[]
@@ -305,7 +304,6 @@ export const AgentStatusPanel = ({
   gitStatus = undefined,
   isRefreshing = false,
   needsReattach = false,
-  onReattach = undefined,
   agent,
   onCollapse,
   cacheHistory,
@@ -542,7 +540,6 @@ export const AgentStatusPanel = ({
         agent={agent}
         isRefreshing={showsRefreshing}
         needsReattach={needsReattach}
-        onReattach={onReattach}
         onCollapse={onCollapse}
         reserveWindowControls={reserveWindowControls}
       />

--- a/src/features/agent-status/hooks/useAgentReattach.test.ts
+++ b/src/features/agent-status/hooks/useAgentReattach.test.ts
@@ -672,6 +672,51 @@ test('the drift tick re-locates a live Codex pane on a cadence', async () => {
   expect(invoke).toHaveBeenCalledTimes(2)
 })
 
+test('stops a drift-started watcher when the active pane switches before it resolves', async () => {
+  let resolveStart: (() => void) | undefined
+
+  vi.mocked(invoke).mockImplementation(((cmd: string) => {
+    if (cmd === 'start_agent_watcher') {
+      return new Promise((resolve) => {
+        resolveStart = (): void => {
+          resolve(null)
+        }
+      })
+    }
+
+    return Promise.resolve(null)
+  }) as unknown as typeof invoke)
+
+  const { rerender } = renderHook(
+    ({ sessionId }) =>
+      useAgentReattach({
+        sessionId,
+        agentSessionId: 'codex-1',
+        staleGeneration: 0,
+        driftEnabled: true,
+      }),
+    { initialProps: { sessionId: 'session-1' } }
+  )
+
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(4000)
+  })
+  expect(resolveStart).toBeDefined()
+
+  act(() => {
+    rerender({ sessionId: 'session-2' })
+  })
+
+  await act(async () => {
+    resolveStart?.()
+    await Promise.resolve()
+  })
+
+  expect(invoke).toHaveBeenCalledWith('stop_agent_watcher', {
+    sessionId: 'pty-session-1',
+  })
+})
+
 test('no drift tick when driftEnabled is false', async () => {
   renderHook(() =>
     useAgentReattach({

--- a/src/features/agent-status/hooks/useAgentReattach.test.ts
+++ b/src/features/agent-status/hooks/useAgentReattach.test.ts
@@ -77,61 +77,6 @@ afterEach(() => {
   vi.clearAllMocks()
 })
 
-test('reattach re-invokes start_agent_watcher for the resolved pty', () => {
-  const { result } = renderHook(() =>
-    useAgentReattach({
-      sessionId: 'session-1',
-      agentSessionId: null,
-      staleGeneration: 0,
-    })
-  )
-
-  act(() => {
-    result.current.reattach()
-  })
-
-  expect(invoke).toHaveBeenCalledWith('start_agent_watcher', {
-    sessionId: 'pty-session-1',
-  })
-})
-
-test('reattach is a no-op without a session', () => {
-  const { result } = renderHook(() =>
-    useAgentReattach({
-      sessionId: null,
-      agentSessionId: null,
-      staleGeneration: 0,
-    })
-  )
-
-  act(() => {
-    result.current.reattach()
-  })
-
-  expect(invoke).not.toHaveBeenCalled()
-})
-
-test('reattach is single-flight while one is in progress', () => {
-  vi.mocked(invoke).mockImplementation(
-    () => new Promise<never>(() => undefined) // never resolves
-  )
-
-  const { result } = renderHook(() =>
-    useAgentReattach({
-      sessionId: 'session-1',
-      agentSessionId: null,
-      staleGeneration: 0,
-    })
-  )
-
-  act(() => {
-    result.current.reattach()
-    result.current.reattach()
-  })
-
-  expect(invoke).toHaveBeenCalledTimes(1)
-})
-
 test('a stale-generation bump marks needsReattach', () => {
   const { result, rerender } = renderHook(
     ({ gen }) =>
@@ -175,7 +120,8 @@ test('stale state triggers a bounded, deferred auto-reattach', async () => {
   })
   expect(invoke).toHaveBeenCalledTimes(1)
 
-  // Bounded: retries cap out (5 issued calls total) and then stop.
+  // Bounded: retries cap out (5 issued calls total) and then stop. Late
+  // recovery is the drift tick's job, not this red-armed window.
   await act(async () => {
     await vi.advanceTimersByTimeAsync(700 * 6)
   })
@@ -204,6 +150,7 @@ test('auto-reattach stops after bounded no-op rounds when pty is absent', async 
   })
 
   expect(invoke).not.toHaveBeenCalled()
+  // Bounded window only (drift is off — no driftEnabled), so it fully stops.
   expect(vi.getTimerCount()).toBe(0)
 })
 
@@ -558,7 +505,8 @@ test('auto-reattach keeps retrying after an IPC failure', async () => {
   })
   expect(invoke).toHaveBeenCalledTimes(1)
 
-  // A rejecting invoke must not halt the bounded retry loop.
+  // A rejecting invoke must not halt the bounded retry loop (a 'failed' invoke
+  // counts as issued, so the budget is spent the same as a resolving one).
   await act(async () => {
     await vi.advanceTimersByTimeAsync(700 * 6)
   })
@@ -602,4 +550,167 @@ test('a recovered pane does not re-arm when re-selected', () => {
     rerender({ sid: 'session-1', aid: 'codex-new', gen: 1 })
   })
   expect(result.current.needsReattach).toBe(false)
+})
+
+test('the auto-retry never clears red on its own without a fresh event', async () => {
+  const { result, rerender } = renderHook(
+    ({ gen }) =>
+      useAgentReattach({
+        sessionId: 'session-1',
+        agentSessionId: null,
+        staleGeneration: gen,
+      }),
+    { initialProps: { gen: 0 } }
+  )
+
+  act(() => {
+    rerender({ gen: 1 })
+  })
+
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(400 + 700 * 6)
+  })
+  // The bounded retry fired its budget...
+  expect(invoke).toHaveBeenCalledTimes(5)
+  // ...but never cleared red on its own — clearing is strictly event-gated.
+  expect(result.current.needsReattach).toBe(true)
+})
+
+test('a late different-id event clears red even after the bounded retry has stopped', async () => {
+  const { result, rerender } = renderHook(
+    ({ aid, gen }) =>
+      useAgentReattach({
+        sessionId: 'session-1',
+        agentSessionId: aid,
+        staleGeneration: gen,
+      }),
+    { initialProps: { aid: 'codex-old' as string | null, gen: 0 } }
+  )
+
+  act(() => {
+    rerender({ aid: 'codex-old', gen: 1 })
+  })
+
+  // Let the bounded retry fully exhaust — red is stuck (no fresh event yet).
+  // This is the idle-`resume` / slow recovery timeline: the drift tick (off in
+  // this unit, gated by driftEnabled) is what eventually relocates in the app;
+  // here we assert the event listener still clears whenever that lands.
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(400 + 700 * 6)
+  })
+  expect(result.current.needsReattach).toBe(true)
+
+  // A relocate finally lands on the new rollout (a DIFFERENT agentSessionId) →
+  // the always-live event listener clears red regardless of retry phase.
+  act(() => {
+    emit('agent-status', makeEvent({ agentSessionId: 'codex-new' }))
+  })
+  expect(result.current.needsReattach).toBe(false)
+})
+
+test('a stale same-id event with no token reset does not clear red', () => {
+  const { result, rerender } = renderHook(
+    ({ aid, total, gen }) =>
+      useAgentReattach({
+        sessionId: 'session-1',
+        agentSessionId: aid,
+        agentTokenTotal: total,
+        staleGeneration: gen,
+      }),
+    {
+      initialProps: {
+        aid: 'codex-1' as string | null,
+        total: 100 as number | null,
+        gen: 0,
+      },
+    }
+  )
+
+  // /clear captures the pre-clear identity: staleId='codex-1', staleTotal=100.
+  act(() => {
+    rerender({ aid: 'codex-1', total: 100, gen: 1 })
+  })
+  expect(result.current.needsReattach).toBe(true)
+
+  // The OLD watcher keeps emitting the captured id with a GROWING token total
+  // (not a reset). With persistent retry now firing forever, this replay must
+  // still not be mistaken for a relocate — clearing requires a different id or
+  // a genuine token reset (codex review: guard the stale-replay exposure).
+  act(() => {
+    emit(
+      'agent-status',
+      makeEvent({
+        agentSessionId: 'codex-1',
+        contextWindow: makeContextWindow(200),
+      })
+    )
+  })
+  expect(result.current.needsReattach).toBe(true)
+})
+
+// --- always-on drift tick (VIM-192): follow an in-session resume ---
+
+test('the drift tick re-locates a live Codex pane on a cadence', async () => {
+  renderHook(() =>
+    useAgentReattach({
+      sessionId: 'session-1',
+      agentSessionId: 'codex-1',
+      // Not stale (gen 0) → no red, no bounded retry. Only the drift tick runs.
+      staleGeneration: 0,
+      driftEnabled: true,
+    })
+  )
+
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(4000)
+  })
+  expect(invoke).toHaveBeenCalledTimes(1)
+
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(4000)
+  })
+  expect(invoke).toHaveBeenCalledTimes(2)
+})
+
+test('no drift tick when driftEnabled is false', async () => {
+  renderHook(() =>
+    useAgentReattach({
+      sessionId: 'session-1',
+      agentSessionId: 'codex-1',
+      staleGeneration: 0,
+      driftEnabled: false,
+    })
+  )
+
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(4000 * 3)
+  })
+  // Not Codex / no live agent → no periodic lsof cost.
+  expect(invoke).not.toHaveBeenCalled()
+})
+
+test('the drift tick never clears red on its own (event-gated)', async () => {
+  // Clearing is strictly event-gated: only a fresh `agent-status` event clears
+  // red. The drift tick is fire-and-forget — it re-locates but never resolves.
+  const { result, rerender } = renderHook(
+    ({ aid, gen }) =>
+      useAgentReattach({
+        sessionId: 'session-1',
+        agentSessionId: aid,
+        staleGeneration: gen,
+        driftEnabled: true,
+      }),
+    { initialProps: { aid: 'codex-1' as string | null, gen: 0 } }
+  )
+
+  act(() => {
+    rerender({ aid: 'codex-1', gen: 1 })
+  })
+
+  // Let both the bounded retry and several drift ticks fire.
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(4000 * 3)
+  })
+  // No agent-status event was emitted → red persists despite the relocates.
+  expect(result.current.needsReattach).toBe(true)
 })

--- a/src/features/agent-status/hooks/useAgentReattach.ts
+++ b/src/features/agent-status/hooks/useAgentReattach.ts
@@ -43,6 +43,14 @@ const eventTokenTotal = (
     : Number(contextWindow.totalInputTokens) +
       Number(contextWindow.totalOutputTokens)
 
+const stopReattachWatcher = async (ptyId: string): Promise<void> => {
+  try {
+    await invoke('stop_agent_watcher', { sessionId: ptyId })
+  } catch {
+    // Watcher may not be running — ignore.
+  }
+}
+
 interface UseAgentReattachOptions {
   /** Workspace session id of the active pty-backed pane (or `null`). */
   sessionId: string | null
@@ -116,7 +124,14 @@ export const useAgentReattach = ({
   agentTokenTotalRef.current = agentTokenTotal
   const currentStaleKeyRef = useRef(staleKey)
   currentStaleKeyRef.current = staleKey
-  // Single-flight guard so a manual click and the auto-retry can't issue
+  const currentSessionIdRef = useRef(sessionId)
+  const reattachGenerationRef = useRef(0)
+  if (currentSessionIdRef.current !== sessionId) {
+    currentSessionIdRef.current = sessionId
+    reattachGenerationRef.current += 1
+  }
+  const isMountedRef = useRef(true)
+  // Single-flight guard so the drift tick and auto-retry can't issue
   // overlapping `start_agent_watcher` invokes.
   const inFlightRef = useRef(false)
   // The agent session id that was live when the pane went stale. The relocated
@@ -136,10 +151,19 @@ export const useAgentReattach = ({
   // newer `/clear` generation that arrived while the event was in flight.
   const armedStaleKeyRef = useRef<string | null>(null)
 
+  useEffect(() => {
+    isMountedRef.current = true
+
+    return (): void => {
+      isMountedRef.current = false
+      reattachGenerationRef.current += 1
+    }
+  }, [])
+
   // Resolve the armed `/clear` cycle: mark its key resolved and drop red. If a
   // NEWER `/clear` armed after this resolve was decided, re-arm for it instead
   // of clearing (it still needs its own recovery). No-op when not currently
-  // stale. Shared by the success listener and the manual button.
+  // stale. Called by the success listener.
   const resolveArmedReattach = useCallback((): void => {
     if (!needsReattachRef.current) {
       return
@@ -180,11 +204,28 @@ export const useAgentReattach = ({
     if (!ptyId || inFlightRef.current) {
       return 'skipped'
     }
+    const startSessionId = sessionId
+    const startGeneration = reattachGenerationRef.current
     inFlightRef.current = true
     // No stop-then-start: the backend re-locates and atomically replaces the
     // watcher; a failed relocate leaves the old watcher intact (rollback-safe).
     try {
       await invoke('start_agent_watcher', { sessionId: ptyId })
+
+      const activeSessionChanged =
+        currentSessionIdRef.current !== startSessionId
+
+      const staleCompletion =
+        !isMountedRef.current ||
+        activeSessionChanged ||
+        reattachGenerationRef.current !== startGeneration
+      if (staleCompletion) {
+        if (activeSessionChanged) {
+          void stopReattachWatcher(ptyId)
+        }
+
+        return 'skipped'
+      }
 
       return 'ok'
     } catch {
@@ -339,7 +380,7 @@ export const useAgentReattach = ({
   // relocate reports `changed=true`, and its fresh `agent-status` event updates
   // the panel (and clears red if a `/clear` cycle happens to be armed). A
   // same-rollout tick is a cheap backend no-op. Single-flight is shared with the
-  // bounded retry + manual button (`inFlightRef`), so the periodic `lsof` can't
+  // bounded retry (`inFlightRef`), so the periodic `lsof` can't
   // stack. Off unless the active pane runs a live Codex agent.
   useEffect(() => {
     if (!driftEnabled || sessionId === null) {

--- a/src/features/agent-status/hooks/useAgentReattach.ts
+++ b/src/features/agent-status/hooks/useAgentReattach.ts
@@ -7,18 +7,33 @@ import type { AgentStatusEvent } from '../types'
 // file on the SAME pid, but the backend transcript watcher was pinned to the
 // old rollout at attach time, so the panel silently stops updating (VIM-188).
 // Reattach re-invokes `start_agent_watcher`, whose `run_watch_sequence`
-// re-locates the rollout (now open-FD authoritative, VIM-191) and atomically
-// replaces the watcher — no stop-then-start.
+// re-locates the rollout (open-FD authoritative, VIM-191; idempotent no-op when
+// unchanged, VIM-192) and atomically replaces the watcher — no stop-then-start.
 //
-// `/clear` is detectable but fires BEFORE codex opens the new rollout, so the
-// auto-reattach is deferred and bounded-retried until a fresh `agent-status`
-// with a new `agentSessionId` proves the relocate landed. The in-session
-// `resume` is undetectable, so the manual Reattach button is the universal
-// recovery.
+// Recovery is fully automatic; there is NO manual button (it would mislead,
+// since the relocate can only land once codex WRITES the conversation — i.e.
+// when the user sends a prompt). Two mechanisms drive it:
+//   - `/clear` is detectable, so it arms a red indicator + a bounded fast
+//     auto-reattach to catch the new rollout the moment codex writes it.
+//   - the in-session `resume` is undetectable, so an always-on drift tick
+//     re-locates the active Codex pane on a cadence; once the resumed
+//     conversation is written it becomes the newest rollout and the relocate
+//     lands. Either way a fresh `agent-status` (new `agentSessionId`) confirms
+//     it and clears the red indicator.
 
 const REATTACH_AUTO_INITIAL_DELAY_MS = 400
 const REATTACH_AUTO_RETRY_INTERVAL_MS = 700
 const REATTACH_AUTO_MAX_ATTEMPTS = 5
+// Always-on drift tick (VIM-192): the active Codex pane re-locates on this
+// cadence, regardless of the red state. An in-session `resume` is undetectable
+// (it types no `/clear`, so red is never armed) and codex exposes no active-thread
+// signal, so the ONLY way the panel can follow a resume is to re-locate
+// periodically and relocate once the resumed conversation is written (it then
+// becomes the newest `updated_at`). The backend relocate is idempotent — a
+// same-rollout re-locate is a cheap no-op (`changed=false`, no re-tail) — so this
+// poll costs one per-pid `lsof` + one sqlite query every few seconds for one
+// pane. Clearing stays event-gated; the drift tick never clears red itself.
+const REATTACH_DRIFT_INTERVAL_MS = 4000
 
 const eventTokenTotal = (
   contextWindow: AgentStatusEvent['contextWindow']
@@ -52,13 +67,24 @@ interface UseAgentReattachOptions {
    * flash red again.
    */
   staleGeneration: number
+  /**
+   * Gate for the always-on drift tick: `true` only when the active pty-backed
+   * pane is running a live Codex agent. Drift re-locates this pane every
+   * `REATTACH_DRIFT_INTERVAL_MS` so the panel follows an in-session `resume`
+   * (undetectable, so it never arms red). Off for non-Codex / no live agent so
+   * the periodic `lsof` cost is paid only where a rollout switch can happen.
+   */
+  driftEnabled?: boolean
 }
 
 export interface AgentReattachControls {
-  /** The session is known-stale and the relocate has not yet landed. */
+  /**
+   * The session is known-stale (a codex `/clear`) and the relocate has not yet
+   * landed. Recovery is automatic — the bounded auto-reattach + the always-on
+   * drift tick relocate once codex writes the conversation — so this drives a
+   * red "send a prompt to reattach" indicator, not a manual action.
+   */
   needsReattach: boolean
-  /** Manually re-invoke the watcher relocate (covers the undetectable resume). */
-  reattach: () => void
 }
 
 /**
@@ -70,6 +96,7 @@ export const useAgentReattach = ({
   agentSessionId,
   agentTokenTotal = null,
   staleGeneration,
+  driftEnabled = false,
 }: UseAgentReattachOptions): AgentReattachControls => {
   const [needsReattach, setNeedsReattach] = useState(false)
 
@@ -109,35 +136,71 @@ export const useAgentReattach = ({
   // newer `/clear` generation that arrived while the event was in flight.
   const armedStaleKeyRef = useRef<string | null>(null)
 
-  // Returns whether it actually issued an invoke (vs skipped under
-  // single-flight) so the auto-retry budget only counts real calls.
-  const reattachAsync = useCallback(async (): Promise<boolean> => {
+  // Resolve the armed `/clear` cycle: mark its key resolved and drop red. If a
+  // NEWER `/clear` armed after this resolve was decided, re-arm for it instead
+  // of clearing (it still needs its own recovery). No-op when not currently
+  // stale. Shared by the success listener and the manual button.
+  const resolveArmedReattach = useCallback((): void => {
+    if (!needsReattachRef.current) {
+      return
+    }
+    const armed = armedStaleKeyRef.current
+    if (armed !== null) {
+      resolvedKeysRef.current.add(armed)
+    }
+    const currentKey = currentStaleKeyRef.current
+    if (
+      currentKey !== null &&
+      currentKey !== armed &&
+      !resolvedKeysRef.current.has(currentKey)
+    ) {
+      armedStaleKeyRef.current = currentKey
+
+      return
+    }
+    armedStaleKeyRef.current = null
+    setNeedsReattach(false)
+  }, [])
+
+  // Issue `start_agent_watcher` under the single-flight guard. Outcome:
+  //   'ok'      — the IPC resolved (await?-propagated; the resolver fails safe
+  //               with `Err`). The backend relocate is idempotent: a same-rollout
+  //               re-locate is a cheap no-op, so this is safe to call on a tick.
+  //   'failed'  — the IPC threw (transient miss / bridge / rollout not open yet).
+  //   'skipped' — no session/pty, or another invoke is already in flight.
+  // Clearing red is strictly event-gated (there is no optimistic clear / manual
+  // button), so the caller never needs to know whether the relocate switched.
+  const issueReattach = useCallback(async (): Promise<
+    'ok' | 'failed' | 'skipped'
+  > => {
     if (sessionId === null) {
-      return false
+      return 'skipped'
     }
     const ptyId = getPtySessionId(sessionId)
     if (!ptyId || inFlightRef.current) {
-      return false
+      return 'skipped'
     }
     inFlightRef.current = true
     // No stop-then-start: the backend re-locates and atomically replaces the
     // watcher; a failed relocate leaves the old watcher intact (rollback-safe).
     try {
       await invoke('start_agent_watcher', { sessionId: ptyId })
+
+      return 'ok'
     } catch {
-      // Relocate failed (transient backend miss / bridge unavailable). Swallow
-      // so the bounded auto-retry keeps going and `void reattach()` never leaves
-      // an unhandled rejection; the old watcher stays intact and we try again.
+      return 'failed'
     } finally {
       inFlightRef.current = false
     }
-
-    return true
   }, [sessionId])
 
-  const reattach = useCallback((): void => {
-    void reattachAsync()
-  }, [reattachAsync])
+  // Auto-retry path: "issued" = an invoke was attempted (ok or failed), so the
+  // budget isn't burned by single-flight skips. It NEVER clears red — clearing
+  // is event-gated (the listener), confirming the relocate actually landed.
+  const reattachAsync = useCallback(
+    async (): Promise<boolean> => (await issueReattach()) !== 'skipped',
+    [issueReattach]
+  )
 
   // Success predicate: a fresh `agent-status` carrying an `agentSessionId` that
   // DIFFERS from the one live when we went stale means the relocated watcher is
@@ -172,22 +235,7 @@ export const useAgentReattach = ({
           (eventTotal === 0 || staleTotal === null || eventTotal < staleTotal)
         const isFresh = id !== null && (id !== staleId || tokensReset)
         if (needsReattachRef.current && isFresh) {
-          const key = armedStaleKeyRef.current
-          if (key !== null) {
-            resolvedKeysRef.current.add(key)
-          }
-          const currentKey = currentStaleKeyRef.current
-          if (
-            currentKey !== null &&
-            currentKey !== key &&
-            !resolvedKeysRef.current.has(currentKey)
-          ) {
-            armedStaleKeyRef.current = currentKey
-
-            return
-          }
-          armedStaleKeyRef.current = null
-          setNeedsReattach(false)
+          resolveArmedReattach()
         }
       })
       if (cancelled) {
@@ -203,7 +251,7 @@ export const useAgentReattach = ({
       cancelled = true
       unlisten?.()
     }
-  }, [sessionId])
+  }, [sessionId, resolveArmedReattach])
 
   // Derive the red state from the active pane's stale key: armed when stale and
   // not yet resolved, cleared otherwise. Keyed by `sessionId:staleGeneration`
@@ -242,11 +290,15 @@ export const useAgentReattach = ({
     setNeedsReattach(true)
   }, [staleKey, sessionId])
 
-  // Deferred, bounded auto-reattach: each attempt waits for its IPC to settle
-  // before scheduling the next, and the budget counts only issued calls — so a
-  // slow `start_agent_watcher` can't exhaust the retries with single-flight
-  // no-ops (codex review VIM-192). Stops as soon as the success predicate
-  // clears `needsReattach` (cleanup cancels the pending timer).
+  // Deferred, bounded auto-reattach for each armed `/clear` cycle (keyed by
+  // `staleKey` so a repeated `/clear` restarts the window). Quick speculative
+  // retries catch the common `/clear` relocate the moment codex opens + writes
+  // the new rollout. The budget counts only issued calls — so a slow
+  // `start_agent_watcher` can't exhaust the retries with single-flight no-ops.
+  // It NEVER clears red itself (event-gated). Late recovery (the user interacts
+  // with the new/resumed rollout long after this window) is covered by the
+  // always-on drift tick below, so this stays bounded. Stops as soon as the
+  // success predicate clears `needsReattach` (cleanup cancels the pending timer).
   useEffect(() => {
     if (!needsReattach) {
       return
@@ -265,9 +317,7 @@ export const useAgentReattach = ({
       if (cancelled) {
         return
       }
-      if (issued) {
-        attempts += 1
-      } else if (!inFlightRef.current) {
+      if (issued || !inFlightRef.current) {
         attempts += 1
       }
       timer = setTimeout(() => void run(), REATTACH_AUTO_RETRY_INTERVAL_MS)
@@ -279,7 +329,47 @@ export const useAgentReattach = ({
       cancelled = true
       clearTimeout(timer)
     }
-  }, [needsReattach, reattachAsync])
+  }, [needsReattach, staleKey, reattachAsync])
 
-  return { needsReattach, reattach }
+  // Always-on drift tick: re-locate the active Codex pane on a fixed cadence so
+  // the panel follows an in-session `resume`. Resume is undetectable (no `/clear`
+  // → red is never armed) and codex exposes no active-thread signal, so the only
+  // way to notice the switch is to re-locate periodically: once the resumed
+  // conversation is written it becomes the newest `updated_at`, the backend
+  // relocate reports `changed=true`, and its fresh `agent-status` event updates
+  // the panel (and clears red if a `/clear` cycle happens to be armed). A
+  // same-rollout tick is a cheap backend no-op. Single-flight is shared with the
+  // bounded retry + manual button (`inFlightRef`), so the periodic `lsof` can't
+  // stack. Off unless the active pane runs a live Codex agent.
+  useEffect(() => {
+    if (!driftEnabled || sessionId === null) {
+      return
+    }
+
+    let cancelled = false
+    let timer: ReturnType<typeof setTimeout>
+
+    const tick = async (): Promise<void> => {
+      if (cancelled) {
+        return
+      }
+      // Fire and forget: clearing is strictly event-gated, so the drift tick
+      // never resolves red on its own — it only re-invites the resolver.
+      await issueReattach()
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- the effect cleanup sets `cancelled` across the await above
+      if (cancelled) {
+        return
+      }
+      timer = setTimeout(() => void tick(), REATTACH_DRIFT_INTERVAL_MS)
+    }
+
+    timer = setTimeout(() => void tick(), REATTACH_DRIFT_INTERVAL_MS)
+
+    return (): void => {
+      cancelled = true
+      clearTimeout(timer)
+    }
+  }, [driftEnabled, sessionId, issueReattach])
+
+  return { needsReattach }
 }

--- a/src/features/workspace/WorkspaceView.command-palette.test.tsx
+++ b/src/features/workspace/WorkspaceView.command-palette.test.tsx
@@ -50,9 +50,8 @@ vi.mock('./hooks/useNotifyInfo')
 vi.mock('../agent-status/hooks/useAgentStatus')
 
 vi.mock('../agent-status/hooks/useAgentReattach', () => ({
-  useAgentReattach: (): { needsReattach: boolean; reattach: () => void } => ({
+  useAgentReattach: (): { needsReattach: boolean } => ({
     needsReattach: false,
-    reattach: (): void => undefined,
   }),
 }))
 
@@ -462,6 +461,38 @@ describe('WorkspaceView - Command Palette Integration', () => {
       'session-1',
       'p0'
     )
+
+    await waitFor(() => {
+      expect(vi.mocked(useAgentStatus)).toHaveBeenLastCalledWith(
+        'pty-session-1',
+        0
+      )
+    })
+  })
+
+  test('a non-/clear command on a Codex pane does not bump the reset generation', async () => {
+    // An in-session `resume` (and any non-`/clear` input) must NOT arm the
+    // agent-status reset/red state — only `/clear` does. This guards the
+    // confirmed root cause: resume is undetectable, so the panel never goes red
+    // for it; a red panel after a resume is leftover `/clear` recovery, not the
+    // resume (codex review, VIM-192).
+    const { useAgentStatus } =
+      await import('../agent-status/hooks/useAgentStatus')
+
+    vi.mocked(useAgentStatus).mockReturnValue(
+      createAgentStatus({
+        sessionId: 'pty-session-1',
+        agentType: 'codex',
+      })
+    )
+
+    render(<WorkspaceView />)
+
+    act(() => {
+      latestTerminalZoneProps().onCommandSubmit?.('pty-session-1', 'resume')
+    })
+
+    expect(mockSessionManager.clearPaneCacheHistory).not.toHaveBeenCalled()
 
     await waitFor(() => {
       expect(vi.mocked(useAgentStatus)).toHaveBeenLastCalledWith(

--- a/src/features/workspace/WorkspaceView.elastic.test.tsx
+++ b/src/features/workspace/WorkspaceView.elastic.test.tsx
@@ -29,9 +29,8 @@ vi.mock('../agent-status/hooks/useAgentStatus', () => ({
 }))
 
 vi.mock('../agent-status/hooks/useAgentReattach', () => ({
-  useAgentReattach: (): { needsReattach: boolean; reattach: () => void } => ({
+  useAgentReattach: (): { needsReattach: boolean } => ({
     needsReattach: false,
-    reattach: (): void => undefined,
   }),
 }))
 

--- a/src/features/workspace/WorkspaceView.integration.test.tsx
+++ b/src/features/workspace/WorkspaceView.integration.test.tsx
@@ -37,9 +37,8 @@ vi.mock('../agent-status/hooks/useAgentStatus', () => ({
 }))
 
 vi.mock('../agent-status/hooks/useAgentReattach', () => ({
-  useAgentReattach: (): { needsReattach: boolean; reattach: () => void } => ({
+  useAgentReattach: (): { needsReattach: boolean } => ({
     needsReattach: false,
-    reattach: (): void => undefined,
   }),
 }))
 

--- a/src/features/workspace/WorkspaceView.notifyInfo.test.tsx
+++ b/src/features/workspace/WorkspaceView.notifyInfo.test.tsx
@@ -23,9 +23,8 @@ vi.mock('../agent-status/hooks/useAgentStatus', () => ({
 }))
 
 vi.mock('../agent-status/hooks/useAgentReattach', () => ({
-  useAgentReattach: (): { needsReattach: boolean; reattach: () => void } => ({
+  useAgentReattach: (): { needsReattach: boolean } => ({
     needsReattach: false,
-    reattach: (): void => undefined,
   }),
 }))
 

--- a/src/features/workspace/WorkspaceView.subscription.test.tsx
+++ b/src/features/workspace/WorkspaceView.subscription.test.tsx
@@ -176,9 +176,8 @@ vi.mock('../agent-status/hooks/useAgentStatus', () => ({
 }))
 
 vi.mock('../agent-status/hooks/useAgentReattach', () => ({
-  useAgentReattach: (): { needsReattach: boolean; reattach: () => void } => ({
+  useAgentReattach: (): { needsReattach: boolean } => ({
     needsReattach: false,
-    reattach: (): void => undefined,
   }),
 }))
 

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -140,9 +140,8 @@ vi.mock('../agent-status/hooks/useAgentStatus', () => ({
 }))
 
 vi.mock('../agent-status/hooks/useAgentReattach', () => ({
-  useAgentReattach: (): { needsReattach: boolean; reattach: () => void } => ({
+  useAgentReattach: (): { needsReattach: boolean } => ({
     needsReattach: false,
-    reattach: (): void => undefined,
   }),
 }))
 

--- a/src/features/workspace/WorkspaceView.top-chrome.test.tsx
+++ b/src/features/workspace/WorkspaceView.top-chrome.test.tsx
@@ -40,9 +40,8 @@ vi.mock('./hooks/useNotifyInfo')
 vi.mock('../agent-status/hooks/useAgentStatus')
 
 vi.mock('../agent-status/hooks/useAgentReattach', () => ({
-  useAgentReattach: (): { needsReattach: boolean; reattach: () => void } => ({
+  useAgentReattach: (): { needsReattach: boolean } => ({
     needsReattach: false,
-    reattach: (): void => undefined,
   }),
 }))
 

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -521,9 +521,11 @@ const WorkspaceViewContent = (): ReactElement => {
     agentStatusResetGeneration
   )
 
-  // Codex watcher relocation recovery (VIM-188): `/clear` arms the red "needs
-  // reattach" state + a bounded auto-reattach; the manual button covers the
-  // undetectable in-session `resume`.
+  // Codex watcher relocation recovery (VIM-188/192): `/clear` arms the red
+  // "needs reattach" indicator + a bounded auto-reattach; the always-on drift
+  // tick relocates the active Codex pane so the panel also follows an
+  // undetectable in-session `resume`. Recovery is automatic once codex writes
+  // the conversation (the user sends a prompt) — there is no manual button.
   const agentReattach = useAgentReattach({
     sessionId: activePtyBackedPanePtyId ?? null,
     agentSessionId: agentStatus.agentSessionId,
@@ -532,6 +534,10 @@ const WorkspaceViewContent = (): ReactElement => {
         agentStatus.contextWindow.totalOutputTokens
       : null,
     staleGeneration: agentStatusResetGeneration,
+    // Drift-detection (VIM-192) runs only for a live Codex pane: it re-locates
+    // periodically so the panel follows an in-session `resume` (which is
+    // undetectable and never arms the red state).
+    driftEnabled: agentStatus.agentType === 'codex',
   })
 
   const visibleAgentStatusPtyIds = useMemo(
@@ -2522,11 +2528,6 @@ const WorkspaceViewContent = (): ReactElement => {
               gitStatus={gitStatus}
               isRefreshing={isAgentStatusRefreshing}
               needsReattach={agentReattach.needsReattach}
-              onReattach={
-                agentStatus.agentType === 'codex'
-                  ? agentReattach.reattach
-                  : undefined
-              }
               onOpenDiff={handleOpenDiff}
               onOpenFile={handleOpenTestFile}
               agent={activityPanelAgent}

--- a/src/features/workspace/WorkspaceView.verification.test.tsx
+++ b/src/features/workspace/WorkspaceView.verification.test.tsx
@@ -37,9 +37,8 @@ vi.mock('../agent-status/hooks/useAgentStatus', () => ({
 }))
 
 vi.mock('../agent-status/hooks/useAgentReattach', () => ({
-  useAgentReattach: (): { needsReattach: boolean; reattach: () => void } => ({
+  useAgentReattach: (): { needsReattach: boolean } => ({
     needsReattach: false,
-    reattach: (): void => undefined,
   }),
 }))
 

--- a/src/features/workspace/WorkspaceView.visual.test.tsx
+++ b/src/features/workspace/WorkspaceView.visual.test.tsx
@@ -33,9 +33,8 @@ vi.mock('../agent-status/hooks/useAgentStatus', () => ({
 }))
 
 vi.mock('../agent-status/hooks/useAgentReattach', () => ({
-  useAgentReattach: (): { needsReattach: boolean; reattach: () => void } => ({
+  useAgentReattach: (): { needsReattach: boolean } => ({
     needsReattach: false,
-    reattach: (): void => undefined,
   }),
 }))
 


### PR DESCRIPTION
## Problem

The codex agent-status panel froze after a `/clear` or an in-session `resume`: the transcript watcher stayed pinned to the old rollout while codex moved to a new one (VIM-188/191/192). codex **leaks rollout FDs** (one pid holds several open) and exposes **no active-thread signal** (sqlite `updated_at` == file mtime, both advance only on write; `session_index.jsonl` is a stale title cache), so the panel can only re-find the live conversation once it is **written** — i.e. when the user sends a prompt.

## Fix

**Backend**
- Resolver binds the **newest open rollout** by `updated_at` (tie → `NotYetReady`, fail-safe).
- `run_watch_sequence` is now **idempotent**: a same-rollout re-locate is a cheap no-op (`changed=false`, no re-tail of a 20–114 MB rollout), via `WatcherHandle.status_path` + `AgentWatcherState::current_status_path`. The `bool` is observed only by tests; production discards it.
- One structured `debug` decision log per multi-FD resolve (`RUST_LOG=vimeflow_lib=debug`).

**Frontend**
- **Always-on drift tick** re-locates the active Codex pane (~4s, single-flight) so the panel follows an *undetectable* in-session `resume` once the resumed conversation is written.
- Bounded fast retry keeps `/clear` recovery snappy (sub-second).
- Removed the **misleading manual reattach button** — recovery is write-driven and automatic, so the red state now reads **"send a prompt to reattach"** (an instruction, not a fake action).

## Verification

- Live-confirmed by the maintainer: `resume`-direct, `/clear`-then-`resume`, and repeated resume all converge (panel follows within ~4s of the first prompt to the resumed conversation).
- Tests: backend 481 adapter + 16 lifecycle + 44 locator (incl. same-rollout no-op, changed-rollout relocate, non-Codex always-respawn, two-phase self-heal); frontend reattach hook + Header + workspace (drift cadence, `driftEnabled` gate, drift-never-clears, event-gated clear, "never renders a manual reattach button"). Full pre-push vitest: 4062 passed.
- Repo-wide lint / prettier / type-check clean.

Part of the **codex-status-relocate** umbrella; out of scope (separate follow-up): the watcher poll `read_to_string`s the whole rollout every 3s + 4 MB tail line cap, which lags on 20–114 MB sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
