### PR TITLE
fix(agent): opencode live-session binding, context window, and cache occupancy

### DIFF
--- a/crates/backend/src/agent/adapter/opencode/install.rs
+++ b/crates/backend/src/agent/adapter/opencode/install.rs
@@ -154,13 +154,15 @@ fn atomic_write(dir: &Path, target: &Path, bytes: &[u8]) -> io::Result<()> {
 }
 
 /// `$HOME` (or a relative fallback for headless/service sessions where home is
-/// unknown). Mirrors the `dirs::home_dir()` precedence used elsewhere.
-fn home_dir() -> PathBuf {
+/// unknown). Mirrors the `dirs::home_dir()` precedence used elsewhere. Shared
+/// with `model_catalog` for the models.dev cache-home resolution.
+pub(super) fn home_dir() -> PathBuf {
     dirs::home_dir().unwrap_or_else(|| PathBuf::from("."))
 }
 
-/// Read an env var, mapping unset / empty to `None`.
-fn non_empty_env(key: &str) -> Option<std::ffi::OsString> {
+/// Read an env var, mapping unset / empty to `None`. Shared with
+/// `model_catalog` so both sides derive XDG paths with identical semantics.
+pub(super) fn non_empty_env(key: &str) -> Option<std::ffi::OsString> {
     match std::env::var_os(key) {
         Some(value) if !value.is_empty() => Some(value),
         _ => None,

--- a/crates/backend/src/agent/adapter/opencode/locator.rs
+++ b/crates/backend/src/agent/adapter/opencode/locator.rs
@@ -164,9 +164,9 @@ impl OpenCodeLocator {
     ///   under one pid are sequential sessions of the same opencode server (one
     ///   pane), so newest-wins is the live one, not a cross-pane guess.
     ///
-    /// `None` when no fresh row carries `agent_pid` (the caller then tries the
-    /// cwd fallback), or when a cache exists but is no longer pid-matched (so the
-    /// caller's `cached_or_err` keeps the live binding rather than jumping).
+    /// `None` when no fresh row carries `agent_pid`, or when a cache exists but
+    /// is no longer pid-matched, so the cwd fallback is tried first;
+    /// `cached_or_err` preserves the binding only if cwd also finds nothing.
     fn resolve_by_pid(&self, rows: &[OpencodeIndexRowDto]) -> Option<String> {
         let floor = self.freshness_floor_ms();
         let candidates: Vec<&OpencodeIndexRowDto> = rows

--- a/crates/backend/src/agent/adapter/opencode/locator.rs
+++ b/crates/backend/src/agent/adapter/opencode/locator.rs
@@ -1,21 +1,29 @@
-//! opencode session locator (filesystem, unambiguous fresh-in-cwd).
+//! opencode session locator (filesystem, pid-primary, fresh-in-cwd fallback).
 //!
 //! Resolves a PTY attach to the `<sessionID>.jsonl` the vimeflow bridge plugin
-//! is writing for the opencode session running in `cwd`. Resolution reads the
+//! is writing for the opencode session Vimeflow detected. Resolution reads the
 //! bridge dir's `index.jsonl` (each row `{sessionID, pid, directory, slug,
-//! time}`) on EVERY `locate` call and picks, among rows whose canonicalized
-//! `directory == cwd` AND whose `time` (epoch-ms) is `>= pty_start − SLACK`, the
-//! row when it names exactly one session. That is the bound session.
+//! time}`) on EVERY `locate` call.
 //!
-//! **pid is not the primary key.** Mirroring the codex resolver
-//! (`ORDER BY updated_at_ms DESC` with a freshness floor, not a pid filter),
-//! cwd plus freshness decides the binding only when it names one session — pid
-//! is at most a tiebreaker between rows with identical `time` for that session.
-//! Live data showed pid-first was wrong: opencode's plugin `process.pid` does
-//! not reliably equal Vimeflow's detected `agent_pid` (the same session can
-//! appear under two different pids in `index.jsonl`, and the written pid drifts
-//! across a session's life), so a pid-first match mis-binds. The freshness floor
-//! rejects a stale same-cwd row left by an earlier run.
+//! **pid is the primary key.** The bridge plugin runs inside the opencode
+//! server process and writes `process.pid` on each index row — exactly the pid
+//! Vimeflow's process-tree scan reports as `agent_pid`. So among fresh rows
+//! (`time` epoch-ms `>= pty_start − SLACK`), the one whose `pid == agent_pid`
+//! is THIS attach's session; bind it directly. The equality is verified against
+//! live data (the detected `agent_pid` matched the bridge row's `pid`). pid
+//! also disambiguates two opencode panes that share a project dir, and (via a
+//! fresh locator built by reattach) picks the active session after `/clear` —
+//! the newest pid-matched row.
+//!
+//! **cwd is the fallback, not the key.** Vimeflow's tracked cwd comes from
+//! OSC 7, but opencode's TUI does not emit OSC 7, so the tracked cwd stays
+//! frozen at the pane's spawn dir (e.g. `~`) while opencode actually runs in a
+//! project subdir the bridge records as `directory`. A `directory == cwd` match
+//! therefore silently fails to bind the live session (the bug this resolver was
+//! re-shaped to fix). It is used only when no fresh index row carries the
+//! detected `agent_pid` (pid detection drifted to a wrapper/child); there it
+//! still binds only an unambiguous single fresh same-cwd session. The freshness
+//! floor rejects a stale row left by an earlier run in either path.
 //!
 //! **Re-resolution.** Each `locate` re-reads the index and re-resolves so a
 //! re-invoked `locate` (reattach, Part 2) can notice a current, unambiguous
@@ -50,7 +58,7 @@ use super::transcript_dto::OpencodeIndexRowDto;
 /// append a slightly wider window over the OSC-detected attach.
 const SLACK_MS: i64 = 5_000;
 
-/// Filesystem, unambiguous fresh-in-cwd opencode locator. Holds the last successful
+/// Filesystem pid-primary opencode locator. Holds the last successful
 /// resolve `(sessionID, status_path)` behind an `Arc<Mutex<…>>` (the Kimi
 /// shared-state pattern) as a transient-empty-read FALLBACK — `locate`
 /// re-reads the index and re-resolves on every call. M5's validator delegates
@@ -59,11 +67,11 @@ pub(crate) struct OpenCodeLocator {
     /// The bridge dir (`trust_root`) — `index.jsonl` and every
     /// `<sessionID>.jsonl` live directly under it.
     bridge_root: PathBuf,
-    /// The detected opencode process's pid. NOT the primary key (live data
-    /// showed the plugin's pid drifts / doesn't match reliably); kept only as a
-    /// tiebreaker between same-session rows with identical `time`.
+    /// The detected opencode process's pid — the PRIMARY binding key. The bridge
+    /// plugin writes `process.pid`, which equals this; the fresh index row
+    /// carrying it names this attach's session (see module docs).
     agent_pid: u32,
-    /// PTY start instant; the cwd resolve rejects rows older than
+    /// PTY start instant; both resolve paths reject rows older than
     /// `pty_start − SLACK`.
     pty_start: SystemTime,
     /// `(sessionID, status_path)` of the last successful `locate`. `None` until
@@ -146,6 +154,47 @@ impl OpenCodeLocator {
         Ok(rows)
     }
 
+    /// The fresh sessionID carrying `pid == agent_pid`, if any — the PRIMARY
+    /// resolution path. Among rows fresh by `time >= pty_start − SLACK` whose
+    /// `pid` equals the detected `agent_pid`:
+    ///
+    /// * if this locator already bound one of them, keep it (identity guard —
+    ///   don't jump sessions mid-life; reattach owns rotation);
+    /// * otherwise the newest by `time` is the active session. Distinct sessions
+    ///   under one pid are sequential sessions of the same opencode server (one
+    ///   pane), so newest-wins is the live one, not a cross-pane guess.
+    ///
+    /// `None` when no fresh row carries `agent_pid` (the caller then tries the
+    /// cwd fallback), or when a cache exists but is no longer pid-matched (so the
+    /// caller's `cached_or_err` keeps the live binding rather than jumping).
+    fn resolve_by_pid(&self, rows: &[OpencodeIndexRowDto]) -> Option<String> {
+        let floor = self.freshness_floor_ms();
+        let candidates: Vec<&OpencodeIndexRowDto> = rows
+            .iter()
+            .filter(|row| row.time.is_some_and(|time| time >= floor))
+            .filter(|row| row.pid == Some(self.agent_pid as u64))
+            .collect();
+
+        if candidates.is_empty() {
+            return None;
+        }
+
+        if let Some(cached_session_id) = self.cached_session_id() {
+            if candidates
+                .iter()
+                .any(|row| row.session_id.as_deref() == Some(cached_session_id.as_str()))
+            {
+                return Some(cached_session_id);
+            }
+            return None;
+        }
+
+        candidates
+            .iter()
+            .max_by_key(|row| row.time.expect("filtered to Some above"))
+            .and_then(|row| row.session_id.clone())
+    }
+
     /// The fresh same-cwd sessionID, if unambiguous. A row qualifies when its
     /// canonicalized `directory == cwd` (string-eq fallback if either side fails
     /// to canonicalize) AND its `time >= pty_start − SLACK`.
@@ -225,20 +274,29 @@ impl OpenCodeLocator {
 
 impl StatusSourceLocator for OpenCodeLocator {
     fn locate(&self, cwd: &Path, _session_id: &str) -> Result<LocatedStatusSource, String> {
-        // Re-resolve on every call, but only accept an unambiguous current
-        // session. The index read may transiently yield zero usable rows — fall
-        // back to a prior resolve rather than dropping a live binding.
+        // Re-resolve on every call. The index read may transiently yield zero
+        // usable rows — fall back to a prior resolve rather than dropping a live
+        // binding.
         let rows = match self.read_index_rows() {
             Ok(rows) => rows,
             Err(not_ready) => return self.cached_or_err(not_ready),
         };
 
-        // Fresh same-cwd row only when it is unambiguous; otherwise keep an
-        // existing cached binding or surface a retry/not-ready error.
+        // Primary: the fresh row whose `pid == agent_pid` is THIS attach's
+        // session. Binds correctly even when Vimeflow's OSC7-tracked cwd never
+        // caught up to opencode's real cwd — which `resolve_by_cwd` cannot.
+        if let Some(session_id) = self.resolve_by_pid(&rows) {
+            return Ok(self.locate_session(session_id));
+        }
+
+        // Fallback: an unambiguous fresh same-cwd session, for the rare case
+        // where the detected `agent_pid` carries no index row (pid detection
+        // drifted to a wrapper/child).
         match self.resolve_by_cwd(&rows, cwd) {
             Ok(Some(session_id)) => Ok(self.locate_session(session_id)),
             Ok(None) => self.cached_or_err(format!(
-                "opencode index not ready: no fresh session in cwd={} in {}",
+                "opencode index not ready: no fresh session for pid={} or cwd={} in {}",
+                self.agent_pid,
                 cwd.display(),
                 self.index_path().display(),
             )),
@@ -424,20 +482,23 @@ mod tests {
         })
     }
 
-    /// Multiple fresh same-cwd sessionIDs are ambiguous without a per-attach
-    /// identity marker. The locator must fail closed instead of choosing the
-    /// newest row by recency and potentially tailing another pane's transcript.
+    /// In the cwd FALLBACK path (neither row carries the detected pid), multiple
+    /// fresh same-cwd sessionIDs are ambiguous without a per-attach identity
+    /// marker. The locator must fail closed instead of choosing the newest row
+    /// by recency and potentially tailing another pane's transcript.
     #[test]
-    fn ambiguous_fresh_same_cwd_sessions_without_cache_is_not_ready_err() {
+    fn ambiguous_fresh_same_cwd_sessions_without_pid_or_cache_is_not_ready_err() {
         let bridge = Bridge::new();
         let cwd = bridge._tmp.path().join("proj");
         std::fs::create_dir_all(&cwd).expect("mkdir cwd");
         let cwd_str = cwd.to_string_lossy().into_owned();
 
         let agent_pid = 4242u32;
+        // Neither row's pid matches `agent_pid`, so the pid path yields nothing
+        // and the cwd-ambiguity guard is what must fire.
         bridge.write_index(&[
-            index_row("ses_ours_old", agent_pid as u64, &cwd_str, 1_000),
-            index_row("ses_other_new", 9999, &cwd_str, 5_000),
+            index_row("ses_a", 9998, &cwd_str, 1_000),
+            index_row("ses_b", 9999, &cwd_str, 5_000),
         ]);
 
         let locator = bridge.locator(agent_pid, epoch_ms(0));
@@ -448,6 +509,101 @@ mod tests {
         assert!(
             err.contains("refusing recency-only binding"),
             "ambiguity failure explains fail-closed binding: {err}"
+        );
+    }
+
+    /// The core fix: pid binds THIS attach's session even when Vimeflow's
+    /// OSC7-tracked cwd never caught up to opencode's real cwd. The index row's
+    /// `directory` is a project subdir; `locate` is called with the stale spawn
+    /// cwd (`~`). `directory == cwd` can never match, but `pid == agent_pid`
+    /// does — and that is the session the user is looking at.
+    #[test]
+    fn pid_match_binds_session_despite_cwd_mismatch() {
+        let bridge = Bridge::new();
+        // opencode's real/project dir (what the bridge records as `directory`).
+        let project = bridge._tmp.path().join("projects/rustgo");
+        std::fs::create_dir_all(&project).expect("mkdir project");
+        let project_str = project.to_string_lossy().into_owned();
+        // Vimeflow's stale OSC7 cwd — the pane's spawn dir, NOT the project.
+        let tracked_cwd = bridge._tmp.path().to_path_buf();
+
+        let agent_pid = 89074u32;
+        bridge.write_index(&[index_row("ses_live", agent_pid as u64, &project_str, 5_000)]);
+
+        let locator = bridge.locator(agent_pid, epoch_ms(0));
+        let located = locator
+            .locate(&tracked_cwd, "pty")
+            .expect("pid match binds despite cwd mismatch");
+        assert_eq!(located.agent_session_id.as_deref(), Some("ses_live"));
+    }
+
+    /// Two opencode panes sharing one project dir are NOT ambiguous under
+    /// pid-primary: the row whose pid matches the detected `agent_pid` is the
+    /// one bound, even though both rows share a cwd.
+    #[test]
+    fn pid_match_disambiguates_two_same_cwd_sessions() {
+        let bridge = Bridge::new();
+        let cwd = bridge._tmp.path().join("shared");
+        std::fs::create_dir_all(&cwd).expect("mkdir cwd");
+        let cwd_str = cwd.to_string_lossy().into_owned();
+
+        let agent_pid = 4242u32;
+        bridge.write_index(&[
+            // Another pane's session in the same dir — newer, but not our pid.
+            index_row("ses_other", 9999, &cwd_str, 9_000),
+            // Our session — older row, but its pid matches.
+            index_row("ses_ours", agent_pid as u64, &cwd_str, 1_000),
+        ]);
+
+        let locator = bridge.locator(agent_pid, epoch_ms(0));
+        let located = locator.locate(&cwd, "pty").expect("pid disambiguates");
+        assert_eq!(
+            located.agent_session_id.as_deref(),
+            Some("ses_ours"),
+            "pid match wins over a newer same-cwd row from another pane"
+        );
+    }
+
+    /// One opencode server (one pid) that created several sessions in sequence:
+    /// the newest pid-matched row is the active session.
+    #[test]
+    fn pid_match_picks_newest_across_sequential_sessions_under_one_pid() {
+        let bridge = Bridge::new();
+        let cwd = bridge._tmp.path().to_path_buf();
+        let cwd_str = cwd.to_string_lossy().into_owned();
+
+        let agent_pid = 59730u32;
+        bridge.write_index(&[
+            index_row("ses_first", agent_pid as u64, &cwd_str, 1_000),
+            index_row("ses_second", agent_pid as u64, &cwd_str, 2_000),
+            index_row("ses_third", agent_pid as u64, &cwd_str, 3_000),
+        ]);
+
+        let locator = bridge.locator(agent_pid, epoch_ms(0));
+        let located = locator.locate(&cwd, "pty").expect("locate ok");
+        assert_eq!(located.agent_session_id.as_deref(), Some("ses_third"));
+    }
+
+    /// A pid-matched row older than `pty_start − SLACK` is rejected; with no
+    /// other candidate, locate returns the not-ready/retry signal.
+    #[test]
+    fn freshness_gate_rejects_stale_pid_matched_row() {
+        let bridge = Bridge::new();
+        let cwd = bridge._tmp.path().join("work");
+        std::fs::create_dir_all(&cwd).expect("mkdir cwd");
+        let cwd_str = cwd.to_string_lossy().into_owned();
+
+        // floor = 10_000 − 5_000 = 5_000ms; the only row is at 4_000ms (stale).
+        let agent_pid = 321u32;
+        bridge.write_index(&[index_row("ses_stale", agent_pid as u64, &cwd_str, 4_000)]);
+
+        let locator = bridge.locator(agent_pid, epoch_ms(10_000));
+        let err = locator
+            .locate(&cwd, "pty")
+            .expect_err("stale pid-matched row must not bind");
+        assert!(
+            err.contains("not ready"),
+            "stale pid-matched row is a retry/not-ready signal: {err}"
         );
     }
 
@@ -536,10 +692,11 @@ mod tests {
         assert!(err.contains("not ready"), "missing index is not-ready: {err}");
     }
 
-    /// A present index with no qualifying same-cwd row and no cached resolve ⇒
-    /// Err (not-ready / retry). The only row lives in a DIFFERENT cwd.
+    /// A present index with no pid-matched row, no qualifying same-cwd row, and
+    /// no cached resolve ⇒ Err (not-ready / retry). The only row carries a
+    /// different pid AND lives in a DIFFERENT cwd.
     #[test]
-    fn no_matching_row_and_no_cache_is_not_ready_err() {
+    fn no_pid_match_no_same_cwd_row_and_no_cache_is_not_ready_err() {
         let bridge = Bridge::new();
         let cwd = bridge._tmp.path().join("proj");
         std::fs::create_dir_all(&cwd).expect("mkdir cwd");
@@ -547,12 +704,13 @@ mod tests {
         std::fs::create_dir_all(&other).expect("mkdir other");
         let other_str = other.to_string_lossy().into_owned();
 
-        bridge.write_index(&[index_row("ses_elsewhere", 1, &other_str, 1)]);
+        // pid 999 ≠ agent_pid 1, and the row's dir is not `proj`.
+        bridge.write_index(&[index_row("ses_elsewhere", 999, &other_str, 1)]);
 
         let locator = bridge.locator(1, epoch_ms(0));
         let err = locator
             .locate(&cwd, "pty")
-            .expect_err("no same-cwd row + no cache ⇒ Err");
+            .expect_err("no pid + no same-cwd row + no cache ⇒ Err");
         assert!(err.contains("not ready"), "no-match is not-ready: {err}");
     }
 

--- a/crates/backend/src/agent/adapter/opencode/mod.rs
+++ b/crates/backend/src/agent/adapter/opencode/mod.rs
@@ -14,6 +14,7 @@
 // staged surface keeps a narrow `#[allow(dead_code)]`.
 pub(crate) mod install;
 pub(crate) mod locator;
+pub(crate) mod model_catalog;
 pub(crate) mod parser;
 pub(crate) mod transcript;
 pub(crate) mod transcript_dto;
@@ -72,7 +73,13 @@ impl TranscriptPathSource for OpenCodeAdapter {
 
 impl StateDecoder for OpenCodeAdapter {
     fn decode(&self, session_id: Option<&str>, raw: &str) -> Result<StatusSnapshot, String> {
-        Ok(parser::parse_bridge_snapshot(session_id, raw))
+        // The bridge stream carries `{providerID, modelID}` but not the model's
+        // context-window size; resolve it from opencode's models.dev cache.
+        Ok(parser::parse_bridge_snapshot(
+            session_id,
+            raw,
+            model_catalog::context_window,
+        ))
     }
 }
 
@@ -150,8 +157,8 @@ use once_cell::sync::Lazy;
 
 /// Serializes every test that mutates the process-wide opencode env vars
 /// (`VIMEFLOW_OPENCODE_BRIDGE_DIR`, `VIMEFLOW_OPENCODE_PLUGINS_DIR`,
-/// `XDG_DATA_HOME`, `HOME`, `OPENCODE_HOME`) so concurrent tests don't observe
-/// each other's mutations.
+/// `XDG_DATA_HOME`, `XDG_CACHE_HOME`, `VIMEFLOW_OPENCODE_MODELS_JSON`, `HOME`,
+/// `OPENCODE_HOME`) so concurrent tests don't observe each other's mutations.
 #[cfg(test)]
 static OPENCODE_ENV_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
@@ -161,7 +168,9 @@ static OPENCODE_ENV_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 const GUARDED_ENV_KEYS: &[&str] = &[
     "VIMEFLOW_OPENCODE_BRIDGE_DIR",
     "VIMEFLOW_OPENCODE_PLUGINS_DIR",
+    "VIMEFLOW_OPENCODE_MODELS_JSON",
     "XDG_DATA_HOME",
+    "XDG_CACHE_HOME",
     "HOME",
     "OPENCODE_HOME",
 ];

--- a/crates/backend/src/agent/adapter/opencode/model_catalog.rs
+++ b/crates/backend/src/agent/adapter/opencode/model_catalog.rs
@@ -1,0 +1,214 @@
+//! opencode model catalog — best-effort context-window lookup.
+//!
+//! The bridge event stream carries the active model as `{providerID, modelID}`
+//! but NOT its context-window size: opencode resolves that internally from the
+//! models.dev database it caches on disk. So to fill
+//! [`StatusSnapshot::context_window_size`] the adapter reads that same cache,
+//! `${XDG_CACHE_HOME:-$HOME/.cache}/opencode/models.json`, keyed
+//! `models[providerID].models[modelID].limit.context`.
+//!
+//! This is the SAME category of opencode-owned path the adapter already manages
+//! in [`super::install`] (which writes the bridge plugin into
+//! `~/.config/opencode/plugins`); it is a read-only metadata cache, not session
+//! state, so it does not reintroduce the SQLite/session coupling the bridge
+//! design avoids.
+//!
+//! **Best-effort, never fatal.** A missing / unreadable / unparseable cache, or
+//! a model the cache does not list, yields [`OPENCODE_CONTEXT_WINDOW_SIZE`]
+//! (`0` = unknown) and the frontend renders the bar without a denominator
+//! ("window unknown") — exactly the pre-lookup behavior. The catalog is loaded
+//! once per process (opencode refreshes it rarely and a model's context window
+//! is static per version), so lookups after the first are a hashmap hit.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+use serde_json::Value;
+
+use super::install::{home_dir, non_empty_env};
+use super::types::OPENCODE_CONTEXT_WINDOW_SIZE;
+
+/// Explicit override for the models.json path (tests + non-standard installs).
+const MODELS_JSON_ENV: &str = "VIMEFLOW_OPENCODE_MODELS_JSON";
+
+/// `(providerID, modelID) -> context-window size in tokens`.
+type Catalog = HashMap<(String, String), u64>;
+
+/// Resolve opencode's models.dev cache path:
+/// `$VIMEFLOW_OPENCODE_MODELS_JSON` (override) else
+/// `${XDG_CACHE_HOME:-$HOME/.cache}/opencode/models.json`. Note this uses the
+/// XDG **cache** home, distinct from the bridge dir's XDG **data** home.
+fn models_json_path() -> PathBuf {
+    if let Some(override_path) = non_empty_env(MODELS_JSON_ENV) {
+        return PathBuf::from(override_path);
+    }
+
+    let cache_home = match non_empty_env("XDG_CACHE_HOME") {
+        Some(xdg) => PathBuf::from(xdg),
+        None => home_dir().join(".cache"),
+    };
+    cache_home.join("opencode").join("models.json")
+}
+
+/// Flatten opencode's `models.json` into `(providerID, modelID) -> context`.
+///
+/// Shape: `{ <providerID>: { "models": { <modelID>: { "limit": { "context": N
+/// } } } } }`. Every layer is probed defensively — a provider with no `models`
+/// object, a model with no `limit.context`, or a non-integer context are all
+/// skipped rather than erroring, so a partially-shaped cache still yields the
+/// entries it can.
+fn parse_catalog(bytes: &[u8]) -> Catalog {
+    let mut catalog = Catalog::new();
+
+    let Ok(root) = serde_json::from_slice::<Value>(bytes) else {
+        return catalog;
+    };
+    let Some(providers) = root.as_object() else {
+        return catalog;
+    };
+
+    for (provider_id, provider) in providers {
+        let Some(models) = provider.get("models").and_then(Value::as_object) else {
+            continue;
+        };
+        for (model_id, model) in models {
+            if let Some(context) = model
+                .get("limit")
+                .and_then(|limit| limit.get("context"))
+                .and_then(Value::as_u64)
+            {
+                catalog.insert((provider_id.clone(), model_id.clone()), context);
+            }
+        }
+    }
+
+    catalog
+}
+
+/// Look up `(providerID, modelID)` in a catalog, returning the unknown sentinel
+/// (`0`) on a miss. Split out from [`context_window`] so the lookup is testable
+/// against a hand-built map without the process-wide cache.
+fn lookup(catalog: &Catalog, provider_id: &str, model_id: &str) -> u64 {
+    catalog
+        .get(&(provider_id.to_string(), model_id.to_string()))
+        .copied()
+        .unwrap_or(OPENCODE_CONTEXT_WINDOW_SIZE)
+}
+
+/// Process-wide catalog, loaded once from the resolved `models.json`. Any read
+/// or parse failure yields an empty map (every lookup then returns the unknown
+/// sentinel).
+fn catalog() -> &'static Catalog {
+    static CATALOG: OnceLock<Catalog> = OnceLock::new();
+    CATALOG.get_or_init(|| match std::fs::read(models_json_path()) {
+        Ok(bytes) => parse_catalog(&bytes),
+        Err(_) => Catalog::new(),
+    })
+}
+
+/// Best-effort context-window size (tokens) for `(providerID, modelID)` from
+/// opencode's models.dev cache. Returns [`OPENCODE_CONTEXT_WINDOW_SIZE`]
+/// (`0` = unknown) when the cache is absent or the model is not listed.
+///
+/// The signature matches the `Fn(&str, &str) -> u64` resolver
+/// [`super::parser::parse_bridge_snapshot`] injects, so the production decode
+/// path passes this function directly while tests pass a deterministic stub.
+pub(crate) fn context_window(provider_id: &str, model_id: &str) -> u64 {
+    lookup(catalog(), provider_id, model_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::adapter::opencode::OpencodeEnvGuard;
+
+    const SAMPLE_MODELS_JSON: &str = r#"{
+        "opencode": {
+            "models": {
+                "deepseek-v4-flash-free": { "limit": { "context": 200000, "output": 128000 } },
+                "no-limit-model": { "name": "missing limit" }
+            }
+        },
+        "anthropic": {
+            "models": {
+                "claude-sonnet-4": { "limit": { "context": 1000000 } }
+            }
+        },
+        "broken-provider": { "models": "not-an-object" }
+    }"#;
+
+    #[test]
+    fn parse_catalog_extracts_provider_scoped_context_windows() {
+        let catalog = parse_catalog(SAMPLE_MODELS_JSON.as_bytes());
+        assert_eq!(
+            catalog.get(&("opencode".into(), "deepseek-v4-flash-free".into())),
+            Some(&200_000)
+        );
+        // The SAME modelID under a different provider is a distinct entry — this
+        // is why the lookup is keyed by (provider, model), not model alone.
+        assert_eq!(
+            catalog.get(&("anthropic".into(), "claude-sonnet-4".into())),
+            Some(&1_000_000)
+        );
+    }
+
+    #[test]
+    fn parse_catalog_skips_models_without_a_context_limit() {
+        let catalog = parse_catalog(SAMPLE_MODELS_JSON.as_bytes());
+        assert!(catalog
+            .get(&("opencode".into(), "no-limit-model".into()))
+            .is_none());
+    }
+
+    #[test]
+    fn parse_catalog_tolerates_garbage_and_bad_shapes() {
+        assert!(parse_catalog(b"not json at all").is_empty());
+        assert!(parse_catalog(b"[1,2,3]").is_empty());
+        // A provider whose `models` is not an object is skipped, not fatal.
+        let catalog = parse_catalog(SAMPLE_MODELS_JSON.as_bytes());
+        assert!(catalog
+            .get(&("broken-provider".into(), "anything".into()))
+            .is_none());
+    }
+
+    #[test]
+    fn lookup_returns_unknown_sentinel_on_miss() {
+        let catalog = parse_catalog(SAMPLE_MODELS_JSON.as_bytes());
+        assert_eq!(
+            lookup(&catalog, "opencode", "deepseek-v4-flash-free"),
+            200_000
+        );
+        assert_eq!(
+            lookup(&catalog, "opencode", "no-such-model"),
+            OPENCODE_CONTEXT_WINDOW_SIZE
+        );
+        assert_eq!(lookup(&Catalog::new(), "opencode", "anything"), 0);
+    }
+
+    #[test]
+    fn models_json_path_honors_explicit_override() {
+        let _guard = OpencodeEnvGuard::acquire();
+        std::env::set_var(MODELS_JSON_ENV, "/custom/models.json");
+        assert_eq!(models_json_path(), PathBuf::from("/custom/models.json"));
+    }
+
+    #[test]
+    fn models_json_path_uses_xdg_cache_home_when_no_override() {
+        let _guard = OpencodeEnvGuard::acquire();
+        std::env::remove_var(MODELS_JSON_ENV);
+        std::env::set_var("XDG_CACHE_HOME", "/xdg/cache");
+        assert_eq!(
+            models_json_path(),
+            PathBuf::from("/xdg/cache/opencode/models.json")
+        );
+    }
+
+    #[test]
+    fn models_json_path_falls_back_to_home_cache() {
+        let _guard = OpencodeEnvGuard::acquire();
+        std::env::remove_var(MODELS_JSON_ENV);
+        std::env::remove_var("XDG_CACHE_HOME");
+        assert!(models_json_path().ends_with(".cache/opencode/models.json"));
+    }
+}

--- a/crates/backend/src/agent/adapter/opencode/model_catalog.rs
+++ b/crates/backend/src/agent/adapter/opencode/model_catalog.rs
@@ -16,12 +16,13 @@
 //! **Best-effort, never fatal.** A missing / unreadable / unparseable cache, or
 //! a model the cache does not list, yields [`OPENCODE_CONTEXT_WINDOW_SIZE`]
 //! (`0` = unknown) and the frontend renders the bar without a denominator
-//! ("window unknown") — exactly the pre-lookup behavior. The catalog is loaded
-//! once per process (opencode refreshes it rarely and a model's context window
-//! is static per version), so lookups after the first are a hashmap hit.
+//! ("window unknown") — exactly the pre-lookup behavior. The first non-empty
+//! catalog is cached for the process (opencode refreshes it rarely and a model's
+//! context window is static per version), so lookups after that are a hashmap
+//! hit while early refresh races can still recover.
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use serde_json::Value;
@@ -96,15 +97,32 @@ fn lookup(catalog: &Catalog, provider_id: &str, model_id: &str) -> u64 {
         .unwrap_or(OPENCODE_CONTEXT_WINDOW_SIZE)
 }
 
-/// Process-wide catalog, loaded once from the resolved `models.json`. Any read
-/// or parse failure yields an empty map (every lookup then returns the unknown
-/// sentinel).
-fn catalog() -> &'static Catalog {
+/// Load a catalog from disk. Missing, unreadable, malformed, or empty caches
+/// return `None` so callers can retry after opencode finishes refreshing
+/// `models.json`.
+fn read_catalog(path: &Path) -> Option<Catalog> {
+    let bytes = std::fs::read(path).ok()?;
+    let catalog = parse_catalog(&bytes);
+    (!catalog.is_empty()).then_some(catalog)
+}
+
+/// Catalog cache, populated only after a non-empty `models.json` load succeeds.
+fn cached_catalog<'a>(cache: &'a OnceLock<Catalog>, path: &Path) -> Option<&'a Catalog> {
+    if let Some(catalog) = cache.get() {
+        return Some(catalog);
+    }
+
+    let catalog = read_catalog(path)?;
+    let _ = cache.set(catalog);
+    cache.get()
+}
+
+/// Process-wide catalog, loaded from the resolved `models.json` once a
+/// successful non-empty parse is available. Earlier read/parse misses are not
+/// cached so first-run and refresh-race sessions can recover without restart.
+fn catalog() -> Option<&'static Catalog> {
     static CATALOG: OnceLock<Catalog> = OnceLock::new();
-    CATALOG.get_or_init(|| match std::fs::read(models_json_path()) {
-        Ok(bytes) => parse_catalog(&bytes),
-        Err(_) => Catalog::new(),
-    })
+    cached_catalog(&CATALOG, &models_json_path())
 }
 
 /// Best-effort context-window size (tokens) for `(providerID, modelID)` from
@@ -115,7 +133,9 @@ fn catalog() -> &'static Catalog {
 /// [`super::parser::parse_bridge_snapshot`] injects, so the production decode
 /// path passes this function directly while tests pass a deterministic stub.
 pub(crate) fn context_window(provider_id: &str, model_id: &str) -> u64 {
-    lookup(catalog(), provider_id, model_id)
+    catalog()
+        .map(|catalog| lookup(catalog, provider_id, model_id))
+        .unwrap_or(OPENCODE_CONTEXT_WINDOW_SIZE)
 }
 
 #[cfg(test)]
@@ -184,6 +204,39 @@ mod tests {
             OPENCODE_CONTEXT_WINDOW_SIZE
         );
         assert_eq!(lookup(&Catalog::new(), "opencode", "anything"), 0);
+    }
+
+    #[test]
+    fn cached_catalog_retries_after_initial_missing_cache() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("models.json");
+        let cache = OnceLock::new();
+
+        assert!(cached_catalog(&cache, &path).is_none());
+        std::fs::write(&path, SAMPLE_MODELS_JSON).expect("write models cache");
+
+        let catalog = cached_catalog(&cache, &path).expect("catalog after cache appears");
+        assert_eq!(
+            lookup(catalog, "opencode", "deepseek-v4-flash-free"),
+            200_000
+        );
+    }
+
+    #[test]
+    fn cached_catalog_retries_after_empty_or_malformed_cache() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("models.json");
+        let cache = OnceLock::new();
+
+        std::fs::write(&path, r#"{"opencode":{"models":{}}}"#).expect("write empty cache");
+        assert!(cached_catalog(&cache, &path).is_none());
+
+        std::fs::write(&path, "not json").expect("write malformed cache");
+        assert!(cached_catalog(&cache, &path).is_none());
+
+        std::fs::write(&path, SAMPLE_MODELS_JSON).expect("write valid cache");
+        let catalog = cached_catalog(&cache, &path).expect("catalog after valid cache");
+        assert_eq!(lookup(catalog, "anthropic", "claude-sonnet-4"), 1_000_000);
     }
 
     #[test]

--- a/crates/backend/src/agent/adapter/opencode/parser.rs
+++ b/crates/backend/src/agent/adapter/opencode/parser.rs
@@ -25,7 +25,7 @@
 //! | `context_window.total_output_tokens` | latest `step-finish` → `data.part.tokens.output`; fallback `session.*` `info.tokens.output` |
 //! | `cost.total_cost_usd`          | `info.cost`                                      |
 //! | `context_window.current_usage` | latest `step-finish` → `data.part.tokens`        |
-//! | `context_window_size`          | `OPENCODE_CONTEXT_WINDOW_SIZE` (0 = unknown)     |
+//! | `context_window_size`          | injected resolver `(providerID, modelID) -> tokens` — opencode's models.dev cache (`model_catalog`); `0` = unknown |
 //! | `rate_limits`                  | safe default (`five_hour: 0.0 / 0`)              |
 //! | `usage_fetched`                | always `false`                                   |
 
@@ -34,7 +34,6 @@ use serde_json::Value;
 use crate::agent::adapter::opencode::transcript_dto::{
     OpencodeEventType, OpencodeKind, OpencodeLineDto,
 };
-use crate::agent::adapter::opencode::types::OPENCODE_CONTEXT_WINDOW_SIZE;
 use crate::agent::adapter::types::StatusSnapshot;
 use crate::agent::types::{
     ContextWindowStatus, CostMetrics, CurrentUsage, RateLimitInfo, RateLimits,
@@ -57,6 +56,14 @@ struct OpencodeFoldState {
     /// events carry no id, so this only fires for older/synthetic transcripts;
     /// it is the lower-priority fallback behind `model_id_from_message`.
     model_id_from_session: String,
+    /// Latest non-empty provider id from a `message.updated`
+    /// (`info.model.providerID`). Pairs with `model_id_from_message` for the
+    /// `(providerID, modelID)` context-window lookup; the model-id priority rule
+    /// applies identically (message wins over session, empty never clobbers).
+    provider_id_from_message: String,
+    /// Lower-priority provider id from a `session.created/updated`
+    /// (`info.model.providerID`).
+    provider_id_from_session: String,
     /// Version string (from `info.version`).
     version: String,
     /// Lifetime total input tokens. Live this is the LATEST `step-finish`
@@ -84,15 +91,61 @@ struct StepUsage {
 }
 
 impl OpencodeFoldState {
-    fn into_snapshot(self) -> StatusSnapshot {
-        let context_window_size = OPENCODE_CONTEXT_WINDOW_SIZE; // 0 = unknown
+    /// `resolve_window(providerID, modelID) -> tokens` (0 = unknown) supplies the
+    /// context-window denominator. Injected so production reads opencode's
+    /// models.dev cache while tests pass a deterministic stub.
+    fn into_snapshot(self, resolve_window: impl Fn(&str, &str) -> u64) -> StatusSnapshot {
+        // Resolve model + provider up front (message wins over session for both —
+        // live opencode only supplies the message form; an empty value never
+        // clobbers a prior non-empty one during the fold).
+        let resolved_model_id = if !self.model_id_from_message.is_empty() {
+            self.model_id_from_message
+        } else {
+            self.model_id_from_session
+        };
+        let resolved_provider_id = if !self.provider_id_from_message.is_empty() {
+            self.provider_id_from_message
+        } else {
+            self.provider_id_from_session
+        };
+
+        // Context-window size comes from opencode's models.dev cache, keyed by
+        // (providerID, modelID). 0 = unknown (no model, cache absent, or model
+        // unlisted) — the frontend then renders the bar without a denominator.
+        let context_window_size = if resolved_model_id.is_empty() {
+            0
+        } else {
+            resolve_window(&resolved_provider_id, &resolved_model_id)
+        };
+
+        // Context occupancy = the FULL prompt sent on the latest step, not just
+        // the fresh delta. opencode (like Anthropic / kimi) reports `input` as
+        // only the uncached tokens once prompt caching engages, parking the bulk
+        // of the conversation in `cache.read`; the running totals therefore read
+        // small (e.g. 152) even when 24k tokens of context are in play. So the
+        // gauge numerator sums fresh input + output + cache-read + cache-write —
+        // mirroring `kimi::parser`'s `used` — and the frontend reconstructs the
+        // token count from this percentage (it deliberately ignores
+        // total_input/output, which exclude cache reads).
+        let (cache_read, cache_write) = self
+            .step_usage
+            .as_ref()
+            .map(|su| (su.cache_read_tokens, su.cache_write_tokens))
+            .unwrap_or((0, 0));
 
         // With context_window_size == 0 we cannot compute a meaningful percentage.
         let used_percentage: Option<f64> = if context_window_size == 0 {
             None
         } else {
-            let total = self.total_input_tokens + self.total_output_tokens;
-            Some((total as f64 / context_window_size as f64 * 100.0).clamp(0.0, 100.0))
+            // Saturating: a malformed / future transcript with huge token counts
+            // must not panic (debug) or wrap (release) — this parser is tolerant
+            // of bad lines, and kimi's numerator saturates for the same reason.
+            let used = self
+                .total_input_tokens
+                .saturating_add(self.total_output_tokens)
+                .saturating_add(cache_read)
+                .saturating_add(cache_write);
+            Some((used as f64 / context_window_size as f64 * 100.0).clamp(0.0, 100.0))
         };
 
         let remaining_percentage = used_percentage
@@ -131,13 +184,7 @@ impl OpencodeFoldState {
             seven_day: None,
         };
 
-        // The `message.updated` id wins over the `session.*` id (live opencode
-        // only ever supplies the former); both fall back to "unknown".
-        let resolved_model_id = if !self.model_id_from_message.is_empty() {
-            self.model_id_from_message
-        } else {
-            self.model_id_from_session
-        };
+        // Fall back to "unknown" when the fold saw no model id.
         let (model_id, model_display_name) = if resolved_model_id.is_empty() {
             ("unknown".to_string(), "unknown".to_string())
         } else {
@@ -206,6 +253,9 @@ fn fold_session_info(state: &mut OpencodeFoldState, info: &Value) {
     if let Some(model_id) = model_id.filter(|value| !value.is_empty()) {
         state.model_id_from_session = model_id.to_string();
     }
+    if let Some(provider) = value_str(info, &["model", "providerID"]).filter(|v| !v.is_empty()) {
+        state.provider_id_from_session = provider.to_string();
+    }
     // Session-event token totals are a fallback only: live they are all-zero,
     // and once a `step-finish` has supplied the running totals we must not let a
     // later (zero) session event overwrite them.
@@ -233,6 +283,9 @@ fn fold_message_info(state: &mut OpencodeFoldState, info: &Value) {
         value_str(info, &["model", "modelID"]).or_else(|| value_str(info, &["modelID"]));
     if let Some(model_id) = model_id.filter(|value| !value.is_empty()) {
         state.model_id_from_message = model_id.to_string();
+    }
+    if let Some(provider) = value_str(info, &["model", "providerID"]).filter(|v| !v.is_empty()) {
+        state.provider_id_from_message = provider.to_string();
     }
 }
 
@@ -313,8 +366,15 @@ fn fold_line(state: &mut OpencodeFoldState, dto: &OpencodeLineDto) {
 ///
 /// The first caller in production is M5's `StateDecoder` impl on
 /// `OpenCodeAdapter`.
+/// `resolve_window(providerID, modelID) -> tokens` (0 = unknown) is injected so
+/// the production decode path passes `model_catalog::context_window` (which
+/// reads opencode's models.dev cache) while tests pass a deterministic stub.
 #[allow(dead_code)]
-pub(crate) fn parse_bridge_snapshot(session_id: Option<&str>, raw: &str) -> StatusSnapshot {
+pub(crate) fn parse_bridge_snapshot(
+    session_id: Option<&str>,
+    raw: &str,
+    resolve_window: impl Fn(&str, &str) -> u64,
+) -> StatusSnapshot {
     let mut state = OpencodeFoldState::default();
 
     let lines: Vec<&str> = raw.split('\n').collect();
@@ -339,7 +399,7 @@ pub(crate) fn parse_bridge_snapshot(session_id: Option<&str>, raw: &str) -> Stat
         }
     }
 
-    state.into_snapshot()
+    state.into_snapshot(resolve_window)
 }
 
 // ─── tests ─────────────────────────────────────────────────────────────────
@@ -347,6 +407,12 @@ pub(crate) fn parse_bridge_snapshot(session_id: Option<&str>, raw: &str) -> Stat
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Window-resolver stub: unit tests never consult the real models.dev cache,
+    /// so the window is "unknown" unless a test injects its own resolver.
+    fn no_window(_provider_id: &str, _model_id: &str) -> u64 {
+        0
+    }
 
     /// Load the authored `sample_bridge.jsonl` fixture (embedded at
     /// compile time so the test works regardless of cwd).
@@ -370,7 +436,7 @@ mod tests {
         // (`glm-4-6-fake`); the session events carry `model:{"providerID":
         // "opencode"}` with no id, and the assistant `message.updated` carries
         // `model:{}` — neither must win or clobber.
-        let snap = parse_bridge_snapshot(None, SAMPLE_BRIDGE);
+        let snap = parse_bridge_snapshot(None, SAMPLE_BRIDGE, no_window);
         assert_eq!(snap.model_id, "glm-4-6-fake");
         assert_eq!(snap.model_display_name, "glm-4-6-fake");
         assert_eq!(snap.version, "1.17.8");
@@ -378,7 +444,7 @@ mod tests {
 
     #[test]
     fn snapshot_has_correct_agent_session_id_from_fixture() {
-        let snap = parse_bridge_snapshot(None, SAMPLE_BRIDGE);
+        let snap = parse_bridge_snapshot(None, SAMPLE_BRIDGE, no_window);
         assert_eq!(snap.agent_session_id, "ses_sample001");
     }
 
@@ -387,7 +453,7 @@ mod tests {
         // Bug C: live `session.*` `info.tokens` are all-zero. The running
         // context-window usage is the LATEST `step-finish` `input`
         // (9000 then 12345 ⇒ 12345), not the first and not a sum.
-        let snap = parse_bridge_snapshot(None, SAMPLE_BRIDGE);
+        let snap = parse_bridge_snapshot(None, SAMPLE_BRIDGE, no_window);
         assert_eq!(snap.context_window.total_input_tokens, 12345);
         assert_eq!(snap.context_window.total_output_tokens, 222);
     }
@@ -395,7 +461,7 @@ mod tests {
     #[test]
     fn snapshot_has_correct_cost_from_fixture() {
         // The final `session.updated` carries `cost: 0.0042`.
-        let snap = parse_bridge_snapshot(None, SAMPLE_BRIDGE);
+        let snap = parse_bridge_snapshot(None, SAMPLE_BRIDGE, no_window);
         let cost = snap.cost.total_cost_usd.expect("cost should be set");
         assert!(
             (cost - 0.0042).abs() < 1e-9,
@@ -407,7 +473,7 @@ mod tests {
     fn snapshot_current_usage_from_latest_step_finish() {
         // The fixture's LATEST `step-finish` part carries
         // tokens: { input: 12345, output: 222, cache: { read: 1200, write: 600 } }.
-        let snap = parse_bridge_snapshot(None, SAMPLE_BRIDGE);
+        let snap = parse_bridge_snapshot(None, SAMPLE_BRIDGE, no_window);
         let cu = snap
             .context_window
             .current_usage
@@ -426,7 +492,7 @@ mod tests {
             "{\"v\":1,\"ts\":1,\"kind\":\"event\",\"type\":\"message.updated\",\"data\":{\"info\":{\"id\":\"msg_u\",\"role\":\"user\",\"model\":{\"providerID\":\"opencode\",\"modelID\":\"deepseek-v4-flash-free\"}}}}\n",
             "{\"v\":1,\"ts\":2,\"kind\":\"event\",\"type\":\"message.updated\",\"data\":{\"info\":{\"id\":\"msg_a\",\"role\":\"assistant\",\"model\":{}}}}\n",
         );
-        let snap = parse_bridge_snapshot(None, raw);
+        let snap = parse_bridge_snapshot(None, raw, no_window);
         assert_eq!(snap.model_id, "deepseek-v4-flash-free");
     }
 
@@ -440,7 +506,7 @@ mod tests {
             "{\"v\":1,\"ts\":3,\"kind\":\"event\",\"type\":\"message.part.updated\",\"data\":{\"part\":{\"type\":\"step-finish\",\"tokens\":{\"input\":11781,\"output\":98,\"reasoning\":19,\"cache\":{\"read\":0,\"write\":0}}}}}\n",
             "{\"v\":1,\"ts\":4,\"kind\":\"event\",\"type\":\"session.updated\",\"data\":{\"info\":{\"id\":\"ses_live\",\"model\":{\"providerID\":\"opencode\"},\"tokens\":{\"input\":0,\"output\":0,\"reasoning\":0,\"cache\":{\"read\":0,\"write\":0}}}}}\n",
         );
-        let snap = parse_bridge_snapshot(None, raw);
+        let snap = parse_bridge_snapshot(None, raw, no_window);
         assert_eq!(snap.model_id, "deepseek-v4-flash-free");
         // The trailing zero session.updated must NOT overwrite the step total.
         assert_eq!(snap.context_window.total_input_tokens, 11781);
@@ -448,16 +514,111 @@ mod tests {
     }
 
     #[test]
-    fn context_window_size_is_zero_unknown() {
-        let snap = parse_bridge_snapshot(None, SAMPLE_BRIDGE);
+    fn context_window_size_is_zero_unknown_when_resolver_returns_zero() {
+        let snap = parse_bridge_snapshot(None, SAMPLE_BRIDGE, no_window);
         assert_eq!(snap.context_window.context_window_size, 0);
         // With size == 0 we cannot compute a percentage.
         assert!(snap.context_window.used_percentage.is_none());
     }
 
     #[test]
+    fn context_window_size_and_percentage_come_from_injected_resolver() {
+        // user `message.updated` supplies {providerID, modelID}; `step-finish`
+        // supplies the running token usage. The resolver maps that model to a
+        // 200k-token window (as opencode's models.dev cache does for
+        // deepseek-v4-flash-free), so the snapshot reports a real percentage.
+        let raw = concat!(
+            "{\"v\":1,\"ts\":1,\"kind\":\"event\",\"type\":\"message.updated\",\"data\":{\"info\":{\"role\":\"user\",\"model\":{\"providerID\":\"opencode\",\"modelID\":\"deepseek-v4-flash-free\"}}}}\n",
+            "{\"v\":1,\"ts\":2,\"kind\":\"event\",\"type\":\"message.part.updated\",\"data\":{\"part\":{\"type\":\"step-finish\",\"tokens\":{\"input\":18000,\"output\":2000,\"cache\":{\"read\":0,\"write\":0}}}}}\n",
+        );
+
+        let resolve = |provider: &str, model: &str| -> u64 {
+            if (provider, model) == ("opencode", "deepseek-v4-flash-free") {
+                200_000
+            } else {
+                0
+            }
+        };
+
+        let snap = parse_bridge_snapshot(None, raw, resolve);
+        assert_eq!(snap.context_window.context_window_size, 200_000);
+        // total = 18000 + 2000 = 20000; 20000 / 200000 = 10%.
+        let used = snap
+            .context_window
+            .used_percentage
+            .expect("percentage set when window known");
+        assert!((used - 10.0).abs() < 1e-9, "used% = {used}");
+        assert!(
+            (snap.context_window.remaining_percentage - 90.0).abs() < 1e-9,
+            "remaining% = {}",
+            snap.context_window.remaining_percentage
+        );
+    }
+
+    #[test]
+    fn context_percentage_includes_cache_read_not_just_fresh_input() {
+        // Regression for the "context not incrementing" bug: once prompt caching
+        // engages, opencode reports `input` as only the fresh delta (152) and
+        // parks the conversation in `cache.read` (24064). The gauge must reflect
+        // the FULL context (152 + 44 + 24064), not collapse to the fresh delta.
+        let raw = concat!(
+            "{\"v\":1,\"ts\":1,\"kind\":\"event\",\"type\":\"message.updated\",\"data\":{\"info\":{\"role\":\"user\",\"model\":{\"providerID\":\"opencode\",\"modelID\":\"deepseek-v4-flash-free\"}}}}\n",
+            "{\"v\":1,\"ts\":2,\"kind\":\"event\",\"type\":\"message.part.updated\",\"data\":{\"part\":{\"type\":\"step-finish\",\"tokens\":{\"input\":152,\"output\":44,\"reasoning\":20,\"cache\":{\"read\":24064,\"write\":0}}}}}\n",
+        );
+        let snap = parse_bridge_snapshot(None, raw, |_, _| 200_000);
+
+        // used = 152 + 44 + 24064 = 24260; 24260 / 200000 = 12.13%.
+        let used = snap
+            .context_window
+            .used_percentage
+            .expect("percentage set when window known");
+        assert!((used - 12.13).abs() < 0.01, "used% = {used}");
+        // The fresh-input total stays the per-step delta (matches kimi); the
+        // cache breakdown is surfaced via current_usage.
+        assert_eq!(snap.context_window.total_input_tokens, 152);
+        let cu = snap.context_window.current_usage.expect("usage present");
+        assert_eq!(cu.cache_read_input_tokens, 24064);
+    }
+
+    #[test]
+    fn resolver_receives_the_message_provider_and_model_ids() {
+        // The resolver must be called with the (providerID, modelID) the bridge
+        // emitted on the user `message.updated`.
+        use std::cell::RefCell;
+        let raw =
+            "{\"v\":1,\"ts\":1,\"kind\":\"event\",\"type\":\"message.updated\",\"data\":{\"info\":{\"role\":\"user\",\"model\":{\"providerID\":\"anthropic\",\"modelID\":\"claude-sonnet-4\"}}}}\n";
+
+        let seen = RefCell::new(None);
+        let resolve = |provider: &str, model: &str| -> u64 {
+            *seen.borrow_mut() = Some((provider.to_string(), model.to_string()));
+            1_000_000
+        };
+
+        let snap = parse_bridge_snapshot(None, raw, resolve);
+        assert_eq!(snap.context_window.context_window_size, 1_000_000);
+        assert_eq!(
+            seen.into_inner(),
+            Some(("anthropic".to_string(), "claude-sonnet-4".to_string()))
+        );
+    }
+
+    #[test]
+    fn resolver_is_not_consulted_when_the_model_is_unknown() {
+        // No model id in the stream ⇒ the resolver must not be called and the
+        // window stays unknown (0).
+        let raw = "{\"v\":1,\"ts\":1,\"kind\":\"event\",\"type\":\"session.created\",\"data\":{\"info\":{\"id\":\"ses_x\"}}}\n";
+        let resolve = |_provider: &str, _model: &str| -> u64 {
+            panic!("resolver must not run when the model is unknown");
+        };
+
+        let snap = parse_bridge_snapshot(None, raw, resolve);
+        assert_eq!(snap.context_window.context_window_size, 0);
+        assert!(snap.context_window.used_percentage.is_none());
+    }
+
+    #[test]
     fn rate_limits_are_safe_default() {
-        let snap = parse_bridge_snapshot(None, SAMPLE_BRIDGE);
+        let snap = parse_bridge_snapshot(None, SAMPLE_BRIDGE, no_window);
         assert!((snap.rate_limits.five_hour.used_percentage - 0.0).abs() < f64::EPSILON);
         assert_eq!(snap.rate_limits.five_hour.resets_at, 0);
         assert!(snap.rate_limits.seven_day.is_none());
@@ -470,7 +631,7 @@ mod tests {
             "{\"v\":1,\"ts\":1,\"kind\":\"event\",\"type\":\"session.created\",\"data\":{\"info\":{\"id\":\"ses_model_id\",\"version\":\"1.2.3\",\"model\":{\"providerID\":\"anthropic\",\"modelID\":\"claude-sonnet-4\"},\"cost\":0.25,\"tokens\":{\"input\":700,\"output\":300,\"cache\":{\"read\":10,\"write\":20}}}}}\n",
         );
 
-        let snap = parse_bridge_snapshot(Some("pty-1"), raw);
+        let snap = parse_bridge_snapshot(Some("pty-1"), raw, no_window);
         assert_eq!(snap.agent_session_id, "ses_model_id");
         assert_eq!(snap.model_id, "claude-sonnet-4");
         assert_eq!(snap.model_display_name, "claude-sonnet-4");
@@ -488,7 +649,7 @@ mod tests {
             "{\"v\":1,\"ts\":2,\"kind\":\"event\",\"type\":\"message.part.updated\",\"data\":{\"part\":{\"type\":\"step-finish\",\"tokens\":{\"input\":321,\"output\":123,\"cache\":{\"read\":40,\"write\":50}}}}}\n",
         );
 
-        let snap = parse_bridge_snapshot(None, raw);
+        let snap = parse_bridge_snapshot(None, raw, no_window);
         assert_eq!(snap.model_id, "claude-haiku");
         assert_eq!(snap.context_window.total_input_tokens, 321);
         assert_eq!(snap.context_window.total_output_tokens, 123);
@@ -512,7 +673,7 @@ mod tests {
             "{\"v\":1,\"ts\":2,\"kind\":\"event\",\"type\":\"session.updated\",\"data\":{\"info\":{\"id\":\"ses_tol\",\"version\":\"1.0.0\",\"model\":{\"id\":\"claude-opus\"},\"cost\":0.001,\"tokens\":{\"input\":200,\"output\":80,\"cache\":{\"read\":0,\"write\":0}}}}}\n",
         );
 
-        let snap = parse_bridge_snapshot(None, raw);
+        let snap = parse_bridge_snapshot(None, raw, no_window);
         assert_eq!(snap.agent_session_id, "ses_tol");
         assert_eq!(snap.model_id, "claude-opus");
         // The second good session.updated (after the garbage line) is applied.
@@ -529,7 +690,7 @@ mod tests {
             "{\"v\":1,\"ts\":1,\"kind\":\"event\",\"type\":\"session.created\",\"data\":{\"info\":{\"id\":\"ses_nostep\",\"version\":\"1.0.0\",\"model\":{\"id\":\"gpt-4o\"},\"cost\":0,\"tokens\":{\"input\":0,\"output\":0,\"cache\":{\"read\":0,\"write\":0}}}}}\n",
         );
 
-        let snap = parse_bridge_snapshot(None, raw);
+        let snap = parse_bridge_snapshot(None, raw, no_window);
         assert_eq!(snap.agent_session_id, "ses_nostep");
         assert!(snap.context_window.current_usage.is_none());
         assert_eq!(snap.context_window.total_input_tokens, 0);
@@ -538,7 +699,7 @@ mod tests {
     /// An entirely empty input produces a default snapshot without panicking.
     #[test]
     fn empty_input_returns_default_snapshot_no_panic() {
-        let snap = parse_bridge_snapshot(None, "");
+        let snap = parse_bridge_snapshot(None, "", no_window);
         assert_eq!(snap.agent_session_id, "");
         assert_eq!(snap.model_id, "unknown");
         assert_eq!(snap.model_display_name, "unknown");
@@ -557,7 +718,7 @@ mod tests {
         // The second line has no trailing '\n' — it must be dropped.
         let raw = "{\"v\":1,\"ts\":1,\"kind\":\"event\",\"type\":\"session.created\",\"data\":{\"info\":{\"id\":\"ses_partial\",\"version\":\"0.9\",\"model\":{\"id\":\"m1\"},\"cost\":0,\"tokens\":{\"input\":10,\"output\":5,\"cache\":{\"read\":0,\"write\":0}}}}}\n{INCOMPLETE";
 
-        let snap = parse_bridge_snapshot(None, raw);
+        let snap = parse_bridge_snapshot(None, raw, no_window);
         assert_eq!(snap.agent_session_id, "ses_partial");
         assert_eq!(snap.model_id, "m1");
     }
@@ -571,7 +732,7 @@ mod tests {
             "{\"v\":1,\"ts\":2,\"kind\":\"event\",\"type\":\"session.updated\",\"data\":{\"info\":{\"id\":\"ses_win\",\"version\":\"1.17.8\",\"model\":{\"id\":\"new-model\"},\"cost\":0.5,\"tokens\":{\"input\":500,\"output\":100,\"cache\":{\"read\":0,\"write\":0}}}}}\n",
         );
 
-        let snap = parse_bridge_snapshot(None, raw);
+        let snap = parse_bridge_snapshot(None, raw, no_window);
         assert_eq!(snap.model_id, "new-model");
         assert_eq!(snap.version, "1.17.8");
         assert_eq!(snap.context_window.total_input_tokens, 500);
@@ -587,7 +748,7 @@ mod tests {
             "{\"v\":1,\"ts\":2,\"kind\":\"event\",\"type\":\"message.part.updated\",\"data\":{\"part\":{\"type\":\"step-finish\",\"tokens\":{\"input\":300,\"output\":60,\"cache\":{\"read\":50,\"write\":10}}}}}\n",
         );
 
-        let snap = parse_bridge_snapshot(None, raw);
+        let snap = parse_bridge_snapshot(None, raw, no_window);
         let cu = snap
             .context_window
             .current_usage

--- a/crates/backend/src/agent/adapter/opencode/types.rs
+++ b/crates/backend/src/agent/adapter/opencode/types.rs
@@ -18,11 +18,12 @@ use std::path::PathBuf;
 #[allow(unused_imports)]
 pub(crate) use super::install::bridge_dir;
 
-/// opencode context-window size placeholder. opencode does not emit a
-/// context-window size into the bridge JSONL, and v1 has no reliable
-/// per-model table, so the decoder (M4) treats `0` as "unknown" and the
-/// frontend renders the bar without a denominator. Mirrors the
-/// `KIMI_CONTEXT_WINDOW_SIZE` shape, but the value is intentionally `0`.
+/// opencode context-window "unknown" sentinel. opencode does not emit a
+/// context-window size into the bridge JSONL; the decoder resolves it from
+/// opencode's models.dev cache by `(providerID, modelID)` (see
+/// [`super::model_catalog`]). This `0` is what the lookup returns when the
+/// cache is absent or the model is unlisted — the frontend then renders the
+/// bar without a denominator. Mirrors the `KIMI_CONTEXT_WINDOW_SIZE` shape.
 pub(crate) const OPENCODE_CONTEXT_WINDOW_SIZE: u64 = 0;
 
 /// opencode home fallback (registry plumbing only — NOT the bridge dir).

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -55,10 +55,10 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 14       | 11   | 2026-06-21   |
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 8        | 2    | 2026-06-19   |
-| [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 3        | 0    | 2026-06-16   |
+| [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 4        | 0    | 2026-06-21   |
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 81       | 36   | 2026-06-21   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
-| [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 90       | 90   | 2026-06-21   |
+| [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 91       | 90   | 2026-06-21   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 72       | 30   | 2026-06-20   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 69       | 69   | 2026-06-21   |

--- a/docs/reviews/patterns/documentation-accuracy.md
+++ b/docs/reviews/patterns/documentation-accuracy.md
@@ -846,3 +846,12 @@ Stale documentation misleads future contributors and review agents.
 - **Finding:** The PR added an Opencode SVG mark while the adjacent file-level comment pointed readers to `icons-NOTICE.md` for Lobe Icons MIT attribution only. Future maintainers could reasonably assume the new mark was covered by the existing vendored-icon notice.
 - **Fix:** Reworded the file-level comment to point to the notice for per-mark provenance and documented the Opencode mark as an original Vimeflow geometric terminal mark outside the Lobe Icons vendored set.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 91. `resolve_by_pid` comment overstated cached fallback guarantee
+
+- **Source:** github-claude | PR #599 round 1 | 2026-06-21
+- **Severity:** LOW
+- **File:** `crates/backend/src/agent/adapter/opencode/locator.rs`
+- **Finding:** The comment said a pid miss with a prior cache returns `None` so `cached_or_err` keeps the live binding. In reality `locate` tries the cwd fallback first, and only preserves the cached binding when cwd also finds nothing.
+- **Fix:** Reworded the comment to document the actual fallback order: pid miss triggers cwd resolution first, and `cached_or_err` preserves the binding only after cwd also misses.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/hot-path-caching.md
+++ b/docs/reviews/patterns/hot-path-caching.md
@@ -2,7 +2,7 @@
 id: hot-path-caching
 category: backend
 created: 2026-06-09
-last_updated: 2026-06-16
+last_updated: 2026-06-21
 ref_count: 0
 ---
 
@@ -48,4 +48,13 @@ feature.
 - **File:** `src/features/agent-status/utils/statusRefreshCoordinator.ts`
 - **Finding:** When `detect_agent_in_session` returned `null` for a pane with a cached active snapshot, the coordinator returned the stale snapshot unchanged. Switching back to that pane restored `isActive: true` until the primary polling hook caught up.
 - **Fix:** Changed the null-detection branch to write a default inactive snapshot instead of returning the previous one, so hot-loaded panes never display a dead agent as active.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 4. Opencode models cache cached an empty first read forever
+
+- **Source:** github-codex-connector | PR #599 round 1 | 2026-06-21
+- **Severity:** P2 / MEDIUM
+- **File:** `crates/backend/src/agent/adapter/opencode/model_catalog.rs`
+- **Finding:** `catalog` used `OnceLock::get_or_init` with `Catalog::new()` on missing, unreadable, malformed, or empty `models.json`. If Vimeflow decoded opencode before opencode finished refreshing the cache, every later `context_window` lookup returned the unknown sentinel until restart.
+- **Fix:** Split disk loading from cache initialization and populate the `OnceLock` only after a non-empty successful parse. Added regression tests proving missing, empty, and malformed first reads remain retryable and a later valid cache is used.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)


### PR DESCRIPTION
## Summary

Three correctness fixes to opencode live observability, found during live-session testing after the M1–M6 milestones merged. Observability-only, confined to `crates/backend/src/agent/adapter/opencode/`.

1. **Locator binds by pid, not stale OSC 7 cwd** — opencode's TUI doesn't emit OSC 7, so Vimeflow's tracked cwd stays at the pane spawn dir while opencode runs in a project subdir; the cwd-only resolver never matched and the session was never ingested. The bridge writes `process.pid == agent_pid` (verified live: 25863, 89074), so resolve **pid-first** (newest fresh row), cwd as fallback. Also fixes `/clear` reattach (two same-cwd sessions the cwd path fails-closed on are disambiguated by pid).
2. **Context-window size from opencode's models.dev cache** — the stream carries `{providerID, modelID}` but not the limit, so the gauge showed "window unknown". New `model_catalog` reads `${XDG_CACHE_HOME:-~/.cache}/opencode/models.json` → `models[providerID].models[modelID].limit.context`. Best-effort, 0 (unknown) on any miss.
3. **Context occupancy counts cached tokens** — opencode (like Anthropic / kimi) reports `input` as only the fresh delta once prompt caching engages, parking the conversation in `cache.read`; the gauge collapsed to the per-step delta (152 instead of 24k). Sum `input + output + cache_read + cache_write` (saturating), mirroring `kimi::parser`'s `used`.

## Verification

- All three verified live; the context card now matches opencode's own TUI exactly (e.g. `13.1K (7%)`).
- 105 opencode tests pass; 590 agent-adapter tests pass; no cross-adapter regressions.
- Reviewed by **codex** (one P2 — saturating arithmetic — applied) and a **ponytail** over-engineering pass (lean; two doc trims applied).

Closes VIM-209. Part of VIM-193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)