### PR TITLE
fix(terminal): correct Ghostty background synthesis (glyph entities + palette colors)

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -58,7 +58,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 26       | 9    | 2026-06-21   |
 | [Terminal DOM Rendering](patterns/terminal-dom-rendering.md)                                         | terminal           | 10       | 6    | 2026-06-21   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
-| [Terminal Render-State Driver Contract](patterns/terminal-render-state-driver-contract.md)           | terminal           | 31       | 9    | 2026-06-21   |
+| [Terminal Render-State Driver Contract](patterns/terminal-render-state-driver-contract.md)           | terminal           | 32       | 9    | 2026-06-21   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 85       | 25   | 2026-06-08   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 51       | 24   | 2026-06-18   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
@@ -91,4 +91,4 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Prototype Handoff Artifacts](patterns/prototype-handoff-artifacts.md)                               | review-process     | 2        | 0    | 2026-06-12   |
 | [CloudFormation Environment Prefix Coupling](patterns/cloudformation-environment-prefix-coupling.md) | infrastructure     | 1        | 0    | 2026-06-12   |
 | [CloudFormation Stale References](patterns/cloudformation-stale-references.md)                       | infrastructure     | 2        | 1    | 2026-06-12   |
-| [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 6        | 3    | 2026-06-21   |
+| [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 7        | 3    | 2026-06-21   |

--- a/docs/reviews/patterns/dead-code.md
+++ b/docs/reviews/patterns/dead-code.md
@@ -70,3 +70,12 @@ code and should be removed.
 - **Finding:** The Electron bridge computed and transmitted `cursor.textOffset`, but the renderer deliberately recomputed cursor offsets from `columnOffset` and the current cell map. The field was dead API surface and could invite future callers to trust a stale main-process offset.
 - **Fix:** Removed `textOffset` from the Electron bridge, preload type, renderer-side native bridge normalizer, and VT snapshot cursor type. Updated tests to assert only the live `rowIndex`, `columnOffset`, and visibility contract.
 - **Commit:** same commit as this entry
+
+### 7. Parser gates must admit every branch a decoder claims to handle
+
+- **Source:** github-claude | PR #598 round 1 | 2026-06-21
+- **Severity:** LOW
+- **File:** `electron/ghostty-render-state-main.ts` L469-L484
+- **Finding:** `decodeNumericHtmlEntity` accepted uppercase `X` hex entities, but `HTML_ENTITY_PATTERN` only matched lowercase `#x...` entities. The uppercase branch was unreachable, so a valid `&#X...;` entity would pass through as literal text and inflate column accounting.
+- **Fix:** Changed the numeric-entity regex to match `#[xX][0-9a-fA-F]+` and added regression coverage for an uppercase-hex Powerline glyph entity.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/terminal-render-state-driver-contract.md
+++ b/docs/reviews/patterns/terminal-render-state-driver-contract.md
@@ -299,3 +299,12 @@ documented explicitly: effect callbacks must be invoked synchronously inside the
 - **Finding:** A trailing sparse styled blank can intentionally leave `fallbackColumn` behind `currentColumn` so visible text includes both the styled blank and the following fallback row text. Cursor-offset lookup still measured trailing text from `currentColumn`, placing the cursor before the following fallback character.
 - **Fix:** Changed trailing cursor lookup to measure from `fallbackColumn`, matching the text slice used by visible-row reconstruction. Added a shared regression for `A B` with a styled blank at column 1 and the cursor after that terminal cell.
 - **Commit:** same commit as this entry
+
+### 31. Styled range clamps must include cursor-row padding extent
+
+- **Source:** github-codex-connector | PR #598 round 1 | 2026-06-21
+- **Severity:** P2 / MEDIUM
+- **File:** `electron/ghostty-render-state-main.ts`
+- **Finding:** The Electron Ghostty bridge clamped synthesized formatter background/reverse ranges to native cell and visible-text extents only. When Ghostty trimmed trailing blanks on the cursor row, the renderer later padded that row back to `cursor.columnOffset`, but the styled blanks before the cursor had already been dropped.
+- **Fix:** Threaded the validated cursor row/column into reverse-range synthesis and included `cursor.columnOffset` in the effective extent for the cursor row only. Added regression coverage for cursor-row styled padding that preserves style up to the cursor without restoring full-width formatter padding.
+- **Commit:** same commit as this entry

--- a/electron/ghostty-render-state-main.test.ts
+++ b/electron/ghostty-render-state-main.test.ts
@@ -1087,6 +1087,55 @@ describe('ghostty render-state main bridge', () => {
     })
   })
 
