### PR TITLE
feat(agent-status): float the activity-panel toggle as a mirrored sidebar control

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -56,7 +56,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 8        | 2    | 2026-06-19   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 4        | 0    | 2026-06-21   |
-| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 82       | 36   | 2026-06-22   |
+| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 83       | 37   | 2026-06-22   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 92       | 90   | 2026-06-22   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 73       | 31   | 2026-06-22   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -56,7 +56,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 8        | 2    | 2026-06-19   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 4        | 0    | 2026-06-21   |
-| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 81       | 36   | 2026-06-21   |
+| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 82       | 36   | 2026-06-22   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 92       | 90   | 2026-06-22   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 73       | 31   | 2026-06-22   |

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -2,7 +2,7 @@
 id: testing-gaps
 category: testing
 created: 2026-04-09
-last_updated: 2026-06-21
+last_updated: 2026-06-22
 ref_count: 36
 ---
 
@@ -799,3 +799,12 @@ filesystem scope restrictions).
 - **Finding:** The OpenCode locator had tests for a missing index with a populated cache and for a present nonmatching index with no cache, but not for a present index whose rows no longer matched cwd after a successful resolve. That left the `resolve_by_cwd -> None` cached fallback contract unpinned.
 - **Fix:** Added a regression test that resolves `ses_A`, rewrites the index to contain only another cwd, and asserts the second `locate` returns the cached `ses_A`.
 - **Commit:** same commit as this entry
+
+### 82. Shared UI control props used in production lacked branch coverage
+
+- **Source:** github-claude | PR #605 round 1 | 2026-06-22
+- **Severity:** LOW
+- **File:** `src/features/workspace/components/SidebarToggle.test.tsx`
+- **Finding:** `SidebarToggle` added exported `label` and `mirrored` props for the right-docked activity-panel toggle, but the sibling tests only covered the updated `inset` variant behavior. A later regression could break the activity-panel accessible name, tooltip text, or mirrored glyph orientation without any focused test failure.
+- **Fix:** Added focused tests asserting `label` overrides both the button accessible name and shared tooltip content, and asserting the SVG mirror class is absent by default and present when `mirrored` is true.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -3,7 +3,7 @@ id: testing-gaps
 category: testing
 created: 2026-04-09
 last_updated: 2026-06-22
-ref_count: 36
+ref_count: 37
 ---
 
 # Testing Gaps
@@ -807,4 +807,13 @@ filesystem scope restrictions).
 - **File:** `src/features/workspace/components/SidebarToggle.test.tsx`
 - **Finding:** `SidebarToggle` added exported `label` and `mirrored` props for the right-docked activity-panel toggle, but the sibling tests only covered the updated `inset` variant behavior. A later regression could break the activity-panel accessible name, tooltip text, or mirrored glyph orientation without any focused test failure.
 - **Fix:** Added focused tests asserting `label` overrides both the button accessible name and shared tooltip content, and asserting the SVG mirror class is absent by default and present when `mirrored` is true.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 83. Moved shell control lost integration-level state-transition coverage
