### PR TITLE
[codex] remove others breakdown pop

### DIFF
--- a/src/features/agent-status/components/ToolCalls/ToolJarBreakdown.tsx
+++ b/src/features/agent-status/components/ToolCalls/ToolJarBreakdown.tsx
@@ -26,7 +26,6 @@ export const ToolJarBreakdown = ({
   >
     <div
       data-testid="tool-jar-breakdown"
-      className="tj-enter-pop"
       style={{
         padding: '8px 4px 6px',
       }}

--- a/src/index.css
+++ b/src/index.css
@@ -318,9 +318,6 @@
 .tj-enter-pill {
   animation: tjEnter 0.4s cubic-bezier(0.2, 0.85, 0.3, 1) both;
 }
-.tj-enter-pop {
-  animation: tjEnter 0.14s ease-out both;
-}
 
 /* Odometer digit-column slide. */
 .tj-digit-roll {
@@ -352,8 +349,7 @@
 
 @media (prefers-reduced-motion: reduce) {
   .tj-enter,
-  .tj-enter-pill,
-  .tj-enter-pop {
+  .tj-enter-pill {
     animation: none;
   }
   .tj-digit-roll,


### PR DESCRIPTION
## Summary
- remove the hover pop animation from the Tool Calls others breakdown
- delete the now-unused tj-enter-pop CSS rule

## Test plan
- npm run test -- ToolJarBreakdown ToolJarTile
- npm run test -- src/components/Menu.test.tsx -t "nested button arrow keys do not move menu row focus"

Note: the pre-push full Vitest hook failed once on the unrelated Menu focus test, which passed when rerun in isolation.

Refs VIM-221