+  test('decodes numeric glyph entities so background ranges align to native columns', () => {
+    const separator = String.fromCodePoint(0xe0b0)
+
+    const bridge = new GhosttyRenderStateMainBridge('/app', {
+      createTerminal: (): ReturnType<
+        GhosttyNativeBindings['createTerminal']
+      > => ({
+        feed: vi.fn(),
+        resize: vi.fn(),
+        snapshot: () => ({
+          rows: 1,
+          cursorRow: 0,
+          cursorCol: 3,
+          visibleLines: [{ row: 0, text: `${separator}ab` }],
+          cells: [
+            { row: 0, col: 0, text: separator, width: 1 },
+            { row: 0, col: 1, text: 'a', width: 1 },
+            { row: 0, col: 2, text: 'b', width: 1 },
+          ],
+        }),
+        formatHtml: vi.fn(
+          () =>
+            '<div style="font-family: monospace; white-space: pre;"><div style="display: inline;color: rgb(1, 2, 3);">&#57520;</div><div style="display: inline;background-color: rgb(64, 64, 72);">ab</div></div>'
+        ),
+        dispose: vi.fn(),
+      }),
+    })
+    const event = createEvent()
+    const createResult = requireResult(bridge.createDriver(event))
+
+    expect(
+      bridge.readSnapshot(event.sender.id, { driverId: createResult.driverId })
+    ).toEqual({
+      ok: true,
+      result: {
+        rows: [`${separator}ab`],
+        cursor: {
+          rowIndex: 0,
+          columnOffset: 3,
+        },
+        cells: [
+          { row: 0, col: 0, text: separator, width: 1 },
+          { row: 0, col: 1, text: 'a', width: 1, background: '#404048' },
+          { row: 0, col: 2, text: 'b', width: 1, background: '#404048' },
+        ],
+      },
+    })
+  })
+
   test('preserves native fallback text before sparse styled empty cells', () => {
     const bridge = new GhosttyRenderStateMainBridge('/app', {
       createTerminal: (): ReturnType<

--- a/electron/ghostty-render-state-main.test.ts
+++ b/electron/ghostty-render-state-main.test.ts
@@ -1087,6 +1087,54 @@ describe('ghostty render-state main bridge', () => {
     })
   })
 
+  test('preserves cursor-row background padding up to the cursor', () => {
+    const bridge = new GhosttyRenderStateMainBridge('/app', {
+      createTerminal: (): ReturnType<
+        GhosttyNativeBindings['createTerminal']
+      > => ({
+        feed: vi.fn(),
+        resize: vi.fn(),
+        snapshot: () => ({
+          rows: 1,
+          cursorRow: 0,
+          cursorCol: 4,
+          visibleLines: [{ row: 0, text: 'AB' }],
+          cells: [
+            { row: 0, col: 0, text: 'A', width: 1 },
+            { row: 0, col: 1, text: 'B', width: 1 },
+          ],
+        }),
+        formatHtml: vi.fn(
+          () =>
+            `<div style="font-family: monospace; white-space: pre;"><span style="background-color: rgb(64, 64, 72);">AB${' '.repeat(
+              38
+            )}</span></div>`
+        ),
+        dispose: vi.fn(),
+      }),
+    })
+    const event = createEvent()
+    const createResult = requireResult(bridge.createDriver(event))
+
+    expect(
+      bridge.readSnapshot(event.sender.id, { driverId: createResult.driverId })
+    ).toEqual({
+      ok: true,
+      result: {
+        rows: ['AB'],
+        cursor: {
+          rowIndex: 0,
+          columnOffset: 4,
+        },
+        cells: [
+          { row: 0, col: 0, text: 'A', width: 1, background: '#404048' },
+          { row: 0, col: 1, text: 'B', width: 1, background: '#404048' },
+          { row: 0, col: 2, text: '  ', width: 2, background: '#404048' },
+        ],
+      },
+    })
+  })
+
   test('decodes numeric glyph entities so background ranges align to native columns', () => {
     const separator = String.fromCodePoint(0xe0b0)
 
@@ -1131,6 +1179,53 @@ describe('ghostty render-state main bridge', () => {
           { row: 0, col: 0, text: separator, width: 1 },
           { row: 0, col: 1, text: 'a', width: 1, background: '#404048' },
           { row: 0, col: 2, text: 'b', width: 1, background: '#404048' },
+        ],
+      },
+    })
+  })
+
+  test('decodes uppercase hex numeric glyph entities', () => {
+    const separator = String.fromCodePoint(0xe0b0)
+
+    const bridge = new GhosttyRenderStateMainBridge('/app', {
+      createTerminal: (): ReturnType<
+        GhosttyNativeBindings['createTerminal']
+      > => ({
+        feed: vi.fn(),
+        resize: vi.fn(),
+        snapshot: () => ({
+          rows: 1,
+          cursorRow: 0,
+          cursorCol: 2,
+          visibleLines: [{ row: 0, text: `${separator}x` }],
+          cells: [
+            { row: 0, col: 0, text: separator, width: 1 },
+            { row: 0, col: 1, text: 'x', width: 1 },
+          ],
+        }),
+        formatHtml: vi.fn(
+          () =>
+            '<div style="font-family: monospace; white-space: pre;"><span>&#XE0B0;</span><span style="background-color: rgb(64, 64, 72);">x</span></div>'
+        ),
+        dispose: vi.fn(),
+      }),
+    })
+    const event = createEvent()
+    const createResult = requireResult(bridge.createDriver(event))
+
+    expect(
+      bridge.readSnapshot(event.sender.id, { driverId: createResult.driverId })
+    ).toEqual({
+      ok: true,
+      result: {
+        rows: [`${separator}x`],
+        cursor: {
+          rowIndex: 0,
+          columnOffset: 2,
+        },
+        cells: [
+          { row: 0, col: 0, text: separator, width: 1 },
+          { row: 0, col: 1, text: 'x', width: 1, background: '#404048' },
         ],
       },
     })

--- a/electron/ghostty-render-state-main.test.ts
+++ b/electron/ghostty-render-state-main.test.ts
@@ -993,7 +993,7 @@ describe('ghostty render-state main bridge', () => {
     })
   })
 
