### PR TITLE
feat(agent-status): opencode quota-unavailable notice + upstream FR link

### DIFF
--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -12,10 +12,28 @@ export interface PaneIdentity {
   onAccent: string
 }
 
+/**
+ * Notice shown in the agent status card's quota slot for an agent that exposes
+ * no readable usage/quota API, in place of rate-limit bars.
+ */
+export interface QuotaNotice {
+  /** One-line reason the quota bars are absent. */
+  message: string
+  /** Upstream feature-request URL the "track" link opens. */
+  trackUrl: string
+}
+
 export interface AgentDef extends PaneIdentity {
   id: string
   model: string | null
   Icon?: AgentIcon
+  /**
+   * Set only for agents that have no readable usage/quota API: the status card
+   * renders this notice + a link to the upstream feature request instead of
+   * 5-hour / weekly bars. Currently opencode (see sst/opencode#16017); cleared
+   * once opencode ships a usage endpoint.
+   */
+  quotaNotice?: QuotaNotice
 }
 
 export const AGENTS = {
@@ -78,6 +96,14 @@ export const AGENTS = {
     accentDim: 'var(--color-agent-opencode-accent-dim)',
     accentSoft: 'var(--color-agent-opencode-accent-soft)',
     onAccent: 'var(--color-agent-opencode-on-accent)',
+    // opencode exposes no readable usage/quota API (Zen is pay-as-you-go
+    // credits; Go's 5h/weekly windows live in opencode.ai's cloud with no
+    // queryable endpoint). Show a notice + link to the upstream request rather
+    // than fabricating empty bars.
+    quotaNotice: {
+      message: 'Usage limits not exposed by opencode yet',
+      trackUrl: 'https://github.com/sst/opencode/issues/16017',
+    },
   },
 } as const satisfies Record<string, AgentDef>
 

