### PR TITLE
fix(terminal): Ghostty composer render fidelity across start/MCP/resume

### DIFF
--- a/docs/debug/2026-06-22-ghostty-composer-render-loop.md
+++ b/docs/debug/2026-06-22-ghostty-composer-render-loop.md
@@ -1,0 +1,103 @@
+# Ghostty composer-render debug loop (VIM-208/214/216 family)
+
+**Status:** in progress · **Started:** 2026-06-22 · **Branch:** `verify/ghostty-m5`
+
+A suspect → observation → cause-analysis → verdict loop for the "gray area incorrect"
+rendering bug in the Ghostty native terminal render path. Each hypothesis is tracked
+with its observation and verdict so the deduction is auditable; this doc feeds a final
+HTML report once the fix lands.
+
+## The bug (light mode makes it visible)
+
+A coding-agent TUI (OpenAI Codex CLI) runs in a PTY rendered by a custom "Ghostty
+native" path: `@coder/libghostty-vt-node` parses PTY bytes → `snapshot()` +
+`formatHtml()` → a custom DOM surface (`terminalTextSurface.ts`). Codex draws its
+input composer as a full-width background bar tinted from the terminal's reported
+`OSC 11` background. **Symptom:** the bar's gray area is wrong — it appears to extend
+onto the status/model line (`gpt-5.5 xhigh · …`) and/or is mis-colored. It looks
+right for a split second on startup, then breaks once Codex's "Starting MCP servers…"
+redraw settles. Only clearly visible in **light mode** (dark-on-dark hid it).
+
+Key wrinkle: a headless harness replaying a captured Codex session shows the status
+row CLEAN with the current fixes, yet the LIVE app still shows the bleed → the live
+state differs from the captured one (Codex actively responding, long status line).
+
+## Success criteria (proof = light-mode screenshots)
+
+1. Codex renders the input area correctly (bar exactly wraps the composer; status line not shaded wrongly).
+2. `/resume` of a previous session does not break the input area.
+3. On exiting Codex, the shell starship/powerline color blocks render correctly.
+
+## Fixes already landed on `verify/ghostty-m5`
+
+| Commit     | Fix                                                                   |
+| ---------- | --------------------------------------------------------------------- |
+| `c4b04f9e` | Answer Codex `OSC 10/11` color queries → composer bar renders         |
+| `6b3f76e9` | Honor synchronized output (DEC 2026) → no torn mid-frame              |
+| `837afbc6` | rAF render coalescing → drop transient redraw frames                  |
+| `ec9b951f` | Fixed-cell geometry (`width` not `min-width`) + 1-cell cursor overlay |
+| `f906f334` | Align bg-synthesis rows with formatHtml wrapper + leading-blank trim  |
+
+Despite these, the gray area is STILL wrong in the live app (light mode) → more causes remain.
+
+## Observation tooling
+
+- **Headless render harness** (jsdom): replay captured PTY chunks through the real
+  bridge + model + surface, dump per-row text / bg-run widths. Cols MUST match
+  (capture == bridge == surface) or full-width bg soft-wraps into artifacts.
+- **Ground-truth dump**: feed chunks to a standalone libghostty terminal; dump
+  `formatHtml()` bg lines + `snapshot().cells` bg-by-row to localize bridge vs render.
+- **Captures**: `/tmp/codex-chunks.json` (codex), `/tmp/shell-chunks.json` (shell).
+
+## Suspect list
+
+A research workflow (ghostty/libghostty, codex CLI, general TUI, our codebase) runs in
+parallel; its ranked suspects get appended here. The codebase + live-capture observations below
+already resolved the headline question, so research now mainly serves to find any _additional_
+causes for `/resume` and shell-exit.
+
+## Hypothesis loop
+
+Observation tooling: a node harness drives the **real** bridge (`GhosttyRenderStateMainBridge` +
+real libghostty + real `formatHtml`/`normalizeSnapshot`) over a captured codex PTY session and
+dumps the normalized snapshot's bg cells per row. Captures made with a Python `pty.fork` that
+answers OSC 10/11 with the chosen theme's fg/bg.
+
+| #   | Hypothesis                                                                                                                                         | Observation                                                                                                                                       | Result                                                                                                                                                                                                                                                                                                                                                                             | Verdict                  | Deduction                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| H1  | After fixes 1–6 + the F3/F4 reconcile, a **fresh** codex composer renders correctly                                                                | Drive real bridge over fresh light + fresh dark captures; dump bg-by-row                                                                          | Light: bar rows 11–13 `#f4f1e6`, composer row 12, status (`gpt-5.5`) **no bg**. Dark: bar rows 11–13 `#393947`, status no bg                                                                                                                                                                                                                                                       | ✅ **CONFIRMED CORRECT** | The render path is NOT the bug for fresh sessions. Composer bar is exactly 3 rows; status line is never shaded. Criterion 1 holds.                                                                                                                                                                                                                                                                                                                                                                                                            |
+| H2  | The light-mode "gray area incorrect" (Image #32) = **theme-switch staleness** (codex cached the dark OSC 11 bg, never re-queried after dark→light) | Capture codex started DARK; at t=10s answer LIGHT + send SIGWINCH; count codex's OSC re-queries; harness the bar bg                               | Codex emits OSC 10/11 **only at startup** (8 queries in first 0.24s); **0** re-queries after the switch/SIGWINCH. Bar stays `#393947` (dark) on the now-light bg                                                                                                                                                                                                                   | ✅ **CONFIRMED**         | Codex caches the bg→bar tint at startup and never re-queries. After a theme switch its bar is stale. This is a **codex limitation**, not an app render bug — our surface faithfully renders codex's (stale) explicit cell bg.                                                                                                                                                                                                                                                                                                                 |
+| H3  | A resize-nudge on theme change would make codex re-query OSC 11 → re-tint                                                                          | SIGWINCH (shrink 1 col + restore) sent post-switch in H2                                                                                          | 0 re-queries followed the SIGWINCH                                                                                                                                                                                                                                                                                                                                                 | ❌ **REJECTED**          | Codex does not re-query colors on resize. Resize-nudge cannot fix theme-switch staleness.                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| H4  | The real live bleed (codex **with history** / `/resume`) = **formatHtml↔snapshot row mismatch from scrollback**                                    | `gt-align`/`gt-anchor`: dump formatHtml content-row count vs snapshot bg rows for fresh vs resume captures; replay resume through the real bridge | Ground truth: snapshot bg only on visible composer rows (24,25,26), but `formatHtml` emits **146** content rows (full scrollback incl. old dimmed `›` prompts at `opacity:0.5`) vs snapshot's **30** visible. The old fixed wrapper/leading offset mapped scrollback bg rows (11, 22) onto visible history rows → bleed. Fresh-idle captures (no scrollback) were clean, hiding it | ✅ **CONFIRMED + FIXED** | `formatHtml` carries scrollback+viewport (blank leading/trailing trimmed); the snapshot is viewport-only. No fixed offset can align them (offset = scrollback height: 0 fresh, −1 shell, **118** on /resume). **Fix:** anchor formatHtml's last content row to the snapshot's last non-blank row, shift all ranges by that delta, drop rows outside the viewport. Verified across all 5 captures + a mutation-checked regression test. This is the root cause of the live Image #32 "status bleed" (codex was mid-response → had scrollback). |
+
+### Fix landed (this loop)
+
+`fix(terminal): anchor Ghostty bg synthesis to the visible viewport (drop scrollback)` — replaces
+the wrapper+leading-empty offset in `normalizeSnapshot` with a last-non-blank-row anchor +
+viewport clamp. Verified on fresh light/dark, `/resume` (scrollback), shell powerline, and the
+theme-switch capture; new mutation-checked regression test
+`anchors the bar to the visible viewport and drops scrollback bg rows`.
+
+### Verification status vs the 3 success criteria
+
+1. **Codex input area correct** — ✅ confirmed through the real bridge for fresh sessions (light `#f4f1e6` / dark `#393947`, status clean) AND for codex-with-history after the H4 fix (resume: bar on 24,25,26, scrollback + status clean). Live light-mode screenshot pending.
+2. **`/resume` does not break the input** — ✅ confirmed via the resume capture through the real bridge (composer row 25, status row 27 clean, scrollback history rows clean). Live screenshot pending.
+3. **Shell starship blocks on codex exit** — ✅ confirmed: all 6 powerline segment colors render on the prompt row, no bleed. Live screenshot pending.
+
+**Separate finding (codex limitation, not an app render bug):** switching theme mid-codex-session
+leaves a stale bar color (codex caches OSC 11 at startup, never re-queries — H2/H3). Recommend
+documenting "restart codex after a theme switch"; a fresh session in either theme is correct.
+
+### Implications for the fix
+
+- **Criterion 1 (codex input correct):** already met for fresh sessions in both themes — proven
+  through the real bridge. Remaining work is to capture a live light-mode screenshot as proof.
+- **Theme-switch staleness:** not cleanly fixable from the terminal side (codex never re-queries).
+  Options: (a) accept + document ("restart codex after switching theme to refresh its bar color");
+  (b) on theme change, kill+`/resume` codex automatically (heavy, loses TUI scroll state);
+  (c) app-side remap of the stale bar bg (fragile — we can't reliably identify it). Recommend (a).
+
+## Open questions (remaining)
+
+- `/resume` (criterion 2): does the composer render correctly after codex replays a long history? (capture + harness pending)
+- shell-exit starship/powerline blocks (criterion 3): correct after codex exits? (capture + harness pending)

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -55,14 +55,14 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 1        | 0    | 2026-06-09   |
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 66       | 34   | 2026-06-20   |
-| [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 28       | 10   | 2026-06-22   |
+| [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 29       | 11   | 2026-06-23   |
 | [Terminal DOM Rendering](patterns/terminal-dom-rendering.md)                                         | terminal           | 10       | 6    | 2026-06-21   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
-| [Terminal Render-State Driver Contract](patterns/terminal-render-state-driver-contract.md)           | terminal           | 33       | 10   | 2026-06-21   |
+| [Terminal Render-State Driver Contract](patterns/terminal-render-state-driver-contract.md)           | terminal           | 35       | 11   | 2026-06-23   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 88       | 27   | 2026-06-22   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 51       | 24   | 2026-06-18   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
-| [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 63       | 23   | 2026-06-08   |
+| [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 64       | 24   | 2026-06-23   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)                                       | backend            | 2        | 1    | 2026-05-20   |
 | [Command Injection](patterns/command-injection.md)                                                   | security           | 7        | 3    | 2026-05-02   |
 | [Policy Judge Hygiene](patterns/policy-judge-hygiene.md)                                             | security           | 15       | 2    | 2026-04-20   |
@@ -83,7 +83,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Verify Render Target](patterns/verify-render-target.md)                                             | code-quality       | 2        | 0    | 2026-05-24   |
 | [UI Visual Regression](patterns/ui-visual-regression.md)                                             | code-quality       | 9        | 4    | 2026-06-13   |
 | [Status Indicator Display](patterns/status-indicator-display.md)                                     | code-quality       | 3        | 0    | 2026-05-26   |
-| [Parser Resilience](patterns/parser-resilience.md)                                                   | code-quality       | 13       | 10   | 2026-06-21   |
+| [Parser Resilience](patterns/parser-resilience.md)                                                   | code-quality       | 13       | 11   | 2026-06-21   |
 | [Persisted State Invariants](patterns/persisted-state-invariants.md)                                 | correctness        | 8        | 4    | 2026-06-13   |
 | [macOS Window Chrome](patterns/macos-window-chrome.md)                                               | cross-platform     | 8        | 2    | 2026-06-11   |
 | [Guard Branch Correctness](patterns/guard-branch-correctness.md)                                     | correctness        | 1        | 0    | 2026-06-11   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -58,7 +58,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 29       | 11   | 2026-06-23   |
 | [Terminal DOM Rendering](patterns/terminal-dom-rendering.md)                                         | terminal           | 10       | 6    | 2026-06-21   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
-| [Terminal Render-State Driver Contract](patterns/terminal-render-state-driver-contract.md)           | terminal           | 35       | 11   | 2026-06-23   |
+| [Terminal Render-State Driver Contract](patterns/terminal-render-state-driver-contract.md)           | terminal           | 36       | 12   | 2026-06-23   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 88       | 27   | 2026-06-22   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 51       | 24   | 2026-06-18   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |

--- a/docs/reviews/patterns/async-race-conditions.md
+++ b/docs/reviews/patterns/async-race-conditions.md
@@ -2,8 +2,8 @@
 id: async-race-conditions
 category: react-patterns
 created: 2026-04-09
-last_updated: 2026-06-08
-ref_count: 23
+last_updated: 2026-06-23
+ref_count: 24
 ---
 
 # Async Race Conditions
@@ -640,4 +640,13 @@ prevent showing previous data.
 - **File:** `src/features/sessions/hooks/useSessionRestore.ts`
 - **Finding:** `useSessionRestore` checked `cancelled` after loading sessions but not immediately before `restoreBrowserPanes`. If cleanup ran after reconstruction, the stale restore still waited through bounded browser-pane creation timeouts before releasing hydration.
 - **Fix:** Add a cancellation guard immediately before `restoreBrowserPanes(restored)` so a cancelled restore reaches `finally` and releases hydration without waiting on per-pane timeouts.
+- **Commit:** same commit as this entry
+
+### 63. Non-cancellable microtask fallbacks need an identity guard
+
+- **Source:** github-claude | PR #612 round 1 | 2026-06-23
+- **Severity:** LOW
+- **File:** `src/features/terminal/components/TerminalPane/ghosttyInstance.ts`
+- **Finding:** The Ghostty render flush scheduler used `queueMicrotask` as its non-browser fallback, but `cancelRenderFlush()` could only cancel a stored `requestAnimationFrame` handle. A queued microtask from before `clear()` or `dispose()` could still run later if future `flushRender` changes added side effects.
+- **Fix:** Added a monotonically increasing render-flush token. Scheduled callbacks capture the token and return early after cancellation increments it, covering both rAF callbacks that survive cancellation and microtask fallbacks that cannot be cancelled directly.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/parser-resilience.md
+++ b/docs/reviews/patterns/parser-resilience.md
@@ -3,7 +3,7 @@ id: parser-resilience
 category: code-quality
 created: 2026-05-24
 last_updated: 2026-06-21
-ref_count: 10
+ref_count: 11
 ---
 
 # Parser Resilience

--- a/docs/reviews/patterns/terminal-control-sequence-handling.md
+++ b/docs/reviews/patterns/terminal-control-sequence-handling.md
@@ -2,8 +2,8 @@
 id: terminal-control-sequence-handling
 category: terminal
 created: 2026-06-17
-last_updated: 2026-06-22
-ref_count: 10
+last_updated: 2026-06-23
+ref_count: 11
 ---
 
 # Terminal Control Sequence Handling
@@ -270,4 +270,13 @@ all required state through pure display-state helpers.
 - **File:** `src/features/terminal/terminalColorQuery.ts`
 - **Finding:** The Ghostty OSC 10/11 responder matched only complete color queries inside one string chunk. If Codex's query split before the BEL or ST terminator, no target was detected and the composer fell back to degraded rendering.
 - **Fix:** Added a carry-aware color query scanner and stored the carry in `useTerminal` for the active PTY subscription. Tests now cover ST-terminated and BEL-terminated queries split across chunks and ensure completed trailing queries are not answered twice.
+- **Commit:** same commit as this entry
+
+### 29. Held DEC 2026 flushes need an explicit pending-output signal
+
+- **Source:** github-codex-connector | PR #612 round 1 | 2026-06-23
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts`
+- **Finding:** When a DEC 2026 synchronized-output frame opened and the close marker was lost, `flushOutput()` returned `null` while keeping the driver dirty. The terminal model treated `null` as settled and did not schedule another frame, so the held-flush failsafe could only advance if more PTY bytes arrived later.
+- **Fix:** Added `hasPendingOutput()` through the parser/adapter interfaces and implemented it from the render-state driver's dirty flag. The terminal model now re-arms render flushes after `null` only when the parser still reports pending output, letting the failsafe paint without creating an infinite loop for settled parsers.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/terminal-render-state-driver-contract.md
+++ b/docs/reviews/patterns/terminal-render-state-driver-contract.md
@@ -3,7 +3,7 @@ id: terminal-render-state-driver-contract
 category: terminal
 created: 2026-06-19
 last_updated: 2026-06-23
-ref_count: 11
+ref_count: 12
 ---
 
 # Terminal Render-State Driver Contract
@@ -334,4 +334,13 @@ documented explicitly: effect callbacks must be invoked synchronously inside the
 - **File:** `electron/ghostty-render-state-main.ts`
 - **Finding:** `contentRowCount` documented the number of rows walked from `formatHtml()`, but returned `0` whenever no reverse/background ranges were emitted. Plain-text formatter output therefore carried inconsistent metadata that happened not to affect the only current range consumer.
 - **Fix:** Return the walked row count whenever terminal content was parsed, independent of whether any ranges were emitted. Keep the empty-wrapper case at `0`.
+- **Commit:** same commit as this entry
+
+### 35. Blank native viewports must not align formatter scrollback ranges
+
+- **Source:** local-codex | PR #612 round 2 | 2026-06-23
+- **Severity:** MEDIUM
+- **File:** `electron/ghostty-render-state-main.ts` L1170
+- **Finding:** When a native viewport was fully blank, reverse-video range alignment still used a `rowShift` of `0`. Old styled rows from `formatHtml()` scrollback whose original rows fit inside the viewport could be synthesized into a blank snapshot during clear/redraw gaps.
+- **Fix:** Added an explicit alignment guard so formatter ranges are shifted and filtered only when the formatter has content rows and the native snapshot has a visible content anchor. Added a regression for a blank native viewport with stale highlighted formatter scrollback.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/terminal-render-state-driver-contract.md
+++ b/docs/reviews/patterns/terminal-render-state-driver-contract.md
@@ -2,8 +2,8 @@
 id: terminal-render-state-driver-contract
 category: terminal
 created: 2026-06-19
-last_updated: 2026-06-21
-ref_count: 10
+last_updated: 2026-06-23
+ref_count: 11
 ---
 
 # Terminal Render-State Driver Contract
@@ -316,4 +316,22 @@ documented explicitly: effect callbacks must be invoked synchronously inside the
 - **File:** `src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.ts`
 - **Finding:** The VT snapshot renderer treated a missing `cursor.visible` field as an implicit stale-cursor signal and hid any cursor on a blank row with later content. Ghostty omits `visible` for normal visible cursors, so legitimate editor/TUI cursors on blank lines above status or menu rows disappeared.
 - **Fix:** Missing `cursor.visible` now preserves the default visible cursor unless the snapshot matches a known parked-cursor shape: an agent prompt follower or a styled blank native cursor artifact above later content. Regression coverage pins both the preserved `rows: ['', 'menu']` case and the styled parked-cursor case.
+- **Commit:** same commit as this entry
+
+### 33. Reverse-video viewport anchors must count styled-blank native rows
+
+- **Source:** github-claude | PR #612 round 1 | 2026-06-23
+- **Severity:** MEDIUM
+- **File:** `electron/ghostty-render-state-main.ts`
+- **Finding:** Ghostty `formatHtml()` includes styled-blank composer bar rows, but the bridge anchored reverse-video row shifts to the last snapshot row whose text was non-blank after `trim()`. When the trailing bar row was the last viewport row with no status row below it, the anchor moved one row too high and full-width bar ranges were shifted off their intended rows.
+- **Fix:** Anchor to the last snapshot row that has non-blank text OR a native styled cell. Added a regression with bar/composer/bar and no status row, asserting all three styled rows keep full-width background coverage.
+- **Commit:** same commit as this entry
+
+### 34. Formatter row-count metadata must not depend on emitted style ranges
+
+- **Source:** github-claude | PR #612 round 1 | 2026-06-23
+- **Severity:** LOW
+- **File:** `electron/ghostty-render-state-main.ts`
+- **Finding:** `contentRowCount` documented the number of rows walked from `formatHtml()`, but returned `0` whenever no reverse/background ranges were emitted. Plain-text formatter output therefore carried inconsistent metadata that happened not to affect the only current range consumer.
+- **Fix:** Return the walked row count whenever terminal content was parsed, independent of whether any ranges were emitted. Keep the empty-wrapper case at `0`.
 - **Commit:** same commit as this entry

--- a/electron/ghostty-render-state-main.test.ts
+++ b/electron/ghostty-render-state-main.test.ts
@@ -516,6 +516,67 @@ describe('ghostty render-state main bridge', () => {
     ).toBe(false)
   })
 
+  test('anchors to a trailing styled-blank bar row without a status row below it', () => {
+    const bg = 'background-color: rgb(57, 57, 71)'
+
+    const wrapperOpen =
+      '<div style="font-family: monospace; white-space: pre;">'
+
+    const barRow = `<div style="display: inline;${bg};">                    </div>`
+
+    const composerRow =
+      `<div style="display: inline;${bg};font-weight: bold;">&gt;</div>` +
+      `<div style="display: inline;${bg};"> hi                </div></div>`
+    const html = `${wrapperOpen}\n${[barRow, composerRow, barRow].join('\n')}`
+
+    const bindings: GhosttyNativeBindings = {
+      createTerminal: () => ({
+        feed: vi.fn(),
+        resize: vi.fn(),
+        snapshot: () => ({
+          rows: 3,
+          cursorRow: 1,
+          cursorCol: 4,
+          visibleLines: [
+            { row: 0, text: '' },
+            { row: 1, text: '> hi' },
+            { row: 2, text: '' },
+          ],
+          cells: [
+            { row: 0, col: 0, text: ' ', width: 1, background: '#393947' },
+            { row: 1, col: 0, text: '>', width: 1, background: '#393947' },
+            { row: 1, col: 2, text: 'h', width: 1, background: '#393947' },
+            { row: 1, col: 3, text: 'i', width: 1, background: '#393947' },
+            { row: 2, col: 0, text: ' ', width: 1, background: '#393947' },
+          ],
+        }),
+        formatHtml: () => html,
+        dispose: vi.fn(),
+      }),
+    }
+
+    const bridge = new GhosttyRenderStateMainBridge('/app', bindings)
+    const event = createEvent()
+    const createResult = requireResult(bridge.createDriver(event))
+
+    const snapshot = requireResult(
+      bridge.readSnapshot(event.sender.id, {
+        driverId: createResult.driverId,
+      })
+    )
+    const cells = snapshot.cells ?? []
+
+    for (const row of [0, 1, 2]) {
+      for (let col = 0; col < 20; col += 1) {
+        const covering = cells.find(
+          (cell) =>
+            cell.row === row && cell.col <= col && col < cell.col + cell.width
+        )
+        expect(covering?.background, `row ${row} col ${col}`).toBe('#393947')
+      }
+    }
+  })
+
   test('returns OSC7 cwd effects across byte chunks before feeding native state', () => {
     const { bindings, terminals } = createNativeBindings()
     const bridge = new GhosttyRenderStateMainBridge('/app', bindings)

--- a/electron/ghostty-render-state-main.test.ts
+++ b/electron/ghostty-render-state-main.test.ts
@@ -579,6 +579,7 @@ describe('ghostty render-state main bridge', () => {
 
   test('drops formatter ranges when a blank native viewport has no content anchor', () => {
     const bg = 'background-color: rgb(57, 57, 71)'
+
     const wrapperOpen =
       '<div style="font-family: monospace; white-space: pre;">'
     const barRow = `<div style="display: inline;${bg};">                    </div>`

--- a/electron/ghostty-render-state-main.test.ts
+++ b/electron/ghostty-render-state-main.test.ts
@@ -277,14 +277,25 @@ describe('ghostty render-state main bridge', () => {
   // formatHtml ranges — a transient "clamp to native content extent" once dropped
   // the blank portions and made the bar vanish (Ghostty terminal BUG-1). This
   // locks the synthesis so the regression can't return.
-  test('synthesizes a full-width background bar from formatHtml when native cells omit blank styled cells', () => {
-    const barRow =
-      '<div style="display: inline;background-color: rgb(57, 57, 71);">                    </div>'
+  test('synthesizes the background bar on the bar rows without bleeding onto the status row below (formatHtml wrapper offset)', () => {
+    // formatHtml wraps every terminal row in an outer <div ...> whose opening
+    // tag sits on its own line. The bar covers terminal rows 0-2 (blank /
+    // composer / blank); a non-bg status line sits at row 3. If the synthesis
+    // counts the wrapper's leading newline, every range shifts +1 and the bar
+    // bleeds onto the status row.
+    const bg = 'background-color: rgb(57, 57, 71)'
 
-    const inputRow =
-      '<div style="display: inline;background-color: rgb(57, 57, 71);font-weight: bold;">&gt;</div>' +
-      '<div style="display: inline;background-color: rgb(57, 57, 71);"> hi                </div>'
-    const html = [barRow, inputRow, barRow].join('\n')
+    const wrapperOpen =
+      '<div style="font-family: monospace; white-space: pre;">'
+    const barRow = `<div style="display: inline;${bg};">                    </div>`
+
+    const composerRow =
+      `<div style="display: inline;${bg};font-weight: bold;">&gt;</div>` +
+      `<div style="display: inline;${bg};"> hi                </div>`
+
+    const statusRow =
+      '<div style="display: inline;color: rgb(241, 189, 69);">status</div></div>'
+    const html = `${wrapperOpen}\n${[barRow, composerRow, barRow, statusRow].join('\n')}`
 
     // cspell:ignore truecolor
     const bindings: GhosttyNativeBindings = {
@@ -292,19 +303,25 @@ describe('ghostty render-state main bridge', () => {
         feed: vi.fn(),
         resize: vi.fn(),
         snapshot: () => ({
-          rows: 5,
+          rows: 6,
           cursorRow: 1,
           cursorCol: 4,
           visibleLines: [
             { row: 0, text: '' },
             { row: 1, text: '> hi' },
             { row: 2, text: '' },
+            { row: 3, text: 'status' },
           ],
-          // native cells: text only, no color, blank cells omitted
+          // native cells carry the bar bg on rows 0-2 (formatHtml keeps these
+          // styled-blank rows, so there is no leading-empty trim); the status
+          // row 3 is foreground-only.
           cells: [
-            { row: 1, col: 0, text: '>', width: 1 },
-            { row: 1, col: 2, text: 'h', width: 1 },
-            { row: 1, col: 3, text: 'i', width: 1 },
+            { row: 0, col: 0, text: ' ', width: 1, background: '#393947' },
+            { row: 1, col: 0, text: '>', width: 1, background: '#393947' },
+            { row: 1, col: 2, text: 'h', width: 1, background: '#393947' },
+            { row: 1, col: 3, text: 'i', width: 1, background: '#393947' },
+            { row: 2, col: 0, text: ' ', width: 1, background: '#393947' },
+            { row: 3, col: 0, text: 's', width: 1, foreground: '#f1bd45' },
           ],
         }),
         formatHtml: () => html,
@@ -323,8 +340,7 @@ describe('ghostty render-state main bridge', () => {
     )
     const cells = snapshot.cells ?? []
 
-    // every column on each composer row (0,1,2) must be covered by a cell
-    // carrying the bar background, including the blank-only top/bottom rows
+    // bar rows 0,1,2 must be fully covered by the bar background
     for (const row of [0, 1, 2]) {
       for (let col = 0; col < 20; col += 1) {
         const covering = cells.find(
@@ -334,6 +350,66 @@ describe('ghostty render-state main bridge', () => {
         expect(covering?.background, `row ${row} col ${col}`).toBe('#393947')
       }
     }
+
+    // the status row (3) must NOT receive the bar background (no bleed)
+    expect(
+      cells.some((cell) => cell.row === 3 && cell.background !== undefined)
+    ).toBe(false)
+  })
+
+  test('keeps the bar on the prompt row when formatHtml trims a truly-empty leading row (shell)', () => {
+    // A shell leaves row 0 truly empty (no text, no bg). formatHtml drops that
+    // leading blank line, so its first content line is the prompt (native row
+    // 1). The synthesis must add the trimmed leading-empty count back, or the
+    // prompt bg lands one row too high on the empty row 0.
+    const bg = 'background-color: rgb(57, 57, 71)'
+
+    const wrapperOpen =
+      '<div style="font-family: monospace; white-space: pre;">'
+    const promptRow = `<div style="display: inline;${bg};">prompt $          </div></div>`
+    // formatHtml omits the empty leading row entirely
+    const html = `${wrapperOpen}\n${promptRow}`
+
+    const bindings: GhosttyNativeBindings = {
+      createTerminal: () => ({
+        feed: vi.fn(),
+        resize: vi.fn(),
+        snapshot: () => ({
+          rows: 5,
+          cursorRow: 1,
+          cursorCol: 8,
+          visibleLines: [
+            { row: 0, text: '' },
+            { row: 1, text: 'prompt $' },
+          ],
+          cells: [
+            { row: 1, col: 0, text: 'p', width: 1, background: '#393947' },
+          ],
+        }),
+        formatHtml: () => html,
+        dispose: vi.fn(),
+      }),
+    }
+
+    const bridge = new GhosttyRenderStateMainBridge('/app', bindings)
+    const event = createEvent()
+    const createResult = requireResult(bridge.createDriver(event))
+
+    const snapshot = requireResult(
+      bridge.readSnapshot(event.sender.id, {
+        driverId: createResult.driverId,
+      })
+    )
+    const cells = snapshot.cells ?? []
+
+    // the prompt bar must be on row 1, never on the empty leading row 0
+    expect(
+      cells.some((cell) => cell.row === 0 && cell.background !== undefined)
+    ).toBe(false)
+
+    expect(
+      cells.some((cell) => cell.row === 1 && cell.background === '#393947')
+    ).toBe(true)
   })
 
   test('returns OSC7 cwd effects across byte chunks before feeding native state', () => {

--- a/electron/ghostty-render-state-main.test.ts
+++ b/electron/ghostty-render-state-main.test.ts
@@ -412,6 +412,110 @@ describe('ghostty render-state main bridge', () => {
     ).toBe(true)
   })
 
+  test('anchors the bar to the visible viewport and drops scrollback bg rows (/resume, codex with history)', () => {
+    // formatHtml carries the WHOLE terminal: scrollback (here two dimmed old
+    // composer prompts) + the visible viewport. The native snapshot carries only
+    // the 5-row viewport. With a fixed wrapper/leading offset the scrollback bar
+    // rows mapped straight onto visible history rows (the /resume "Verified:" /
+    // status bleed). The synthesis must anchor formatHtml's last content row to
+    // the snapshot's last non-blank row and drop everything above the viewport.
+    const bg = 'background-color: rgb(57, 57, 71)'
+    const dim = `${bg};opacity: 0.5`
+
+    const wrapperOpen =
+      '<div style="font-family: monospace; white-space: pre;">'
+    const barRow = `<div style="display: inline;${bg};">                    </div>`
+
+    const composerRow =
+      `<div style="display: inline;${bg};font-weight: bold;">&gt;</div>` +
+      `<div style="display: inline;${bg};"> hi                </div>`
+
+    const oldPrompt =
+      `<div style="display: inline;${dim};font-weight: bold;">&gt;</div>` +
+      `<div style="display: inline;${dim};"> old prompt         </div>`
+
+    const plain = (text: string): string =>
+      `<div style="display: inline;">${text}</div>`
+
+    const statusRow =
+      '<div style="display: inline;color: rgb(241, 189, 69);">status</div></div>'
+
+    // 8 content rows: [0..2] scrollback (incl. a dimmed bar), then the visible
+    // viewport [3..7] = old output / bar / composer / bar / status.
+    const html = `${wrapperOpen}\n${[
+      oldPrompt,
+      plain('history line a'),
+      plain('history line b'),
+      plain('old output'),
+      barRow,
+      composerRow,
+      barRow,
+      statusRow,
+    ].join('\n')}`
+
+    const bindings: GhosttyNativeBindings = {
+      createTerminal: () => ({
+        feed: vi.fn(),
+        resize: vi.fn(),
+        snapshot: () => ({
+          rows: 5,
+          cursorRow: 2,
+          cursorCol: 4,
+          // visible viewport only — the bottom 5 rows of the grid
+          visibleLines: [
+            { row: 0, text: 'old output' },
+            { row: 1, text: '' },
+            { row: 2, text: '> hi' },
+            { row: 3, text: '' },
+            { row: 4, text: 'status' },
+          ],
+          cells: [
+            { row: 1, col: 0, text: ' ', width: 1, background: '#393947' },
+            { row: 2, col: 0, text: '>', width: 1, background: '#393947' },
+            { row: 2, col: 2, text: 'h', width: 1, background: '#393947' },
+            { row: 2, col: 3, text: 'i', width: 1, background: '#393947' },
+            { row: 3, col: 0, text: ' ', width: 1, background: '#393947' },
+            { row: 4, col: 0, text: 's', width: 1, foreground: '#f1bd45' },
+          ],
+        }),
+        formatHtml: () => html,
+        dispose: vi.fn(),
+      }),
+    }
+
+    const bridge = new GhosttyRenderStateMainBridge('/app', bindings)
+    const event = createEvent()
+    const createResult = requireResult(bridge.createDriver(event))
+
+    const snapshot = requireResult(
+      bridge.readSnapshot(event.sender.id, {
+        driverId: createResult.driverId,
+      })
+    )
+    const cells = snapshot.cells ?? []
+
+    // bar rows 1,2,3 fully covered by the bar background
+    for (const row of [1, 2, 3]) {
+      for (let col = 0; col < 20; col += 1) {
+        const covering = cells.find(
+          (cell) =>
+            cell.row === row && cell.col <= col && col < cell.col + cell.width
+        )
+        expect(covering?.background, `row ${row} col ${col}`).toBe('#393947')
+      }
+    }
+
+    // visible history row 0 ('old output') and the status row 4 must stay clean —
+    // the scrollback's dimmed prompt bg must NOT bleed onto them
+    expect(
+      cells.some((cell) => cell.row === 0 && cell.background !== undefined)
+    ).toBe(false)
+
+    expect(
+      cells.some((cell) => cell.row === 4 && cell.background !== undefined)
+    ).toBe(false)
+  })
+
   test('returns OSC7 cwd effects across byte chunks before feeding native state', () => {
     const { bindings, terminals } = createNativeBindings()
     const bridge = new GhosttyRenderStateMainBridge('/app', bindings)

--- a/electron/ghostty-render-state-main.test.ts
+++ b/electron/ghostty-render-state-main.test.ts
@@ -577,6 +577,46 @@ describe('ghostty render-state main bridge', () => {
     }
   })
 
+  test('drops formatter ranges when a blank native viewport has no content anchor', () => {
+    const bg = 'background-color: rgb(57, 57, 71)'
+    const wrapperOpen =
+      '<div style="font-family: monospace; white-space: pre;">'
+    const barRow = `<div style="display: inline;${bg};">                    </div>`
+    const html = `${wrapperOpen}\n${[barRow, 'old scrollback'].join('\n')}</div>`
+
+    const bindings: GhosttyNativeBindings = {
+      createTerminal: () => ({
+        feed: vi.fn(),
+        resize: vi.fn(),
+        snapshot: () => ({
+          rows: 3,
+          cursorRow: 0,
+          cursorCol: 0,
+          visibleLines: [
+            { row: 0, text: '' },
+            { row: 1, text: '' },
+            { row: 2, text: '' },
+          ],
+          cells: [],
+        }),
+        formatHtml: () => html,
+        dispose: vi.fn(),
+      }),
+    }
+
+    const bridge = new GhosttyRenderStateMainBridge('/app', bindings)
+    const event = createEvent()
+    const createResult = requireResult(bridge.createDriver(event))
+
+    const snapshot = requireResult(
+      bridge.readSnapshot(event.sender.id, {
+        driverId: createResult.driverId,
+      })
+    )
+
+    expect(snapshot.cells).toBeUndefined()
+  })
+
   test('returns OSC7 cwd effects across byte chunks before feeding native state', () => {
     const { bindings, terminals } = createNativeBindings()
     const bridge = new GhosttyRenderStateMainBridge('/app', bindings)

--- a/electron/ghostty-render-state-main.ts
+++ b/electron/ghostty-render-state-main.ts
@@ -807,9 +807,7 @@ const hasSnapshotRowStyledCell = (
   Array.isArray(snapshot.cells) &&
   snapshot.cells.some(
     (cell) =>
-      isRecord(cell) &&
-      cell.row === rowIndex &&
-      hasRawSnapshotCellStyle(cell)
+      isRecord(cell) && cell.row === rowIndex && hasRawSnapshotCellStyle(cell)
   )
 
 const readLastSnapshotContentRow = (

--- a/electron/ghostty-render-state-main.ts
+++ b/electron/ghostty-render-state-main.ts
@@ -681,9 +681,18 @@ const appendReverseVideoRange = (
   ranges.push(range)
 }
 
+interface ReverseVideoRangesResult {
+  readonly ranges: readonly ReverseVideoRange[]
+  // Total number of terminal rows formatHtml emitted (scrollback + visible,
+  // wrapper line excluded). Used to anchor these rows onto the visible-only
+  // native snapshot — formatHtml carries the whole scrollback, the snapshot
+  // carries just the viewport, so a fixed offset cannot align them.
+  readonly contentRowCount: number
+}
+
 const readReverseVideoRangesFromHtml = (
   html: string
-): readonly ReverseVideoRange[] => {
+): ReverseVideoRangesResult => {
   const ranges: ReverseVideoRange[] = []
   const styleStack: Pick<ReverseVideoRange, 'background' | 'reverse'>[] = [{}]
   let row = 0
@@ -748,20 +757,28 @@ const readReverseVideoRangesFromHtml = (
     }
   })
 
-  return ranges
+  // `row` indexes the last terminal row the parser walked; +1 makes it a count.
+  // formatHtml trims truly-blank LEADING and TRAILING rows, so the last content
+  // row is the grid's last non-blank row.
+  return { ranges, contentRowCount: ranges.length === 0 ? 0 : row + 1 }
+}
+
+const EMPTY_REVERSE_VIDEO_RESULT: ReverseVideoRangesResult = {
+  ranges: [],
+  contentRowCount: 0,
 }
 
 const readTerminalReverseVideoRanges = (
   terminal: GhosttyNativeTerminal
-): readonly ReverseVideoRange[] => {
+): ReverseVideoRangesResult => {
   if (!terminal.formatHtml) {
-    return []
+    return EMPTY_REVERSE_VIDEO_RESULT
   }
 
   try {
     return readReverseVideoRangesFromHtml(terminal.formatHtml())
   } catch {
-    return []
+    return EMPTY_REVERSE_VIDEO_RESULT
   }
 }
 
@@ -1085,7 +1102,7 @@ const readSnapshotCells = (
 const normalizeSnapshot = (
   snapshot: GhosttyNativeTerminalSnapshot,
   cursorVisible: boolean,
-  reverseVideoRanges: readonly ReverseVideoRange[]
+  reverseVideo: ReverseVideoRangesResult
 ): GhosttyRenderStateBridgeSnapshot => {
   const rows = readSnapshotRows(snapshot)
 
@@ -1106,37 +1123,29 @@ const normalizeSnapshot = (
     columnOffset: snapshot.cursorCol,
   }
 
-  // formatHtml drops truly-blank rows that lead the grid before the first row
-  // with content (in addition to the wrapper <div> line that
-  // readReverseVideoRangesFromHtml already skips). Shift the reverse-video
-  // ranges back down by that leading count so they land on the same rows as
-  // the native snapshot — otherwise the bar bg lands one row too high on a
-  // shell (empty row 0) and one too low when the wrapper is the only lead
-  // (codex). "Content" includes a styled blank row (native bg cell), which
-  // formatHtml keeps, so a leading bar row is NOT counted. See the alignment tests.
-  const nativeBgRows = new Set<number>()
-  ;(snapshot.cells ?? []).forEach((cell) => {
-    if (
-      isRecord(cell) &&
-      cell.background !== undefined &&
-      isNonNegativeInteger(cell.row)
-    ) {
-      nativeBgRows.add(cell.row)
+  // formatHtml carries the whole terminal (scrollback + viewport) with blank
+  // leading/trailing rows trimmed; the native snapshot carries only the visible
+  // viewport. Anchor formatHtml's LAST content row to the snapshot's last
+  // non-blank row (both are the grid's last non-blank row), then shift every
+  // reverse-video range by that delta and drop rows that fall outside the
+  // viewport (scrollback above, padding below). A fixed wrapper/leading offset
+  // cannot do this: with scrollback the offset is the scrollback height (e.g.
+  // 118 rows on /resume), without it it is 0 (fresh) or -1 (shell empty row 0).
+  let lastNonBlankRow = -1
+  rows.forEach((row, index) => {
+    if (row.trim().length > 0) {
+      lastNonBlankRow = index
     }
   })
 
-  const firstContentRow = rows.findIndex(
-    (row, index) => row.trim().length > 0 || nativeBgRows.has(index)
-  )
-  const leadingEmptyRows = firstContentRow < 0 ? 0 : firstContentRow
+  const rowShift =
+    reverseVideo.contentRowCount > 0 && lastNonBlankRow >= 0
+      ? lastNonBlankRow - (reverseVideo.contentRowCount - 1)
+      : 0
 
-  const alignedRanges =
-    leadingEmptyRows === 0
-      ? reverseVideoRanges
-      : reverseVideoRanges.map((range) => ({
-          ...range,
-          row: range.row + leadingEmptyRows,
-        }))
+  const alignedRanges = reverseVideo.ranges
+    .map((range) => ({ ...range, row: range.row + rowShift }))
+    .filter((range) => range.row >= 0 && range.row < rows.length)
 
   const cells = readSnapshotCells(snapshot, rows, alignedRanges)
 

--- a/electron/ghostty-render-state-main.ts
+++ b/electron/ghostty-render-state-main.ts
@@ -760,7 +760,7 @@ const readReverseVideoRangesFromHtml = (
   // `row` indexes the last terminal row the parser walked; +1 makes it a count.
   // formatHtml trims truly-blank LEADING and TRAILING rows, so the last content
   // row is the grid's last non-blank row.
-  return { ranges, contentRowCount: ranges.length === 0 ? 0 : row + 1 }
+  return { ranges, contentRowCount: row === 0 && column === 0 ? 0 : row + 1 }
 }
 
 const EMPTY_REVERSE_VIDEO_RESULT: ReverseVideoRangesResult = {
@@ -791,6 +791,41 @@ const hasSnapshotCellStyle = (
   cell.foreground !== undefined ||
   cell.background !== undefined ||
   cell.reverse === true
+
+const hasRawSnapshotCellStyle = (cell: Record<string, unknown>): boolean =>
+  cell.bold === true ||
+  cell.italic === true ||
+  cell.underline === true ||
+  typeof cell.foreground === 'string' ||
+  typeof cell.background === 'string' ||
+  cell.reverse === true
+
+const hasSnapshotRowStyledCell = (
+  snapshot: GhosttyNativeTerminalSnapshot,
+  rowIndex: number
+): boolean =>
+  Array.isArray(snapshot.cells) &&
+  snapshot.cells.some(
+    (cell) =>
+      isRecord(cell) &&
+      cell.row === rowIndex &&
+      hasRawSnapshotCellStyle(cell)
+  )
+
+const readLastSnapshotContentRow = (
+  snapshot: GhosttyNativeTerminalSnapshot,
+  rows: readonly string[]
+): number => {
+  let lastContentRow = -1
+
+  rows.forEach((row, index) => {
+    if (row.trim().length > 0 || hasSnapshotRowStyledCell(snapshot, index)) {
+      lastContentRow = index
+    }
+  })
+
+  return lastContentRow
+}
 
 const copySnapshotCellStyle = (
   source: GhosttyRenderStateBridgeSnapshotCell,
@@ -1125,22 +1160,18 @@ const normalizeSnapshot = (
 
   // formatHtml carries the whole terminal (scrollback + viewport) with blank
   // leading/trailing rows trimmed; the native snapshot carries only the visible
-  // viewport. Anchor formatHtml's LAST content row to the snapshot's last
-  // non-blank row (both are the grid's last non-blank row), then shift every
-  // reverse-video range by that delta and drop rows that fall outside the
-  // viewport (scrollback above, padding below). A fixed wrapper/leading offset
-  // cannot do this: with scrollback the offset is the scrollback height (e.g.
-  // 118 rows on /resume), without it it is 0 (fresh) or -1 (shell empty row 0).
-  let lastNonBlankRow = -1
-  rows.forEach((row, index) => {
-    if (row.trim().length > 0) {
-      lastNonBlankRow = index
-    }
-  })
+  // viewport. Anchor formatHtml's LAST content row to the snapshot's last row
+  // with text OR native styling, then shift every reverse-video range by that
+  // delta and drop rows that fall outside the viewport (scrollback above,
+  // padding below). Styled-blank rows are content in formatHtml even though the
+  // snapshot row text trims empty. A fixed wrapper/leading offset cannot do
+  // this: with scrollback the offset is the scrollback height (e.g. 118 rows on
+  // /resume), without it it is 0 (fresh) or -1 (shell empty row 0).
+  const lastContentRow = readLastSnapshotContentRow(snapshot, rows)
 
   const rowShift =
-    reverseVideo.contentRowCount > 0 && lastNonBlankRow >= 0
-      ? lastNonBlankRow - (reverseVideo.contentRowCount - 1)
+    reverseVideo.contentRowCount > 0 && lastContentRow >= 0
+      ? lastContentRow - (reverseVideo.contentRowCount - 1)
       : 0
 
   const alignedRanges = reverseVideo.ranges

--- a/electron/ghostty-render-state-main.ts
+++ b/electron/ghostty-render-state-main.ts
@@ -1166,15 +1166,17 @@ const normalizeSnapshot = (
   // this: with scrollback the offset is the scrollback height (e.g. 118 rows on
   // /resume), without it it is 0 (fresh) or -1 (shell empty row 0).
   const lastContentRow = readLastSnapshotContentRow(snapshot, rows)
+  const canAlign = reverseVideo.contentRowCount > 0 && lastContentRow >= 0
 
-  const rowShift =
-    reverseVideo.contentRowCount > 0 && lastContentRow >= 0
-      ? lastContentRow - (reverseVideo.contentRowCount - 1)
-      : 0
+  const rowShift = canAlign
+    ? lastContentRow - (reverseVideo.contentRowCount - 1)
+    : 0
 
-  const alignedRanges = reverseVideo.ranges
-    .map((range) => ({ ...range, row: range.row + rowShift }))
-    .filter((range) => range.row >= 0 && range.row < rows.length)
+  const alignedRanges = canAlign
+    ? reverseVideo.ranges
+        .map((range) => ({ ...range, row: range.row + rowShift }))
+        .filter((range) => range.row >= 0 && range.row < rows.length)
+    : []
 
   const cells = readSnapshotCells(snapshot, rows, alignedRanges)
 

--- a/electron/ghostty-render-state-main.ts
+++ b/electron/ghostty-render-state-main.ts
@@ -1127,6 +1127,10 @@ const readSnapshotCells = (
 
   appendMissingReverseCells(cells, rows, reverseVideoRanges)
 
+  if (cells.length === 0) {
+    return undefined
+  }
+
   return cells.sort((left, right) =>
     left.row === right.row ? left.col - right.col : left.row - right.row
   )

--- a/electron/ghostty-render-state-main.ts
+++ b/electron/ghostty-render-state-main.ts
@@ -688,6 +688,7 @@ const readReverseVideoRangesFromHtml = (
   const styleStack: Pick<ReverseVideoRange, 'background' | 'reverse'>[] = [{}]
   let row = 0
   let column = 0
+  let skippedWrapperNewline = false
 
   Array.from(html.matchAll(HTML_TOKEN_PATTERN)).forEach((match) => {
     const token = match[0]
@@ -717,6 +718,16 @@ const readReverseVideoRangesFromHtml = (
 
     for (const character of decodeHtmlText(token)) {
       if (character === '\n') {
+        // formatHtml wraps all rows in an outer <div ...> whose opening tag
+        // sits on its own line, ending with a structural newline before the
+        // first terminal row. Counting it shifts every range down one row
+        // (the composer bar bg bleeds onto the status line below). Skip that
+        // one leading newline so range rows align with the native snapshot.
+        if (!skippedWrapperNewline && row === 0 && column === 0) {
+          skippedWrapperNewline = true
+          continue
+        }
+
         row += 1
         column = 0
         continue
@@ -1094,7 +1105,40 @@ const normalizeSnapshot = (
     rowIndex: snapshot.cursorRow,
     columnOffset: snapshot.cursorCol,
   }
-  const cells = readSnapshotCells(snapshot, rows, reverseVideoRanges)
+
+  // formatHtml drops truly-blank rows that lead the grid before the first row
+  // with content (in addition to the wrapper <div> line that
+  // readReverseVideoRangesFromHtml already skips). Shift the reverse-video
+  // ranges back down by that leading count so they land on the same rows as
+  // the native snapshot — otherwise the bar bg lands one row too high on a
+  // shell (empty row 0) and one too low when the wrapper is the only lead
+  // (codex). "Content" includes a styled blank row (native bg cell), which
+  // formatHtml keeps, so a leading bar row is NOT counted. See the alignment tests.
+  const nativeBgRows = new Set<number>()
+  ;(snapshot.cells ?? []).forEach((cell) => {
+    if (
+      isRecord(cell) &&
+      cell.background !== undefined &&
+      isNonNegativeInteger(cell.row)
+    ) {
+      nativeBgRows.add(cell.row)
+    }
+  })
+
+  const firstContentRow = rows.findIndex(
+    (row, index) => row.trim().length > 0 || nativeBgRows.has(index)
+  )
+  const leadingEmptyRows = firstContentRow < 0 ? 0 : firstContentRow
+
+  const alignedRanges =
+    leadingEmptyRows === 0
+      ? reverseVideoRanges
+      : reverseVideoRanges.map((range) => ({
+          ...range,
+          row: range.row + leadingEmptyRows,
+        }))
+
+  const cells = readSnapshotCells(snapshot, rows, alignedRanges)
 
   return {
     rows,

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
@@ -268,6 +268,97 @@ describe('ghosttyInstance', () => {
     expect(cursor?.previousSibling?.textContent).toBe('rendered')
   })
 
+  test('re-arms held VT render-state flushes until the failsafe paints', () => {
+    const animationFrames: FrameRequestCallback[] = []
+
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      animationFrames.push(callback)
+
+      return animationFrames.length
+    })
+
+    const created = createTrackedGhosttyTerminal({
+      createVtRenderStateDriver: (): GhosttyVtRenderStateDriver => ({
+        writeBytes: vi.fn(),
+        readSnapshot: () => ({
+          rows: ['failsafe frame'],
+          cursor: {
+            rowIndex: 0,
+            columnOffset: 8,
+          },
+        }),
+      }),
+    })
+
+    created.output.writeOutput({
+      text: 'lossy fallback',
+      bytesBase64: encodeText('\x1b[?2026h redraw without close'),
+      offsetStart: 0,
+      byteLen: 28,
+      phase: 'live',
+    })
+
+    for (let index = 0; index < 9; index += 1) {
+      const frame = animationFrames.shift()
+
+      if (frame === undefined) {
+        throw new Error(`Expected frame ${index} to be scheduled`)
+      }
+
+      frame(index)
+    }
+
+    expect(created.viewportReader.readVisibleText()).toBe('failsafe frame')
+  })
+
+  test('cancels queued microtask render flushes when clearing', async () => {
+    vi.stubGlobal('requestAnimationFrame', undefined)
+    vi.stubGlobal('cancelAnimationFrame', undefined)
+
+    const parser: TerminalParser = {
+      onEvent: (): TerminalDisposable => ({ dispose: vi.fn() }),
+    }
+
+    const flushOutput = vi.fn((): TerminalParserEngineOutput => ({
+      visibleText: 'stale render',
+    }))
+    const reset = vi.fn()
+
+    const created = createTrackedGhosttyTerminal({
+      createParserEngine: () => ({
+        inputMode: 'bytes' as const,
+        capabilities: ghosttyTerminalRenderer.capabilities,
+        parser,
+        parseText: (text: string): TerminalParserEngineOutput => ({
+          visibleText: text,
+        }),
+        parseInput: (
+          input: TerminalParserEngineInput
+        ): TerminalParserEngineOutput => ({
+          visibleText: input.text,
+        }),
+        parseOutput: (): TerminalParserEngineOutput => ({ visibleText: '' }),
+        flushOutput,
+        reset,
+      }),
+    })
+
+    created.output.writeOutput({
+      text: 'pending',
+      bytesBase64: encodeText('pending'),
+      offsetStart: 0,
+      byteLen: 7,
+      phase: 'live',
+    })
+    created.terminal.clear()
+
+    await Promise.resolve()
+
+    expect(reset).toHaveBeenCalledOnce()
+    expect(flushOutput).not.toHaveBeenCalled()
+    expect(created.viewportReader.readVisibleText()).toBe('')
+  })
+
   test('syncs terminal size and clear resets into the VT render-state driver', () => {
     const reset = vi.fn()
     const resize = vi.fn()

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
@@ -1,5 +1,5 @@
 // cspell:ignore ghostty xhigh
-import { afterEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import type {
   TerminalDisposable,
   TerminalOutputChunk,
@@ -20,6 +20,22 @@ import {
 import type { GhosttyVtRenderStateDriver } from './ghosttyVtRenderStateDriver'
 import { createGhosttyVtRenderSnapshotOutput } from './ghosttyVtRenderSnapshot'
 import { GHOSTTY_TERMINAL_CAPABILITIES } from './terminalRendererCapabilities'
+
+// The render-state byte path coalesces rendering to requestAnimationFrame.
+// Run rAF synchronously so these tests can assert the rendered surface right
+// after writeOutput; the coalescing itself is covered in the driver tests.
+beforeEach(() => {
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    callback(0)
+
+    return 0
+  })
+  vi.stubGlobal('cancelAnimationFrame', () => undefined)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
 const setElementSize = (
   element: HTMLElement,
@@ -1343,9 +1359,7 @@ describe('ghosttyInstance', () => {
     expect(blankRun?.style.backgroundColor).toBe(TRUE_COLOR_BASE)
     expect(blankRun?.style.display).toBe('inline-block')
     expect(blankRun?.style.height).toBe('var(--terminal-line-height)')
-    expect(blankRun?.style.minWidth).toBe(
-      'calc(var(--terminal-cell-width) * 1)'
-    )
+    expect(blankRun?.style.width).toBe('calc(var(--terminal-cell-width) * 1)')
     expect(blankRun?.style.overflow).toBe('visible')
   })
 
@@ -1403,7 +1417,7 @@ describe('ghosttyInstance', () => {
       '> Explain this codebase   '
     )
 
-    expect(backgroundRuns.map((run) => run.style.minWidth)).toEqual([
+    expect(backgroundRuns.map((run) => run.style.width)).toEqual([
       'calc(var(--terminal-cell-width) * 1)',
       'calc(var(--terminal-cell-width) * 24)',
     ])
@@ -1465,7 +1479,7 @@ describe('ghosttyInstance', () => {
       '> Explain this codebase   '
     )
 
-    expect(reverseRuns.map((run) => run.style.minWidth)).toEqual([
+    expect(reverseRuns.map((run) => run.style.width)).toEqual([
       'calc(var(--terminal-cell-width) * 1)',
       'calc(var(--terminal-cell-width) * 24)',
     ])

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.test.ts
@@ -319,9 +319,11 @@ describe('ghosttyInstance', () => {
       onEvent: (): TerminalDisposable => ({ dispose: vi.fn() }),
     }
 
-    const flushOutput = vi.fn((): TerminalParserEngineOutput => ({
-      visibleText: 'stale render',
-    }))
+    const flushOutput = vi.fn(
+      (): TerminalParserEngineOutput => ({
+        visibleText: 'stale render',
+      })
+    )
     const reset = vi.fn()
 
     const created = createTrackedGhosttyTerminal({

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.ts
@@ -50,6 +50,8 @@ class GhosttyTerminalModel {
   private isDisposed = false
   private isRendererDisposed = false
   private syncedParserEngineSize: TerminalSize | null = null
+  private renderFlushScheduled = false
+  private renderFlushHandle: number | null = null
   readonly terminal: TerminalTextSurface
   readonly parser: TerminalParser
 
@@ -73,6 +75,7 @@ class GhosttyTerminalModel {
 
     const originalTerminalClear = this.terminal.clear.bind(this.terminal)
     this.terminal.clear = (): void => {
+      this.cancelRenderFlush()
       originalTerminalClear()
       this.parserEngine.reset?.()
       this.syncParserEngineSize({ force: true })
@@ -85,6 +88,7 @@ class GhosttyTerminalModel {
       }
 
       this.isDisposed = true
+      this.cancelRenderFlush()
       originalTerminalDispose()
       this.parserEngine.dispose?.()
     }
@@ -100,10 +104,64 @@ class GhosttyTerminalModel {
         return
       }
 
+      // Feed bytes synchronously — OSC7 effects + 2026 tracking happen here.
+      // Synchronous parsers return their render delta now; the render-state
+      // byte path returns empty and renders later via flushOutput.
       const output = this.parserEngine.parseOutput(chunk)
-
       this.terminal.writeParsedOutput(output, callback)
+
+      // Coalesce the render-state snapshot read + render to one per animation
+      // frame so transient mid-redraw frames are never painted. A no-op for the
+      // synchronous path (its flushOutput returns null).
+      if (this.parserEngine.flushOutput) {
+        this.scheduleRenderFlush()
+      }
     },
+  }
+
+  private scheduleRenderFlush(): void {
+    if (this.renderFlushScheduled) {
+      return
+    }
+
+    this.renderFlushScheduled = true
+
+    const flush = (): void => {
+      this.renderFlushScheduled = false
+      this.renderFlushHandle = null
+      this.flushRender()
+    }
+
+    if (typeof requestAnimationFrame === 'function') {
+      this.renderFlushHandle = requestAnimationFrame(flush)
+    } else {
+      // Non-browser (tests): fall back to a microtask.
+      queueMicrotask(flush)
+    }
+  }
+
+  private cancelRenderFlush(): void {
+    if (
+      this.renderFlushHandle !== null &&
+      typeof cancelAnimationFrame === 'function'
+    ) {
+      cancelAnimationFrame(this.renderFlushHandle)
+    }
+
+    this.renderFlushScheduled = false
+    this.renderFlushHandle = null
+  }
+
+  private flushRender(): void {
+    if (this.terminal.isDisposed()) {
+      return
+    }
+
+    const output = this.parserEngine.flushOutput?.()
+
+    if (output) {
+      this.terminal.writeParsedOutput(output)
+    }
   }
 
   readonly viewportReader: TerminalViewportReader = {

--- a/src/features/terminal/components/TerminalPane/ghosttyInstance.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyInstance.ts
@@ -52,6 +52,7 @@ class GhosttyTerminalModel {
   private syncedParserEngineSize: TerminalSize | null = null
   private renderFlushScheduled = false
   private renderFlushHandle: number | null = null
+  private renderFlushToken = 0
   readonly terminal: TerminalTextSurface
   readonly parser: TerminalParser
 
@@ -125,8 +126,13 @@ class GhosttyTerminalModel {
     }
 
     this.renderFlushScheduled = true
+    const flushToken = this.renderFlushToken
 
     const flush = (): void => {
+      if (flushToken !== this.renderFlushToken) {
+        return
+      }
+
       this.renderFlushScheduled = false
       this.renderFlushHandle = null
       this.flushRender()
@@ -148,6 +154,7 @@ class GhosttyTerminalModel {
       cancelAnimationFrame(this.renderFlushHandle)
     }
 
+    this.renderFlushToken += 1
     this.renderFlushScheduled = false
     this.renderFlushHandle = null
   }
@@ -161,6 +168,12 @@ class GhosttyTerminalModel {
 
     if (output) {
       this.terminal.writeParsedOutput(output)
+
+      return
+    }
+
+    if (this.parserEngine.hasPendingOutput?.()) {
+      this.scheduleRenderFlush()
     }
   }
 

--- a/src/features/terminal/components/TerminalPane/ghosttyParserEngine.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyParserEngine.ts
@@ -26,6 +26,7 @@ export interface GhosttyByteParserAdapter {
     input: GhosttyByteParserAdapterInput
   ) => TerminalParserEngineOutput
   flushOutput?: () => TerminalParserEngineOutput | null
+  hasPendingOutput?: () => boolean
   reset?: () => void
   resize?: (size: TerminalSize) => void
   dispose?: () => void
@@ -137,6 +138,14 @@ export class GhosttyControlSequenceParserEngine
     }
 
     return this.byteParserAdapter.flushOutput?.() ?? null
+  }
+
+  hasPendingOutput(): boolean {
+    if (this.isDisposed) {
+      return false
+    }
+
+    return this.byteParserAdapter.hasPendingOutput?.() ?? false
   }
 
   reset(): void {

--- a/src/features/terminal/components/TerminalPane/ghosttyParserEngine.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyParserEngine.ts
@@ -25,6 +25,7 @@ export interface GhosttyByteParserAdapter {
   parseBytes: (
     input: GhosttyByteParserAdapterInput
   ) => TerminalParserEngineOutput
+  flushOutput?: () => TerminalParserEngineOutput | null
   reset?: () => void
   resize?: (size: TerminalSize) => void
   dispose?: () => void
@@ -128,6 +129,14 @@ export class GhosttyControlSequenceParserEngine
     this.byteParserAdapter.reset?.()
 
     return super.parseInput(input)
+  }
+
+  flushOutput(): TerminalParserEngineOutput | null {
+    if (this.isDisposed) {
+      return null
+    }
+
+    return this.byteParserAdapter.flushOutput?.() ?? null
   }
 
   reset(): void {

--- a/src/features/terminal/components/TerminalPane/ghosttyVtByteParserAdapter.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtByteParserAdapter.ts
@@ -23,6 +23,7 @@ export interface GhosttyVtParserDriver {
    * synchronized-output frame).
    */
   flushOutput?: () => TerminalParserEngineOutput | null
+  hasPendingOutput?: () => boolean
   reset?: () => void
   resize?: (size: TerminalSize) => void
   dispose?: () => void
@@ -61,6 +62,14 @@ export class GhosttyVtByteParserAdapter implements GhosttyByteParserAdapter {
     }
 
     return this.driver.flushOutput?.() ?? null
+  }
+
+  hasPendingOutput(): boolean {
+    if (this.isDisposed) {
+      return false
+    }
+
+    return this.driver.hasPendingOutput?.() ?? false
   }
 
   reset(): void {

--- a/src/features/terminal/components/TerminalPane/ghosttyVtByteParserAdapter.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtByteParserAdapter.ts
@@ -12,12 +12,17 @@ export interface GhosttyVtParserEffects {
 
 export interface GhosttyVtParserDriver {
   /**
-   * Consume raw PTY bytes and return renderer-delta output for the text surface.
-   *
-   * A full libghostty-vt terminal bridge should diff terminal/render state before
-   * returning so callers do not append a whole-screen snapshot per chunk.
+   * Consume raw PTY bytes. Feeds terminal state and fires effects synchronously;
+   * the render output is produced by `flushOutput` so a burst of redraw chunks
+   * coalesces into one render per animation frame.
    */
   writeBytes: (bytes: Uint8Array) => TerminalParserEngineOutput
+  /**
+   * Return the latest pending render output (the settled snapshot), or `null`
+   * when nothing new should paint yet (no new bytes, or still inside an open
+   * synchronized-output frame).
+   */
+  flushOutput?: () => TerminalParserEngineOutput | null
   reset?: () => void
   resize?: (size: TerminalSize) => void
   dispose?: () => void
@@ -48,6 +53,14 @@ export class GhosttyVtByteParserAdapter implements GhosttyByteParserAdapter {
     } finally {
       this.activeInput = null
     }
+  }
+
+  flushOutput(): TerminalParserEngineOutput | null {
+    if (this.isDisposed) {
+      return null
+    }
+
+    return this.driver.flushOutput?.() ?? null
   }
 
   reset(): void {

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
@@ -24,7 +24,7 @@ const createInput = (
 })
 
 describe('ghosttyVtRenderStateDriver', () => {
-  test('bridges driver-owned render state into replace snapshot output', () => {
+  test('feeds bytes on parseBytes and renders the snapshot only on flushOutput', () => {
     const writeBytes = vi.fn()
 
     const readSnapshot = vi.fn(() => ({
@@ -35,14 +35,22 @@ describe('ghosttyVtRenderStateDriver', () => {
       },
     }))
 
-    const adapter = createGhosttyVtRenderStateByteParserAdapter(() => ({
-      writeBytes,
-      readSnapshot,
-    }))
+    const adapter = createGhosttyVtRenderStateByteParserAdapter(
+      (): GhosttyVtRenderStateDriver => ({
+        writeBytes,
+        readSnapshot,
+      })
+    )
 
     const bytes = new Uint8Array([0x70, 0x74, 0x79])
 
-    expect(adapter.parseBytes(createInput(bytes))).toEqual({
+    // parseBytes feeds synchronously and defers rendering
+    expect(adapter.parseBytes(createInput(bytes))).toEqual({ visibleText: '' })
+    expect(writeBytes).toHaveBeenCalledWith(bytes)
+    expect(readSnapshot).not.toHaveBeenCalled()
+
+    // flushOutput reads the settled snapshot once and renders it
+    expect(adapter.flushOutput?.()).toEqual({
       visibleText: 'prompt\noutput',
       displayDelta: {
         operations: [
@@ -54,8 +62,42 @@ describe('ghosttyVtRenderStateDriver', () => {
         ],
       },
     })
-    expect(writeBytes).toHaveBeenCalledWith(bytes)
     expect(readSnapshot).toHaveBeenCalledOnce()
+  })
+
+  test('coalesces multiple chunks into one flushed render of the latest state', () => {
+    let snapshotReads = 0
+    const writeBytes = vi.fn()
+
+    const adapter = createGhosttyVtRenderStateByteParserAdapter(
+      (): GhosttyVtRenderStateDriver => ({
+        writeBytes,
+        readSnapshot: (): GhosttyVtRenderSnapshot => {
+          snapshotReads += 1
+
+          return {
+            rows: [`frame${snapshotReads}`],
+            cursor: { rowIndex: 0, columnOffset: 0 },
+          }
+        },
+      })
+    )
+    const encode = (text: string): Uint8Array => new TextEncoder().encode(text)
+
+    // three chunks fed without an intervening flush -> no snapshot reads
+    adapter.parseBytes(createInput(encode('a')))
+    adapter.parseBytes(createInput(encode('b')))
+    adapter.parseBytes(createInput(encode('c')))
+    expect(writeBytes).toHaveBeenCalledTimes(3)
+    expect(snapshotReads).toBe(0)
+
+    // one flush -> one snapshot read
+    expect(adapter.flushOutput?.()?.visibleText).toBe('frame1')
+    expect(snapshotReads).toBe(1)
+
+    // a flush with no new bytes paints nothing
+    expect(adapter.flushOutput?.()).toBeNull()
+    expect(snapshotReads).toBe(1)
   })
 
   test('can be injected behind the Ghostty parser engine byte path', () => {
@@ -77,6 +119,7 @@ describe('ghosttyVtRenderStateDriver', () => {
     const parserEngine = createGhosttyParserEngine({ byteParserAdapter })
     const bytes = new Uint8Array([0xff, 0xfe])
 
+    // parseInput feeds (returns empty); flushOutput produces the render
     expect(
       parserEngine.parseInput({
         inputMode: 'bytes',
@@ -84,7 +127,10 @@ describe('ghosttyVtRenderStateDriver', () => {
         text: 'lossy fallback',
         output: null,
       })
-    ).toEqual({
+    ).toEqual({ visibleText: '' })
+    expect(writeBytes).toHaveBeenCalledWith(bytes)
+
+    expect(parserEngine.flushOutput?.()).toEqual({
       visibleText: 'vt prompt',
       displayDelta: {
         operations: [
@@ -96,7 +142,6 @@ describe('ghosttyVtRenderStateDriver', () => {
         ],
       },
     })
-    expect(writeBytes).toHaveBeenCalledWith(bytes)
   })
 
   test('keeps cwd effects on the parser event path', () => {
@@ -172,15 +217,13 @@ describe('ghosttyVtRenderStateDriver', () => {
     const encode = (text: string): Uint8Array => new TextEncoder().encode(text)
 
     // chunk ends inside an open 2026 frame (clear sent, redraw pending)
-    expect(
-      adapter.parseBytes(createInput(encode('\x1b[?2026h\x1b[2J partial')))
-    ).toEqual({ visibleText: '' })
+    adapter.parseBytes(createInput(encode('\x1b[?2026h\x1b[2J partial')))
+    expect(adapter.flushOutput?.()).toBeNull()
     expect(snapshotReads).toBe(0)
 
-    // closing chunk completes the frame -> full render
-    expect(
-      adapter.parseBytes(createInput(encode('redraw\x1b[?2026l')))
-    ).toEqual({
+    // closing chunk completes the frame -> flush renders it
+    adapter.parseBytes(createInput(encode('redraw\x1b[?2026l')))
+    expect(adapter.flushOutput?.()).toEqual({
       visibleText: 'composer',
       displayDelta: {
         operations: [{ type: 'replace', text: 'composer', cursorOffset: 2 }],
@@ -189,7 +232,7 @@ describe('ghosttyVtRenderStateDriver', () => {
     expect(snapshotReads).toBe(1)
   })
 
-  test('failsafe renders if a 2026 frame never closes', () => {
+  test('failsafe flushes if a 2026 frame never closes', () => {
     const adapter = createGhosttyVtRenderStateByteParserAdapter(
       (): GhosttyVtRenderStateDriver => ({
         writeBytes: vi.fn(),
@@ -201,14 +244,17 @@ describe('ghosttyVtRenderStateDriver', () => {
     )
     const encode = (text: string): Uint8Array => new TextEncoder().encode(text)
 
-    let output = adapter.parseBytes(createInput(encode('\x1b[?2026h open')))
-    // 8 held chunks, then the failsafe forces a render on the 9th
-    for (let index = 0; index < 8; index += 1) {
-      output = adapter.parseBytes(createInput(encode('still drawing')))
+    // open a 2026 frame and never close it
+    adapter.parseBytes(createInput(encode('\x1b[?2026h open')))
+
+    // first 8 flushes are held; the failsafe forces a render on the 9th
+    let output: ReturnType<NonNullable<typeof adapter.flushOutput>> = null
+    for (let index = 0; index < 9; index += 1) {
+      output = adapter.flushOutput?.() ?? null
     }
 
-    expect(output).not.toEqual({ visibleText: '' })
-    expect(output.visibleText).toBe('held')
+    expect(output).not.toBeNull()
+    expect(output?.visibleText).toBe('held')
   })
 
   test('rejects text input instead of falling back to the text parser', () => {

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
@@ -257,6 +257,33 @@ describe('ghosttyVtRenderStateDriver', () => {
     expect(output?.visibleText).toBe('held')
   })
 
+  test('reports pending output while a 2026 frame is held', () => {
+    const adapter = createGhosttyVtRenderStateByteParserAdapter(
+      (): GhosttyVtRenderStateDriver => ({
+        writeBytes: vi.fn(),
+        readSnapshot: (): GhosttyVtRenderSnapshot => ({
+          rows: ['held'],
+          cursor: { rowIndex: 0, columnOffset: 0 },
+        }),
+      })
+    )
+    const encode = (text: string): Uint8Array => new TextEncoder().encode(text)
+
+    adapter.parseBytes(createInput(encode('\x1b[?2026h open')))
+
+    expect(adapter.hasPendingOutput?.()).toBe(true)
+    expect(adapter.flushOutput?.()).toBeNull()
+    expect(adapter.hasPendingOutput?.()).toBe(true)
+
+    let output: ReturnType<NonNullable<typeof adapter.flushOutput>> = null
+    for (let index = 0; index < 8; index += 1) {
+      output = adapter.flushOutput?.() ?? null
+    }
+
+    expect(output?.visibleText).toBe('held')
+    expect(adapter.hasPendingOutput?.()).toBe(false)
+  })
+
   test('rejects text input instead of falling back to the text parser', () => {
     const writeBytes = vi.fn()
     const reset = vi.fn()

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
@@ -93,6 +93,7 @@ export const createGhosttyVtRenderStateParserDriverFactory =
           renderStateDriver.readSnapshot()
         )
       },
+      hasPendingOutput: (): boolean => dirty,
       reset: (): void => {
         syncFrameState = createSyncFrameParserState()
         heldFlushes = 0

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
@@ -21,12 +21,13 @@ import {
 } from './terminalSyncFrame'
 import type { TerminalParserEngineOutput } from './terminalParserEngine'
 
-// No-op render output: holds the surface on its last complete frame.
+// No-op render output: byte feed is synchronous, but the actual render is
+// produced by flushOutput (coalesced to one per animation frame).
 const EMPTY_RENDER_OUTPUT: TerminalParserEngineOutput = { visibleText: '' }
 
-// Failsafe: render even while "inside" a 2026 frame after this many held
-// chunks, so a missed close marker can never freeze the surface.
-const MAX_SUPPRESSED_FRAMES = 8
+// Failsafe: flush even while "inside" a 2026 frame after this many held
+// flushes, so a missed close marker can never freeze the surface.
+const MAX_HELD_FLUSHES = 8
 
 export interface GhosttyVtRenderStateDriver {
   /**
@@ -58,26 +59,35 @@ export const createGhosttyVtRenderStateParserDriverFactory =
   (effects): GhosttyVtParserDriver => {
     const renderStateDriver = createRenderStateDriver(effects)
     let syncFrameState = createSyncFrameParserState()
-    let suppressedFrames = 0
+    let heldFlushes = 0
+    let dirty = false
 
     return {
       writeBytes: (bytes): TerminalParserEngineOutput => {
+        // Feed bytes + track 2026 synchronously (effects fire here, per chunk).
+        // Defer the snapshot read+render to flushOutput so a burst of redraw
+        // chunks coalesces into a single render per animation frame.
         renderStateDriver.writeBytes(bytes)
-
         syncFrameState = readSyncFrameState(bytes, syncFrameState)
+        dirty = true
 
-        // Inside a synchronized-output frame the redraw is mid-flight; holding
-        // the last complete frame avoids rendering a torn/blank intermediate.
-        if (
-          syncFrameState.insideFrame &&
-          suppressedFrames < MAX_SUPPRESSED_FRAMES
-        ) {
-          suppressedFrames += 1
-
-          return EMPTY_RENDER_OUTPUT
+        return EMPTY_RENDER_OUTPUT
+      },
+      flushOutput: (): TerminalParserEngineOutput | null => {
+        if (!dirty) {
+          return null
         }
 
-        suppressedFrames = 0
+        // Inside an open synchronized-output frame the redraw is mid-flight;
+        // hold the last complete frame instead of painting a torn intermediate.
+        if (syncFrameState.insideFrame && heldFlushes < MAX_HELD_FLUSHES) {
+          heldFlushes += 1
+
+          return null
+        }
+
+        heldFlushes = 0
+        dirty = false
 
         return createGhosttyVtRenderSnapshotOutput(
           renderStateDriver.readSnapshot()
@@ -85,7 +95,8 @@ export const createGhosttyVtRenderStateParserDriverFactory =
       },
       reset: (): void => {
         syncFrameState = createSyncFrameParserState()
-        suppressedFrames = 0
+        heldFlushes = 0
+        dirty = false
         renderStateDriver.reset?.()
       },
       resize: (size): void => {

--- a/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
+++ b/src/features/terminal/components/TerminalPane/plainTextInstance.test.ts
@@ -184,7 +184,7 @@ describe('plainTextInstance', () => {
     expect(marker?.style.borderLeft).toBe('')
     expect(marker?.style.animationName).toBe('vfTerminalCursorBlink')
     expect(marker?.style.position).toBe('absolute')
-    expect(marker?.style.width).toBe('0.62em')
+    expect(marker?.style.width).toBe('var(--terminal-cell-width)')
     expect(created.viewportReader.readVisibleText()).toBe('abc')
   })
 

--- a/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
+++ b/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
@@ -51,6 +51,7 @@ export interface TerminalParserEngine {
    * synchronously from `parseOutput` return `null` (or omit this).
    */
   flushOutput?: () => TerminalParserEngineOutput | null
+  hasPendingOutput?: () => boolean
   reset?: () => void
   resize?: (size: TerminalSize) => void
   dispose?: () => void

--- a/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
+++ b/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
@@ -43,6 +43,14 @@ export interface TerminalParserEngine {
   ) => TerminalParserEngineOutput
   parseInput: (input: TerminalParserEngineInput) => TerminalParserEngineOutput
   parseOutput: (chunk: TerminalOutputChunk) => TerminalParserEngineOutput
+  /**
+   * Coalesced render flush. Engines that defer rendering (e.g. the native
+   * render-state byte path, which feeds bytes per chunk but reads the snapshot
+   * once per animation frame) return the latest pending render output here, or
+   * `null` when there is nothing new to paint. Engines that render
+   * synchronously from `parseOutput` return `null` (or omit this).
+   */
+  flushOutput?: () => TerminalParserEngineOutput | null
   reset?: () => void
   resize?: (size: TerminalSize) => void
   dispose?: () => void

--- a/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
+++ b/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
@@ -863,7 +863,9 @@ export class TerminalTextSurface implements TerminalSurface {
       left: '0',
       position: 'absolute',
       top: '0',
-      width: '0.62em',
+      // Overlay exactly one terminal cell so the block cursor stays on the grid
+      // (a fixed em guess drifts off the measured monospace cell width).
+      width: 'var(--terminal-cell-width)',
     })
 
     cursor.append(marker)
@@ -898,7 +900,10 @@ export class TerminalTextSurface implements TerminalSurface {
       element.style.display = 'inline-block'
       element.style.height = 'var(--terminal-line-height)'
       element.style.lineHeight = 'var(--terminal-line-height)'
-      element.style.minWidth = `calc(var(--terminal-cell-width) * ${cellWidth})`
+      // Fixed cell geometry: a styled cell must occupy exactly its column span,
+      // not just a minimum, so backgrounds/reverse cells stay on the grid
+      // instead of drifting with proportional glyph metrics.
+      element.style.width = `calc(var(--terminal-cell-width) * ${cellWidth})`
       element.style.overflow = 'visible'
       element.style.verticalAlign = 'top'
     }


### PR DESCRIPTION
## Summary

Ghostty native render-path fidelity fixes for the Codex composer input area. After these, the
input box renders correctly and stays steady across **codex start → MCP loading → `/resume`**
(manual smoke confirmed). Part of **VIM-139** (Ghostty Terminal Migration, M5 render fidelity).
Stacks on #608 (OSC 10/11 + DEC 2026), which is already merged into the umbrella.

## What changed (4 commits)

1. **perf: coalesce render-state snapshots to one per animation frame** — feed PTY bytes per
   chunk (OSC7 + DEC 2026 stay synchronous) but defer the snapshot read+render to a single rAF
   flush, so a burst of redraw chunks (MCP loading / model switch) no longer paints transient
   "composer jumped to the top" intermediates. Reconciled with #608's carry-aware 2026 state.
2. **fix: fixed-cell geometry** — styled cells use exact `width` (not `min-width`) and the block
   cursor is a 1-cell overlay, so a colored run can't expand the grid into a stray block.
3. **fix: align bg-synthesis rows with formatHtml row trimming** — handle the wrapper `<div>`
   line + trimmed blank leading rows.
4. **fix: anchor bg synthesis to the visible viewport (drop scrollback)** — the real root cause
   of the "gray bar bleeding onto history / status" the moment Codex had output.

## Root cause (commit 4)

`formatHtml()` emits the **whole terminal** (scrollback + viewport, blank leading/trailing rows
trimmed); the native `snapshot()` carries only the **visible viewport**. With scrollback (Codex
mid-response or `/resume`) formatHtml has far more rows than the snapshot — e.g. 146 vs 30 — so a
fixed offset mapped scrollback bg rows (old dimmed `›` prompts at `opacity:0.5`) straight onto
visible history + status rows. Fresh-idle sessions have no scrollback, which is why earlier
captures looked clean while the live app bled.

**Fix:** anchor formatHtml's last content row to the snapshot's last non-blank row (both are the
grid's last non-blank row), shift every reverse-video range by that delta, and drop ranges
outside the viewport. Subsumes the fresh (Δ0) and shell-empty-row-0 (Δ−1) cases and adds correct
`/resume` (Δ = scrollback height) handling.

## Test plan

- New mutation-checked regression test: scrollback bar rows are dropped; visible history + status
  rows stay clean (`electron/ghostty-render-state-main.test.ts`).
- Verified by replaying 5 **real** captured Codex/shell sessions (fresh light/dark, `/resume`,
  shell powerline, theme-switch) through the real bridge + libghostty + `formatHtml`.
- Full terminal suite green; repo-wide lint / prettier / type-check green.
- Manual smoke (light mode): composer correct + steady across start, MCP load, `/resume`; shell
  starship powerline renders all segments; status line never shaded.
- Loop documented in `docs/debug/2026-06-22-ghostty-composer-render-loop.md`.

## Known limitation (not this PR — codex behavior)

Switching the **app theme mid-codex-session** leaves a stale bar tint: codex queries OSC 10/11
only at startup and never re-queries (not even on resize), so its bar keeps the startup-theme bg.
A fresh codex session in either theme is correct. Tracked separately; recommend documenting
"restart codex after a theme switch". Scrollback **scrolling** remains VIM-216.
