### PR TITLE
[codex] fix(sessions): fall back when workspace restore fails

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -86,7 +86,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [UI Visual Regression](patterns/ui-visual-regression.md)                                             | code-quality       | 15       | 9    | 2026-06-20   |
 | [Status Indicator Display](patterns/status-indicator-display.md)                                     | code-quality       | 3        | 0    | 2026-05-26   |
 | [Parser Resilience](patterns/parser-resilience.md)                                                   | code-quality       | 14       | 8    | 2026-06-22   |
-| [Persisted State Invariants](patterns/persisted-state-invariants.md)                                 | correctness        | 13       | 6    | 2026-06-20   |
+| [Persisted State Invariants](patterns/persisted-state-invariants.md)                                 | correctness        | 14       | 7    | 2026-06-23   |
 | [macOS Window Chrome](patterns/macos-window-chrome.md)                                               | cross-platform     | 9        | 2    | 2026-06-15   |
 | [Guard Branch Correctness](patterns/guard-branch-correctness.md)                                     | correctness        | 2        | 0    | 2026-06-19   |
 | [Identifier Prefix Matching](patterns/identifier-prefix-matching.md)                                 | correctness        | 4        | 2    | 2026-06-17   |

--- a/docs/reviews/patterns/persisted-state-invariants.md
+++ b/docs/reviews/patterns/persisted-state-invariants.md
@@ -2,8 +2,8 @@
 id: persisted-state-invariants
 category: correctness
 created: 2026-06-08
-last_updated: 2026-06-20
-ref_count: 6
+last_updated: 2026-06-23
+ref_count: 7
 ---
 
 # Persisted State Invariants
@@ -129,4 +129,13 @@ Durable user-facing state (workspace shapes, caches, settings files) can be malf
 - **File:** `crates/backend/src/agent/adapter/opencode/locator.rs`
 - **Finding:** The opencode locator treated any row with `pid == agent_pid` as authoritative before applying the existing freshness gate. Because the bridge index is append-only, OS PID reuse could make an old row for the same pid bind a new opencode process to a previous session's transcript instead of returning the startup-window retry signal.
 - **Fix:** Applied the `pty_start - SLACK` freshness floor to pid matches as well as cwd fallback matches, preserving pid-first disambiguation only for fresh rows. Added a reused-PID regression test proving stale pid rows return the not-ready error.
+- **Commit:** same commit as this entry
+
+### 14. Exited-only PTY cache masked durable restore failure
+
+- **Source:** github-claude | PR #613 round 1 | 2026-06-23
+- **Severity:** MEDIUM
+- **File:** `src/features/sessions/hooks/useSessionRestore.ts`
+- **Finding:** The store-load failure guard treated any non-empty PTY cache as a usable fallback. If the durable workspace layout was unreadable and `listSessions()` returned only `Exited` rows, restore reconstructed stale completed sessions and called `onRestore` instead of taking the intended failure path.
+- **Fix:** Changed the fallback eligibility check to require at least one `Alive` PTY row before suppressing the store-load failure. Added a regression test proving an exited-only cache after store-load failure does not call `onRestore` and still releases hydration.
 - **Commit:** same commit as this entry

--- a/src/features/sessions/hooks/useSessionRestore.test.ts
+++ b/src/features/sessions/hooks/useSessionRestore.test.ts
@@ -169,6 +169,48 @@ describe('useSessionRestore', () => {
     expect(endWorkspaceHydration).toHaveBeenCalledTimes(1)
   })
 
+  test('does not treat exited-only PTY cache as a restore fallback after store load failure', async () => {
+    loadWorkspaceForRestore.mockRejectedValue(
+      new Error('corrupt workspace layout')
+    )
+
+    const service = {
+      onData: vi.fn().mockResolvedValue(() => undefined),
+      listSessions: vi.fn().mockResolvedValue({
+        sessions: [
+          {
+            id: 'pty-old',
+            cwd: '/home/will/repo',
+            shell: '/bin/zsh',
+            status: {
+              kind: 'Exited',
+              exit_code: 0,
+            },
+          },
+        ],
+        activeSessionId: null,
+      }),
+    } as unknown as ITerminalService
+    const onRestore = vi.fn<(sessions: Session[]) => void>()
+    const onActiveResolved = vi.fn<(id: string) => void>()
+
+    const { result } = renderHook(() =>
+      useSessionRestore({
+        service,
+        buffer: buildBuffer(),
+        onRestore,
+        onActiveResolved,
+      })
+    )
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(service.listSessions).toHaveBeenCalled()
+    expect(onRestore).not.toHaveBeenCalled()
+    expect(onActiveResolved).not.toHaveBeenCalled()
+    expect(endWorkspaceHydration).toHaveBeenCalledTimes(1)
+  })
+
   // Fragmentation regression (captured evidence for the multi-pane restore
   // bug): when several PTYs belonged to ONE workspace session (e.g. a quad
   // layout with 3 agents + 1 shell), restore currently fragments them into

