### PR TITLE
fix(terminal): render + hold the Codex composer bar on the Ghostty path

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -55,11 +55,11 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 1        | 0    | 2026-06-09   |
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 66       | 34   | 2026-06-20   |
-| [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 26       | 9    | 2026-06-21   |
+| [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 28       | 10   | 2026-06-22   |
 | [Terminal DOM Rendering](patterns/terminal-dom-rendering.md)                                         | terminal           | 10       | 6    | 2026-06-21   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Terminal Render-State Driver Contract](patterns/terminal-render-state-driver-contract.md)           | terminal           | 33       | 10   | 2026-06-21   |
-| [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 85       | 25   | 2026-06-08   |
+| [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 88       | 27   | 2026-06-22   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 51       | 24   | 2026-06-18   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 63       | 23   | 2026-06-08   |
@@ -83,7 +83,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Verify Render Target](patterns/verify-render-target.md)                                             | code-quality       | 2        | 0    | 2026-05-24   |
 | [UI Visual Regression](patterns/ui-visual-regression.md)                                             | code-quality       | 9        | 4    | 2026-06-13   |
 | [Status Indicator Display](patterns/status-indicator-display.md)                                     | code-quality       | 3        | 0    | 2026-05-26   |
-| [Parser Resilience](patterns/parser-resilience.md)                                                   | code-quality       | 13       | 9    | 2026-06-21   |
+| [Parser Resilience](patterns/parser-resilience.md)                                                   | code-quality       | 13       | 10   | 2026-06-21   |
 | [Persisted State Invariants](patterns/persisted-state-invariants.md)                                 | correctness        | 8        | 4    | 2026-06-13   |
 | [macOS Window Chrome](patterns/macos-window-chrome.md)                                               | cross-platform     | 8        | 2    | 2026-06-11   |
 | [Guard Branch Correctness](patterns/guard-branch-correctness.md)                                     | correctness        | 1        | 0    | 2026-06-11   |

--- a/docs/reviews/patterns/documentation-accuracy.md
+++ b/docs/reviews/patterns/documentation-accuracy.md
@@ -2,8 +2,8 @@
 id: documentation-accuracy
 category: code-quality
 created: 2026-04-09
-last_updated: 2026-06-14
-ref_count: 26
+last_updated: 2026-06-22
+ref_count: 27
 ---
 
 # Documentation Accuracy
@@ -809,4 +809,22 @@ Stale documentation misleads future contributors and review agents.
 - **File:** `docs/design/UNIFIED.md`
 - **Finding:** The Popover contract in `UNIFIED.md` §5.9 said focus is modal with `initialFocus: -1` and lands on the container on open, but `src/components/Popover.tsx` passes `focus={{ initialFocus: 0, modal: true }}` and `src/components/Popover.test.tsx` asserts focus lands on the first tabbable child. The mismatch creates a misleading public primitive contract that future consumers or tests may encode the wrong expectation against.
 - **Fix:** Updated the Popover focus rule to document `initialFocus: 0`, focus landing on the first tabbable child on open, and `modal: true` engaging the focus trap.
+- **Commit:** same commit as this entry
+
+### 87. Sync-frame docblock understated split END marker hold duration
+
+- **Source:** github-claude | PR #608 round 1 | 2026-06-22
+- **Severity:** LOW
+- **File:** `src/features/terminal/components/TerminalPane/terminalSyncFrame.ts`
+- **Finding:** The sync-frame helper comment claimed a split marker would at worst render one torn frame or hold the previous frame for one extra chunk. A split END marker with no later DEC 2026 marker could instead keep the Ghostty renderer suppressed until the eight-frame failsafe.
+- **Fix:** Replaced the stale caveat by implementing carry-aware marker parsing, so the documented limitation no longer applies. Regression tests now cover split begin and end markers.
+- **Commit:** same commit as this entry
+
+### 88. Non-standard doc label obscured a sync-frame caveat
+
+- **Source:** github-claude | PR #608 round 1 | 2026-06-22
+- **Severity:** LOW
+- **File:** `src/features/terminal/components/TerminalPane/terminalSyncFrame.ts`
+- **Finding:** The docblock used `ponytail:` as a caveat label, which is not a recognized JSDoc or project convention and made the limitation look accidental rather than intentional.
+- **Fix:** Removed the obsolete caveat while making the parser carry-aware across chunk boundaries, eliminating the misleading label and the documented limitation together.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/parser-resilience.md
+++ b/docs/reviews/patterns/parser-resilience.md
@@ -3,7 +3,7 @@ id: parser-resilience
 category: code-quality
 created: 2026-05-24
 last_updated: 2026-06-21
-ref_count: 9
+ref_count: 10
 ---
 
 # Parser Resilience

--- a/docs/reviews/patterns/terminal-control-sequence-handling.md
+++ b/docs/reviews/patterns/terminal-control-sequence-handling.md
@@ -2,8 +2,8 @@
 id: terminal-control-sequence-handling
 category: terminal
 created: 2026-06-17
-last_updated: 2026-06-21
-ref_count: 9
+last_updated: 2026-06-22
+ref_count: 10
 ---
 
 # Terminal Control Sequence Handling
@@ -252,4 +252,22 @@ all required state through pure display-state helpers.
 - **File:** `electron/ghostty-render-state-main.ts` L420
 - **Finding:** `CursorVisibilityScanner` kept an unterminated private CSI sequence from `ESC[?` onward with no size limit. A process could stream arbitrary parameter bytes without a final byte and grow the Electron main-process buffer indefinitely.
 - **Fix:** Added a private-CSI pending-buffer limit matching the OSC limit and discard overlong pending sequences before they can accumulate. Added a regression that writes an over-limit unterminated private CSI sequence, then verifies a later suffix cannot complete it into a cursor visibility toggle.
+- **Commit:** same commit as this entry
+
+### 27. DEC 2026 markers split across PTY chunks were missed
+
+- **Source:** github-codex-connector | PR #608 round 1 | 2026-06-22
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/terminalSyncFrame.ts`
+- **Finding:** The Ghostty synchronized-output tracker scanned only complete `\x1b[?2026h/l` markers inside the current byte chunk. PTY event boundaries are arbitrary, so a split begin marker allowed torn redraw snapshots and a split end marker could keep suppressing frames until the failsafe.
+- **Fix:** Threaded a `SyncFrameParserState` through the Ghostty render-state driver, carrying the last seven bytes so split DEC 2026 markers are recognized on the next chunk. Added regression coverage for split begin and end markers.
+- **Commit:** same commit as this entry
+
+### 28. OSC color queries split across PTY chunks were not answered
+
+- **Source:** github-codex-connector | PR #608 round 1 | 2026-06-22
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/terminal/terminalColorQuery.ts`
+- **Finding:** The Ghostty OSC 10/11 responder matched only complete color queries inside one string chunk. If Codex's query split before the BEL or ST terminator, no target was detected and the composer fell back to degraded rendering.
+- **Fix:** Added a carry-aware color query scanner and stored the carry in `useTerminal` for the active PTY subscription. Tests now cover ST-terminated and BEL-terminated queries split across chunks and ensure completed trailing queries are not answered twice.
 - **Commit:** same commit as this entry

--- a/electron/ghostty-render-state-main.test.ts
+++ b/electron/ghostty-render-state-main.test.ts
@@ -270,6 +270,72 @@ describe('ghostty render-state main bridge', () => {
     expect(terminals[0]?.snapshot).toHaveBeenCalledWith({ includeCells: true })
   })
 
+  // Regression: codex's input composer is a full-width truecolor background bar
+  // (rgb(57,57,71)) drawn over mostly-blank cells. libghostty's native snapshot
+  // carries no color and omits blank cells, so the bar exists only in formatHtml.
+  // The bridge must synthesize bg cells across the WHOLE row width from
+  // formatHtml ranges — a transient "clamp to native content extent" once dropped
+  // the blank portions and made the bar vanish (Ghostty terminal BUG-1). This
+  // locks the synthesis so the regression can't return.
+  test('synthesizes a full-width background bar from formatHtml when native cells omit blank styled cells', () => {
+    const barRow =
+      '<div style="display: inline;background-color: rgb(57, 57, 71);">                    </div>'
+
+    const inputRow =
+      '<div style="display: inline;background-color: rgb(57, 57, 71);font-weight: bold;">&gt;</div>' +
+      '<div style="display: inline;background-color: rgb(57, 57, 71);"> hi                </div>'
+    const html = [barRow, inputRow, barRow].join('\n')
+
+    // cspell:ignore truecolor
+    const bindings: GhosttyNativeBindings = {
+      createTerminal: () => ({
+        feed: vi.fn(),
+        resize: vi.fn(),
+        snapshot: () => ({
+          rows: 5,
+          cursorRow: 1,
+          cursorCol: 4,
+          visibleLines: [
+            { row: 0, text: '' },
+            { row: 1, text: '> hi' },
+            { row: 2, text: '' },
+          ],
+          // native cells: text only, no color, blank cells omitted
+          cells: [
+            { row: 1, col: 0, text: '>', width: 1 },
+            { row: 1, col: 2, text: 'h', width: 1 },
+            { row: 1, col: 3, text: 'i', width: 1 },
+          ],
+        }),
+        formatHtml: () => html,
+        dispose: vi.fn(),
+      }),
+    }
+
+    const bridge = new GhosttyRenderStateMainBridge('/app', bindings)
+    const event = createEvent()
+    const createResult = requireResult(bridge.createDriver(event))
+
+    const snapshot = requireResult(
+      bridge.readSnapshot(event.sender.id, {
+        driverId: createResult.driverId,
+      })
+    )
+    const cells = snapshot.cells ?? []
+
+    // every column on each composer row (0,1,2) must be covered by a cell
+    // carrying the bar background, including the blank-only top/bottom rows
+    for (const row of [0, 1, 2]) {
+      for (let col = 0; col < 20; col += 1) {
+        const covering = cells.find(
+          (cell) =>
+            cell.row === row && cell.col <= col && col < cell.col + cell.width
+        )
+        expect(covering?.background, `row ${row} col ${col}`).toBe('#393947')
+      }
+    }
+  })
+
   test('returns OSC7 cwd effects across byte chunks before feeding native state', () => {
     const { bindings, terminals } = createNativeBindings()
     const bridge = new GhosttyRenderStateMainBridge('/app', bindings)

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
@@ -153,6 +153,64 @@ describe('ghosttyVtRenderStateDriver', () => {
     expect(dispose).toHaveBeenCalledOnce()
   })
 
+  test('holds the last frame while inside a synchronized-output (2026) frame', () => {
+    let snapshotReads = 0
+
+    const adapter = createGhosttyVtRenderStateByteParserAdapter(
+      (): GhosttyVtRenderStateDriver => ({
+        writeBytes: vi.fn(),
+        readSnapshot: (): GhosttyVtRenderSnapshot => {
+          snapshotReads += 1
+
+          return {
+            rows: ['composer'],
+            cursor: { rowIndex: 0, columnOffset: 2 },
+          }
+        },
+      })
+    )
+    const encode = (text: string): Uint8Array => new TextEncoder().encode(text)
+
+    // chunk ends inside an open 2026 frame (clear sent, redraw pending)
+    expect(
+      adapter.parseBytes(createInput(encode('\x1b[?2026h\x1b[2J partial')))
+    ).toEqual({ visibleText: '' })
+    expect(snapshotReads).toBe(0)
+
+    // closing chunk completes the frame -> full render
+    expect(
+      adapter.parseBytes(createInput(encode('redraw\x1b[?2026l')))
+    ).toEqual({
+      visibleText: 'composer',
+      displayDelta: {
+        operations: [{ type: 'replace', text: 'composer', cursorOffset: 2 }],
+      },
+    })
+    expect(snapshotReads).toBe(1)
+  })
+
+  test('failsafe renders if a 2026 frame never closes', () => {
+    const adapter = createGhosttyVtRenderStateByteParserAdapter(
+      (): GhosttyVtRenderStateDriver => ({
+        writeBytes: vi.fn(),
+        readSnapshot: (): GhosttyVtRenderSnapshot => ({
+          rows: ['held'],
+          cursor: { rowIndex: 0, columnOffset: 0 },
+        }),
+      })
+    )
+    const encode = (text: string): Uint8Array => new TextEncoder().encode(text)
+
+    let output = adapter.parseBytes(createInput(encode('\x1b[?2026h open')))
+    // 8 held chunks, then the failsafe forces a render on the 9th
+    for (let index = 0; index < 8; index += 1) {
+      output = adapter.parseBytes(createInput(encode('still drawing')))
+    }
+
+    expect(output).not.toEqual({ visibleText: '' })
+    expect(output.visibleText).toBe('held')
+  })
+
   test('rejects text input instead of falling back to the text parser', () => {
     const writeBytes = vi.fn()
     const reset = vi.fn()

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
@@ -15,7 +15,15 @@ import {
   createGhosttyVtRenderSnapshotOutput,
   type GhosttyVtRenderSnapshot,
 } from './ghosttyVtRenderSnapshot'
+import { readSyncFrameState } from './terminalSyncFrame'
 import type { TerminalParserEngineOutput } from './terminalParserEngine'
+
+// No-op render output: holds the surface on its last complete frame.
+const EMPTY_RENDER_OUTPUT: TerminalParserEngineOutput = { visibleText: '' }
+
+// Failsafe: render even while "inside" a 2026 frame after this many held
+// chunks, so a missed close marker can never freeze the surface.
+const MAX_SUPPRESSED_FRAMES = 8
 
 export interface GhosttyVtRenderStateDriver {
   /**
@@ -46,16 +54,32 @@ export const createGhosttyVtRenderStateParserDriverFactory =
   ): GhosttyVtParserDriverFactory =>
   (effects): GhosttyVtParserDriver => {
     const renderStateDriver = createRenderStateDriver(effects)
+    let insideSyncFrame = false
+    let suppressedFrames = 0
 
     return {
       writeBytes: (bytes): TerminalParserEngineOutput => {
         renderStateDriver.writeBytes(bytes)
+
+        insideSyncFrame = readSyncFrameState(bytes, insideSyncFrame)
+
+        // Inside a synchronized-output frame the redraw is mid-flight; holding
+        // the last complete frame avoids rendering a torn/blank intermediate.
+        if (insideSyncFrame && suppressedFrames < MAX_SUPPRESSED_FRAMES) {
+          suppressedFrames += 1
+
+          return EMPTY_RENDER_OUTPUT
+        }
+
+        suppressedFrames = 0
 
         return createGhosttyVtRenderSnapshotOutput(
           renderStateDriver.readSnapshot()
         )
       },
       reset: (): void => {
+        insideSyncFrame = false
+        suppressedFrames = 0
         renderStateDriver.reset?.()
       },
       resize: (size): void => {

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
@@ -15,7 +15,10 @@ import {
   createGhosttyVtRenderSnapshotOutput,
   type GhosttyVtRenderSnapshot,
 } from './ghosttyVtRenderSnapshot'
-import { readSyncFrameState } from './terminalSyncFrame'
+import {
+  createSyncFrameParserState,
+  readSyncFrameState,
+} from './terminalSyncFrame'
 import type { TerminalParserEngineOutput } from './terminalParserEngine'
 
 // No-op render output: holds the surface on its last complete frame.
@@ -54,18 +57,21 @@ export const createGhosttyVtRenderStateParserDriverFactory =
   ): GhosttyVtParserDriverFactory =>
   (effects): GhosttyVtParserDriver => {
     const renderStateDriver = createRenderStateDriver(effects)
-    let insideSyncFrame = false
+    let syncFrameState = createSyncFrameParserState()
     let suppressedFrames = 0
 
     return {
       writeBytes: (bytes): TerminalParserEngineOutput => {
         renderStateDriver.writeBytes(bytes)
 
-        insideSyncFrame = readSyncFrameState(bytes, insideSyncFrame)
+        syncFrameState = readSyncFrameState(bytes, syncFrameState)
 
         // Inside a synchronized-output frame the redraw is mid-flight; holding
         // the last complete frame avoids rendering a torn/blank intermediate.
-        if (insideSyncFrame && suppressedFrames < MAX_SUPPRESSED_FRAMES) {
+        if (
+          syncFrameState.insideFrame &&
+          suppressedFrames < MAX_SUPPRESSED_FRAMES
+        ) {
           suppressedFrames += 1
 
           return EMPTY_RENDER_OUTPUT
@@ -78,7 +84,7 @@ export const createGhosttyVtRenderStateParserDriverFactory =
         )
       },
       reset: (): void => {
-        insideSyncFrame = false
+        syncFrameState = createSyncFrameParserState()
         suppressedFrames = 0
         renderStateDriver.reset?.()
       },

--- a/src/features/terminal/components/TerminalPane/terminalSyncFrame.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalSyncFrame.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'vitest'
-import { readSyncFrameState } from './terminalSyncFrame'
+import {
+  createSyncFrameParserState,
+  readSyncFrameState,
+  type SyncFrameParserState,
+} from './terminalSyncFrame'
 
 const bytes = (text: string): Uint8Array => new TextEncoder().encode(text)
 
@@ -7,43 +11,67 @@ const BEGIN = '\x1b[?2026h'
 const END = '\x1b[?2026l'
 
 describe('readSyncFrameState', () => {
+  const readInsideFrame = (
+    text: string,
+    previousInsideFrame: boolean
+  ): boolean =>
+    readSyncFrameState(bytes(text), {
+      insideFrame: previousInsideFrame,
+      carryBytes: new Uint8Array(),
+    }).insideFrame
+
   test('a complete frame in one chunk ends outside', () => {
-    expect(
-      readSyncFrameState(bytes(`${BEGIN}cleared redraw${END}`), false)
-    ).toBe(false)
+    expect(readInsideFrame(`${BEGIN}cleared redraw${END}`, false)).toBe(false)
   })
 
   test('a chunk ending after begin (before end) stays inside', () => {
-    expect(readSyncFrameState(bytes(`${BEGIN}\x1b[2J partial`), false)).toBe(
-      true
-    )
+    expect(readInsideFrame(`${BEGIN}\x1b[2J partial`, false)).toBe(true)
   })
 
   test('a chunk closing a previously-open frame ends outside', () => {
-    expect(readSyncFrameState(bytes(`redraw rest${END}`), true)).toBe(false)
+    expect(readInsideFrame(`redraw rest${END}`, true)).toBe(false)
   })
 
   test('carries the previous state when no markers are present', () => {
-    expect(readSyncFrameState(bytes('just normal output'), true)).toBe(true)
-    expect(readSyncFrameState(bytes('just normal output'), false)).toBe(false)
+    expect(readInsideFrame('just normal output', true)).toBe(true)
+    expect(readInsideFrame('just normal output', false)).toBe(false)
   })
 
   test('uses the last marker when several appear in one chunk', () => {
     // begin, end, begin again -> still inside
-    expect(readSyncFrameState(bytes(`${BEGIN}a${END}b${BEGIN}c`), false)).toBe(
-      true
-    )
+    expect(readInsideFrame(`${BEGIN}a${END}b${BEGIN}c`, false)).toBe(true)
     // end, begin, end -> outside
-    expect(readSyncFrameState(bytes(`${END}${BEGIN}${END}`), true)).toBe(false)
+    expect(readInsideFrame(`${END}${BEGIN}${END}`, true)).toBe(false)
   })
 
   test('ignores unrelated CSI sequences', () => {
-    expect(readSyncFrameState(bytes('\x1b[?25h\x1b[2J\x1b[1;1H'), false)).toBe(
-      false
-    )
+    expect(readInsideFrame('\x1b[?25h\x1b[2J\x1b[1;1H', false)).toBe(false)
   })
 
   test('detects a begin marker at the very end of a chunk', () => {
-    expect(readSyncFrameState(bytes(`output${BEGIN}`), false)).toBe(true)
+    expect(readInsideFrame(`output${BEGIN}`, false)).toBe(true)
+  })
+
+  test('detects a begin marker split across chunks', () => {
+    let state: SyncFrameParserState = createSyncFrameParserState()
+
+    state = readSyncFrameState(bytes('output\x1b[?20'), state)
+    expect(state.insideFrame).toBe(false)
+
+    state = readSyncFrameState(bytes('26h\x1b[2J partial'), state)
+    expect(state.insideFrame).toBe(true)
+  })
+
+  test('detects an end marker split across chunks', () => {
+    let state: SyncFrameParserState = {
+      insideFrame: true,
+      carryBytes: new Uint8Array(),
+    }
+
+    state = readSyncFrameState(bytes('redraw\x1b[?202'), state)
+    expect(state.insideFrame).toBe(true)
+
+    state = readSyncFrameState(bytes('6l after'), state)
+    expect(state.insideFrame).toBe(false)
   })
 })

--- a/src/features/terminal/components/TerminalPane/terminalSyncFrame.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalSyncFrame.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'vitest'
+import { readSyncFrameState } from './terminalSyncFrame'
+
+const bytes = (text: string): Uint8Array => new TextEncoder().encode(text)
+
+const BEGIN = '\x1b[?2026h'
+const END = '\x1b[?2026l'
+
+describe('readSyncFrameState', () => {
+  test('a complete frame in one chunk ends outside', () => {
+    expect(
+      readSyncFrameState(bytes(`${BEGIN}cleared redraw${END}`), false)
+    ).toBe(false)
+  })
+
+  test('a chunk ending after begin (before end) stays inside', () => {
+    expect(readSyncFrameState(bytes(`${BEGIN}\x1b[2J partial`), false)).toBe(
+      true
+    )
+  })
+
+  test('a chunk closing a previously-open frame ends outside', () => {
+    expect(readSyncFrameState(bytes(`redraw rest${END}`), true)).toBe(false)
+  })
+
+  test('carries the previous state when no markers are present', () => {
+    expect(readSyncFrameState(bytes('just normal output'), true)).toBe(true)
+    expect(readSyncFrameState(bytes('just normal output'), false)).toBe(false)
+  })
+
+  test('uses the last marker when several appear in one chunk', () => {
+    // begin, end, begin again -> still inside
+    expect(readSyncFrameState(bytes(`${BEGIN}a${END}b${BEGIN}c`), false)).toBe(
+      true
+    )
+    // end, begin, end -> outside
+    expect(readSyncFrameState(bytes(`${END}${BEGIN}${END}`), true)).toBe(false)
+  })
+
+  test('ignores unrelated CSI sequences', () => {
+    expect(readSyncFrameState(bytes('\x1b[?25h\x1b[2J\x1b[1;1H'), false)).toBe(
+      false
+    )
+  })
+
+  test('detects a begin marker at the very end of a chunk', () => {
+    expect(readSyncFrameState(bytes(`output${BEGIN}`), false)).toBe(true)
+  })
+})

--- a/src/features/terminal/components/TerminalPane/terminalSyncFrame.ts
+++ b/src/features/terminal/components/TerminalPane/terminalSyncFrame.ts
@@ -16,31 +16,36 @@ const ESC = 0x1b
 const SEQUENCE_PREFIX = [0x5b, 0x3f, 0x32, 0x30, 0x32, 0x36]
 const SET_FINAL = 0x68 // 'h' — begin synchronized update
 const RESET_FINAL = 0x6c // 'l' — end synchronized update
+const SYNC_FRAME_SEQUENCE_LENGTH = SEQUENCE_PREFIX.length + 2
+const MAX_CARRY_LENGTH = SYNC_FRAME_SEQUENCE_LENGTH - 1
+
+export interface SyncFrameParserState {
+  insideFrame: boolean
+  carryBytes: Uint8Array
+}
 
 /**
  * Fold a chunk of raw PTY bytes into the running synchronized-output state.
- * Returns whether, after this chunk, the stream is inside an open 2026 frame.
- *
- * ponytail: scans complete `\x1b[?2026h/l` sequences only — a sequence split
- * across a chunk boundary is missed, which at worst renders one torn frame or
- * holds the previous frame one extra chunk before the next marker corrects it.
+ * Returns whether, after this chunk, the stream is inside an open 2026 frame
+ * plus enough trailing bytes to recognize a marker split across the next chunk.
  */
 export const readSyncFrameState = (
   bytes: Uint8Array,
-  previousInsideFrame: boolean
-): boolean => {
-  let insideFrame = previousInsideFrame
+  previousState: SyncFrameParserState
+): SyncFrameParserState => {
+  let insideFrame = previousState.insideFrame
+  const scannedBytes = appendCarryBytes(previousState.carryBytes, bytes)
 
   // last index where ESC + 6 prefix bytes + 1 final byte all fit
-  const lastStart = bytes.length - (SEQUENCE_PREFIX.length + 2)
+  const lastStart = scannedBytes.length - SYNC_FRAME_SEQUENCE_LENGTH
   for (let index = 0; index <= lastStart; index += 1) {
-    if (bytes[index] !== ESC) {
+    if (scannedBytes[index] !== ESC) {
       continue
     }
 
     let matchesPrefix = true
     for (let offset = 0; offset < SEQUENCE_PREFIX.length; offset += 1) {
-      if (bytes[index + 1 + offset] !== SEQUENCE_PREFIX[offset]) {
+      if (scannedBytes[index + 1 + offset] !== SEQUENCE_PREFIX[offset]) {
         matchesPrefix = false
         break
       }
@@ -50,7 +55,7 @@ export const readSyncFrameState = (
       continue
     }
 
-    const final = bytes[index + 1 + SEQUENCE_PREFIX.length]
+    const final = scannedBytes[index + 1 + SEQUENCE_PREFIX.length]
 
     if (final === SET_FINAL) {
       insideFrame = true
@@ -59,5 +64,36 @@ export const readSyncFrameState = (
     }
   }
 
-  return insideFrame
+  return {
+    insideFrame,
+    carryBytes: sliceCarryBytes(scannedBytes),
+  }
+}
+
+export const createSyncFrameParserState = (): SyncFrameParserState => ({
+  insideFrame: false,
+  carryBytes: new Uint8Array(),
+})
+
+const appendCarryBytes = (
+  carryBytes: Uint8Array,
+  bytes: Uint8Array
+): Uint8Array => {
+  if (carryBytes.length === 0) {
+    return bytes
+  }
+
+  const combined = new Uint8Array(carryBytes.length + bytes.length)
+  combined.set(carryBytes)
+  combined.set(bytes, carryBytes.length)
+
+  return combined
+}
+
+const sliceCarryBytes = (bytes: Uint8Array): Uint8Array => {
+  if (bytes.length <= MAX_CARRY_LENGTH) {
+    return bytes.slice()
+  }
+
+  return bytes.slice(bytes.length - MAX_CARRY_LENGTH)
 }

--- a/src/features/terminal/components/TerminalPane/terminalSyncFrame.ts
+++ b/src/features/terminal/components/TerminalPane/terminalSyncFrame.ts
@@ -1,0 +1,63 @@
+// cspell:ignore ghostty libghostty
+/**
+ * Tracks DEC private mode 2026 (synchronized output) across PTY chunks.
+ *
+ * Agents like Codex wrap each atomic screen redraw in `\x1b[?2026h` …
+ * `\x1b[?2026l` (begin/end synchronized update). The Ghostty render path
+ * snapshots libghostty after every PTY chunk, so a chunk that ends *inside* a
+ * frame — after a clear-screen but before the redraw — produces a torn/blank
+ * snapshot that flashes the terminal blank (e.g. Codex's input bar "collapsing"
+ * while MCP servers load). Honoring 2026 lets the renderer hold the last
+ * complete frame until the in-progress one closes.
+ */
+
+const ESC = 0x1b
+// bytes after ESC for `[?2026`
+const SEQUENCE_PREFIX = [0x5b, 0x3f, 0x32, 0x30, 0x32, 0x36]
+const SET_FINAL = 0x68 // 'h' — begin synchronized update
+const RESET_FINAL = 0x6c // 'l' — end synchronized update
+
+/**
+ * Fold a chunk of raw PTY bytes into the running synchronized-output state.
+ * Returns whether, after this chunk, the stream is inside an open 2026 frame.
+ *
+ * ponytail: scans complete `\x1b[?2026h/l` sequences only — a sequence split
+ * across a chunk boundary is missed, which at worst renders one torn frame or
+ * holds the previous frame one extra chunk before the next marker corrects it.
+ */
+export const readSyncFrameState = (
+  bytes: Uint8Array,
+  previousInsideFrame: boolean
+): boolean => {
+  let insideFrame = previousInsideFrame
+
+  // last index where ESC + 6 prefix bytes + 1 final byte all fit
+  const lastStart = bytes.length - (SEQUENCE_PREFIX.length + 2)
+  for (let index = 0; index <= lastStart; index += 1) {
+    if (bytes[index] !== ESC) {
+      continue
+    }
+
+    let matchesPrefix = true
+    for (let offset = 0; offset < SEQUENCE_PREFIX.length; offset += 1) {
+      if (bytes[index + 1 + offset] !== SEQUENCE_PREFIX[offset]) {
+        matchesPrefix = false
+        break
+      }
+    }
+
+    if (!matchesPrefix) {
+      continue
+    }
+
+    const final = bytes[index + 1 + SEQUENCE_PREFIX.length]
+
+    if (final === SET_FINAL) {
+      insideFrame = true
+    } else if (final === RESET_FINAL) {
+      insideFrame = false
+    }
+  }
+
+  return insideFrame
+}

--- a/src/features/terminal/hooks/useTerminal.ts
+++ b/src/features/terminal/hooks/useTerminal.ts
@@ -2,7 +2,7 @@ import { useEffect, useState, useCallback, useRef } from 'react'
 import type { ITerminalService } from '../services/terminalService'
 import {
   formatTerminalColorResponse,
-  scanTerminalColorQueries,
+  scanTerminalColorQueriesWithCarry,
 } from '../terminalColorQuery'
 import type {
   TerminalOutputChunk,
@@ -238,6 +238,7 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
   // Events with offsetStart < cursor are dropped. Advances on every write
   // so a buffered drain that overlaps a live event is filtered (no doubled bytes).
   const cursorRef = useRef<number>(restoredFrom?.replayEndOffset ?? 0)
+  const colorQueryCarryRef = useRef('')
 
   // Latest onPaneReady, kept in a ref so the data-subscribe effect can call
   // it without depending on the function identity (which would re-run the
@@ -541,6 +542,8 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
       return
     }
 
+    colorQueryCarryRef.current = ''
+
     const handleData = (
       eventSessionId: string,
       data: string,
@@ -580,7 +583,12 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
     // renderer never sets them, so an empty read self-gates this off there.
     // cspell:ignore ghostty
     const respondToColorQueries = (data: string): void => {
-      const targets = scanTerminalColorQueries(data)
+      const result = scanTerminalColorQueriesWithCarry(
+        data,
+        colorQueryCarryRef.current
+      )
+      const targets = result.targets
+      colorQueryCarryRef.current = result.carry
       const element = terminal.element
 
       if (targets.length === 0 || !element) {

--- a/src/features/terminal/hooks/useTerminal.ts
+++ b/src/features/terminal/hooks/useTerminal.ts
@@ -1,5 +1,9 @@
 import { useEffect, useState, useCallback, useRef } from 'react'
 import type { ITerminalService } from '../services/terminalService'
+import {
+  formatTerminalColorResponse,
+  scanTerminalColorQueries,
+} from '../terminalColorQuery'
 import type {
   TerminalOutputChunk,
   TerminalOutputWriter,
@@ -564,6 +568,46 @@ export const useTerminal = (options: UseTerminalOptions): UseTerminalReturn => {
           if (writtenEnd > cursorRef.current) {
             cursorRef.current = writtenEnd
           }
+
+          respondToColorQueries(data)
+        }
+      }
+    }
+
+    // Answer OSC 10/11 color queries for the native render surface, which
+    // (unlike the xterm renderer) never replies on its own. The active theme
+    // color lives in the `--terminal-*` CSS vars set by that surface; the xterm
+    // renderer never sets them, so an empty read self-gates this off there.
+    // cspell:ignore ghostty
+    const respondToColorQueries = (data: string): void => {
+      const targets = scanTerminalColorQueries(data)
+      const element = terminal.element
+
+      if (targets.length === 0 || !element) {
+        return
+      }
+
+      const styles = window.getComputedStyle(element)
+
+      for (const target of targets) {
+        const hex = styles
+          .getPropertyValue(
+            target === 'foreground'
+              ? '--terminal-foreground'
+              : '--terminal-background'
+          )
+          .trim()
+        const response = hex ? formatTerminalColorResponse(target, hex) : null
+
+        if (response) {
+          const writeResponse = async (): Promise<void> => {
+            try {
+              await service.write({ sessionId: session.id, data: response })
+            } catch {
+              // Session may have exited between the query and our reply.
+            }
+          }
+          void writeResponse()
         }
       }
     }

--- a/src/features/terminal/terminalColorQuery.test.ts
+++ b/src/features/terminal/terminalColorQuery.test.ts
@@ -1,0 +1,65 @@
+/* eslint-disable vimeflow/no-hardcoded-colors -- this suite exercises hex→OSC color conversion, so literal colors are the inputs/outputs under test */
+// cspell:ignore cdcd
+import { describe, expect, test } from 'vitest'
+import {
+  formatTerminalColorResponse,
+  hexToOscColor,
+  scanTerminalColorQueries,
+} from './terminalColorQuery'
+
+describe('scanTerminalColorQueries', () => {
+  test('detects OSC 11 (background) and OSC 10 (foreground) with ST terminator', () => {
+    // exactly what Codex emits at startup (see capture)
+    const data = '\x1b]10;?\x1b\\\x1b]11;?\x1b\\'
+
+    expect(scanTerminalColorQueries(data)).toEqual(['foreground', 'background'])
+  })
+
+  test('detects queries terminated by BEL', () => {
+    expect(scanTerminalColorQueries('\x1b]11;?\x07')).toEqual(['background'])
+  })
+
+  test('ignores OSC color SET sequences (only answers queries)', () => {
+    // setting a color (not a "?" query) must not trigger a response
+    expect(
+      scanTerminalColorQueries('\x1b]11;rgb:1e1e/1e1e/2e2e\x1b\\')
+    ).toEqual([])
+  })
+
+  test('returns nothing for unrelated output', () => {
+    expect(
+      scanTerminalColorQueries('regular output, no osc query here')
+    ).toEqual([])
+  })
+})
+
+describe('hexToOscColor', () => {
+  test('expands 8-bit hex channels to the 16-bit OSC color form', () => {
+    expect(hexToOscColor('#1e1e2e')).toBe('rgb:1e1e/1e1e/2e2e')
+    expect(hexToOscColor('cdd6f4')).toBe('rgb:cdcd/d6d6/f4f4')
+  })
+
+  test('rejects non-hex / partial colors', () => {
+    expect(hexToOscColor('rgb(30,30,46)')).toBeNull()
+    expect(hexToOscColor('#fff')).toBeNull()
+    expect(hexToOscColor('')).toBeNull()
+  })
+})
+
+describe('formatTerminalColorResponse', () => {
+  test('builds the OSC 11 background report Codex needs to draw its composer bar', () => {
+    expect(formatTerminalColorResponse('background', '#1e1e2e')).toBe(
+      '\x1b]11;rgb:1e1e/1e1e/2e2e\x1b\\'
+    )
+  })
+
+  test('builds the OSC 10 foreground report', () => {
+    expect(formatTerminalColorResponse('foreground', '#cdd6f4')).toBe(
+      '\x1b]10;rgb:cdcd/d6d6/f4f4\x1b\\'
+    )
+  })
+
+  test('returns null when the color is unusable', () => {
+    expect(formatTerminalColorResponse('background', 'transparent')).toBeNull()
+  })
+})

--- a/src/features/terminal/terminalColorQuery.test.ts
+++ b/src/features/terminal/terminalColorQuery.test.ts
@@ -5,6 +5,7 @@ import {
   formatTerminalColorResponse,
   hexToOscColor,
   scanTerminalColorQueries,
+  scanTerminalColorQueriesWithCarry,
 } from './terminalColorQuery'
 
 describe('scanTerminalColorQueries', () => {
@@ -30,6 +31,33 @@ describe('scanTerminalColorQueries', () => {
     expect(
       scanTerminalColorQueries('regular output, no osc query here')
     ).toEqual([])
+  })
+
+  test('detects a query split before the ST terminator', () => {
+    const first = scanTerminalColorQueriesWithCarry('\x1b]11;?', '')
+    expect(first.targets).toEqual([])
+
+    const second = scanTerminalColorQueriesWithCarry('\x1b\\', first.carry)
+    expect(second.targets).toEqual(['background'])
+  })
+
+  test('detects a query split before the BEL terminator', () => {
+    const first = scanTerminalColorQueriesWithCarry('\x1b]10;?', '')
+    expect(first.targets).toEqual([])
+
+    const second = scanTerminalColorQueriesWithCarry('\x07', first.carry)
+    expect(second.targets).toEqual(['foreground'])
+  })
+
+  test('does not repeat a completed trailing query on the next scan', () => {
+    const first = scanTerminalColorQueriesWithCarry('\x1b]11;?\x07', '')
+    expect(first.targets).toEqual(['background'])
+
+    const second = scanTerminalColorQueriesWithCarry(
+      'regular output',
+      first.carry
+    )
+    expect(second.targets).toEqual([])
   })
 })
 

--- a/src/features/terminal/terminalColorQuery.ts
+++ b/src/features/terminal/terminalColorQuery.ts
@@ -13,22 +13,49 @@
 
 export type TerminalColorQueryTarget = 'foreground' | 'background'
 
+export interface TerminalColorQueryScanResult {
+  targets: readonly TerminalColorQueryTarget[]
+  carry: string
+}
+
 // OSC 10;? (fg) or OSC 11;? (bg), terminated by BEL (\x07) or ST (\x1b\\).
 const COLOR_QUERY_PATTERN = /\x1b\]1([01]);\?(?:\x07|\x1b\\)/g
+const MAX_COLOR_QUERY_CARRY_LENGTH = '\x1b]10;?\x1b\\'.length - 1
 
 const HEX_COLOR_PATTERN = /^#?([0-9a-fA-F]{6})$/
 
 /** Detect OSC 10/11 color queries in a chunk of raw PTY output. */
 export const scanTerminalColorQueries = (
   data: string
-): readonly TerminalColorQueryTarget[] => {
-  const targets: TerminalColorQueryTarget[] = []
+): readonly TerminalColorQueryTarget[] =>
+  scanTerminalColorQueriesWithCarry(data, '').targets
 
-  for (const match of data.matchAll(COLOR_QUERY_PATTERN)) {
+/**
+ * Detect OSC 10/11 color queries across arbitrary PTY event boundaries.
+ *
+ * The carry is at most one byte shorter than the longest query sequence, and
+ * starts after the last complete match so already-answered queries do not
+ * repeat on the next scan.
+ */
+export const scanTerminalColorQueriesWithCarry = (
+  data: string,
+  previousCarry: string
+): TerminalColorQueryScanResult => {
+  const scannedData = `${previousCarry}${data}`
+  const targets: TerminalColorQueryTarget[] = []
+  let lastConsumedIndex = 0
+
+  for (const match of scannedData.matchAll(COLOR_QUERY_PATTERN)) {
     targets.push(match[1] === '0' ? 'foreground' : 'background')
+    lastConsumedIndex = match.index + match[0].length
   }
 
-  return targets
+  const unconsumed = scannedData.slice(lastConsumedIndex)
+
+  return {
+    targets,
+    carry: unconsumed.slice(-MAX_COLOR_QUERY_CARRY_LENGTH),
+  }
 }
 
 /** Convert `#1e1e2e` to the xterm OSC color form `rgb:1e1e/1e1e/2e2e`. */

--- a/src/features/terminal/terminalColorQuery.ts
+++ b/src/features/terminal/terminalColorQuery.ts
@@ -1,0 +1,64 @@
+// cspell:ignore ghostty libghostty
+/**
+ * Answers terminal OSC color queries (`OSC 10` = default foreground,
+ * `OSC 11` = default background) for the Ghostty native render path.
+ *
+ * libghostty-vt parses PTY output for render state but never writes responses
+ * back to the PTY. Agents like Codex query the terminal's default background
+ * (`\x1b]11;?`) and tint their input composer from the reply — with no answer
+ * they render a degraded, bar-less composer. `@xterm/xterm` answers these
+ * queries itself, so this only matters for the Ghostty surface; it restores
+ * parity by replying with the active terminal theme color.
+ */
+
+export type TerminalColorQueryTarget = 'foreground' | 'background'
+
+// OSC 10;? (fg) or OSC 11;? (bg), terminated by BEL (\x07) or ST (\x1b\\).
+const COLOR_QUERY_PATTERN = /\x1b\]1([01]);\?(?:\x07|\x1b\\)/g
+
+const HEX_COLOR_PATTERN = /^#?([0-9a-fA-F]{6})$/
+
+/** Detect OSC 10/11 color queries in a chunk of raw PTY output. */
+export const scanTerminalColorQueries = (
+  data: string
+): readonly TerminalColorQueryTarget[] => {
+  const targets: TerminalColorQueryTarget[] = []
+
+  for (const match of data.matchAll(COLOR_QUERY_PATTERN)) {
+    targets.push(match[1] === '0' ? 'foreground' : 'background')
+  }
+
+  return targets
+}
+
+/** Convert `#1e1e2e` to the xterm OSC color form `rgb:1e1e/1e1e/2e2e`. */
+export const hexToOscColor = (hex: string): string | null => {
+  const match = HEX_COLOR_PATTERN.exec(hex.trim())
+
+  if (!match) {
+    return null
+  }
+
+  const channels = match[1]
+  const red = channels.slice(0, 2)
+  const green = channels.slice(2, 4)
+  const blue = channels.slice(4, 6)
+
+  return `rgb:${red}${red}/${green}${green}/${blue}${blue}`
+}
+
+/** Build the OSC color report a terminal sends in answer to an OSC 10/11 query. */
+export const formatTerminalColorResponse = (
+  target: TerminalColorQueryTarget,
+  hex: string
+): string | null => {
+  const oscColor = hexToOscColor(hex)
+
+  if (!oscColor) {
+    return null
+  }
+
+  const code = target === 'foreground' ? '10' : '11'
+
+  return `\x1b]${code};${oscColor}\x1b\\`
+}


### PR DESCRIPTION
## Summary

Two focused fixes that make the Codex input composer usable on the Ghostty native render path.

### 1. Render the bar — answer OSC 10/11 color queries (`c4b04f9e`)
Codex draws its input composer as a full-width background bar tinted from the terminal's reported default background, which it learns by querying `OSC 11` (bg) / `OSC 10` (fg) at startup. The Ghostty path parses PTY output for display but never wrote responses back, so Codex got no answer and rendered a **bar-less** composer (`@xterm/xterm` answers these itself). `useTerminal` now detects the queries and replies via the existing PTY-write path with the active theme color read from the `--terminal-*` CSS vars (set only by the Ghostty/plain surface → self-gates off xterm).

### 2. Stop it collapsing — honor synchronized output (DEC 2026) (`6b3f76e9`)
Codex wraps every redraw in `\x1b[?2026h … \x1b[?2026l`. The bridge snapshotted libghostty on every PTY chunk, so a chunk landing mid-frame (after a clear, before the redraw) rendered a torn/blank grid — the bar "collapsing" while MCP servers load. The render path now holds the last complete frame while inside an open sync frame and repaints only on close (a failsafe renders after a few held chunks so a missed close marker can't freeze the surface). This is effectively the frame-coalescing of VIM-210.

## Verification
- Real Codex capture replayed through the production pipeline: bar renders with `background:#393947` across the composer; torn blank frames eliminated by the 2026 gate.
- Manual smoke: bar renders and **holds** through MCP loading (screen recordings).
- Confirmed the OSC responder does **not** fire for the shell (zsh emits no OSC color queries).
- Unit + driver tests added (color-query scan/convert, sync-frame tracking, suppression + failsafe); full suite green (4034 passed).

## Scope
Part of VIM-210 (frame coalescing) and the Ghostty migration (VIM-139); addresses the Codex composer-bar item. Residual vertical-layout work (empty band below content) is tracked in VIM-208. Targets the `umbrella/ghostty-terminal-investigation` branch, not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)