### PR TITLE
fix(terminal): hide stale parked cursor on blank rows above content (VIM-207)

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -58,7 +58,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 26       | 9    | 2026-06-21   |
 | [Terminal DOM Rendering](patterns/terminal-dom-rendering.md)                                         | terminal           | 10       | 6    | 2026-06-21   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
-| [Terminal Render-State Driver Contract](patterns/terminal-render-state-driver-contract.md)           | terminal           | 32       | 9    | 2026-06-21   |
+| [Terminal Render-State Driver Contract](patterns/terminal-render-state-driver-contract.md)           | terminal           | 33       | 10   | 2026-06-21   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 85       | 25   | 2026-06-08   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 51       | 24   | 2026-06-18   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |

--- a/docs/reviews/patterns/terminal-render-state-driver-contract.md
+++ b/docs/reviews/patterns/terminal-render-state-driver-contract.md
@@ -3,7 +3,7 @@ id: terminal-render-state-driver-contract
 category: terminal
 created: 2026-06-19
 last_updated: 2026-06-21
-ref_count: 9
+ref_count: 10
 ---
 
 # Terminal Render-State Driver Contract
@@ -307,4 +307,13 @@ documented explicitly: effect callbacks must be invoked synchronously inside the
 - **File:** `electron/ghostty-render-state-main.ts`
 - **Finding:** The Electron Ghostty bridge clamped synthesized formatter background/reverse ranges to native cell and visible-text extents only. When Ghostty trimmed trailing blanks on the cursor row, the renderer later padded that row back to `cursor.columnOffset`, but the styled blanks before the cursor had already been dropped.
 - **Fix:** Threaded the validated cursor row/column into reverse-range synthesis and included `cursor.columnOffset` in the effective extent for the cursor row only. Added regression coverage for cursor-row styled padding that preserves style up to the cursor without restoring full-width formatter padding.