+
+- **Source:** github-claude | PR #605 round 2 | 2026-06-22
+- **Severity:** MEDIUM
+- **File:** `src/features/workspace/WorkspaceView.integration.test.tsx`
+- **Finding:** The activity-panel expand/collapse control moved out of the rail/header subcomponents and into `WorkspaceView` as the root-owned `activity-toggle-fixed` control, but the deleted lower-level callback tests were not re-expressed at the new owner boundary. A wrong boolean update or stale handler wiring regression could leave the user-facing activity panel toggle broken while the suite stayed green.
+- **Fix:** Updated the WorkspaceView integration coverage to click `activity-toggle-fixed` directly and assert both transitions: expanded panel header to collapsed rail, then collapsed rail back to expanded panel header.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/src/features/agent-status/components/AgentStatusPanel/Header.test.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/Header.test.tsx
@@ -1,16 +1,10 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import { test, expect, vi } from 'vitest'
+import { test, expect } from 'vitest'
 import { AGENTS } from '../../../../agents/registry'
 import { AgentStatusPanelHeader } from './Header'
 
 test('renders agent glyph and short label', () => {
-  render(
-    <AgentStatusPanelHeader
-      agent={AGENTS.claude}
-      onCollapse={() => undefined}
-    />
-  )
+  render(<AgentStatusPanelHeader agent={AGENTS.claude} />)
   const glyphChip = screen.getByTestId('agent-glyph-chip')
   // eslint-disable-next-line testing-library/no-node-access -- claude renders an svg brand mark
   const brandMark = glyphChip.querySelector('svg')
@@ -20,24 +14,13 @@ test('renders agent glyph and short label', () => {
 })
 
 test('reserves a fixed 44px header height', () => {
-  render(
-    <AgentStatusPanelHeader
-      agent={AGENTS.claude}
-      onCollapse={() => undefined}
-    />
-  )
+  render(<AgentStatusPanelHeader agent={AGENTS.claude} />)
 
   expect(screen.getByTestId('agent-status-panel-header')).toHaveClass('h-11')
 })
 
 test('shows compact refresh affordance without replacing status', () => {
-  render(
-    <AgentStatusPanelHeader
-      agent={AGENTS.claude}
-      isRefreshing
-      onCollapse={() => undefined}
-    />
-  )
+  render(<AgentStatusPanelHeader agent={AGENTS.claude} isRefreshing />)
 
   expect(screen.queryByTestId('status-dot')).not.toBeInTheDocument()
   expect(screen.getByText('fetching latest')).toBeInTheDocument()
@@ -48,68 +31,32 @@ test('shows compact refresh affordance without replacing status', () => {
   )
 })
 
-test('chevron button fires onCollapse when clicked', async () => {
-  const onCollapse = vi.fn()
-  render(
-    <AgentStatusPanelHeader agent={AGENTS.claude} onCollapse={onCollapse} />
-  )
-
-  await userEvent.click(
-    screen.getByRole('button', { name: /collapse activity panel/i })
-  )
-  expect(onCollapse).toHaveBeenCalledTimes(1)
-})
-
-test('gradient wash uses agent.accentDim in inline style', () => {
-  render(
-    <AgentStatusPanelHeader agent={AGENTS.codex} onCollapse={() => undefined} />
-  )
-  const header = screen.getByTestId('agent-status-panel-header')
-  expect(header.getAttribute('style')).toMatch(/linear-gradient\(180deg/)
-  expect(header.getAttribute('style')).toMatch(
-    /var\(--color-agent-codex-accent-dim\)/
-  )
-})
-
-test('adds macOS drag coverage while keeping collapse clickable', () => {
-  render(
-    <AgentStatusPanelHeader
-      agent={AGENTS.claude}
-      onCollapse={() => undefined}
-      reserveWindowControls
-    />
-  )
+test('adds macOS drag coverage with a no-drag clearance for the floating toggle', () => {
+  render(<AgentStatusPanelHeader agent={AGENTS.claude} reserveWindowControls />)
 
   expect(screen.getByTestId('agent-status-panel-header')).toHaveClass(
     'vf-app-drag-region'
   )
 
-  expect(
-    screen.getByRole('button', { name: /collapse activity panel/i })
-  ).toHaveClass('vf-app-no-drag')
+  expect(screen.getByTestId('activity-toggle-clearance')).toHaveClass(
+    'vf-app-no-drag'
+  )
 })
 
-test('does not add drag coverage when native controls are not reserved', () => {
-  render(
-    <AgentStatusPanelHeader
-      agent={AGENTS.claude}
-      onCollapse={() => undefined}
-    />
-  )
+test('omits drag coverage and clearance when native controls are not reserved', () => {
+  render(<AgentStatusPanelHeader agent={AGENTS.claude} />)
 
   expect(screen.getByTestId('agent-status-panel-header')).not.toHaveClass(
     'vf-app-drag-region'
   )
+
+  expect(
+    screen.queryByTestId('activity-toggle-clearance')
+  ).not.toBeInTheDocument()
 })
 
 test('shows the red needs-reattach state when stale', () => {
-  render(
-    <AgentStatusPanelHeader
-      agent={AGENTS.codex}
-      needsReattach
-      onCollapse={() => undefined}
-    />
-  )
+  render(<AgentStatusPanelHeader agent={AGENTS.codex} needsReattach />)
 
   expect(screen.getByTestId('agent-glyph-chip')).toHaveAttribute(
     'data-stale',
@@ -122,13 +69,7 @@ test('shows the red needs-reattach state when stale', () => {
 })
 
 test('never renders a manual reattach button (recovery is automatic)', () => {
-  render(
-    <AgentStatusPanelHeader
-      agent={AGENTS.codex}
-      needsReattach
-      onCollapse={() => undefined}
-    />
-  )
+  render(<AgentStatusPanelHeader agent={AGENTS.codex} needsReattach />)
 
   expect(
     screen.queryByRole('button', { name: /reattach agent session/i })

--- a/src/features/agent-status/components/AgentStatusPanel/Header.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/Header.tsx
@@ -1,5 +1,4 @@
 import type { ReactElement } from 'react'
-import { IconButton } from '@/components/IconButton'
 import { AgentGlyph } from '@/components/AgentGlyph'
 import type { Agent } from '../../../../agents/registry'
 
@@ -12,7 +11,6 @@ export interface AgentStatusPanelHeaderProps {
    * (i.e. when the user sends a prompt), so this is an instruction, not a button.
    */
   needsReattach?: boolean
-  onCollapse: () => void
   reserveWindowControls?: boolean
 }
 
@@ -20,17 +18,13 @@ export const AgentStatusPanelHeader = ({
   agent,
   isRefreshing = false,
   needsReattach = false,
-  onCollapse,
   reserveWindowControls = false,
 }: AgentStatusPanelHeaderProps): ReactElement => (
   <div
     data-testid="agent-status-panel-header"
-    className={`relative flex h-11 shrink-0 items-center gap-2.5 pr-2 pl-3.5 ${
+    className={`relative flex h-11 shrink-0 items-center gap-2.5 pr-[44px] pl-3.5 ${
       reserveWindowControls ? 'vf-app-drag-region' : ''
     }`}
-    style={{
-      background: `linear-gradient(180deg, ${agent.accentDim}, transparent 80%)`,
-    }}
   >
     <div
       data-testid="agent-glyph-chip"
@@ -78,12 +72,18 @@ export const AgentStatusPanelHeader = ({
             : 'updated now'}
       </span>
     </div>
-    <IconButton
-      icon="chevron_right"
-      label="Collapse activity panel"
-      onClick={onCollapse}
-      className="vf-app-no-drag shrink-0"
-    />
+    {/* No-drag clearance for the workspace-root activity toggle that floats
+        above this header (top:7/right:8/28²), matching the collapsed rail. The
+        floating toggle is a sibling of the drag region, so this descendant span
+        carves the hole that keeps it clickable. */}
+    {reserveWindowControls && (
+      <span
+        aria-hidden="true"
+        data-testid="activity-toggle-clearance"
+        className="vf-app-no-drag pointer-events-none absolute"
+        style={{ top: 7, right: 8, width: 28, height: 28 }}
+      />
+    )}
     <div
       className="absolute right-0 bottom-0 left-0 h-px overflow-hidden bg-outline-variant/25"
       aria-hidden="true"

--- a/src/features/agent-status/components/AgentStatusPanel/index.test.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/index.test.tsx
@@ -112,7 +112,6 @@ const defaultProps = {
   cwd: '/test',
   onOpenDiff: vi.fn(),
   agent: AGENTS.shell,
-  onCollapse: (): void => undefined,
   cacheHistory: [],
 }
 
@@ -1249,15 +1248,13 @@ describe('AgentStatusPanel', () => {
     )
   })
 
-  test('renders Header above the body with the provided agent status and onCollapse', async () => {
-    const onCollapse = vi.fn()
+  test('renders Header above the body with the provided agent status', () => {
     render(
       <AgentStatusPanel
         {...defaultProps}
         agentStatus={inactiveAgentStatus}
         cwd="/home/x"
         agent={AGENTS.claude}
-        onCollapse={onCollapse}
       />
     )
 
@@ -1266,11 +1263,6 @@ describe('AgentStatusPanel', () => {
     expect(
       header.compareDocumentPosition(body) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy()
-
-    await userEvent.click(
-      screen.getByRole('button', { name: /collapse activity panel/i })
-    )
-    expect(onCollapse).toHaveBeenCalledTimes(1)
   })
 
   test('passes refreshing state into the fixed header affordance', () => {

--- a/src/features/agent-status/components/AgentStatusPanel/index.tsx
+++ b/src/features/agent-status/components/AgentStatusPanel/index.tsx
@@ -39,7 +39,6 @@ interface AgentStatusPanelProps {
   isRefreshing?: boolean
   needsReattach?: boolean
   agent: Agent
-  onCollapse: () => void
   cacheHistory: number[]
   snapshotKey?: string | null
   reserveWindowControls?: boolean
@@ -305,7 +304,6 @@ export const AgentStatusPanel = ({
   isRefreshing = false,
   needsReattach = false,
   agent,
-  onCollapse,
   cacheHistory,
   snapshotKey = null,
   reserveWindowControls = false,
@@ -540,7 +538,6 @@ export const AgentStatusPanel = ({
         agent={agent}
         isRefreshing={showsRefreshing}
         needsReattach={needsReattach}
-        onCollapse={onCollapse}
         reserveWindowControls={reserveWindowControls}
       />
 

--- a/src/features/agent-status/components/AgentStatusRail.test.tsx
+++ b/src/features/agent-status/components/AgentStatusRail.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen, within } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import { test, expect, vi } from 'vitest'
+import { test, expect } from 'vitest'
 import { AGENTS } from '../../../agents/registry'
 import { AgentStatusRail } from './AgentStatusRail'
 import { ctxTone } from '../utils/contextTone'
@@ -11,7 +10,6 @@ test('renders glyph chip, context meter, and cache meter', () => {
       agent={AGENTS.claude}
       contextUsedPercentage={42}
       cacheHitPercentage={75}
-      onExpand={() => undefined}
     />
   )
 
@@ -40,7 +38,6 @@ test('context meter color follows the shared ctxTone sweep', () => {
       agent={AGENTS.claude}
       contextUsedPercentage={92}
       cacheHitPercentage={null}
-      onExpand={() => undefined}
     />
   )
 
@@ -53,7 +50,6 @@ test('context meter color follows the shared ctxTone sweep', () => {
       agent={AGENTS.claude}
       contextUsedPercentage={40}
       cacheHitPercentage={null}
-      onExpand={() => undefined}
     />
   )
 
@@ -68,7 +64,6 @@ test('hides context meter when contextUsedPercentage is null', () => {
       agent={AGENTS.claude}
       contextUsedPercentage={null}
       cacheHitPercentage={null}
-      onExpand={() => undefined}
     />
   )
 
@@ -81,7 +76,6 @@ test('hides cache meter when cacheHitPercentage is null', () => {
       agent={AGENTS.claude}
       contextUsedPercentage={50}
       cacheHitPercentage={null}
-      onExpand={() => undefined}
     />
   )
 
@@ -94,7 +88,6 @@ test('cache ring tone is mint at >=70%, lavender 40-70%, coral <40%', () => {
       agent={AGENTS.claude}
       contextUsedPercentage={null}
       cacheHitPercentage={85}
-      onExpand={() => undefined}
     />
   )
 
@@ -108,7 +101,6 @@ test('cache ring tone is mint at >=70%, lavender 40-70%, coral <40%', () => {
       agent={AGENTS.claude}
       contextUsedPercentage={null}
       cacheHitPercentage={55}
-      onExpand={() => undefined}
     />
   )
 
@@ -122,7 +114,6 @@ test('cache ring tone is mint at >=70%, lavender 40-70%, coral <40%', () => {
       agent={AGENTS.claude}
       contextUsedPercentage={null}
       cacheHitPercentage={20}
-      onExpand={() => undefined}
     />
   )
 
@@ -138,7 +129,6 @@ test('renders the cache rate as a ring, not the liquid bar', () => {
       agent={AGENTS.claude}
       contextUsedPercentage={42}
       cacheHitPercentage={75}
-      onExpand={() => undefined}
     />
   )
 
@@ -156,7 +146,6 @@ test('drops the visible CACHE caption from the rail ring', () => {
       agent={AGENTS.claude}
       contextUsedPercentage={null}
       cacheHitPercentage={75}
-      onExpand={() => undefined}
     />
   )
 
@@ -166,31 +155,12 @@ test('drops the visible CACHE caption from the rail ring', () => {
   ).not.toBeInTheDocument()
 })
 
-test('chevron expand button fires onExpand', async () => {
-  const onExpand = vi.fn()
-
-  render(
-    <AgentStatusRail
-      agent={AGENTS.claude}
-      contextUsedPercentage={10}
-      cacheHitPercentage={null}
-      onExpand={onExpand}
-    />
-  )
-
-  await userEvent.click(
-    screen.getByRole('button', { name: /expand activity panel/i })
-  )
-  expect(onExpand).toHaveBeenCalledTimes(1)
-})
-
 test('rail is 44px wide', () => {
   render(
     <AgentStatusRail
       agent={AGENTS.claude}
       contextUsedPercentage={50}
       cacheHitPercentage={null}
-      onExpand={() => undefined}
     />
   )
 
@@ -203,7 +173,6 @@ test('rail sits on the canvas surface token', () => {
       agent={AGENTS.claude}
       contextUsedPercentage={50}
       cacheHitPercentage={null}
-      onExpand={() => undefined}
     />
   )
 
@@ -213,13 +182,12 @@ test('rail sits on the canvas surface token', () => {
   expect(rail.className).not.toContain('bg-surface-container')
 })
 
-test('adds macOS drag coverage while keeping expand clickable', () => {
+test('adds macOS drag coverage with a no-drag clearance for the floating toggle', () => {
   render(
     <AgentStatusRail
       agent={AGENTS.claude}
       contextUsedPercentage={50}
       cacheHitPercentage={null}
-      onExpand={() => undefined}
       reserveWindowControls
     />
   )
@@ -228,9 +196,23 @@ test('adds macOS drag coverage while keeping expand clickable', () => {
     'vf-app-drag-region'
   )
 
+  expect(screen.getByTestId('activity-toggle-clearance')).toHaveClass(
+    'vf-app-no-drag'
+  )
+})
+
+test('omits the drag clearance when native controls are not reserved', () => {
+  render(
+    <AgentStatusRail
+      agent={AGENTS.claude}
+      contextUsedPercentage={50}
+      cacheHitPercentage={null}
+    />
+  )
+
   expect(
-    screen.getByRole('button', { name: /expand activity panel/i })
-  ).toHaveClass('vf-app-no-drag')
+    screen.queryByTestId('activity-toggle-clearance')
+  ).not.toBeInTheDocument()
 })
 
 test('does not add rail drag coverage when native controls are not reserved', () => {
@@ -239,7 +221,6 @@ test('does not add rail drag coverage when native controls are not reserved', ()
       agent={AGENTS.claude}
       contextUsedPercentage={50}
       cacheHitPercentage={null}
-      onExpand={() => undefined}
     />
   )
 

--- a/src/features/agent-status/components/AgentStatusRail.tsx
+++ b/src/features/agent-status/components/AgentStatusRail.tsx
@@ -1,5 +1,4 @@
 import type { ReactElement } from 'react'
-import { IconButton } from '@/components/IconButton'
 import type { Agent } from '../../../agents/registry'
 import { AgentGlyph } from '@/components/AgentGlyph'
 import { RailMeter } from './RailMeter'
@@ -10,7 +9,6 @@ export interface AgentStatusRailProps {
   agent: Agent
   contextUsedPercentage: number | null
   cacheHitPercentage: number | null
-  onExpand: () => void
   reserveWindowControls?: boolean
 }
 
@@ -45,7 +43,6 @@ export const AgentStatusRail = ({
   agent,
   contextUsedPercentage,
   cacheHitPercentage,
-  onExpand,
   reserveWindowControls = false,
 }: AgentStatusRailProps): ReactElement => {
   const ctxPct = contextUsedPercentage
@@ -54,21 +51,27 @@ export const AgentStatusRail = ({
   return (
     <aside
       data-testid="agent-status-rail"
-      className={`flex h-full flex-col items-center bg-surface pb-3 pt-2 ${
+      className={`relative flex h-full flex-col items-center bg-surface pb-3 pt-[40px] ${
         reserveWindowControls ? 'vf-app-drag-region' : ''
       }`}
       style={{ width: RAIL_WIDTH_PX }}
     >
-      <IconButton
-        icon="chevron_left"
-        label="Expand activity panel"
-        onClick={onExpand}
-        className="vf-app-no-drag shrink-0"
-      />
+      {/* No-drag clearance for the workspace-root activity toggle that floats
+          above this rail (top:7/right:8/28²). The floating toggle is a sibling
+          of the drag region, so it cannot subtract from it on its own — this
+          descendant span carves the hole, mirroring the sidebar toggle. */}
+      {reserveWindowControls && (
+        <span
+          aria-hidden="true"
+          data-testid="activity-toggle-clearance"
+          className="vf-app-no-drag pointer-events-none absolute"
+          style={{ top: 7, right: 8, width: 28, height: 28 }}
+        />
+      )}
 
       <div
         data-testid="agent-glyph-chip"
-        className="mb-3 mt-2 grid h-[26px] w-[26px] shrink-0 place-items-center rounded-md border font-mono text-[12px] font-bold"
+        className="mb-3 grid h-[26px] w-[26px] shrink-0 place-items-center rounded-md border font-mono text-[12px] font-bold"
         style={{
           background: agent.accentDim,
           color: agent.accent,

--- a/src/features/workspace/WorkspaceView.integration.test.tsx
+++ b/src/features/workspace/WorkspaceView.integration.test.tsx
@@ -345,7 +345,7 @@ describe('WorkspaceView Integration Tests', () => {
       // Panel is a shell — collapsible sections will be added in sub-specs 5-7
     })
 
-    test('clicking the header chevron renders the rail; clicking the rail chevron returns to the panel', async () => {
+    test('clicking the fixed activity toggle switches between panel and rail states', async () => {
       const user = userEvent.setup()
       render(<WorkspaceView />)
 
@@ -353,12 +353,14 @@ describe('WorkspaceView Integration Tests', () => {
       expect(
         screen.getByTestId('agent-status-panel-header')
       ).toBeInTheDocument()
+      expect(screen.queryByTestId('agent-status-rail')).not.toBeInTheDocument()
 
-      await user.click(
-        screen.getByRole('button', { name: /collapse activity panel/i })
-      )
+      await user.click(screen.getByTestId('activity-toggle-fixed'))
 
       expect(await screen.findByTestId('agent-status-rail')).toBeInTheDocument()
+      expect(
+        screen.queryByTestId('agent-status-panel-header')
+      ).not.toBeInTheDocument()
 
       // Session-scoped UI state — must NOT call the agent/PTY backend.
       const serviceResults = vi.mocked(createTerminalService).mock.results
@@ -369,13 +371,12 @@ describe('WorkspaceView Integration Tests', () => {
       }
       expect(service.setSessionActivityPanelCollapsed).not.toHaveBeenCalled()
 
-      await user.click(
-        screen.getByRole('button', { name: /expand activity panel/i })
-      )
+      await user.click(screen.getByTestId('activity-toggle-fixed'))
 
       expect(
         await screen.findByTestId('agent-status-panel-header')
       ).toBeInTheDocument()
+      expect(screen.queryByTestId('agent-status-rail')).not.toBeInTheDocument()
     })
   })
 

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -186,6 +186,9 @@ const SIDEBAR_TOP_BAR_HEIGHT = 42
 const SIDEBAR_TOGGLE_SIZE = 28
 const SIDEBAR_TOGGLE_TOP = 7
 const SIDEBAR_TOGGLE_SURFACE_PADDING_END = 12
+// Right-edge inset for the activity-panel toggle. (44 - 28) / 2 = 8 centers it
+// in the collapsed rail, so the control reads as symmetric in both states.
+const ACTIVITY_TOGGLE_RIGHT = 8
 const MACOS_WINDOW_CONTROL_SAFE_AREA_PX = 82
 
 const SIDEBAR_INITIAL = clampSize(SIDEBAR_DEFAULT, SIDEBAR_MIN, SIDEBAR_MAX)
@@ -2524,6 +2527,35 @@ const WorkspaceViewContent = (): ReactElement => {
         />
       </main>
 
+      {/* Persistent activity-panel toggle — the right-edge mirror of the
+          sidebar toggle. Anchored to the workspace root (not the rail/header)
+          so it holds one fixed coordinate while the panel collapses/expands;
+          `mirrored` flips the glyph to a right-docked panel and the fill flips
+          with the collapse state. The rail/header carry a no-drag clearance
+          span so this floats reliably over the macOS drag region. */}
+      {!isCompactViewport && (
+        <div
+          data-testid="activity-toggle-fixed-shell"
+          className="vf-app-no-drag absolute z-40"
+          style={{ right: ACTIVITY_TOGGLE_RIGHT, top: SIDEBAR_TOGGLE_TOP }}
+        >
+          <SidebarToggle
+            collapsed={activityPanelCollapsed}
+            mirrored
+            onClick={() => {
+              handleActivityPanelCollapsed(!activityPanelCollapsed)
+            }}
+            size={SIDEBAR_TOGGLE_SIZE}
+            label={
+              activityPanelCollapsed
+                ? 'Expand activity panel'
+                : 'Collapse activity panel'
+            }
+            data-testid="activity-toggle-fixed"
+          />
+        </div>
+      )}
+
       {!isCompactViewport && (
         <div
           data-testid="activity-panel-shell"
@@ -2541,9 +2573,6 @@ const WorkspaceViewContent = (): ReactElement => {
               cacheHitPercentage={cacheHitPercentage(
                 agentStatus.contextWindow?.currentUsage
               )}
-              onExpand={() => {
-                handleActivityPanelCollapsed(false)
-              }}
               reserveWindowControls={reserveWindowControls}
             />
           ) : (
@@ -2558,9 +2587,6 @@ const WorkspaceViewContent = (): ReactElement => {
               onOpenFile={handleOpenTestFile}
               agent={activityPanelAgent}
               snapshotKey={activePtyBackedPanePtyId ?? null}
-              onCollapse={() => {
-                handleActivityPanelCollapsed(true)
-              }}
               reserveWindowControls={reserveWindowControls}
             />
           )}

--- a/src/features/workspace/components/SidebarToggle.test.tsx
+++ b/src/features/workspace/components/SidebarToggle.test.tsx
@@ -94,10 +94,11 @@ describe('SidebarToggle', () => {
     expect(onClick).toHaveBeenCalledTimes(1)
   })
 
-  test('variant=inset: className includes the recessed-well background', () => {
+  test('variant=inset: transparent at rest (no recessed-well background)', () => {
     renderToggle({ collapsed: false, variant: 'inset' })
 
-    expect(screen.getByRole('button')).toHaveClass(
+    // Blends into the parent surface — no resting fill, only a hover lift.
+    expect(screen.getByRole('button')).not.toHaveClass(
       'bg-surface-container-lowest/[0.45]'
     )
   })

--- a/src/features/workspace/components/SidebarToggle.test.tsx
+++ b/src/features/workspace/components/SidebarToggle.test.tsx
@@ -50,6 +50,22 @@ describe('SidebarToggle', () => {
     expect(screen.getByTestId('tooltip-shortcut')).toHaveTextContent('Ctrl+⇧B')
   })
 
+  test('label: overrides the default accessible name and tooltip content', async () => {
+    const user = userEvent.setup()
+    renderToggle({ collapsed: false, label: 'Collapse activity panel' })
+
+    const button = screen.getByRole('button', {
+      name: 'Collapse activity panel',
+    })
+    expect(button).toHaveAttribute('aria-label', 'Collapse activity panel')
+
+    await user.hover(button)
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      'Collapse activity panel'
+    )
+  })
+
   // Open glyph = outline rect + rail-fill rect (2); collapsed glyph drops the
   // rail fill (1). The divider <path> is always drawn either way. SVG shapes
   // have no accessible role, so container.querySelectorAll is the only option.
@@ -73,6 +89,20 @@ describe('SidebarToggle', () => {
     const paths = container.querySelectorAll('path')
     expect(rects).toHaveLength(1)
     expect(paths).toHaveLength(1)
+  })
+
+  test('mirrored=false: leaves the svg unmirrored', () => {
+    const { container } = renderToggle({ collapsed: false })
+
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- SVG has no a11y role
+    expect(container.querySelector('svg')).not.toHaveClass('scale-x-[-1]')
+  })
+
+  test('mirrored=true: applies the svg mirror class', () => {
+    const { container } = renderToggle({ collapsed: false, mirrored: true })
+
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- SVG has no a11y role
+    expect(container.querySelector('svg')).toHaveClass('scale-x-[-1]')
   })
 
   test('fireEvent: calls onClick when clicked', () => {

--- a/src/features/workspace/components/SidebarToggle.test.tsx
+++ b/src/features/workspace/components/SidebarToggle.test.tsx
@@ -91,7 +91,7 @@ describe('SidebarToggle', () => {
     expect(paths).toHaveLength(1)
   })
 
-  test('mirrored=false: leaves the svg unmirrored', () => {
+  test('mirrored=false: leaves the svg without the mirror class', () => {
     const { container } = renderToggle({ collapsed: false })
 
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- SVG has no a11y role

--- a/src/features/workspace/components/SidebarToggle.tsx
+++ b/src/features/workspace/components/SidebarToggle.tsx
@@ -11,26 +11,28 @@ export interface SidebarToggleProps {
   /** Square hit-target size in px. Rail wants 34 to match other rail buttons; in-card wants 28. */
   size?: number
   /**
-   * `ghost` (default): transparent with a hover tint — for the icon rail.
-   * `inset`: a recessed well (fill only, no visible border) so the control
-   * belongs to the top bar without leaving a sticky outline after focus restore.
+   * `ghost` (default) and `inset` are both transparent at rest with no visible
+   * border — they differ only in hover-tint strength (`inset` lifts slightly
+   * more). Use `inset` for the top-bar toggle, `ghost` for icon rails.
    */
   variant?: SidebarToggleVariant
   'data-testid'?: string
-  /** Platform-appropriate shortcut hint shown as the tooltip chip (e.g. '⌘B' or 'Ctrl+⇧B'). Default '⌘B'. */
+  /** Platform-appropriate shortcut hint shown as the tooltip chip (e.g. '⌘B' or 'Ctrl+⇧B'). Omit for controls with no shortcut (e.g. the activity panel). */
   shortcutHint?: string
+  /** Mirror the glyph so the rail/fill sits on the RIGHT — for a right-docked panel. */
+  mirrored?: boolean
+  /** Override the default Show/Hide-sidebar tooltip + aria label (e.g. 'Expand activity panel'). */
+  label?: string
 }
 
 const VARIANT_CLASS: Record<SidebarToggleVariant, string> = {
   ghost:
     'border border-transparent text-on-surface-muted hover:bg-primary/[0.08] hover:text-primary',
-  // Inset = a recessed well at rest (surface-container-lowest); on hover it
-  // lifts with a primary (lavender) tint in both collapse states, matching the
-  // ghost variant's primary hover. An earlier revision deepened the well toward
-  // navy on hover when expanded, but against the now-transparent sidebar that
-  // read as no change at all — so the toggle always lifts lighter.
+  // Inset = transparent at rest so the control is the same color as its parent
+  // (the transparent sidebar surface) with no recessed-well chip. On hover it
+  // lifts with a primary (lavender) tint, slightly stronger than ghost.
   inset:
-    'border border-transparent bg-surface-container-lowest/[0.45] text-on-surface-muted hover:bg-primary/[0.14] hover:text-primary',
+    'border border-transparent text-on-surface-muted hover:bg-primary/[0.14] hover:text-primary',
 }
 
 // Codex / VS-Code-style "panel-left" glyph. Outline + left-rail divider are
@@ -47,56 +49,63 @@ export const SidebarToggle = forwardRef<HTMLButtonElement, SidebarToggleProps>(
       size = 28,
       variant = 'ghost',
       'data-testid': testId = 'sidebar-toggle',
-      shortcutHint = '⌘B',
+      shortcutHint = undefined,
+      mirrored = false,
+      label = undefined,
     },
     ref
-  ): ReactElement => (
-    <Tooltip
-      content={collapsed ? 'Show sidebar' : 'Hide sidebar'}
-      shortcut={shortcutHint}
-      placement="bottom"
-    >
-      <button
-        ref={ref}
-        type="button"
-        data-testid={testId}
-        onClick={onClick}
-        aria-label={collapsed ? 'Show sidebar' : 'Hide sidebar'}
-        aria-expanded={!collapsed}
-        style={{ width: size, height: size }}
-        className={`vf-app-no-drag grid shrink-0 cursor-pointer place-items-center rounded-[7px] transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-container ${VARIANT_CLASS[variant]}`}
+  ): ReactElement => {
+    const resolvedLabel = label ?? (collapsed ? 'Show sidebar' : 'Hide sidebar')
+
+    return (
+      <Tooltip
+        content={resolvedLabel}
+        shortcut={shortcutHint}
+        placement="bottom"
       >
-        <svg
-          width="16"
-          height="16"
-          viewBox="0 0 16 16"
-          fill="none"
-          aria-hidden="true"
+        <button
+          ref={ref}
+          type="button"
+          data-testid={testId}
+          onClick={onClick}
+          aria-label={resolvedLabel}
+          aria-expanded={!collapsed}
+          style={{ width: size, height: size }}
+          className={`vf-app-no-drag grid shrink-0 cursor-pointer place-items-center rounded-[7px] transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-container ${VARIANT_CLASS[variant]}`}
         >
-          <rect
-            x="1.6"
-            y="2.6"
-            width="12.8"
-            height="10.8"
-            rx="2.4"
-            stroke="currentColor"
-            strokeWidth="1.3"
-          />
-          <path d="M5.9 2.9V13.1" stroke="currentColor" strokeWidth="1.3" />
-          {!collapsed && (
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            fill="none"
+            aria-hidden="true"
+            className={mirrored ? 'scale-x-[-1]' : undefined}
+          >
             <rect
-              x="2.2"
-              y="3.2"
-              width="3.1"
-              height="9.6"
-              rx="1.4"
-              fill="currentColor"
-              fillOpacity="0.28"
+              x="1.6"
+              y="2.6"
+              width="12.8"
+              height="10.8"
+              rx="2.4"
+              stroke="currentColor"
+              strokeWidth="1.3"
             />
-          )}
-        </svg>
-      </button>
-    </Tooltip>
-  )
+            <path d="M5.9 2.9V13.1" stroke="currentColor" strokeWidth="1.3" />
+            {!collapsed && (
+              <rect
+                x="2.2"
+                y="3.2"
+                width="3.1"
+                height="9.6"
+                rx="1.4"
+                fill="currentColor"
+                fillOpacity="0.28"
+              />
+            )}
+          </svg>
+        </button>
+      </Tooltip>
+    )
+  }
 )
 SidebarToggle.displayName = 'SidebarToggle'


### PR DESCRIPTION
## What

Reworks the right-side **activity-panel toggle** to use the established **sidebar-toggle pattern** — a single workspace-root-anchored floating control — instead of two separate per-state buttons that lived inside the rail/header and jumped position.

## Changes

- **Single floating toggle** anchored to the workspace root at `top:7 / right:8`, so it holds one fixed coordinate while the panel collapses ↔ expands (no jump). The glyph is mirrored (`scale-x-[-1]`) into a right-docked panel, and its fill reflects open/closed — the same on/off signal the sidebar toggle uses.
- **Symmetric padding** in the collapsed rail: `right:8` = `(44 − 28) / 2`, centering the glyph in the 44px rail.
- **No-drag clearance spans** in the rail/header so the floating control stays clickable over the macOS drag region (a sibling `no-drag` element can't subtract from a drag region on its own — a descendant span carves the hole, mirroring the sidebar toggle's clearance).
- **Removed** the rail/header `onExpand`/`onCollapse` toggles + props now that the toggle is owned by the workspace root.
- **Sidebar toggle** `inset` variant is now transparent at rest (blends into its parent surface); added `mirrored` / `label` props for reuse.
- **Removed** the activity-panel header's translucent gradient wash.

Net **−36 lines**.

## Review

- `codex review --uncommitted`: clean — no regressions found.
- `ponytail-review`: lean (one optional clearance-span dedupe noted, not applied).

## Test plan

- `npx vitest run`: 4008 passed, 3 skipped. The lone failure is the pre-existing macOS `/users` vs `/Users` casing flake in `editorFileLifecycleStatus.test.ts` (green on CI), unrelated to this change.
- type-check, eslint, prettier: clean (pre-commit hooks passed).
- ⚠️ Not verified in a running Electron window — pixel placement (`top:7/right:8`, rail `pt-[40px]`, header `pr-[44px]`) is eyeballed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs VIM-217