--- a/src/features/sessions/hooks/useSessionRestore.test.ts
+++ b/src/features/sessions/hooks/useSessionRestore.test.ts
@@ -120,6 +120,55 @@ describe('useSessionRestore', () => {
     expect(restoredSessions[0].panes[0].status).toBe('running')
   })
 
+  test('falls back to PTY sessions when durable workspace load fails', async () => {
+    loadWorkspaceForRestore.mockRejectedValue(
+      new Error('corrupt workspace layout')
+    )
+
+    const service = {
+      onData: vi.fn().mockResolvedValue(() => undefined),
+      listSessions: vi.fn().mockResolvedValue({
+        sessions: [
+          {
+            id: 'pty-1',
+            cwd: '/home/will/repo',
+            shell: '/bin/zsh',
+            status: {
+              kind: 'Alive',
+              pid: 1234,
+              replay_data: '',
+              replay_end_offset: BigInt(0),
+            },
+          },
+        ],
+        activeSessionId: 'pty-1',
+      }),
+    } as unknown as ITerminalService
+    const onRestore = vi.fn<(sessions: Session[]) => void>()
+    const onActiveResolved = vi.fn<(id: string) => void>()
+
+    const { result } = renderHook(() =>
+      useSessionRestore({
+        service,
+        buffer: buildBuffer(),
+        onRestore,
+        onActiveResolved,
+      })
+    )
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(service.listSessions).toHaveBeenCalled()
+    const restoredSessions = onRestore.mock.calls[0]?.[0]
+    if (!restoredSessions) {
+      throw new Error('expected onRestore to be called')
+    }
+    expect(restoredSessions).toHaveLength(1)
+    expect(restoredSessions[0].panes[0].ptyId).toBe('pty-1')
+    expect(onActiveResolved).toHaveBeenCalledWith('pty-1')
+    expect(endWorkspaceHydration).toHaveBeenCalledTimes(1)
+  })
+
   // Fragmentation regression (captured evidence for the multi-pane restore
   // bug): when several PTYs belonged to ONE workspace session (e.g. a quad
   // layout with 3 agents + 1 shell), restore currently fragments them into

--- a/src/features/sessions/hooks/useSessionRestore.ts
+++ b/src/features/sessions/hooks/useSessionRestore.ts
@@ -370,11 +370,22 @@ export const useSessionRestore = ({
         hydrationStarted = true
 
         // The durable store is the authoritative shape; live PTYs overlay it
-        // by ptyId. Load both, then reconstruct.
-        let storeShape = await loadWorkspaceForRestore({
-          projectId,
-          workingDirectory,
-        })
+        // by ptyId. If the shape store is unreadable, keep the PTY cache as a
+        // fallback when it has sessions to recover.
+        let storeShape: PersistedWorkspaceShape | null = null
+        let storeLoadFailed = false
+        try {
+          storeShape = await loadWorkspaceForRestore({
+            projectId,
+            workingDirectory,
+          })
+        } catch (err) {
+          storeLoadFailed = true
+          log.warn(
+            'workspace layout restore failed; falling back to PTY sessions',
+            err
+          )
+        }
         onCustomPaneLayoutsRestoreRef.current?.(
           storeShape?.customPaneLayouts ?? []
         )
@@ -382,6 +393,12 @@ export const useSessionRestore = ({
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         if (cancelled) {
           return
+        }
+
+        if (storeLoadFailed && list.sessions.length === 0) {
+          throw new Error(
+            'workspace layout restore failed and PTY cache was empty'
+          )
         }
 
         let liveSessions = list.sessions

--- a/src/features/sessions/hooks/useSessionRestore.ts
+++ b/src/features/sessions/hooks/useSessionRestore.ts
@@ -395,9 +395,13 @@ export const useSessionRestore = ({
           return
         }
 
-        if (storeLoadFailed && list.sessions.length === 0) {
+        const hasRecoverablePtySession = list.sessions.some(
+          (session) => session.status.kind === 'Alive'
+        )
+
+        if (storeLoadFailed && !hasRecoverablePtySession) {
           throw new Error(
-            'workspace layout restore failed and PTY cache was empty'
+            'workspace layout restore failed and PTY cache had no live sessions'
           )
         }
 


### PR DESCRIPTION
## Summary

- Keep session restore from aborting when the durable workspace layout cannot be read but PTY sessions are still available.
- Preserve the existing no-empty-write behavior when both the workspace layout load fails and the PTY cache is empty.
- Add regression coverage for PTY fallback restore.

## Root Cause

`loadWorkspaceForRestore` failure previously caused the whole restore path to fail, so a refresh could start with no restored sessions even when the Rust PTY cache still had recoverable sessions.

## Validation

- `npm test -- --run src/features/sessions/hooks/useSessionRestore.test.ts`
- `npm test -- --run src/features/sessions/hooks/useSessionRestore.test.ts src/features/sessions/hooks/useSessionManager.test.ts`
- `npx eslint src/features/sessions/hooks/useSessionRestore.ts src/features/sessions/hooks/useSessionRestore.test.ts src/features/sessions/hooks/useSessionManager.test.ts`
- Pre-push `npm test`: 342 test files passed, 4243 tests passed, 3 skipped

Refs VIM-220