+- **Commit:** same commit as this entry
+
+### 32. Omitted native cursor visibility means default visible
+
+- **Source:** github-codex-connector | PR #600 round 1 | 2026-06-21
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.ts`
+- **Finding:** The VT snapshot renderer treated a missing `cursor.visible` field as an implicit stale-cursor signal and hid any cursor on a blank row with later content. Ghostty omits `visible` for normal visible cursors, so legitimate editor/TUI cursors on blank lines above status or menu rows disappeared.
+- **Fix:** Missing `cursor.visible` now preserves the default visible cursor unless the snapshot matches a known parked-cursor shape: an agent prompt follower or a styled blank native cursor artifact above later content. Regression coverage pins both the preserved `rows: ['', 'menu']` case and the styled parked-cursor case.
 - **Commit:** same commit as this entry

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.test.ts
@@ -332,6 +332,47 @@ describe('ghosttyVtRenderSnapshot', () => {
     expect(output.displayDelta?.cursorVisible).toBe(false)
   })
 
+  test('hides an implicit cursor stranded on a blank row above later content', () => {
+    // Agent exit: a lone block parked on a blank row between "Bye!" and the
+    // relaunched banner must not render even though the follower is not a `>`
+    // prompt (it is the agent welcome banner).
+    const output = createGhosttyVtRenderSnapshotOutput({
+      rows: ['Bye!', '', 'session ready'],
+      cursor: {
+        rowIndex: 1,
+        columnOffset: 0,
+      },
+    })
+
+    expect(output.displayDelta?.cursorVisible).toBe(false)
+  })
+
+  test('keeps an implicit cursor on a trailing blank row with no content below', () => {
+    // The normal "waiting at the bottom" cursor: a blank row whose only content
+    // is above it stays visible.
+    const output = createGhosttyVtRenderSnapshotOutput({
+      rows: ['last output', ''],
+      cursor: {
+        rowIndex: 1,
+        columnOffset: 0,
+      },
+    })
+
+    expect(output.displayDelta?.cursorVisible).toBeUndefined()
+  })
+
+  test('keeps an implicit cursor on a fully blank screen', () => {
+    const output = createGhosttyVtRenderSnapshotOutput({
+      rows: ['', '', ''],
+      cursor: {
+        rowIndex: 0,
+        columnOffset: 0,
+      },
+    })
+
+    expect(output.displayDelta?.cursorVisible).toBeUndefined()
+  })
+
   test('renders styled empty native cells as occupied blanks', () => {
     const output = createGhosttyVtRenderSnapshotOutput({
       rows: ['A B'],

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.test.ts
@@ -64,15 +64,16 @@ describe('ghosttyVtRenderSnapshot', () => {
   })
 
   test('preserves an intentional empty top row when the cursor is above content', () => {
-    expect(
-      createGhosttyVtRenderSnapshotOutput({
-        rows: ['', 'menu'],
-        cursor: {
-          rowIndex: 0,
-          columnOffset: 0,
-        },
-      }).displayDelta?.operations[0]
-    ).toEqual({
+    const output = createGhosttyVtRenderSnapshotOutput({
+      rows: ['', 'menu'],
+      cursor: {
+        rowIndex: 0,
+        columnOffset: 0,
+      },
+    })
+
+    expect(output.displayDelta?.cursorVisible).toBeUndefined()
+    expect(output.displayDelta?.operations[0]).toEqual({
       type: 'replace',
       text: '\nmenu',
       cursorOffset: 0,
@@ -335,16 +336,38 @@ describe('ghosttyVtRenderSnapshot', () => {
   test('hides an implicit cursor stranded on a blank row above later content', () => {
     // Agent exit: a lone block parked on a blank row between "Bye!" and the
     // relaunched banner must not render even though the follower is not a `>`
-    // prompt (it is the agent welcome banner).
+    // prompt (it is the agent welcome banner). The styled blank marks this as a
+    // native cursor artifact instead of an ordinary default-visible cursor.
     const output = createGhosttyVtRenderSnapshotOutput({
       rows: ['Bye!', '', 'session ready'],
       cursor: {
         rowIndex: 1,
         columnOffset: 0,
       },
+      cells: [
+        {
+          row: 1,
+          col: 0,
+          text: '',
+          width: 1,
+          reverse: true,
+        },
+      ],
     })
 
     expect(output.displayDelta?.cursorVisible).toBe(false)
+  })
+
+  test('keeps an implicit default-visible cursor on a blank row above later content', () => {
+    const output = createGhosttyVtRenderSnapshotOutput({
+      rows: ['editor body', '', 'status footer'],
+      cursor: {
+        rowIndex: 1,
+        columnOffset: 0,
+      },
+    })
+
+    expect(output.displayDelta?.cursorVisible).toBeUndefined()
   })
 
   test('keeps an implicit cursor on a trailing blank row with no content below', () => {

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.ts
@@ -307,14 +307,32 @@ const readSnapshotCursorOffset = (
   return precedingRowsLength + rowTextOffset
 }
 
-// An implicit cursor (no explicit show/hide flag) parked on a blank row that
-// still has content BELOW it is a stale/dead cursor left behind by a scroll or
-// agent redraw — e.g. a lone block stranded on an empty row above a relaunched
-// agent banner or prompt. Real cursors sit at the end of output with nothing
-// below them, so hide the parked one. A blank row with content only above (the
-// normal "waiting at the bottom" cursor) or a fully blank screen (just after
-// `clear`) keeps its cursor. An explicit cursor.visible flag always wins — this
-// heuristic only runs when it is absent.
+const PROMPT_MARKER_PATTERN = /^\s*>/
+
+const hasCellStyle = (cell: GhosttyVtRenderSnapshotCell): boolean =>
+  cell.bold === true ||
+  cell.italic === true ||
+  cell.underline === true ||
+  cell.foreground !== undefined ||
+  cell.background !== undefined ||
+  cell.reverse === true
+
+const hasStyledBlankCellAtCursor = (
+  rowCells: readonly GhosttyVtRenderSnapshotCell[] | undefined,
+  columnOffset: number
+): boolean =>
+  rowCells?.some(
+    (cell) =>
+      hasCellStyle(cell) &&
+      cell.text.trim().length === 0 &&
+      cell.col <= columnOffset &&
+      columnOffset < cell.col + cell.width
+  ) ?? false
+
+// A missing cursor.visible flag means "native default visible", not
+// "synthetic cursor". Keep ordinary blank-row cursors visible unless the
+// snapshot matches a known stale parked-cursor shape: an agent prompt follower
+// or a styled blank native cell stranded above later content.
 const shouldHideImplicitParkedCursor = (
   snapshot: GhosttyVtRenderSnapshot,
   cellsByRow: CellsByRow
@@ -336,15 +354,21 @@ const shouldHideImplicitParkedCursor = (
     return false
   }
 
-  return snapshot.rows
+  const nextContentRow = snapshot.rows
     .slice(rowIndex + 1)
-    .some(
-      (row, offset) =>
-        readCellRowVisibleText(
-          row,
-          cellsByRow.get(rowIndex + offset + 1)
-        ).trim().length > 0
+    .map((row, offset) =>
+      readCellRowVisibleText(row, cellsByRow.get(rowIndex + offset + 1))
     )
+    .find((row) => row.trim().length > 0)
+
+  if (nextContentRow === undefined) {
+    return false
+  }
+
+  return (
+    PROMPT_MARKER_PATTERN.test(nextContentRow) ||
+    hasStyledBlankCellAtCursor(cellsByRow.get(rowIndex), cursor.columnOffset)
+  )
 }
 
 export const createGhosttyVtRenderSnapshotOutput = (

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.ts
@@ -307,9 +307,15 @@ const readSnapshotCursorOffset = (
   return precedingRowsLength + rowTextOffset
 }
 
-const PROMPT_MARKER_PATTERN = /^\s*>/
-
-const shouldHideImplicitPromptCursor = (
+// An implicit cursor (no explicit show/hide flag) parked on a blank row that
+// still has content BELOW it is a stale/dead cursor left behind by a scroll or
+// agent redraw — e.g. a lone block stranded on an empty row above a relaunched
+// agent banner or prompt. Real cursors sit at the end of output with nothing
+// below them, so hide the parked one. A blank row with content only above (the
+// normal "waiting at the bottom" cursor) or a fully blank screen (just after
+// `clear`) keeps its cursor. An explicit cursor.visible flag always wins — this
+// heuristic only runs when it is absent.
+const shouldHideImplicitParkedCursor = (
   snapshot: GhosttyVtRenderSnapshot,
   cellsByRow: CellsByRow
 ): boolean => {
@@ -330,16 +336,15 @@ const shouldHideImplicitPromptCursor = (
     return false
   }
 
-  const nextContentRow = snapshot.rows
+  return snapshot.rows
     .slice(rowIndex + 1)
-    .map((row, offset) =>
-      readCellRowVisibleText(row, cellsByRow.get(rowIndex + offset + 1))
+    .some(
+      (row, offset) =>
+        readCellRowVisibleText(
+          row,
+          cellsByRow.get(rowIndex + offset + 1)
+        ).trim().length > 0
     )
-    .find((row) => row.trim().length > 0)
-
-  return nextContentRow === undefined
-    ? false
-    : PROMPT_MARKER_PATTERN.test(nextContentRow)
 }
 
 export const createGhosttyVtRenderSnapshotOutput = (
@@ -353,7 +358,7 @@ export const createGhosttyVtRenderSnapshotOutput = (
 
   const cursorVisible =
     normalizedSnapshot.cursor?.visible ??
-    (shouldHideImplicitPromptCursor(normalizedSnapshot, cellsByRow)
+    (shouldHideImplicitParkedCursor(normalizedSnapshot, cellsByRow)
       ? false
       : undefined)
 


### PR DESCRIPTION
## What
Hide an **implicit** cursor (no explicit visibility flag) parked on a **blank row that has content below it** — a real cursor sits at the end of output with nothing below, so a parked one is stale/dead.

## Why (VIM-207, the Kimi side)
On a Kimi exit/relaunch, a lone stale block cursor was left stranded on a blank row (the block under "Bye!"). The existing implicit-cursor suppression (`shouldHideImplicitPromptCursor`) only hid the cursor when the next content row was a literal `>` prompt. Starship and agent relaunches present a banner or a non-`>` prompt char, so they fell through and rendered the stray block.

Root-caused via multi-agent investigation + adversarial verification against the live code: it is **not** DOM persistence (every frame is a full `replace`) and **not** an offset divergence (SGR sentinels are stripped). It's that `cursorVisible` defaults to `true` on replace frames and the only suppressor was too narrow.

## Change
`shouldHideImplicitPromptCursor` → `shouldHideImplicitParkedCursor`: hide when the cursor's blank row has **any** content below it (generalizes the `>`-only rule; the `>` case is now a subset). Guards: only when `cursor.visible` is unset; a blank row with content only above (normal bottom-of-buffer cursor) or a fully blank screen still shows the cursor.

## Tests
`ghosttyVtRenderSnapshot.test.ts`: new — stranded-block-above-banner → hidden; bottom blank line (content above only) → shown; fully blank screen → shown. Existing `>`-prompt suppression + explicit `visible:false` still green. 22 snapshot + 113 terminal-area tests pass; type-check / eslint / prettier clean.

## Deferred (NOT in this PR)
Two **transient single-frame** artifacts from the same recording are inherent to per-chunk full-replace snapshots tracking a real scrolling terminal and need **frame-coalescing** (out of scope, risks cursor/OSC timing): a stale cursor coordinate flashing over content for one relaunch frame, and the one-frame prompt-color **bar flash** (re-clamping would re-break VIM-206's full-width input box). Tracked under VIM-207 follow-up.

Part of VIM-139 (Ghostty M4). Manual smoke requested before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)