--- a/src/features/agent-status/components/QuotaUnavailableNotice.test.tsx
+++ b/src/features/agent-status/components/QuotaUnavailableNotice.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react'
+import { describe, test, expect } from 'vitest'
+import { QuotaUnavailableNotice } from './QuotaUnavailableNotice'
+
+describe('QuotaUnavailableNotice', () => {
+  test('renders the message and a track-the-request link to the feature request', () => {
+    render(
+      <QuotaUnavailableNotice
+        message="Usage limits not exposed by opencode yet"
+        trackUrl="https://github.com/sst/opencode/issues/16017"
+      />
+    )
+
+    expect(
+      screen.getByText('Usage limits not exposed by opencode yet')
+    ).toBeInTheDocument()
+
+    const link = screen.getByRole('link', { name: /track the request/i })
+    expect(link).toHaveAttribute(
+      'href',
+      'https://github.com/sst/opencode/issues/16017'
+    )
+  })
+
+  test('opens the link safely in a new tab', () => {
+    render(
+      <QuotaUnavailableNotice message="m" trackUrl="https://example.test/fr" />
+    )
+
+    const link = screen.getByRole('link', { name: /track the request/i })
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+})

--- a/src/features/agent-status/components/QuotaUnavailableNotice.tsx
+++ b/src/features/agent-status/components/QuotaUnavailableNotice.tsx
@@ -1,0 +1,51 @@
+import type { ReactElement } from 'react'
+import { Tooltip } from '@/components/Tooltip'
+import type { QuotaNotice } from '@/agents/registry'
+
+/**
+ * Fills the agent status card's quota slot for an agent that exposes no
+ * readable usage/quota API (currently opencode — see sst/opencode#16017).
+ *
+ * Mirrors the shape of kimi's consent-gated `SlotOff` — a caption plus a single
+ * full-width affordance inside the fixed `CARD_BODY_H` slot — but the affordance
+ * is an external "track the request" link to the upstream feature request
+ * instead of a poll button, because there is nothing to poll yet. When opencode
+ * ships a usage API, this is replaced by real 5-hour / weekly bars.
+ *
+ * Styling matches the shell quick-reference link in `AgentStatusCard` (semantic
+ * tokens only, per `vimeflow/no-hardcoded-colors`; `Tooltip` rather than a
+ * native `title`).
+ */
+export const QuotaUnavailableNotice = ({
+  message,
+  trackUrl,
+}: QuotaNotice): ReactElement => (
+  <div className="flex flex-col gap-[7px]">
+    <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.12em] text-on-surface-muted">
+      {message}
+    </span>
+    <Tooltip content="Opencode usage API — open the feature request (sst/opencode#16017)">
+      <a
+        href={trackUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex w-full items-center gap-[7px] rounded-[7px] bg-surface-container-lowest/45 py-[5px] pr-[7px] pl-[9px] font-mono text-[10.5px] leading-none text-on-surface-muted no-underline transition-colors hover:bg-primary/10 hover:text-primary"
+      >
+        <span
+          className="material-symbols-outlined text-[15px]"
+          aria-hidden="true"
+        >
+          monitoring
+        </span>
+        <span>Track the request</span>
+        <span className="flex-1" />
+        <span
+          className="material-symbols-outlined text-[13px] opacity-[0.55]"
+          aria-hidden="true"
+        >
+          open_in_new
+        </span>
+      </a>
+    </Tooltip>
+  </div>
+)

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -87,7 +87,11 @@ import { LAYOUT_IDS } from '../terminal/layout-registry'
 import { lineDelta } from '../sessions/utils/lineDelta'
 import { isLiveStatus, isOpenSession } from '../sessions/utils/sessionStatus'
 import { pickNextVisibleSessionId } from '../sessions/utils/pickNextVisibleSessionId'
-import { AGENTS, agentTypeToRegistryKey } from '../../agents/registry'
+import {
+  AGENTS,
+  agentTypeToRegistryKey,
+  type AgentDef,
+} from '../../agents/registry'
 import type { PaneLayoutId, SessionCloseResult } from '../sessions/types'
 import {
   buildWorkspaceCommands,
@@ -1614,6 +1618,13 @@ const WorkspaceViewContent = (): ReactElement => {
   const sidebarCardIsKimi = agentStatus.agentType === 'kimi'
   const sidebarCardHasUsageData = agentStatus.usageFetched ?? false
 
+  // Agents with no readable usage API (opencode) show a notice + feature-request
+  // link in the quota slot instead of bars; the data is registry-driven. The
+  // `as AgentDef` upcast reaches the optional `quotaNotice` past the `as const`
+  // union of literals (only the opencode entry carries it).
+  const sidebarCardQuotaNotice =
+    (activityPanelAgent as AgentDef).quotaNotice ?? null
+
   // Non-kimi bars use `rateLimitPercentage` (a zeroed/placeholder window reads
   // as absent). For kimi, `usageFetched` proves a fetch landed, not that every
   // window came back — `/usages` can be weekly-only, and the required backend
@@ -2288,6 +2299,7 @@ const WorkspaceViewContent = (): ReactElement => {
                   weekPct={sidebarCardWeekPct}
                   isKimi={sidebarCardIsKimi}
                   hasUsageData={sidebarCardHasUsageData}
+                  quotaNotice={sidebarCardQuotaNotice}
                   shellName={activePtyBackedPane?.shell ?? null}
                 />
               }

--- a/src/features/workspace/components/AgentStatusCard.test.tsx
+++ b/src/features/workspace/components/AgentStatusCard.test.tsx
@@ -1,4 +1,4 @@
-// cspell:ignore cheatsheet incard powershell pwsh zsh
+// cspell:ignore cheatsheet deepseek incard powershell pwsh zsh
 import type { ReactElement } from 'react'
 import { render, screen } from '@testing-library/react'
 import { describe, test, expect, vi } from 'vitest'
@@ -201,6 +201,30 @@ describe('AgentStatusCard', () => {
 
     expect(screen.queryByTestId('kimi-usage-gate')).not.toBeInTheDocument()
     expect(screen.getByText('5-hour Session')).toBeInTheDocument()
+  })
+
+  test('renders the quota-unavailable notice + feature-request link (not bars) when quotaNotice is set', () => {
+    render(
+      <AgentStatusCard
+        title="deepseek-v4-pro"
+        fiveHourPct={null}
+        weekPct={null}
+        quotaNotice={{
+          message: 'Usage limits not exposed by opencode yet',
+          trackUrl: 'https://github.com/sst/opencode/issues/16017',
+        }}
+      />
+    )
+
+    expect(
+      screen.getByText('Usage limits not exposed by opencode yet')
+    ).toBeInTheDocument()
+
+    expect(
+      screen.getByRole('link', { name: /track the request/i })
+    ).toHaveAttribute('href', 'https://github.com/sst/opencode/issues/16017')
+    expect(screen.queryByText('5-hour Session')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('kimi-usage-gate')).not.toBeInTheDocument()
   })
 
   test('renders zero turns in the header pill', () => {

--- a/src/features/workspace/components/AgentStatusCard.tsx
+++ b/src/features/workspace/components/AgentStatusCard.tsx
@@ -4,7 +4,9 @@ import { Chip } from '@/components/Chip'
 import { Tooltip } from '@/components/Tooltip'
 import { RateLimitBar } from '../../agent-status/components/RateLimitBar'
 import { KimiUsageGate } from '../../agent-status/components/KimiUsageGate'
+import { QuotaUnavailableNotice } from '../../agent-status/components/QuotaUnavailableNotice'
 import { parseModelTitle } from '../utils/parseModelTitle'
+import type { QuotaNotice } from '@/agents/registry'
 
 // Fused agent-status card (VIM-66 — AGENT-STATUS-CARD-HANDOFF + SHELL-CARD-KIT).
 // ONE fixed card height in every state: switching the active pane between an
@@ -33,6 +35,9 @@ export interface AgentStatusCardProps {
   /** The backend `usageFetched` signal — true once a real kimi `/usages` fetch
    * has landed; lets the gate tell ON (incl. genuine 0%) from LOADING. */
   hasUsageData?: boolean
+  /** Set for agents with no readable usage API (opencode): the quota slot shows
+   * this notice + a feature-request link instead of rate-limit bars. */
+  quotaNotice?: QuotaNotice | null
   /** Resolved shell path/name for pure shell panes, e.g. `/bin/zsh`. */
   shellName?: string | null
 }
@@ -193,6 +198,7 @@ export const AgentStatusCard = ({
   weekPct = null,
   isKimi = false,
   hasUsageData = false,
+  quotaNotice = null,
   shellName = null,
 }: AgentStatusCardProps): ReactElement => {
   const hasUsage = fiveHourPct !== null || weekPct !== null
@@ -259,6 +265,8 @@ export const AgentStatusCard = ({
                 weekPct={weekPct}
                 hasUsageData={hasUsageData}
               />
+            ) : quotaNotice ? (
+              <QuotaUnavailableNotice {...quotaNotice} />
             ) : (
               hasUsage && (
                 <div


### PR DESCRIPTION
## Summary

opencode exposes no readable usage/quota API (verified live, incl. an OpenCode **Go** session) — Zen is pay-as-you-go credits with no time windows, and Go's 5h/weekly windows live in opencode.ai's cloud with no queryable endpoint, no local persistence, no event/DB field. So unlike Claude (`statusline.json`), Codex (rollout + account headers), and Kimi (live `/usages` fetch), there is **nothing to populate `rate_limits` from**.

Instead of leaving the opencode card's quota slot blank (a zeroed-stub coincidence), this renders an explicit notice + a link to the upstream feature request, mirroring kimi's consent-gated "offline" slot.

- New `QuotaUnavailableNotice` — caption + a "Track the request" external link → **sst/opencode#16017** (`GET /api/v1/usage/plan` FR); semantic tokens, `Tooltip`, `open_in_new`, styled like the shell quick-reference link.
- Registry-driven via a new optional `AgentDef.quotaNotice { message, trackUrl }`, set only for opencode. Clearing it auto-reverts the card to real bars once opencode ships a usage API.
- `AgentStatusCard` renders the notice when `quotaNotice` is set (branch order: kimi gate → notice → rate bars); `WorkspaceView` derives it from the registry.

## Tests / review

- 22 component/card tests (new `QuotaUnavailableNotice.test.tsx` + an `AgentStatusCard` branch test); 1166 agent-status + workspace tests green; type-check, ESLint, Prettier clean.
- Reviewed by **codex** (clean on the change) and a **ponytail** over-engineering pass (one DRY nit applied — reuse the registry's `QuotaNotice` type).

Closes VIM-212. Part of VIM-193. Follow-up tracker: VIM-213 (build the real 5h/weekly card when sst/opencode#16017 ships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)