### PR TITLE
feat(agent): opencode follows /clear via reattach (part 2)

### DIFF
--- a/src/features/workspace/WorkspaceView.command-palette.test.tsx
+++ b/src/features/workspace/WorkspaceView.command-palette.test.tsx
@@ -440,7 +440,37 @@ describe('WorkspaceView - Command Palette Integration', () => {
     })
   })
 
-  test('terminal /clear does not reset agent-status generation for non-Codex panes', async () => {
+  test('terminal /clear resets the active pane status generation and cache history when pane is opencode', async () => {
+    const { useAgentStatus } =
+      await import('../agent-status/hooks/useAgentStatus')
+
+    vi.mocked(useAgentStatus).mockReturnValue(
+      createAgentStatus({
+        sessionId: 'pty-session-1',
+        agentType: 'opencode',
+      })
+    )
+
+    render(<WorkspaceView />)
+
+    act(() => {
+      latestTerminalZoneProps().onCommandSubmit?.('pty-session-1', '/clear')
+    })
+
+    expect(mockSessionManager.clearPaneCacheHistory).toHaveBeenCalledWith(
+      'session-1',
+      'p0'
+    )
+
+    await waitFor(() => {
+      expect(vi.mocked(useAgentStatus)).toHaveBeenLastCalledWith(
+        'pty-session-1',
+        1
+      )
+    })
+  })
+
+  test('terminal /clear does not reset agent-status generation for non-Codex/non-opencode panes', async () => {
     const { useAgentStatus } =
       await import('../agent-status/hooks/useAgentStatus')
 
@@ -448,6 +478,36 @@ describe('WorkspaceView - Command Palette Integration', () => {
       createAgentStatus({
         sessionId: 'pty-session-1',
         agentType: 'claude-code',
+      })
+    )
+
+    render(<WorkspaceView />)
+
+    act(() => {
+      latestTerminalZoneProps().onCommandSubmit?.('pty-session-1', '/clear')
+    })
+
+    expect(mockSessionManager.clearPaneCacheHistory).toHaveBeenCalledWith(
+      'session-1',
+      'p0'
+    )
+
+    await waitFor(() => {
+      expect(vi.mocked(useAgentStatus)).toHaveBeenLastCalledWith(
+        'pty-session-1',
+        0
+      )
+    })
+  })
+
+  test('terminal /clear does not reset agent-status generation for generic panes', async () => {
+    const { useAgentStatus } =
+      await import('../agent-status/hooks/useAgentStatus')
+
+    vi.mocked(useAgentStatus).mockReturnValue(
+      createAgentStatus({
+        sessionId: 'pty-session-1',
+        agentType: null,
       })
     )
 

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -521,11 +521,12 @@ const WorkspaceViewContent = (): ReactElement => {
     agentStatusResetGeneration
   )
 
-  // Codex watcher relocation recovery (VIM-188/192): `/clear` arms the red
-  // "needs reattach" indicator + a bounded auto-reattach; the always-on drift
-  // tick relocates the active Codex pane so the panel also follows an
-  // undetectable in-session `resume`. Recovery is automatic once codex writes
-  // the conversation (the user sends a prompt) — there is no manual button.
+  // Watcher relocation recovery (VIM-188/192): a `/clear` on a codex or
+  // opencode pane arms the red "needs reattach" indicator + a bounded
+  // auto-reattach; the always-on drift tick additionally relocates the active
+  // Codex pane so the panel follows an undetectable in-session `resume`.
+  // Recovery is automatic once the agent writes the new session (the user
+  // sends a prompt) — there is no manual button.
   const agentReattach = useAgentReattach({
     sessionId: activePtyBackedPanePtyId ?? null,
     agentSessionId: agentStatus.agentSessionId,
@@ -536,7 +537,9 @@ const WorkspaceViewContent = (): ReactElement => {
     staleGeneration: agentStatusResetGeneration,
     // Drift-detection (VIM-192) runs only for a live Codex pane: it re-locates
     // periodically so the panel follows an in-session `resume` (which is
-    // undetectable and never arms the red state).
+    // undetectable and never arms the red state). opencode does not need drift
+    // — its bridge writes are append-close so the lsof open-FD signal doesn't
+    // apply; `/clear` reattach is covered by the command path above.
     driftEnabled: agentStatus.agentType === 'codex' && agentStatus.isActive,
   })
 
@@ -577,28 +580,29 @@ const WorkspaceViewContent = (): ReactElement => {
   const handleTerminalCommandSubmit = useCallback(
     (ptyId: string, command: string): void => {
       // A codex `/clear` opens a fresh conversation and `/resume` switches to a
-      // different one — both point codex at a NEW rollout, so the live status
-      // is now stale. Treat both as a context switch: reset agent-status and arm
-      // the red "send a prompt to reattach" indicator until the watcher
+      // different one — both point codex/opencode at a NEW session, so the live
+      // status is now stale. Treat both as a context switch: reset agent-status
+      // and arm the red "send a prompt to reattach" indicator until the watcher
       // relocates onto the new conversation (VIM-192). `/resume <id>` is the
-      // arg form.
-      const isCodexContextSwitch =
+      // arg form (codex-only; harmless for opencode which only uses `/clear`).
+      const isContextSwitch =
         command === '/clear' ||
         command === '/resume' ||
         command.startsWith('/resume ')
-      if (!isCodexContextSwitch) {
+      if (!isContextSwitch) {
         return
       }
 
       // Only reset agent-status state when the active pane is actually running
-      // Codex. Raw PTY input (e.g. vim's `/clear` search followed by Enter) is
-      // syntactically identical to a Codex command, and a false reset for a
-      // live Codex session would suppress same-run events until the next
+      // Codex or opencode. Raw PTY input (e.g. vim's `/clear` search followed
+      // by Enter) is syntactically identical to an agent command, and a false
+      // reset for a live session would suppress same-run events until the next
       // session boundary (Claude Code Review on PR #469).
-      if (
-        ptyId === activePtyBackedPanePtyId &&
-        agentStatus.agentType === 'codex'
-      ) {
+      const at = agentStatus.agentType
+      // opencode follows `/clear` via the command path only; its bridge writes
+      // are append-close so the codex lsof open-FD drift signal doesn't apply.
+      const followsClearReattach = at === 'codex' || at === 'opencode'
+      if (ptyId === activePtyBackedPanePtyId && followsClearReattach) {
         setAgentStatusReset((prev) => ({
           ptyId,
           generation: prev?.ptyId === ptyId ? prev.generation + 1 : 1,


### PR DESCRIPTION
## opencode follows /clear via reattach (Bug D, Part 2)

Part of VIM-193. Closes VIM-205.

Now that the codex watcher-reattach infrastructure is merged into the feature branch, this extends the `/clear` reattach-arming to opencode panes. A `/clear` on an active opencode pane arms the red "needs reattach" state + the bounded auto-reattach, which re-invokes `start_agent_watcher` → opencode's `locate()` (re-resolution-ready from Part 1, VIM-203) re-binds the new post-`/clear` session; the hook's bounded retry covers the new-session startup window.

### Change (`WorkspaceView.tsx`)
- `handleTerminalCommandSubmit`: the `/clear` reset-arming guard now covers `codex || opencode`.
- `driftEnabled` stays **codex-only** — opencode's bridge writes are append-close, so the codex lsof open-FD drift signal doesn't apply; opencode follows `/clear` via the command path. (In-session `resume` is not an opencode concept.)
- `useAgentReattach`/`Header` untouched (already agent-agnostic).

### Verification (local; CI re-runs full suite)
- `type-check` / `lint` / `format:check` green; workspace + agent-status suites **1163 pass** (2 new opencode `/clear` tests + a non-opencode negative).

🤖 Generated with [Claude Code](https://claude.com/claude-code)