### PR TITLE
feat(terminal): starter layout template factories + creator gallery

### DIFF
--- a/src/features/terminal/components/LayoutCreator/LayoutCreatorModal.test.tsx
+++ b/src/features/terminal/components/LayoutCreator/LayoutCreatorModal.test.tsx
@@ -233,6 +233,99 @@ describe('LayoutCreatorModal', () => {
     ).toBeDisabled()
   })
 
+  test('seeds the grid from a starter template without touching the name', async () => {
+    const user = userEvent.setup()
+    const onSave = vi.fn<SaveSpy>()
+
+    render(
+      <LayoutCreatorModal
+        isOpen
+        existingLayouts={[]}
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />
+    )
+
+    const nameInput = screen.getByRole('textbox', { name: 'Layout name' })
+    expect(nameInput).toHaveValue('')
+
+    await user.click(
+      screen.getByRole('button', { name: 'Start from 2 × 3 grid' })
+    )
+
+    expect(nameInput).toHaveValue('')
+    expect(
+      screen.getAllByRole('button', { name: /^Remove pane p/ })
+    ).toHaveLength(6)
+
+    await user.type(nameInput, 'From template')
+    await user.click(screen.getByRole('button', { name: 'Save & apply' }))
+
+    expect(onSave).toHaveBeenCalledOnce()
+    expect(onSave.mock.calls[0][0].title).toBe('From template')
+    expect(onSave.mock.calls[0][0].slots).toHaveLength(6)
+    // The template seed id is discarded; save mints a fresh custom id.
+    expect(onSave.mock.calls[0][0].id).toMatch(/^custom:/)
+    expect(onSave.mock.calls[0][0].id).not.toBe('custom:template-2x3')
+  })
+
+  test('seeds a spanning-slot template through the gallery', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <LayoutCreatorModal
+        isOpen
+        existingLayouts={[]}
+        onSave={vi.fn<SaveSpy>()}
+        onCancel={vi.fn()}
+      />
+    )
+
+    await user.click(
+      screen.getByRole('button', { name: 'Start from Main + right stack' })
+    )
+
+    // Main + right stack is a 4-slot layout with one row-spanning main pane.
+    expect(
+      screen.getAllByRole('button', { name: /^Remove pane / })
+    ).toHaveLength(4)
+  })
+
+  test('hides the template gallery when editing an existing layout', () => {
+    const editLayout: PaneLayoutDefinition = {
+      schemaVersion: 1,
+      id: 'custom:existing',
+      title: 'Existing',
+      source: 'workspace',
+      tracks: {
+        columns: [{ id: 'col-0', units: 24 }],
+        rows: [{ id: 'row-0', units: 24 }],
+      },
+      slots: [
+        { id: 'slot:p0', rect: { col: 0, row: 0, colSpan: 1, rowSpan: 1 } },
+      ],
+      addOrder: ['slot:p0'],
+    }
+
+    render(
+      <LayoutCreatorModal
+        isOpen
+        existingLayouts={[]}
+        editLayout={editLayout}
+        onSave={vi.fn<SaveSpy>()}
+        onCancel={vi.fn()}
+      />
+    )
+
+    expect(
+      screen.queryByRole('button', { name: 'Start from 2 × 3 grid' })
+    ).not.toBeInTheDocument()
+
+    expect(screen.getByRole('textbox', { name: 'Layout name' })).toHaveValue(
+      'Existing'
+    )
+  })
+
   test('adds an empty grid cell through keyboard activation', async () => {
     const user = userEvent.setup()
     const onSave = vi.fn<SaveSpy>()

--- a/src/features/terminal/components/LayoutCreator/LayoutCreatorModal.tsx
+++ b/src/features/terminal/components/LayoutCreator/LayoutCreatorModal.tsx
@@ -18,8 +18,10 @@ import type { CustomPaneLayoutId } from '../../../sessions/types'
 import {
   MAX_LAYOUT_TRACKS,
   MAX_LAYOUT_SLOTS,
+  STARTER_LAYOUT_TEMPLATES,
   type PaneLayoutDefinition,
 } from '../../layout-registry'
+import { LayoutGlyph } from '../LayoutSwitcher/LayoutGlyph'
 import {
   addFirstFreeSlot,
   addSlotRect,
@@ -726,6 +728,41 @@ const TrackStepper = ({
   </div>
 )
 
+interface TemplateGalleryProps {
+  onSelect: (definition: PaneLayoutDefinition) => void
+}
+
+const TemplateGallery = ({ onSelect }: TemplateGalleryProps): ReactElement => (
+  <div className="flex flex-col gap-2">
+    <span
+      id="layout-template-gallery-label"
+      className="font-mono text-[10px] uppercase tracking-[0.14em] text-on-surface-muted"
+    >
+      Start from a template
+    </span>
+    <div
+      role="group"
+      aria-labelledby="layout-template-gallery-label"
+      className="flex flex-wrap gap-2"
+    >
+      {STARTER_LAYOUT_TEMPLATES.map((definition) => (
+        <button
+          key={definition.id}
+          type="button"
+          aria-label={`Start from ${definition.title}`}
+          className="group flex items-center gap-2 rounded-lg border border-outline-variant/30 bg-surface-container-lowest/55 px-2.5 py-1.5 text-left text-on-surface-variant outline-none transition hover:border-primary/45 hover:bg-primary/10 hover:text-on-surface focus-visible:ring-1 focus-visible:ring-primary/60"
+          onClick={(): void => onSelect(definition)}
+        >
+          <span className="text-primary/80 transition group-hover:text-primary">
+            <LayoutGlyph layoutId={definition.id} definition={definition} />
+          </span>
+          <span className="font-mono text-[11px]">{definition.title}</span>
+        </button>
+      ))}
+    </div>
+  </div>
+)
+
 export const LayoutCreatorModal = ({
   isOpen,
   existingLayouts,
@@ -1032,6 +1069,14 @@ export const LayoutCreatorModal = ({
                 {LAYOUT_CREATOR_UNIT_TOTAL}-unit tracks
               </span>
             </div>
+
+            {editLayout === undefined && (
+              <TemplateGallery
+                onSelect={(definition): void =>
+                  updateDraft(draftFromDefinition(definition))
+                }
+              />
+            )}
 
             <GridCanvas draft={draft} onDraftChange={updateDraft} />
 

--- a/src/features/terminal/layout-registry/index.ts
+++ b/src/features/terminal/layout-registry/index.ts
@@ -71,6 +71,13 @@ export {
 } from './prebuiltLayouts'
 
 export {
+  STARTER_LAYOUT_TEMPLATES,
+  createGridTemplate,
+  createMainBottomRowTemplate,
+  createMainRightStackTemplate,
+} from './layoutTemplates'
+
+export {
   DEFAULT_RATIOS,
   SPLIT_DIVIDER_PX,
   buildTrackTemplate,

--- a/src/features/terminal/layout-registry/layoutTemplates.test.ts
+++ b/src/features/terminal/layout-registry/layoutTemplates.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, test } from 'vitest'
+import {
+  MAX_LAYOUT_SLOTS,
+  PaneLayoutRegistry,
+  STARTER_LAYOUT_TEMPLATES,
+  createGridTemplate,
+  createLayoutShape,
+  createMainBottomRowTemplate,
+  createMainRightStackTemplate,
+  isCustomPaneLayoutId,
+  validatePaneLayoutDefinition,
+  type PaneLayoutDefinition,
+} from '.'
+
+const expectsValid = (definition: PaneLayoutDefinition): void => {
+  const result = validatePaneLayoutDefinition(definition)
+  expect(result.errors).toEqual([])
+  expect(result.ok).toBe(true)
+}
+
+const cellOwners = (
+  definition: PaneLayoutDefinition
+): readonly (string | null)[][] => {
+  const colCount = definition.tracks.columns.length
+  const rowCount = definition.tracks.rows.length
+
+  const grid: (string | null)[][] = Array.from({ length: rowCount }, () =>
+    Array.from({ length: colCount }, () => null)
+  )
+
+  for (const slot of definition.slots) {
+    for (
+      let row = slot.rect.row;
+      row < slot.rect.row + slot.rect.rowSpan;
+      row += 1
+    ) {
+      for (
+        let col = slot.rect.col;
+        col < slot.rect.col + slot.rect.colSpan;
+        col += 1
+      ) {
+        expect(grid[row][col]).toBeNull()
+        grid[row][col] = slot.id
+      }
+    }
+  }
+
+  return grid
+}
+
+describe('layoutTemplates', () => {
+  test('every starter template is a valid workspace definition with a custom id', () => {
+    expect(STARTER_LAYOUT_TEMPLATES).not.toHaveLength(0)
+
+    for (const definition of STARTER_LAYOUT_TEMPLATES) {
+      expect(definition.title.length).toBeGreaterThan(0)
+      expect(definition.source).toBe('workspace')
+      expect(isCustomPaneLayoutId(definition.id)).toBe(true)
+      expectsValid(definition)
+    }
+  })
+
+  test('starter template ids are unique', () => {
+    const ids = STARTER_LAYOUT_TEMPLATES.map((definition) => definition.id)
+
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  test('every starter template tiles every grid cell exactly once', () => {
+    for (const definition of STARTER_LAYOUT_TEMPLATES) {
+      const grid = cellOwners(definition)
+
+      for (const row of grid) {
+        for (const owner of row) {
+          expect(owner).not.toBeNull()
+        }
+      }
+    }
+  })
+
+  test('every starter template round-trips through the registry render path', () => {
+    for (const definition of STARTER_LAYOUT_TEMPLATES) {
+      const shape = createLayoutShape(definition)
+
+      expect(shape.id).toBe(definition.id)
+      expect(shape.capacity).toBe(definition.slots.length)
+
+      const registry = new PaneLayoutRegistry([definition])
+      expect(registry.rejected).toEqual([])
+      expect(registry.getLayout(definition.id)).not.toBeNull()
+    }
+  })
+
+  test('2x3 grid reads as 2 columns by 3 rows, row-major', () => {
+    // "2 x 3" means 2 columns wide and 3 rows tall: 6 single-cell slots
+    // numbered left-to-right, top-to-bottom (row-major reading order).
+    const definition = createGridTemplate(2, 3)
+
+    expect(definition.tracks.columns).toHaveLength(2)
+    expect(definition.tracks.rows).toHaveLength(3)
+    expect(definition.slots).toHaveLength(6)
+    expectsValid(definition)
+
+    const grid = cellOwners(definition)
+    expect(grid[0][0]).toBe('slot:p0')
+    expect(grid[0][1]).toBe('slot:p1')
+    expect(grid[1][0]).toBe('slot:p2')
+    expect(grid[1][1]).toBe('slot:p3')
+    expect(grid[2][0]).toBe('slot:p4')
+    expect(grid[2][1]).toBe('slot:p5')
+  })
+
+  test('3x3 grid has 9 single-cell slots', () => {
+    const definition = createGridTemplate(3, 3)
+
+    expect(definition.tracks.columns).toHaveLength(3)
+    expect(definition.tracks.rows).toHaveLength(3)
+    expect(definition.slots).toHaveLength(9)
+    expectsValid(definition)
+  })
+
+  test('4x4 grid fills exactly the maximum slot capacity', () => {
+    const definition = createGridTemplate(4, 4)
+
+    expect(definition.slots).toHaveLength(16)
+    expect(definition.slots).toHaveLength(MAX_LAYOUT_SLOTS)
+    expectsValid(definition)
+  })
+
+  test('grid track units total the 24-unit budget on each axis', () => {
+    const definition = createGridTemplate(3, 3)
+
+    const sum = (units: readonly { readonly units: number }[]): number =>
+      units.reduce((total, track) => total + track.units, 0)
+
+    expect(sum(definition.tracks.columns)).toBe(24)
+    expect(sum(definition.tracks.rows)).toBe(24)
+  })
+
+  test('main + right stack spans the main slot across all rows', () => {
+    const definition = createMainRightStackTemplate()
+
+    expect(definition.tracks.columns).toHaveLength(2)
+    expect(definition.tracks.columns[0].units).toBeGreaterThan(
+      definition.tracks.columns[1].units
+    )
+    expect(definition.tracks.rows).toHaveLength(3)
+    expect(definition.slots).toHaveLength(4)
+    expectsValid(definition)
+
+    const grid = cellOwners(definition)
+    // Main slot owns the entire left column across all three rows.
+    expect(grid[0][0]).toBe(grid[1][0])
+    expect(grid[1][0]).toBe(grid[2][0])
+    // The right column has three distinct stacked slots.
+    expect(new Set([grid[0][1], grid[1][1], grid[2][1]]).size).toBe(3)
+  })
+
+  test('main + bottom row spans the main slot across all columns', () => {
+    const definition = createMainBottomRowTemplate()
+
+    expect(definition.tracks.rows).toHaveLength(2)
+    expect(definition.tracks.rows[0].units).toBeGreaterThan(
+      definition.tracks.rows[1].units
+    )
+    expect(definition.tracks.columns).toHaveLength(3)
+    expect(definition.slots).toHaveLength(4)
+    expectsValid(definition)
+
+    const grid = cellOwners(definition)
+    // Main slot owns the entire top row across all three columns.
+    expect(grid[0][0]).toBe(grid[0][1])
+    expect(grid[0][1]).toBe(grid[0][2])
+    // The bottom row has three distinct side-by-side slots.
+    expect(new Set([grid[1][0], grid[1][1], grid[1][2]]).size).toBe(3)
+  })
+})

--- a/src/features/terminal/layout-registry/layoutTemplates.ts
+++ b/src/features/terminal/layout-registry/layoutTemplates.ts
@@ -1,0 +1,181 @@
+import {
+  createIndexedPaneSlotId,
+  createPaneSlotId,
+  CUSTOM_PANE_LAYOUT_ID_PREFIX,
+  PANE_LAYOUT_SCHEMA_VERSION,
+  type LayoutSlotId,
+  type PaneLayoutDefinition,
+  type PaneSlotSpec,
+  type TrackSpec,
+} from './layoutDefinition'
+
+/**
+ * Starter layouts surfaced in the LayoutCreator gallery. Each entry is a fully
+ * valid {@link PaneLayoutDefinition} minted by a factory below — they are NOT
+ * builtin layouts (no `LAYOUT_IDS` / `PREBUILT_PANE_LAYOUTS_BY_ID` entry) and
+ * render through the same registry / glyph / grid paths as user-authored custom
+ * layouts. The creator discards the seed `custom:` id and mints a fresh one on
+ * save, so these stable ids are only ever used as gallery seeds.
+ */
+
+/** Track-unit budget per axis — the 24-unit mental model from VIM-164. */
+const TRACK_UNIT_BUDGET = 24
+
+/** Even split of the 24-unit budget across `count` tracks (ratios summing to 24). */
+const evenTrackUnits = (count: number): readonly number[] =>
+  Array.from({ length: count }, () => TRACK_UNIT_BUDGET / count)
+
+const tracksFromUnits = (
+  prefix: string,
+  units: readonly number[]
+): readonly TrackSpec[] =>
+  units.map((unit, index) => ({ id: `${prefix}${index}`, units: unit }))
+
+const addOrderFor = (slots: readonly PaneSlotSpec[]): readonly LayoutSlotId[] =>
+  slots.map((slot) => slot.id)
+
+const buildDefinition = ({
+  id,
+  title,
+  columns,
+  rows,
+  slots,
+}: {
+  readonly id: string
+  readonly title: string
+  readonly columns: readonly TrackSpec[]
+  readonly rows: readonly TrackSpec[]
+  readonly slots: readonly PaneSlotSpec[]
+}): PaneLayoutDefinition => ({
+  schemaVersion: PANE_LAYOUT_SCHEMA_VERSION,
+  id: `${CUSTOM_PANE_LAYOUT_ID_PREFIX}${id}`,
+  title,
+  source: 'workspace',
+  tracks: { columns, rows },
+  slots,
+  addOrder: addOrderFor(slots),
+})
+
+/**
+ * Even N-column by M-row grid: `colCount` columns wide and `rowCount` rows tall,
+ * with one single-cell slot per cell numbered row-major (left-to-right,
+ * top-to-bottom). A 2x3 grid is therefore 2 columns and 3 rows = 6 slots, with
+ * `slot:p0` top-left and `slot:p5` bottom-right.
+ */
+export const createGridTemplate = (
+  colCount: number,
+  rowCount: number
+): PaneLayoutDefinition => {
+  const columns = tracksFromUnits('c', evenTrackUnits(colCount))
+  const rows = tracksFromUnits('r', evenTrackUnits(rowCount))
+
+  const slots: PaneSlotSpec[] = []
+  for (let row = 0; row < rowCount; row += 1) {
+    for (let col = 0; col < colCount; col += 1) {
+      slots.push({
+        id: createIndexedPaneSlotId(slots.length),
+        rect: { col, row, colSpan: 1, rowSpan: 1 },
+      })
+    }
+  }
+
+  return buildDefinition({
+    id: `template-${colCount}x${rowCount}`,
+    title: `${colCount} × ${rowCount} grid`,
+    columns,
+    rows,
+    slots,
+  })
+}
+
+/**
+ * Wide main column on the left spanning all rows, with a right column of three
+ * stacked slots. Columns use a 16/8 split so the main pane reads as the focus.
+ */
+export const createMainRightStackTemplate = (): PaneLayoutDefinition => {
+  const columns: readonly TrackSpec[] = [
+    { id: 'main', units: 16 },
+    { id: 'side', units: 8 },
+  ]
+  const rows = tracksFromUnits('r', evenTrackUnits(3))
+
+  const slots: readonly PaneSlotSpec[] = [
+    {
+      id: createPaneSlotId('main'),
+      rect: { col: 0, row: 0, colSpan: 1, rowSpan: 3 },
+    },
+    {
+      id: createPaneSlotId('side-top'),
+      rect: { col: 1, row: 0, colSpan: 1, rowSpan: 1 },
+    },
+    {
+      id: createPaneSlotId('side-middle'),
+      rect: { col: 1, row: 1, colSpan: 1, rowSpan: 1 },
+    },
+    {
+      id: createPaneSlotId('side-bottom'),
+      rect: { col: 1, row: 2, colSpan: 1, rowSpan: 1 },
+    },
+  ]
+
+  return buildDefinition({
+    id: 'template-main-right-stack',
+    title: 'Main + right stack',
+    columns,
+    rows,
+    slots,
+  })
+}
+
+/**
+ * Tall main row across the top spanning all columns, with a bottom row of three
+ * side-by-side slots. Rows use a 16/8 split so the main pane reads as the focus.
+ */
+export const createMainBottomRowTemplate = (): PaneLayoutDefinition => {
+  const columns = tracksFromUnits('c', evenTrackUnits(3))
+
+  const rows: readonly TrackSpec[] = [
+    { id: 'main', units: 16 },
+    { id: 'row', units: 8 },
+  ]
+
+  const slots: readonly PaneSlotSpec[] = [
+    {
+      id: createPaneSlotId('main'),
+      rect: { col: 0, row: 0, colSpan: 3, rowSpan: 1 },
+    },
+    {
+      id: createPaneSlotId('bottom-left'),
+      rect: { col: 0, row: 1, colSpan: 1, rowSpan: 1 },
+    },
+    {
+      id: createPaneSlotId('bottom-center'),
+      rect: { col: 1, row: 1, colSpan: 1, rowSpan: 1 },
+    },
+    {
+      id: createPaneSlotId('bottom-right'),
+      rect: { col: 2, row: 1, colSpan: 1, rowSpan: 1 },
+    },
+  ]
+
+  return buildDefinition({
+    id: 'template-main-bottom-row',
+    title: 'Main + bottom row',
+    columns,
+    rows,
+    slots,
+  })
+}
+
+/**
+ * Ordered starter templates the gallery maps over (array order is display order).
+ * Each is a plain {@link PaneLayoutDefinition}; the gallery reads `.id`/`.title`
+ * directly, so no wrapper type is needed.
+ */
+export const STARTER_LAYOUT_TEMPLATES: readonly PaneLayoutDefinition[] = [
+  createGridTemplate(2, 3),
+  createGridTemplate(3, 3),
+  createGridTemplate(4, 4),
+  createMainRightStackTemplate(),
+  createMainBottomRowTemplate(),
+]


### PR DESCRIPTION
## Summary

First of two sub-PRs for **VIM-167** (custom layout templates + advanced pane placement), stacked on the `feature/vim-164-workspace-layout-customization-clean` umbrella branch.

Adds the five starter layouts as `PaneLayoutDefinition` **factories** and surfaces them through a "Start from a template" gallery in the existing LayoutCreator:

- `2 × 3`, `3 × 3`, `4 × 4` even grids
- `Main + right stack` (wide left main spanning all rows + 3 stacked right slots)
- `Main + bottom row` (tall top main spanning all columns + 3 bottom slots)

Tracks use the 24-unit mental model. Selecting a template in **create mode** seeds the draft via the existing `seedLayout` / `draftFromDefinition` path; the user names it and **Save** mints a fresh `custom:` id (the seed id is discarded). The gallery is hidden in edit mode.

## Why this satisfies the acceptance criteria

- ✅ New templates are valid `PaneLayoutDefinition` objects produced by factories.
- ✅ They render through the **same** registry / generic glyph / grid / divider / ratio paths as any other custom layout (verified by a `createLayoutShape` + `PaneLayoutRegistry` round-trip test).
- ✅ **No** SplitView layout-id switch/case reintroduced; SplitView untouched.
- ✅ No new builtin `LayoutId` / `LAYOUT_IDS` / `PREBUILT_PANE_LAYOUTS_BY_ID` / `DEFAULT_RATIOS` entries.
- ✅ No `@floating-ui/react` feature imports.

## Tests

- New `layoutTemplates.test.ts` (validity, cell-tiling, capacity incl. 4×4 == MAX_LAYOUT_SLOTS, custom-id, registry round-trip, 2×3 orientation).
- LayoutCreatorModal: gallery seeds the draft without touching the name, seed id is discarded on save, spanning-slot template (main + right stack) round-trips, gallery hidden in edit mode.
- Layout-registry + LayoutCreator suites: **58 passing**. Repo-wide eslint / prettier / type-check clean.

## Scope

5 files, +145 / new factory module. Pure-additive; no behavioral change to existing layouts.

Part of VIM-167.