### PR TITLE
fix(agent-status): arm red invalidation on codex /resume

### DIFF
--- a/src/features/agent-status/hooks/useAgentReattach.ts
+++ b/src/features/agent-status/hooks/useAgentReattach.ts
@@ -13,22 +13,24 @@ import type { AgentStatusEvent } from '../types'
 // Recovery is fully automatic; there is NO manual button (it would mislead,
 // since the relocate can only land once codex WRITES the conversation — i.e.
 // when the user sends a prompt). Two mechanisms drive it:
-//   - `/clear` is detectable, so it arms a red indicator + a bounded fast
-//     auto-reattach to catch the new rollout the moment codex writes it.
-//   - the in-session `resume` is undetectable, so an always-on drift tick
-//     re-locates the active Codex pane on a cadence; once the resumed
-//     conversation is written it becomes the newest rollout and the relocate
-//     lands. Either way a fresh `agent-status` (new `agentSessionId`) confirms
-//     it and clears the red indicator.
+//   - A typed `/clear` or `/resume` is detectable (WorkspaceView), so it arms a
+//     red indicator + a bounded fast auto-reattach to catch the new rollout the
+//     moment codex writes it.
+//   - A switch that surfaces no typed command (codex's TUI resume picker, or a
+//     resume that stays idle before the user interacts) is undetectable, so an
+//     always-on drift tick re-locates the active Codex pane on a cadence; once
+//     the new conversation is written it becomes the newest rollout and the
+//     relocate lands. Either way a fresh `agent-status` (new `agentSessionId`)
+//     confirms it and clears the red indicator.
 
 const REATTACH_AUTO_INITIAL_DELAY_MS = 400
 const REATTACH_AUTO_RETRY_INTERVAL_MS = 700
 const REATTACH_AUTO_MAX_ATTEMPTS = 5
 const REATTACH_AUTO_MAX_TIMER_FIRES = REATTACH_AUTO_MAX_ATTEMPTS * 2
 // Always-on drift tick (VIM-192): the active Codex pane re-locates on this
-// cadence, regardless of the red state. An in-session `resume` is undetectable
-// (it types no `/clear`, so red is never armed) and codex exposes no active-thread
-// signal, so the ONLY way the panel can follow a resume is to re-locate
+// cadence, regardless of the red state. A resume that surfaces no typed command
+// (codex's TUI picker) never arms red, and codex exposes no active-thread
+// signal, so the ONLY way the panel can follow such a switch is to re-locate
 // periodically and relocate once the resumed conversation is written (it then
 // becomes the newest `updated_at`). The backend relocate is idempotent — a
 // same-rollout re-locate is a cheap no-op (`changed=false`, no re-tail) — so this

--- a/src/features/workspace/WorkspaceView.command-palette.test.tsx
+++ b/src/features/workspace/WorkspaceView.command-palette.test.tsx
@@ -470,12 +470,10 @@ describe('WorkspaceView - Command Palette Integration', () => {
     })
   })
 
-  test('a non-/clear command on a Codex pane does not bump the reset generation', async () => {
-    // An in-session `resume` (and any non-`/clear` input) must NOT arm the
-    // agent-status reset/red state — only `/clear` does. This guards the
-    // confirmed root cause: resume is undetectable, so the panel never goes red
-    // for it; a red panel after a resume is leftover `/clear` recovery, not the
-    // resume (codex review, VIM-192).
+  test('a non-context-switch command on a Codex pane does not bump the reset generation', async () => {
+    // Only the codex slash commands `/clear` and `/resume` switch the rollout.
+    // A bare `resume` (no slash — a shell command, not codex's `/resume`) and any
+    // other input must NOT arm the reset/red state (codex review, VIM-192).
     const { useAgentStatus } =
       await import('../agent-status/hooks/useAgentStatus')
 
@@ -498,6 +496,38 @@ describe('WorkspaceView - Command Palette Integration', () => {
       expect(vi.mocked(useAgentStatus)).toHaveBeenLastCalledWith(
         'pty-session-1',
         0
+      )
+    })
+  })
+
+  test('terminal /resume invalidates the status (bumps generation + clears cache) on a Codex pane', async () => {
+    // `/resume` switches codex to another conversation — same invalidation as
+    // `/clear` so the panel goes red until the watcher relocates (VIM-192).
+    const { useAgentStatus } =
+      await import('../agent-status/hooks/useAgentStatus')
+
+    vi.mocked(useAgentStatus).mockReturnValue(
+      createAgentStatus({
+        sessionId: 'pty-session-1',
+        agentType: 'codex',
+      })
+    )
+
+    render(<WorkspaceView />)
+
+    act(() => {
+      latestTerminalZoneProps().onCommandSubmit?.('pty-session-1', '/resume')
+    })
+
+    expect(mockSessionManager.clearPaneCacheHistory).toHaveBeenCalledWith(
+      'session-1',
+      'p0'
+    )
+
+    await waitFor(() => {
+      expect(vi.mocked(useAgentStatus)).toHaveBeenLastCalledWith(
+        'pty-session-1',
+        1
       )
     })
   })

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -576,14 +576,24 @@ const WorkspaceViewContent = (): ReactElement => {
 
   const handleTerminalCommandSubmit = useCallback(
     (ptyId: string, command: string): void => {
-      if (command !== '/clear') {
+      // A codex `/clear` opens a fresh conversation and `/resume` switches to a
+      // different one — both point codex at a NEW rollout, so the live status
+      // is now stale. Treat both as a context switch: reset agent-status and arm
+      // the red "send a prompt to reattach" indicator until the watcher
+      // relocates onto the new conversation (VIM-192). `/resume <id>` is the
+      // arg form.
+      const isCodexContextSwitch =
+        command === '/clear' ||
+        command === '/resume' ||
+        command.startsWith('/resume ')
+      if (!isCodexContextSwitch) {
         return
       }
 
       // Only reset agent-status state when the active pane is actually running
       // Codex. Raw PTY input (e.g. vim's `/clear` search followed by Enter) is
-      // syntactically identical to a Codex `/clear` command, and a false reset
-      // for a live Codex session would suppress same-run events until the next
+      // syntactically identical to a Codex command, and a false reset for a
+      // live Codex session would suppress same-run events until the next
       // session boundary (Claude Code Review on PR #469).
       if (
         ptyId === activePtyBackedPanePtyId &&


### PR DESCRIPTION
## Problem

A typed codex `/resume` switches to another conversation, but — unlike `/clear` — it left the agent-status panel showing the **previous** conversation's stats, with no red invalidation. It only updated once the user sent a prompt to the resumed conversation. (Reported on Linux after VIM-192 landed.)

## Fix

`handleTerminalCommandSubmit` now treats `/resume` (and `/resume <id>`) as a context switch, exactly like `/clear`: it resets agent-status and arms the red **"send a prompt to reattach"** indicator. The existing recovery (bounded fast retry + always-on drift tick, both event-gated) then clears it once codex writes the resumed conversation — same flow as `/clear`.

One-line change in the detector; the recovery machinery is unchanged.

## Ceiling (documented)

A **cancelled** `/resume` picker (no actual switch) leaves red armed until the next context switch. Recovery is write-driven, so a cancel is indistinguishable from a resume that hasn't been written yet. The common case (resume → interact) clears correctly.

## Tests

- `WorkspaceView.command-palette.test.tsx`: new — `/resume` bumps the reset generation + clears cache history on a Codex pane; updated the negative test (bare `resume` with no slash still does not arm).
- Workspace suite 617 pass; eslint / prettier / type-check clean.

Part of VIM-192 (codex-status-relocate umbrella).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