-  test('clamps full-width background runs to the native content extent', () => {
+  test('renders a palette (var--vt-palette) background box across blank cells the snapshot omits', () => {
     const bridge = new GhosttyRenderStateMainBridge('/app', {
       createTerminal: (): ReturnType<
         GhosttyNativeBindings['createTerminal']
@@ -1003,18 +1003,12 @@ describe('ghostty render-state main bridge', () => {
         snapshot: () => ({
           rows: 1,
           cursorRow: 0,
-          cursorCol: 2,
-          visibleLines: [{ row: 0, text: 'AB' }],
-          cells: [
-            { row: 0, col: 0, text: 'A', width: 1 },
-            { row: 0, col: 1, text: 'B', width: 1 },
-          ],
+          cursorCol: 3,
+          visibleLines: [{ row: 0, text: ' ab' }],
         }),
         formatHtml: vi.fn(
           () =>
-            `<div style="font-family: monospace; white-space: pre;"><span style="background-color: rgb(64, 64, 72);">AB${' '.repeat(
-              38
-            )}</span></div>`
+            '<div style="font-family: monospace; white-space: pre;"><div style="display: inline;background-color: var(--vt-palette-236);"> ab   </div></div>'
         ),
         dispose: vi.fn(),
       }),
@@ -1027,109 +1021,13 @@ describe('ghostty render-state main bridge', () => {
     ).toEqual({
       ok: true,
       result: {
-        rows: ['AB'],
+        rows: [' ab'],
         cursor: {
           rowIndex: 0,
-          columnOffset: 2,
+          columnOffset: 3,
         },
         cells: [
-          { row: 0, col: 0, text: 'A', width: 1, background: '#404048' },
-          { row: 0, col: 1, text: 'B', width: 1, background: '#404048' },
-        ],
-      },
-    })
-  })
-
-  test('clamps multi-segment background runs without bleeding past content', () => {
-    const bridge = new GhosttyRenderStateMainBridge('/app', {
-      createTerminal: (): ReturnType<
-        GhosttyNativeBindings['createTerminal']
-      > => ({
-        feed: vi.fn(),
-        resize: vi.fn(),
-        snapshot: () => ({
-          rows: 1,
-          cursorRow: 0,
-          cursorCol: 2,
-          visibleLines: [{ row: 0, text: 'ab' }],
-          cells: [
-            { row: 0, col: 0, text: 'a', width: 1 },
-            { row: 0, col: 1, text: 'b', width: 1 },
-          ],
-        }),
-        formatHtml: vi.fn(
-          () =>
-            `<div style="font-family: monospace; white-space: pre;"><span style="background-color: rgb(200, 30, 30);">a</span><span style="background-color: rgb(30, 30, 200);">b${' '.repeat(
-              38
-            )}</span></div>`
-        ),
-        dispose: vi.fn(),
-      }),
-    })
-    const event = createEvent()
-    const createResult = requireResult(bridge.createDriver(event))
-
-    expect(
-      bridge.readSnapshot(event.sender.id, { driverId: createResult.driverId })
-    ).toEqual({
-      ok: true,
-      result: {
-        rows: ['ab'],
-        cursor: {
-          rowIndex: 0,
-          columnOffset: 2,
-        },
-        cells: [
-          { row: 0, col: 0, text: 'a', width: 1, background: '#c81e1e' },
-          { row: 0, col: 1, text: 'b', width: 1, background: '#1e1ec8' },
-        ],
-      },
-    })
-  })
-
-  test('preserves cursor-row background padding up to the cursor', () => {
-    const bridge = new GhosttyRenderStateMainBridge('/app', {
-      createTerminal: (): ReturnType<
-        GhosttyNativeBindings['createTerminal']
-      > => ({
-        feed: vi.fn(),
-        resize: vi.fn(),
-        snapshot: () => ({
-          rows: 1,
-          cursorRow: 0,
-          cursorCol: 4,
-          visibleLines: [{ row: 0, text: 'AB' }],
-          cells: [
-            { row: 0, col: 0, text: 'A', width: 1 },
-            { row: 0, col: 1, text: 'B', width: 1 },
-          ],
-        }),
-        formatHtml: vi.fn(
-          () =>
-            `<div style="font-family: monospace; white-space: pre;"><span style="background-color: rgb(64, 64, 72);">AB${' '.repeat(
-              38
-            )}</span></div>`
-        ),
-        dispose: vi.fn(),
-      }),
-    })
-    const event = createEvent()
-    const createResult = requireResult(bridge.createDriver(event))
-
-    expect(
-      bridge.readSnapshot(event.sender.id, { driverId: createResult.driverId })
-    ).toEqual({
-      ok: true,
-      result: {
-        rows: ['AB'],
-        cursor: {
-          rowIndex: 0,
-          columnOffset: 4,
-        },
-        cells: [
-          { row: 0, col: 0, text: 'A', width: 1, background: '#404048' },
-          { row: 0, col: 1, text: 'B', width: 1, background: '#404048' },
-          { row: 0, col: 2, text: '  ', width: 2, background: '#404048' },
+          { row: 0, col: 0, text: ' ab   ', width: 6, background: '#303030' },
         ],
       },
     })

--- a/electron/ghostty-render-state-main.test.ts
+++ b/electron/ghostty-render-state-main.test.ts
@@ -993,6 +993,100 @@ describe('ghostty render-state main bridge', () => {
     })
   })
 
+  test('clamps full-width background runs to the native content extent', () => {
+    const bridge = new GhosttyRenderStateMainBridge('/app', {
+      createTerminal: (): ReturnType<
+        GhosttyNativeBindings['createTerminal']
+      > => ({
+        feed: vi.fn(),
+        resize: vi.fn(),
+        snapshot: () => ({
+          rows: 1,
+          cursorRow: 0,
+          cursorCol: 2,
+          visibleLines: [{ row: 0, text: 'AB' }],
+          cells: [
+            { row: 0, col: 0, text: 'A', width: 1 },
+            { row: 0, col: 1, text: 'B', width: 1 },
+          ],
+        }),
+        formatHtml: vi.fn(
+          () =>
+            `<div style="font-family: monospace; white-space: pre;"><span style="background-color: rgb(64, 64, 72);">AB${' '.repeat(
+              38
+            )}</span></div>`
+        ),
+        dispose: vi.fn(),
+      }),
+    })
+    const event = createEvent()
+    const createResult = requireResult(bridge.createDriver(event))
+
+    expect(
+      bridge.readSnapshot(event.sender.id, { driverId: createResult.driverId })
+    ).toEqual({
+      ok: true,
+      result: {
+        rows: ['AB'],
+        cursor: {
+          rowIndex: 0,
+          columnOffset: 2,
+        },
+        cells: [
+          { row: 0, col: 0, text: 'A', width: 1, background: '#404048' },
+          { row: 0, col: 1, text: 'B', width: 1, background: '#404048' },
+        ],
+      },
+    })
+  })
+
+  test('clamps multi-segment background runs without bleeding past content', () => {
+    const bridge = new GhosttyRenderStateMainBridge('/app', {
+      createTerminal: (): ReturnType<
+        GhosttyNativeBindings['createTerminal']
+      > => ({
+        feed: vi.fn(),
+        resize: vi.fn(),
+        snapshot: () => ({
+          rows: 1,
+          cursorRow: 0,
+          cursorCol: 2,
+          visibleLines: [{ row: 0, text: 'ab' }],
+          cells: [
+            { row: 0, col: 0, text: 'a', width: 1 },
+            { row: 0, col: 1, text: 'b', width: 1 },
+          ],
+        }),
+        formatHtml: vi.fn(
+          () =>
+            `<div style="font-family: monospace; white-space: pre;"><span style="background-color: rgb(200, 30, 30);">a</span><span style="background-color: rgb(30, 30, 200);">b${' '.repeat(
+              38
+            )}</span></div>`
+        ),
+        dispose: vi.fn(),
+      }),
+    })
+    const event = createEvent()
+    const createResult = requireResult(bridge.createDriver(event))
+
+    expect(
+      bridge.readSnapshot(event.sender.id, { driverId: createResult.driverId })
+    ).toEqual({
+      ok: true,
+      result: {
+        rows: ['ab'],
+        cursor: {
+          rowIndex: 0,
+          columnOffset: 2,
+        },
+        cells: [
+          { row: 0, col: 0, text: 'a', width: 1, background: '#c81e1e' },
+          { row: 0, col: 1, text: 'b', width: 1, background: '#1e1ec8' },
+        ],
+      },
+    })
+  })
+
   test('preserves native fallback text before sparse styled empty cells', () => {
     const bridge = new GhosttyRenderStateMainBridge('/app', {
       createTerminal: (): ReturnType<

--- a/electron/ghostty-render-state-main.ts
+++ b/electron/ghostty-render-state-main.ts
@@ -1,4 +1,4 @@
-// cspell:ignore ghostty libghostty prebuilds powerline
+// cspell:ignore ghostty libghostty prebuilds powerline Kimi
 import fs from 'node:fs'
 import path from 'node:path'
 import { createRequire } from 'node:module'
@@ -466,17 +466,15 @@ interface ReverseVideoRange {
   readonly endColumn: number
 }
 
-interface SnapshotCursorExtent {
-  readonly rowIndex: number
-  readonly columnOffset: number
-}
-
 const HTML_ENTITY_PATTERN = /&(?:amp|lt|gt|quot|#[xX][0-9a-fA-F]+|#\d+);/g
 const HTML_TOKEN_PATTERN = /<[^>]*>|[^<]+/g
 const HTML_STYLE_ATTRIBUTE_PATTERN = /\bstyle="([^"]*)"/i
 
 const HTML_BACKGROUND_RGB_PATTERN =
   /background-color:\s*rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)/i
+
+const HTML_BACKGROUND_PALETTE_PATTERN =
+  /background-color:\s*var\(--vt-palette-(\d{1,3})\)/i
 const HTML_REVERSE_FILTER_PATTERN = /filter:\s*invert\(100%\)/i
 
 const HTML_VOID_TAG_PATTERN =
@@ -545,6 +543,71 @@ const toHexColor = (red: number, green: number, blue: number): string =>
     )
     .join('')}`
 
+// Standard xterm 16-color base; indices 0-15 are theme-dependent in a real
+// terminal but agent input boxes use the theme-independent 16-255 range.
+const ANSI_BASE_PALETTE = [
+  '#000000',
+  '#800000',
+  '#008000',
+  '#808000',
+  '#000080',
+  '#800080',
+  '#008080',
+  '#c0c0c0',
+  '#808080',
+  '#ff0000',
+  '#00ff00',
+  '#ffff00',
+  '#0000ff',
+  '#ff00ff',
+  '#00ffff',
+  '#ffffff',
+]
+const ANSI_CUBE_LEVELS = [0, 95, 135, 175, 215, 255]
+
+// Ghostty emits indexed (256-color) backgrounds as `var(--vt-palette-N)` rather
+// than rgb(); resolve N to the same hex the native cells already use so a
+// palette-colored input box (Codex/Kimi) paints instead of being dropped.
+const paletteIndexToHex = (index: number): string | undefined => {
+  if (!Number.isInteger(index) || index < 0 || index > 255) {
+    return undefined
+  }
+
+  if (index < 16) {
+    return ANSI_BASE_PALETTE[index]
+  }
+
+  if (index < 232) {
+    const value = index - 16
+
+    return toHexColor(
+      ANSI_CUBE_LEVELS[Math.floor(value / 36) % 6],
+      ANSI_CUBE_LEVELS[Math.floor(value / 6) % 6],
+      ANSI_CUBE_LEVELS[value % 6]
+    )
+  }
+
+  const gray = 8 + (index - 232) * 10
+
+  return toHexColor(gray, gray, gray)
+}
+
+const readBackgroundColor = (style: string): string | undefined => {
+  const rgb = HTML_BACKGROUND_RGB_PATTERN.exec(style)
+
+  if (rgb) {
+    return toHexColor(Number(rgb[1]), Number(rgb[2]), Number(rgb[3]))
+  }
+
+  const palette = HTML_BACKGROUND_PALETTE_PATTERN.exec(style)
+
+  if (palette) {
+    return paletteIndexToHex(Number(palette[1]))
+  }
+
+  return undefined
+}
+
 const readTagCellStyle = (
   token: string
 ): Pick<ReverseVideoRange, 'background' | 'reverse'> => {
@@ -555,19 +618,11 @@ const readTagCellStyle = (
   }
 
   const style = match[1]
-  const background = HTML_BACKGROUND_RGB_PATTERN.exec(style)
+  const background = readBackgroundColor(style)
 
   return {
     ...(HTML_REVERSE_FILTER_PATTERN.test(style) ? { reverse: true } : {}),
-    ...(background
-      ? {
-          background: toHexColor(
-            Number(background[1]),
-            Number(background[2]),
-            Number(background[3])
-          ),
-        }
-      : {}),
+    ...(background ? { background } : {}),
   }
 }
 
@@ -863,58 +918,13 @@ const splitSnapshotCellByReverseVideoRanges = (
   })
 }
 
-// Ghostty's formatHtml() paints background runs across the full terminal width
-// (erase-to-EOL prompts render every padded column under `white-space: pre`),
-// but the native snapshot omits those trailing blank columns. Synthesizing a
-// cell for every HTML-covered column would fabricate a full-width colored bar
-// that bleeds over agent TUIs and shifts the cursor's visible position. Clamp
-// fabrication to the row's real content extent — the wider of the native cell
-// span and the visible-line text width — so only columns the snapshot actually
-// reported get a background, never the pre-formatted padding beyond them.
-const readRowContentExtents = (
-  cells: readonly GhosttyRenderStateBridgeSnapshotCell[],
-  rows: readonly string[],
-  cursor: SnapshotCursorExtent
-): ReadonlyMap<number, number> => {
-  const extents = new Map<number, number>()
-
-  cells.forEach((cell) => {
-    extents.set(
-      cell.row,
-      Math.max(extents.get(cell.row) ?? 0, cell.col + cell.width)
-    )
-  })
-
-  rows.forEach((rowText, row) => {
-    extents.set(
-      row,
-      Math.max(extents.get(row) ?? 0, readTextCellWidth(rowText))
-    )
-  })
-
-  extents.set(
-    cursor.rowIndex,
-    Math.max(extents.get(cursor.rowIndex) ?? 0, cursor.columnOffset)
-  )
-
-  return extents
-}
-
 const appendMissingReverseCells = (
   cells: GhosttyRenderStateBridgeSnapshotCell[],
   rows: readonly string[],
-  ranges: readonly ReverseVideoRange[],
-  cursor: SnapshotCursorExtent
+  ranges: readonly ReverseVideoRange[]
 ): void => {
-  const contentExtents = readRowContentExtents(cells, rows, cursor)
-
   ranges.forEach((range) => {
-    const endColumn = Math.min(
-      range.endColumn,
-      contentExtents.get(range.row) ?? 0
-    )
-
-    if (range.row >= rows.length || endColumn <= range.startColumn) {
+    if (range.row >= rows.length || range.endColumn <= range.startColumn) {
       return
     }
 
@@ -924,7 +934,7 @@ const appendMissingReverseCells = (
       .filter(
         (cell) =>
           cell.row === range.row &&
-          cell.col < endColumn &&
+          cell.col < range.endColumn &&
           cell.col + cell.width > range.startColumn
       )
       .sort((left, right) => left.col - right.col)
@@ -937,16 +947,16 @@ const appendMissingReverseCells = (
             text: readRowTextByCellColumns(
               rows[range.row] ?? '',
               startColumn,
-              Math.min(cell.col, endColumn)
+              Math.min(cell.col, range.endColumn)
             ),
-            width: Math.min(cell.col, endColumn) - startColumn,
+            width: Math.min(cell.col, range.endColumn) - startColumn,
           })
         }
 
         startColumn = Math.max(startColumn, cell.col + cell.width)
       })
 
-    if (startColumn < endColumn) {
+    if (startColumn < range.endColumn) {
       cells.push({
         ...readRangeStyle(range),
         row: range.row,
@@ -954,9 +964,9 @@ const appendMissingReverseCells = (
         text: readRowTextByCellColumns(
           rows[range.row] ?? '',
           startColumn,
-          endColumn
+          range.endColumn
         ),
-        width: endColumn - startColumn,
+        width: range.endColumn - startColumn,
       })
     }
   })
@@ -994,8 +1004,7 @@ const readSnapshotRows = (
 const readSnapshotCells = (
   snapshot: GhosttyNativeTerminalSnapshot,
   rows: readonly string[],
-  reverseVideoRanges: readonly ReverseVideoRange[],
-  cursor: SnapshotCursorExtent
+  reverseVideoRanges: readonly ReverseVideoRange[]
 ): readonly GhosttyRenderStateBridgeSnapshotCell[] | undefined => {
   if (snapshot.cells === undefined && reverseVideoRanges.length === 0) {
     return undefined
@@ -1061,7 +1070,7 @@ const readSnapshotCells = (
       )
     )
 
-  appendMissingReverseCells(cells, rows, reverseVideoRanges, cursor)
+  appendMissingReverseCells(cells, rows, reverseVideoRanges)
 
   return cells.sort((left, right) =>
     left.row === right.row ? left.col - right.col : left.row - right.row
@@ -1091,7 +1100,7 @@ const normalizeSnapshot = (
     rowIndex: snapshot.cursorRow,
     columnOffset: snapshot.cursorCol,
   }
-  const cells = readSnapshotCells(snapshot, rows, reverseVideoRanges, cursor)
+  const cells = readSnapshotCells(snapshot, rows, reverseVideoRanges)
 
   return {
     rows,

--- a/electron/ghostty-render-state-main.ts
+++ b/electron/ghostty-render-state-main.ts
@@ -466,7 +466,12 @@ interface ReverseVideoRange {
   readonly endColumn: number
 }
 
-const HTML_ENTITY_PATTERN = /&(?:amp|lt|gt|quot|#x[0-9a-fA-F]+|#\d+);/g
+interface SnapshotCursorExtent {
+  readonly rowIndex: number
+  readonly columnOffset: number
+}
+
+const HTML_ENTITY_PATTERN = /&(?:amp|lt|gt|quot|#[xX][0-9a-fA-F]+|#\d+);/g
 const HTML_TOKEN_PATTERN = /<[^>]*>|[^<]+/g
 const HTML_STYLE_ATTRIBUTE_PATTERN = /\bstyle="([^"]*)"/i
 
@@ -868,7 +873,8 @@ const splitSnapshotCellByReverseVideoRanges = (
 // reported get a background, never the pre-formatted padding beyond them.
 const readRowContentExtents = (
   cells: readonly GhosttyRenderStateBridgeSnapshotCell[],
-  rows: readonly string[]
+  rows: readonly string[],
+  cursor: SnapshotCursorExtent
 ): ReadonlyMap<number, number> => {
   const extents = new Map<number, number>()
 
@@ -886,15 +892,21 @@ const readRowContentExtents = (
     )
   })
 
+  extents.set(
+    cursor.rowIndex,
+    Math.max(extents.get(cursor.rowIndex) ?? 0, cursor.columnOffset)
+  )
+
   return extents
 }
 
 const appendMissingReverseCells = (
   cells: GhosttyRenderStateBridgeSnapshotCell[],
   rows: readonly string[],
-  ranges: readonly ReverseVideoRange[]
+  ranges: readonly ReverseVideoRange[],
+  cursor: SnapshotCursorExtent
 ): void => {
-  const contentExtents = readRowContentExtents(cells, rows)
+  const contentExtents = readRowContentExtents(cells, rows, cursor)
 
   ranges.forEach((range) => {
     const endColumn = Math.min(
@@ -982,7 +994,8 @@ const readSnapshotRows = (
 const readSnapshotCells = (
   snapshot: GhosttyNativeTerminalSnapshot,
   rows: readonly string[],
-  reverseVideoRanges: readonly ReverseVideoRange[]
+  reverseVideoRanges: readonly ReverseVideoRange[],
+  cursor: SnapshotCursorExtent
 ): readonly GhosttyRenderStateBridgeSnapshotCell[] | undefined => {
   if (snapshot.cells === undefined && reverseVideoRanges.length === 0) {
     return undefined
@@ -1048,7 +1061,7 @@ const readSnapshotCells = (
       )
     )
 
-  appendMissingReverseCells(cells, rows, reverseVideoRanges)
+  appendMissingReverseCells(cells, rows, reverseVideoRanges, cursor)
 
   return cells.sort((left, right) =>
     left.row === right.row ? left.col - right.col : left.row - right.row
@@ -1061,7 +1074,6 @@ const normalizeSnapshot = (
   reverseVideoRanges: readonly ReverseVideoRange[]
 ): GhosttyRenderStateBridgeSnapshot => {
   const rows = readSnapshotRows(snapshot)
-  const cells = readSnapshotCells(snapshot, rows, reverseVideoRanges)
 
   const snapshotCursorVisible =
     typeof snapshot.cursorVisible === 'boolean'
@@ -1075,11 +1087,16 @@ const normalizeSnapshot = (
     throw new Error('Ghostty native render-state snapshot cursor is invalid')
   }
 
+  const cursor = {
+    rowIndex: snapshot.cursorRow,
+    columnOffset: snapshot.cursorCol,
+  }
+  const cells = readSnapshotCells(snapshot, rows, reverseVideoRanges, cursor)
+
   return {
     rows,
     cursor: {
-      rowIndex: snapshot.cursorRow,
-      columnOffset: snapshot.cursorCol,
+      ...cursor,
       ...(snapshotCursorVisible === false ? { visible: false } : {}),
     },
     ...(cells === undefined ? {} : { cells }),

--- a/electron/ghostty-render-state-main.ts
+++ b/electron/ghostty-render-state-main.ts
@@ -1,4 +1,4 @@
-// cspell:ignore ghostty libghostty prebuilds
+// cspell:ignore ghostty libghostty prebuilds powerline
 import fs from 'node:fs'
 import path from 'node:path'
 import { createRequire } from 'node:module'
@@ -466,7 +466,7 @@ interface ReverseVideoRange {
   readonly endColumn: number
 }
 
-const HTML_ENTITY_PATTERN = /&(?:amp|lt|gt|quot|#39);/g
+const HTML_ENTITY_PATTERN = /&(?:amp|lt|gt|quot|#x[0-9a-fA-F]+|#\d+);/g
 const HTML_TOKEN_PATTERN = /<[^>]*>|[^<]+/g
 const HTML_STYLE_ATTRIBUTE_PATTERN = /\bstyle="([^"]*)"/i
 
@@ -477,6 +477,31 @@ const HTML_REVERSE_FILTER_PATTERN = /filter:\s*invert\(100%\)/i
 const HTML_VOID_TAG_PATTERN =
   /^<(?:area|base|br|col|embed|hr|img|input|link|meta|source|track|wbr)\b/i
 
+const decodeNumericHtmlEntity = (entity: string): string => {
+  const body = entity.slice(2, -1)
+
+  const codePoint =
+    body.startsWith('x') || body.startsWith('X')
+      ? Number.parseInt(body.slice(1), 16)
+      : Number.parseInt(body, 10)
+
+  if (!Number.isInteger(codePoint) || codePoint < 0 || codePoint > 0x10ffff) {
+    return entity
+  }
+
+  try {
+    return String.fromCodePoint(codePoint)
+  } catch {
+    return entity
+  }
+}
+
+// Ghostty's formatter emits Nerd Font / powerline glyphs as numeric entities
+// (e.g. the apple logo as &#983093;, the powerline separator as &#57520;).
+// Decoding them is load-bearing for column accounting: an undecoded
+// "&#57520;" is 8 string characters, so readReverseVideoRangesFromHtml would
+// count it as 8 cells instead of 1 and every background range past it would
+// drift right off its real column — bleeding prompt colors onto typed input.
 const decodeHtmlText = (text: string): string =>
   text.replace(HTML_ENTITY_PATTERN, (entity) => {
     if (entity === '&amp;') {
@@ -495,7 +520,7 @@ const decodeHtmlText = (text: string): string =>
       return '"'
     }
 
-    return "'"
+    return decodeNumericHtmlEntity(entity)
   })
 
 const isOpeningHtmlTag = (token: string): boolean =>

--- a/electron/ghostty-render-state-main.ts
+++ b/electron/ghostty-render-state-main.ts
@@ -833,13 +833,51 @@ const splitSnapshotCellByReverseVideoRanges = (
   })
 }
 
+// Ghostty's formatHtml() paints background runs across the full terminal width
+// (erase-to-EOL prompts render every padded column under `white-space: pre`),
+// but the native snapshot omits those trailing blank columns. Synthesizing a
+// cell for every HTML-covered column would fabricate a full-width colored bar
+// that bleeds over agent TUIs and shifts the cursor's visible position. Clamp
+// fabrication to the row's real content extent — the wider of the native cell
+// span and the visible-line text width — so only columns the snapshot actually
+// reported get a background, never the pre-formatted padding beyond them.
+const readRowContentExtents = (
+  cells: readonly GhosttyRenderStateBridgeSnapshotCell[],
+  rows: readonly string[]
+): ReadonlyMap<number, number> => {
+  const extents = new Map<number, number>()
+
+  cells.forEach((cell) => {
+    extents.set(
+      cell.row,
+      Math.max(extents.get(cell.row) ?? 0, cell.col + cell.width)
+    )
+  })
+
+  rows.forEach((rowText, row) => {
+    extents.set(
+      row,
+      Math.max(extents.get(row) ?? 0, readTextCellWidth(rowText))
+    )
+  })
+
+  return extents
+}
+
 const appendMissingReverseCells = (
   cells: GhosttyRenderStateBridgeSnapshotCell[],
   rows: readonly string[],
   ranges: readonly ReverseVideoRange[]
 ): void => {
+  const contentExtents = readRowContentExtents(cells, rows)
+
   ranges.forEach((range) => {
-    if (range.row >= rows.length || range.endColumn <= range.startColumn) {
+    const endColumn = Math.min(
+      range.endColumn,
+      contentExtents.get(range.row) ?? 0
+    )
+
+    if (range.row >= rows.length || endColumn <= range.startColumn) {
       return
     }
 
@@ -849,7 +887,7 @@ const appendMissingReverseCells = (
       .filter(
         (cell) =>
           cell.row === range.row &&
-          cell.col < range.endColumn &&
+          cell.col < endColumn &&
           cell.col + cell.width > range.startColumn
       )
       .sort((left, right) => left.col - right.col)
@@ -862,16 +900,16 @@ const appendMissingReverseCells = (
             text: readRowTextByCellColumns(
               rows[range.row] ?? '',
               startColumn,
-              Math.min(cell.col, range.endColumn)
+              Math.min(cell.col, endColumn)
             ),
-            width: Math.min(cell.col, range.endColumn) - startColumn,
+            width: Math.min(cell.col, endColumn) - startColumn,
           })
         }
 
         startColumn = Math.max(startColumn, cell.col + cell.width)
       })
 
-    if (startColumn < range.endColumn) {
+    if (startColumn < endColumn) {
       cells.push({
         ...readRangeStyle(range),
         row: range.row,
@@ -879,9 +917,9 @@ const appendMissingReverseCells = (
         text: readRowTextByCellColumns(
           rows[range.row] ?? '',
           startColumn,
-          range.endColumn
+          endColumn
         ),
-        width: range.endColumn - startColumn,
+        width: endColumn - startColumn,
       })
     }
   })

--- a/electron/ghostty-render-state-main.ts
+++ b/electron/ghostty-render-state-main.ts
@@ -9,6 +9,7 @@ import {
   readTextCellWidth,
   type GhosttyCellTraversalCell,
 } from '../shared/ghosttyCellTraversal'
+import { palette256ToRgb } from '../shared/ansiPalette'
 import {
   GHOSTTY_RENDER_STATE_CREATE,
   GHOSTTY_RENDER_STATE_DISPOSE,
@@ -543,8 +544,12 @@ const toHexColor = (red: number, green: number, blue: number): string =>
     )
     .join('')}`
 
-// Standard xterm 16-color base; indices 0-15 are theme-dependent in a real
-// terminal but agent input boxes use the theme-independent 16-255 range.
+// xterm 0-15 base. These are theme-dependent in a real terminal, but the main
+// process has no DOM/theme access (the renderer resolves them to
+// `var(--terminal-ansi-*)`). The 16-255 range is theme-independent and shared
+// via palette256ToRgb. ponytail: 0-15 input-box backgrounds are vanishingly
+// rare; a standard-hex fallback beats an unpainted box, upgrade to a
+// theme-resolved value if a real 0-15 box ever shows the wrong shade.
 const ANSI_BASE_PALETTE = [
   '#000000',
   '#800000',
@@ -563,33 +568,22 @@ const ANSI_BASE_PALETTE = [
   '#00ffff',
   '#ffffff',
 ]
-const ANSI_CUBE_LEVELS = [0, 95, 135, 175, 215, 255]
 
 // Ghostty emits indexed (256-color) backgrounds as `var(--vt-palette-N)` rather
 // than rgb(); resolve N to the same hex the native cells already use so a
 // palette-colored input box (Codex/Kimi) paints instead of being dropped.
 const paletteIndexToHex = (index: number): string | undefined => {
-  if (!Number.isInteger(index) || index < 0 || index > 255) {
-    return undefined
+  const rgb = palette256ToRgb(index)
+
+  if (rgb) {
+    return toHexColor(rgb[0], rgb[1], rgb[2])
   }
 
-  if (index < 16) {
+  if (Number.isInteger(index) && index >= 0 && index < 16) {
     return ANSI_BASE_PALETTE[index]
   }
 
-  if (index < 232) {
-    const value = index - 16
-
-    return toHexColor(
-      ANSI_CUBE_LEVELS[Math.floor(value / 36) % 6],
-      ANSI_CUBE_LEVELS[Math.floor(value / 6) % 6],
-      ANSI_CUBE_LEVELS[value % 6]
-    )
-  }
-
-  const gray = 8 + (index - 232) * 10
-
-  return toHexColor(gray, gray, gray)
+  return undefined
 }
 
 const readBackgroundColor = (style: string): string | undefined => {

--- a/shared/ansiPalette.test.ts
+++ b/shared/ansiPalette.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'vitest'
+import { palette256ToRgb } from './ansiPalette'
+
+describe('palette256ToRgb', () => {
+  test('returns null for theme-dependent base indices 0-15', () => {
+    expect(palette256ToRgb(0)).toBeNull()
+    expect(palette256ToRgb(7)).toBeNull()
+    expect(palette256ToRgb(15)).toBeNull()
+  })
+
+  test('resolves the 6x6x6 color cube (16-231)', () => {
+    expect(palette256ToRgb(16)).toEqual([0, 0, 0])
+    expect(palette256ToRgb(231)).toEqual([255, 255, 255])
+    // 196 = pure red corner of the cube
+    expect(palette256ToRgb(196)).toEqual([255, 0, 0])
+  })
+
+  test('resolves the 24-step grayscale ramp (232-255)', () => {
+    expect(palette256ToRgb(232)).toEqual([8, 8, 8])
+    expect(palette256ToRgb(236)).toEqual([48, 48, 48])
+    expect(palette256ToRgb(255)).toEqual([238, 238, 238])
+  })
+
+  test('returns null for out-of-range or non-integer indices', () => {
+    expect(palette256ToRgb(-1)).toBeNull()
+    expect(palette256ToRgb(256)).toBeNull()
+    expect(palette256ToRgb(12.5)).toBeNull()
+  })
+})

--- a/shared/ansiPalette.ts
+++ b/shared/ansiPalette.ts
@@ -1,0 +1,43 @@
+// Shared xterm 256-color resolution. Indices 16-255 (the 6×6×6 color cube and
+// the 24-step grayscale ramp) are theme-INDEPENDENT and resolve to fixed RGB.
+// Indices 0-15 are theme-dependent and intentionally NOT handled here — each
+// renderer resolves them itself (the DOM surface to `var(--terminal-ansi-*)`
+// theme tokens, the Electron bridge to the native cell's already-resolved hex).
+
+const XTERM_CUBE_FIRST_INDEX = 16
+const XTERM_CUBE_LAST_INDEX = 231
+const XTERM_GRAYSCALE_FIRST_INDEX = 232
+const XTERM_GRAYSCALE_LAST_INDEX = 255
+const XTERM_CUBE_LEVELS = [0, 95, 135, 175, 215, 255] as const
+const XTERM_GRAYSCALE_BASE = 8
+const XTERM_GRAYSCALE_STEP = 10
+
+export type Rgb = readonly [red: number, green: number, blue: number]
+
+// Resolve an xterm 256-color index in the theme-independent 16-255 range to its
+// RGB triple. Returns null for 0-15 (theme-dependent) or out-of-range indices.
+export const palette256ToRgb = (index: number): Rgb | null => {
+  if (
+    !Number.isInteger(index) ||
+    index < XTERM_CUBE_FIRST_INDEX ||
+    index > XTERM_GRAYSCALE_LAST_INDEX
+  ) {
+    return null
+  }
+
+  if (index <= XTERM_CUBE_LAST_INDEX) {
+    const value = index - XTERM_CUBE_FIRST_INDEX
+
+    return [
+      XTERM_CUBE_LEVELS[Math.floor(value / 36) % 6],
+      XTERM_CUBE_LEVELS[Math.floor(value / 6) % 6],
+      XTERM_CUBE_LEVELS[value % 6],
+    ]
+  }
+
+  const level =
+    XTERM_GRAYSCALE_BASE +
+    (index - XTERM_GRAYSCALE_FIRST_INDEX) * XTERM_GRAYSCALE_STEP
+
+  return [level, level, level]
+}

--- a/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
+++ b/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
@@ -12,17 +12,12 @@ import {
   readCursorPositionSentinel,
   readSgrStyleSentinel,
 } from './terminalControlParser'
+import { palette256ToRgb } from '../../../../../shared/ansiPalette'
 
 const DEFAULT_MAX_SCROLLBACK_LINES = 10_000
 const MIN_SOFT_WRAP_COLUMNS = 2
 const MAX_CURSOR_POSITION_VALUE = 4_096
 const CSS_RGB_FUNCTION = 'rgb'
-const XTERM_COLOR_CUBE_FIRST_INDEX = 16
-const XTERM_COLOR_CUBE_LAST_INDEX = 231
-const XTERM_GRAYSCALE_FIRST_INDEX = 232
-const XTERM_GRAYSCALE_LAST_INDEX = 255
-const XTERM_GRAYSCALE_BASE = 8
-const XTERM_GRAYSCALE_STEP = 10
 
 export interface TerminalDisplayStyle {
   readonly background?: string
@@ -169,12 +164,7 @@ const readAnsiBackground = (code: number): string | null => {
 }
 
 const readIndexedAnsiColor = (index: number | undefined): string | null => {
-  if (
-    index === undefined ||
-    !Number.isInteger(index) ||
-    index < 0 ||
-    index > XTERM_GRAYSCALE_LAST_INDEX
-  ) {
+  if (index === undefined || !Number.isInteger(index) || index < 0) {
     return null
   }
 
@@ -186,21 +176,9 @@ const readIndexedAnsiColor = (index: number | undefined): string | null => {
     return `var(--terminal-ansi-${ANSI_BRIGHT_COLOR_NAMES[index - 8]})`
   }
 
-  if (index <= XTERM_COLOR_CUBE_LAST_INDEX) {
-    const colorIndex = index - XTERM_COLOR_CUBE_FIRST_INDEX
-    const colorCubeSteps = [0, 95, 135, 175, 215, 255] as const
-    const red = colorCubeSteps[Math.floor(colorIndex / 36)]
-    const green = colorCubeSteps[Math.floor((colorIndex % 36) / 6)]
-    const blue = colorCubeSteps[colorIndex % 6]
+  const rgb = palette256ToRgb(index)
 
-    return formatRgbColor(red, green, blue)
-  }
-
-  const level =
-    XTERM_GRAYSCALE_BASE +
-    (index - XTERM_GRAYSCALE_FIRST_INDEX) * XTERM_GRAYSCALE_STEP
-
-  return formatRgbColor(level, level, level)
+  return rgb ? formatRgbColor(rgb[0], rgb[1], rgb[2]) : null
 }
 
 const applySgrStyle = (


### PR DESCRIPTION
## What

Fixes how the Ghostty native render-state rebuilds prompt/agent backgrounds from `formatHtml()`. Three of the original M4 bugs share this one synthesis pipeline:

### 1. Glyph-entity column drift → powerline cursor + Kimi bleed (BUG-2/3)
`formatHtml()` emits Nerd Font / powerline glyphs as numeric HTML entities (apple `&#983093;`, separator `&#57520;`). `decodeHtmlText` only decoded the five named entities, so an undecoded `"&#57520;"` counted as **8 cells instead of 1** — every background range past a glyph drifted right and bled prompt colors onto typed input / agent rows. Fix: decode decimal + hex (`&#x..` / `&#X..`) numeric entities so columns match the native grid.

### 2. Palette backgrounds dropped → Codex/Kimi input box missing (BUG-1)
Indexed 256-color backgrounds are emitted as `var(--vt-palette-N)`, not `rgb()`; the matcher only handled `rgb()`, so a palette-colored input box (palette 236 = `#303030`) painted nothing. Fix: resolve `var(--vt-palette-N)` through the xterm-256 table to the same hex the native cells already use, so the full-width box (including the blank padding the snapshot omits) renders.

### Dropped: the extent clamp
An earlier commit in this PR clamped synthesis to row content width. That **conflicts** with the Codex box (a full-width palette background whose blank padding the clamp dropped), and the "bleed" it targeted was actually the glyph-drift above. With ranges aligned there is no spurious bar to clamp, so the clamp is removed.

## Verified live (`@coder/libghostty-vt-node`)
- starship powerline prompt: ranges align (pink 1–12, orange 12–16, lavender 19–29); typed input keeps default background.
- `\x1b[48;5;236m … \x1b[K`: snapshot omits blank cells; palette `var(--vt-palette-236)` → `#303030`; box renders full-width in a native build.

## Tests
Unit: glyph-entity alignment (incl. uppercase hex), palette box full-width synthesis, all #591 fixtures. 111 terminal-area tests green; `type-check:generated`, eslint, prettier clean.

Part of VIM-139 (Ghostty M4 renderer fidelity). Forward-fix on #591.

🤖 Generated with [Claude Code](https://claude.com/claude-code)