### PR TITLE
chore(ui): Collapse workspace dock by default

### DIFF
--- a/src/features/workspace/WorkspaceView.elastic.test.tsx
+++ b/src/features/workspace/WorkspaceView.elastic.test.tsx
@@ -146,6 +146,8 @@ describe('WorkspaceView elastic resize size persistence', () => {
     const user = userEvent.setup()
     render(<WorkspaceView />)
 
+    await user.click(screen.getByTestId('status-bar-dock-toggle'))
+
     await waitFor(() => {
       expect(screen.getByTestId('dock-panel')).toBeInTheDocument()
     })
@@ -184,6 +186,8 @@ describe('WorkspaceView elastic resize size persistence', () => {
   test('vertical and horizontal sizes are independent across position switches', async () => {
     const user = userEvent.setup()
     render(<WorkspaceView />)
+
+    await user.click(screen.getByTestId('status-bar-dock-toggle'))
 
     await waitFor(() => {
       expect(screen.getByTestId('dock-panel')).toBeInTheDocument()

--- a/src/features/workspace/WorkspaceView.integration.test.tsx
+++ b/src/features/workspace/WorkspaceView.integration.test.tsx
@@ -128,6 +128,12 @@ const switchToFilesTab = async (user: User): Promise<void> => {
   await user.click(screen.getByRole('button', { name: 'FILES' }))
 }
 
+const openDockPanel = async (user: User): Promise<HTMLElement> => {
+  await user.click(screen.getByTestId('status-bar-dock-toggle'))
+
+  return screen.findByTestId('dock-panel')
+}
+
 /**
  * Integration tests for WorkspaceView
  *
@@ -248,7 +254,7 @@ describe('WorkspaceView Integration Tests', () => {
       const user = userEvent.setup()
       render(<WorkspaceView />)
 
-      const dockPanel = screen.getByTestId('dock-panel')
+      const dockPanel = await openDockPanel(user)
 
       // Diff is the default tab now — the editor panel is not shown yet.
       expect(
@@ -266,7 +272,7 @@ describe('WorkspaceView Integration Tests', () => {
       const user = userEvent.setup()
       render(<WorkspaceView />)
 
-      const dockPanel = screen.getByTestId('dock-panel')
+      const dockPanel = await openDockPanel(user)
 
       // Click Diff Viewer tab
       const diffTab = within(dockPanel).getByText('Diff Viewer')
@@ -285,7 +291,7 @@ describe('WorkspaceView Integration Tests', () => {
       const user = userEvent.setup()
       render(<WorkspaceView />)
 
-      const dockPanel = screen.getByTestId('dock-panel')
+      const dockPanel = await openDockPanel(user)
 
       // Click Diff Viewer tab
       await user.click(within(dockPanel).getByText('Diff Viewer'))
@@ -308,7 +314,7 @@ describe('WorkspaceView Integration Tests', () => {
       const user = userEvent.setup()
       render(<WorkspaceView />)
 
-      const dockPanel = screen.getByTestId('dock-panel')
+      const dockPanel = await openDockPanel(user)
       const diffTab = within(dockPanel).getByText('Diff Viewer')
 
       // Click Diff Viewer tab
@@ -1058,34 +1064,28 @@ describe('WorkspaceView focus orchestration', () => {
     )
   })
 
-  test('initial state: terminal zone is focused, dock does not have focus outline', async () => {
+  test('initial state: terminal zone is focused with dock collapsed', () => {
     render(<WorkspaceView />)
 
-    // Dock starts open but terminal is the active container
-    await waitFor(() => {
-      expect(screen.getByTestId('dock-panel')).toBeInTheDocument()
-    })
+    expect(screen.queryByTestId('dock-panel')).not.toBeInTheDocument()
 
     const terminalZone = screen.getByTestId('terminal-zone')
-    const dockPanel = screen.getByTestId('dock-panel')
 
     // Terminal zone should be at full opacity (active)
     expect(terminalZone.className).not.toContain('opacity-[0.65]')
-    // Dock should NOT have the focus outline span
-    expect(
-      dockPanel.querySelector('[data-testid="dock-focus-outline"]')
-    ).toBeNull()
+    expect(screen.getByTestId('status-bar-dock-toggle')).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    )
   })
 
   test('clicking dock claims dock focus: terminal dims (no competing dock outline)', async () => {
+    const user = userEvent.setup()
     render(<WorkspaceView />)
 
-    await waitFor(() => {
-      expect(screen.getByTestId('dock-panel')).toBeInTheDocument()
-    })
+    const dockPanel = await openDockPanel(user)
 
     // Click a non-interactive part of the dock panel
-    const dockPanel = screen.getByTestId('dock-panel')
     dockPanel.focus() // simulate focus entering dock via onFocus
 
     await waitFor(() => {
@@ -1102,14 +1102,12 @@ describe('WorkspaceView focus orchestration', () => {
   })
 
   test('closing the dock returns container focus to terminal', async () => {
+    const user = userEvent.setup()
     render(<WorkspaceView />)
 
-    await waitFor(() => {
-      expect(screen.getByTestId('dock-panel')).toBeInTheDocument()
-    })
+    const dockPanel = await openDockPanel(user)
 
     // Give focus to dock first
-    const dockPanel = screen.getByTestId('dock-panel')
     dockPanel.focus()
 
     await waitFor(() => {

--- a/src/features/workspace/WorkspaceView.subscription.test.tsx
+++ b/src/features/workspace/WorkspaceView.subscription.test.tsx
@@ -325,6 +325,12 @@ vi.mock('./components/DockPanel', () => ({
   },
 }))
 
+const openDockPanelMock = async (): Promise<HTMLElement> => {
+  fireEvent.click(screen.getByTestId('status-bar-dock-toggle'))
+
+  return screen.findByTestId('dock-panel-mock')
+}
+
 describe('WorkspaceView lifted-subscription contract', () => {
   beforeEach(() => {
     capturedPanelProps.agentStatus = undefined
@@ -420,7 +426,7 @@ describe('WorkspaceView lifted-subscription contract', () => {
     render(<WorkspaceView />)
 
     await screen.findByTestId('agent-status-panel-mock')
-    await screen.findByTestId('dock-panel-mock')
+    await openDockPanelMock()
 
     expect(capturedPanelProps.gitStatus).toBeDefined()
     expect(capturedDockPanelProps.gitStatus).toBeDefined()
@@ -430,7 +436,7 @@ describe('WorkspaceView lifted-subscription contract', () => {
   test('DockPanel receives a workspace feedback batch that clears on cwd change', async () => {
     render(<WorkspaceView />)
 
-    await screen.findByTestId('dock-panel-mock')
+    await openDockPanelMock()
     await screen.findByTestId('terminal-pane-mock')
 
     const feedbackBatch = capturedDockPanelProps.feedbackBatch
@@ -531,7 +537,7 @@ describe('WorkspaceView lifted-subscription contract', () => {
 
     try {
       render(<WorkspaceView />)
-      await screen.findByTestId('dock-panel-mock')
+      await openDockPanelMock()
 
       // First render: agent idle + tab='diff' (the default) → enabled: true.
       // The agent is idle, so this `true` can only come from the
@@ -594,7 +600,7 @@ describe('WorkspaceView lifted-subscription contract', () => {
 
     try {
       render(<WorkspaceView />)
-      await screen.findByTestId('dock-panel-mock')
+      await openDockPanelMock()
 
       vi.mocked(useGitStatus).mockClear()
       fireEvent.click(screen.getByTestId('mock-switch-to-editor'))
@@ -639,7 +645,7 @@ describe('WorkspaceView lifted-subscription contract', () => {
     })
 
     const view = render(<WorkspaceView />)
-    await screen.findByTestId('dock-panel-mock')
+    await openDockPanelMock()
 
     expect(capturedDockPanelProps.editorFileLifecycleStatus).toBe('NEW')
 
@@ -677,7 +683,7 @@ describe('WorkspaceView lifted-subscription contract', () => {
     })
 
     const view = render(<WorkspaceView />)
-    await screen.findByTestId('dock-panel-mock')
+    await openDockPanelMock()
 
     expect(capturedDockPanelProps.editorFileLifecycleStatus).toBe('NEW')
 
@@ -721,7 +727,14 @@ describe('WorkspaceView lifted-subscription contract', () => {
 
     try {
       render(<WorkspaceView />)
-      await screen.findByTestId('dock-panel-mock')
+      expect(screen.queryByTestId('dock-panel-mock')).not.toBeInTheDocument()
+      expect(useGitStatus).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ watch: true, enabled: false })
+      )
+
+      vi.mocked(useGitStatus).mockClear()
+      await openDockPanelMock()
 
       fireEvent.click(screen.getByTestId('mock-switch-to-diff'))
       expect(useGitStatus).toHaveBeenCalledWith(

--- a/src/features/workspace/WorkspaceView.test.tsx
+++ b/src/features/workspace/WorkspaceView.test.tsx
@@ -389,13 +389,17 @@ describe('WorkspaceView', () => {
     })
   })
 
-  test('renders workspace zones (sidebar, terminal, dock panel, agent status panel)', () => {
+  test('renders workspace zones with the dock collapsed by default', () => {
     render(<WorkspaceView />)
 
     // VIM-76: icon rail removed; sidebar | main | activity.
     expect(screen.getByTestId('sidebar')).toBeInTheDocument()
     expect(screen.getByTestId('terminal-zone')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Editor' })).toBeInTheDocument() // DockPanel
+    expect(screen.queryByTestId('dock-panel')).not.toBeInTheDocument()
+    expect(screen.getByTestId('status-bar-dock-toggle')).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    )
     expect(screen.getByTestId('agent-status-panel')).toBeInTheDocument()
   })
 
@@ -1489,10 +1493,14 @@ describe('WorkspaceView', () => {
     }
   })
 
-  test('DockPanel is present below TerminalZone', () => {
+  test('DockPanel opens below TerminalZone from the status bar toggle', async () => {
+    const user = userEvent.setup()
     render(<WorkspaceView />)
 
-    // DockPanel should render with Editor tab active
+    expect(screen.queryByTestId('dock-panel')).not.toBeInTheDocument()
+
+    await user.click(screen.getByTestId('status-bar-dock-toggle'))
+
     expect(screen.getByRole('button', { name: 'Editor' })).toBeInTheDocument()
     expect(
       screen.getByRole('button', { name: /diff viewer/i })
@@ -1503,6 +1511,7 @@ describe('WorkspaceView', () => {
     const user = userEvent.setup()
     render(<WorkspaceView />)
 
+    await user.click(screen.getByTestId('status-bar-dock-toggle'))
     await user.click(screen.getByRole('button', { name: /dock: left/i }))
 
     const inner = screen.getByTestId('dock-canvas-wrapper')
@@ -1525,6 +1534,7 @@ describe('WorkspaceView', () => {
     const user = userEvent.setup()
     render(<WorkspaceView />)
 
+    await user.click(screen.getByTestId('status-bar-dock-toggle'))
     await user.click(screen.getByRole('button', { name: /dock: right/i }))
 
     const inner = screen.getByTestId('dock-canvas-wrapper')
@@ -1555,12 +1565,10 @@ describe('WorkspaceView', () => {
     const user = userEvent.setup()
     render(<WorkspaceView />)
 
-    // Dock starts open.
-    expect(screen.getByTestId('dock-panel')).toBeInTheDocument()
+    // Dock starts closed.
+    expect(screen.queryByTestId('dock-panel')).toBeNull()
 
-    await user.click(screen.getByRole('button', { name: /collapse panel/i }))
-
-    // Closed: the dock is gone and there is no "show panel" peek affordance —
+    // Closed: the dock is gone and there is no "show panel" peek affordance -
     // only the terminal remains. The bottom action bar's dock toggle is the
     // single reopen control.
     expect(screen.queryByTestId('dock-panel')).toBeNull()
@@ -1574,6 +1582,10 @@ describe('WorkspaceView', () => {
 
     expect(screen.getByTestId('dock-panel')).toBeInTheDocument()
     expect(dockToggle).toHaveAttribute('aria-pressed', 'true')
+
+    await user.click(screen.getByRole('button', { name: /collapse panel/i }))
+
+    expect(screen.queryByTestId('dock-panel')).toBeNull()
   })
 
   test('main workspace area uses flex-col layout', () => {
@@ -1643,7 +1655,7 @@ describe('WorkspaceView', () => {
     expect(screen.getByTestId('sidebar')).toBeInTheDocument()
     expect(screen.getByTestId('terminal-zone')).toBeInTheDocument()
     expect(screen.getByTestId('agent-status-panel')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Editor' })).toBeInTheDocument()
+    expect(screen.queryByTestId('dock-panel')).not.toBeInTheDocument()
   })
 
   test('grid columns: sidebar auto (drawer), main 1fr, activity auto', () => {
@@ -2448,6 +2460,7 @@ describe('WorkspaceView', () => {
 
     render(<WorkspaceView />)
 
+    await user.click(screen.getByTestId('status-bar-dock-toggle'))
     await user.click(screen.getByRole('button', { name: 'Editor' }))
 
     expect(screen.getByTestId('code-editor')).toBeInTheDocument()

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -937,7 +937,7 @@ const WorkspaceViewContent = (): ReactElement => {
   // Dock panel controlled state.
   const dockCanvasRef = useRef<HTMLDivElement>(null)
   const [dockPosition, setDockPosition] = useState<DockPosition>('bottom')
-  const [isDockOpen, setIsDockOpen] = useState(true)
+  const [isDockOpen, setIsDockOpen] = useState(false)
   const [dockTab, setDockTab] = useState<DockTab>('diff')
 
   const [activeContainerId, setActiveContainerId] = useState<string>(

--- a/src/features/workspace/WorkspaceView.verification.test.tsx
+++ b/src/features/workspace/WorkspaceView.verification.test.tsx
@@ -102,7 +102,7 @@ import { WorkspaceView } from './WorkspaceView'
 
 describe('Feature 23: Final Phase 2 Verification', () => {
   describe('1. workspace zones render (VIM-76: icon rail removed)', () => {
-    test('renders sidebar (with top bar), terminal, dock panel, and activity zones', () => {
+    test('renders sidebar, terminal, collapsed dock affordance, and activity zones', () => {
       render(<WorkspaceView />)
 
       // VIM-76: icon rail removed; sidebar chrome remains in the sidebar.
@@ -110,7 +110,11 @@ describe('Feature 23: Final Phase 2 Verification', () => {
       expect(screen.getByTestId('sidebar-top-bar')).toBeInTheDocument()
       expect(screen.getByTestId('sidebar-footer-wrapper')).toBeInTheDocument()
       expect(screen.getByTestId('terminal-zone')).toBeInTheDocument()
-      expect(screen.getByTestId('dock-panel')).toBeInTheDocument()
+      expect(screen.queryByTestId('dock-panel')).not.toBeInTheDocument()
+      expect(screen.getByTestId('status-bar-dock-toggle')).toHaveAttribute(
+        'aria-pressed',
+        'false'
+      )
       expect(screen.getByTestId('agent-status-panel')).toBeInTheDocument()
     })
   })
@@ -176,8 +180,11 @@ describe('Feature 23: Final Phase 2 Verification', () => {
       expect(screen.getByText('File Explorer')).toBeInTheDocument()
     })
 
-    test('dock panel displays Editor and Diff Viewer tabs', () => {
+    test('dock panel displays Editor and Diff Viewer tabs when opened', async () => {
+      const user = userEvent.setup()
       render(<WorkspaceView />)
+
+      await user.click(screen.getByTestId('status-bar-dock-toggle'))
 
       const dockPanel = screen.getByTestId('dock-panel')
 
@@ -265,7 +272,11 @@ describe('Feature 23: Final Phase 2 Verification', () => {
       // Verify all zones are present (VIM-76: icon rail removed).
       expect(screen.getByTestId('sidebar')).toBeInTheDocument()
       expect(screen.getByTestId('terminal-zone')).toBeInTheDocument()
-      expect(screen.getByTestId('dock-panel')).toBeInTheDocument()
+      expect(screen.queryByTestId('dock-panel')).not.toBeInTheDocument()
+      expect(screen.getByTestId('status-bar-dock-toggle')).toHaveAttribute(
+        'aria-pressed',
+        'false'
+      )
       expect(screen.getByTestId('agent-status-panel')).toBeInTheDocument()
     })
   })

--- a/src/features/workspace/WorkspaceView.visual.test.tsx
+++ b/src/features/workspace/WorkspaceView.visual.test.tsx
@@ -254,8 +254,12 @@ describe('WorkspaceView - Visual Verification (Feature #20)', () => {
       expect(workspace.className).not.toContain('border-')
     })
 
-    test('DockPanel uses prototype border for separation', () => {
+    test('DockPanel uses prototype border for separation', async () => {
+      const user = userEvent.setup()
       render(<WorkspaceView />)
+
+      await user.click(screen.getByTestId('status-bar-dock-toggle'))
+
       const dockPanel = screen.getByTestId('dock-panel')
 
       // Bottom-docked DockPanel keeps its border on the edge facing terminal.
@@ -293,13 +297,19 @@ describe('WorkspaceView - Visual Verification (Feature #20)', () => {
 
       expect(screen.getByTestId('top-chrome')).toBeInTheDocument()
       expect(screen.getByTestId('terminal-zone')).toBeInTheDocument()
-      expect(screen.getByTestId('dock-panel')).toBeInTheDocument()
+      expect(screen.queryByTestId('dock-panel')).not.toBeInTheDocument()
+      expect(screen.getByTestId('status-bar-dock-toggle')).toHaveAttribute(
+        'aria-pressed',
+        'false'
+      )
       expect(screen.getByTestId('agent-status-panel')).toBeInTheDocument()
     })
 
     test('dock panel has Editor/Diff tabs, FILES tab has file explorer (v2)', async () => {
       const user = userEvent.setup()
       render(<WorkspaceView />)
+
+      await user.click(screen.getByTestId('status-bar-dock-toggle'))
 
       // Editor and Diff Viewer tabs are in dock panel
       expect(screen.getByText('Editor')).toBeInTheDocument()


### PR DESCRIPTION
## Summary

- Initialize the workspace dock as collapsed when the app opens.
- Update workspace tests so startup assertions expect the collapsed dock affordance.
- Open the dock through the existing status-bar toggle in tests that inspect dock UI, layout, focus, or mocked subscription props.

## Impact

Users now land in a terminal-first workspace with the editor/diff dock hidden by default. Existing dock reopen and close flows continue to use the status-bar toggle and dock collapse button.

## Validation

- `npx vitest run src/features/workspace/WorkspaceView.test.tsx src/features/workspace/WorkspaceView.elastic.test.tsx src/features/workspace/WorkspaceView.integration.test.tsx src/features/workspace/WorkspaceView.subscription.test.tsx src/features/workspace/WorkspaceView.verification.test.tsx src/features/workspace/WorkspaceView.visual.test.tsx src/features/workspace/WorkspaceView.command-palette.test.tsx src/features/workspace/WorkspaceView.top-chrome.test.tsx src/features/workspace/WorkspaceView.notifyInfo.test.tsx`
- `npx eslint src/features/workspace/WorkspaceView.tsx src/features/workspace/WorkspaceView.test.tsx src/features/workspace/WorkspaceView.elastic.test.tsx src/features/workspace/WorkspaceView.integration.test.tsx src/features/workspace/WorkspaceView.subscription.test.tsx src/features/workspace/WorkspaceView.verification.test.tsx src/features/workspace/WorkspaceView.visual.test.tsx`
- Commit hook: eslint, `tsc --noEmit`, prettier
- Pre-push hook: `npm test` (323 files, 4038 passed, 3 skipped)

Refs VIM-204