### PR TITLE
[codex] fix(ui): restore claude code glyph height

### DIFF
--- a/src/agents/brandIcons.test.tsx
+++ b/src/agents/brandIcons.test.tsx
@@ -10,7 +10,7 @@ const BRAND_ICONS: readonly (readonly [string, AgentIcon])[] = [
 ]
 
 test.each(BRAND_ICONS)(
-  '%s renders a mono currentColor svg sized by the size prop',
+  '%s renders a mono currentColor svg with height sized by the size prop',
   (_name, Icon) => {
     const { container } = render(<Icon size={16} />)
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- verifying vendored SVG shape
@@ -18,7 +18,7 @@ test.each(BRAND_ICONS)(
 
     expect(svg).toBeInTheDocument()
     expect(svg?.getAttribute('fill')).toBe('currentColor')
-    expect(svg?.getAttribute('width')).toBe('16')
+    expect(svg?.getAttribute('height')).toBe('16')
   }
 )
 
@@ -33,6 +33,7 @@ test('ClaudeCode keeps the original mark and adjusts only its rendered ratio', (
   expect(container.querySelector('circle')).toBeNull()
   expect(svg?.getAttribute('viewBox')).toBe('0 4 24 17')
   expect(svg?.getAttribute('preserveAspectRatio')).toBeNull()
+  expect(svg?.getAttribute('height')).toBe('16')
   expect(
     Number(svg?.getAttribute('width')) / Number(svg?.getAttribute('height'))
   ).toBeCloseTo(24 / 17, 5)

--- a/src/agents/brandIcons.tsx
+++ b/src/agents/brandIcons.tsx
@@ -42,7 +42,8 @@ export const ClaudeCode = ({
   <BrandSvg
     size={size}
     viewBox="0 4 24 17"
-    height={(size * CLAUDE_CODE_VIEW_BOX_HEIGHT) / CLAUDE_CODE_VIEW_BOX_WIDTH}
+    width={(size * CLAUDE_CODE_VIEW_BOX_WIDTH) / CLAUDE_CODE_VIEW_BOX_HEIGHT}
+    height={size}
     {...props}
   >
     <path


### PR DESCRIPTION
## Summary

- Makes the Claude Code brand SVG use the requested `size` as its rendered height.
- Keeps the cropped `viewBox="0 4 24 17"` and natural 24:17 width/height ratio.
- Updates regression coverage to assert height-based sizing and the ratio invariant.

## Why

PR #572 preserved the mark's natural aspect ratio, but the rendered SVG was still width-driven. In the small agent glyph chips, that left the visible Claude Code mark looking too flat.

## Impact

Claude Code glyphs render taller in existing chips without reintroducing non-uniform SVG stretching or changing other agent marks.

## Root Cause

The previous fix set `height = size * 17 / 24`, so `size` controlled width. For a `size={16}` mark, the SVG height was only about 11px.

## Validation

- Pre-commit hook: ESLint, `tsc --noEmit`, Prettier on staged files
- `CI=true npm test -- src/agents/brandIcons.test.tsx src/components/AgentGlyph.test.tsx --run`
- Pre-push hook: full `npm test` suite, 337 test files passed, 4136 tests passed, 3 skipped


Refs VIM-219