### PR TITLE
feat(terminal): ghostty styled scrollback — scroll history in shell & codex (VIM-216)

### DIFF
--- a/.claude/skills/run-ghostty-dev/SKILL.md
+++ b/.claude/skills/run-ghostty-dev/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: run-ghostty-dev
+description: Run, debug, and read logs from the Vimeflow Ghostty native terminal dev build, isolated from the installed production app. Use when launching the dev app, testing/verifying the ghostty renderer, reproducing a terminal render/scroll/input bug, reading dev logs, or when the live dev window seems to show stale/old code. Trigger phrases include "run the ghostty build", "launch vimeflow dev", "test the ghostty renderer", "debug the terminal", "scroll/render bug in ghostty", "open the app to test", "read the dev logs", "why is the dev window showing old code".
+version: 1.0.0
+author: winoooops
+tags:
+  - electron
+  - ghostty
+  - terminal
+  - dev
+  - debugging
+---
+
+# Run & Debug the Ghostty Native Dev Build
+
+How to launch the Vimeflow dev app on the **Ghostty native** render path, keep it
+isolated from any installed production app, and read its logs reliably. Distilled
+from a long VIM-216 debugging session that burned many cycles on environment traps.
+
+## TL;DR
+
+```bash
+npm run dev:ghostty
+```
+
+That wrapper (`scripts/dev-ghostty.sh`) sets the opt-in Ghostty env, points Electron
+at an **isolated userData dir**, and runs `electron:dev`. Launch it as a background
+task so you can read its bridged logs from the task's stdout.
+
+## The non-negotiables (each one cost hours)
+
+1. **Use `electron:dev`, never `npx vite --mode electron`.** `electron:dev` regenerates
+   the ts-rs bindings and builds the Rust sidecar first; the bare vite command skips
+   both and can run against a stale backend.
+
+2. **Ghostty is opt-in.** The renderer registry defaults to **xterm.js**. The native
+   path only activates with:
+   - `VITE_TERMINAL_RENDERER=ghostty`
+   - `VITE_GHOSTTY_RENDER_STATE_DRIVER_PROVIDER=native`
+     Without them you are testing xterm, not the ghostty code — its render artifacts
+     (ghosting, etc.) are NOT your ghostty changes.
+
+3. **Isolate userData from the installed app — this is the big one.** A production
+   `/Applications/Vimeflow.app` and the dev build BOTH default to the same `vibm`
+   Electron userData dir. Run dev while production is open and Electron fights over
+   the shared Local Storage lock (or single-instance behaviour hands your launch off
+   to the already-open production window) — so the dev window **silently shows
+   production's built code, not your dev server's**. Symptom: your edits/`console`
+   probes never appear even though vite serves them. Fix: the wrapper exports
+   `VIMEFLOW_USER_DATA_DIR` (honored by `electron/sandbox.ts` → Electron
+   `--user-data-dir`), giving dev its own dir.
+
+4. **Never kill or touch `/Applications/Vimeflow.app`** (or its `vibm` dir / cache).
+   It's the user's running app. Only ever stop the _dev_ instance, identified by
+   `--user-data-dir=<your isolated dir>`.
+
+## Reading logs
+
+- Run `npm run dev:ghostty` as a **background task**; read its output file.
+- The renderer console is bridged to stdout as `[renderer:info] [vimeflow:<ns>] …`.
+- **For debug telemetry, log from the MAIN process** (`electron/*.ts`, e.g.
+  `electron/ghostty-render-state-main.ts`). Main-process `console.info` goes
+  **straight to stdout** and `vite-plugin-electron` **restarts Electron** when a main
+  file changes, so it always runs. Renderer-side probes are unreliable: HMR does NOT
+  full-reload deep non-component modules (the driver/surface), so renderer edits often
+  don't reach the running window without a manual restart.
+
+## When the dev window shows stale code
+
+In order of likelihood:
+
+1. You're looking at the **production** window, not the isolated dev one (see #3).
+2. A stale dev `vite` is squatting port **5173** — Electron always loads the renderer
+   from 5173, so an old server serves old modules. Confirm the listener on 5173 is
+   _your_ current vite; if not, stop the stale one and relaunch.
+3. Renderer HMR didn't reload a deep module — **restart** the dev instance (fresh
+   import) rather than relying on HMR.
+4. Stale Electron HTTP/Code cache in the userData dir — delete the isolated dir's
+   `Cache` / `Code Cache` and relaunch (safe: never the `vibm` production dir).
+
+## The debug loop that worked
+
+`suspect → instrument the right boundary → restart → read stdout → verify → repeat`.
+Instrument at **component boundaries** (main-process snapshot read, driver, surface)
+and dedupe logs (log only on state change) so a per-frame path doesn't flood. The
+decisive signal for the VIM-216 scroll bug came from a deduped main-process log of
+`isAltScreen` + `scrollbackRowCount` — which proved Claude Code runs on the **alt
+screen** (no terminal scrollback), while shell/codex use the normal buffer.
+
+## Stopping the dev instance safely
+
+Target only the isolated dev, e.g.:
+
+```bash
+pkill -f 'user-data-dir=<your isolated dir>'      # the dev Electron
+pkill -f 'ghostty-verify/node_modules/.bin/vite --mode electron'   # the dev vite
+```
+
+Never match on `vibm` or `Vimeflow.app`.

--- a/docs/debug/2026-06-22-ghostty-scrollback-plan.md
+++ b/docs/debug/2026-06-22-ghostty-scrollback-plan.md
@@ -1,0 +1,59 @@
+# Ghostty scrollback (scroll up to see history) — VIM-216 plan
+
+**Status:** approved approach, implementing · **Branch:** `fix/ghostty-scrollback` · base umbrella
+
+## The bug (root cause — confirmed, not a mystery)
+
+On the Ghostty native render path you cannot scroll up to see history in any agent session
+(codex/claude/shell). Three concrete gaps:
+
+1. **No wheel/scroll handler** anywhere in `src/features/terminal/`.
+2. **Every render snaps to `'bottom'`** (`terminalTextSurface.applyScrollMode`) — even if you could
+   scroll, the next snapshot yanks you down.
+3. **Scrollback is never fetched** — the bridge calls `snapshot({includeCells:true})`, never
+   `includeScrollback`. Only the ~30 visible rows reach the DOM.
+
+Confirmed: codex/claude run on the **main screen** (`isAltScreen=false`) and DO accumulate real
+libghostty scrollback (resumed codex = 119 lines; fresh shell = 0). libghostty exposes it:
+`snapshot({includeScrollback:true})` → `scrollbackLines` (text-only), and `formatHtml()` → the
+**full styled** buffer (already parsed per-frame in the bridge for bg synthesis).
+
+## Decision: STYLED history (user choice, 2026-06-22), fetched lazily
+
+Live viewport stays styled via the existing `cells[]` path. Scrolled-up history is **also fully
+styled**. Because per-frame styled-scrollback over IPC would jank, styling is fetched **lazily**:
+
+- Per-frame snapshot: viewport-only + `scrollbackRowCount` + `isAltScreen` (cheap).
+- Dedicated channel `READ_SCROLLBACK(driverId)` → styled scrollback cells, parsed from `formatHtml`'s
+  scrollback rows (extend the existing HTML walker to emit fg/bg/bold/italic/underline). Fetched
+  only while `userScrolledUp`, refreshed on a throttle as scrollback grows.
+- Scroll UX: xterm.js sticky-bottom. Default stuck-to-bottom (live). Wheel-up → freeze
+  (`applyScrollMode` no-op) + scroll-anchor across prepends. Scroll back to bottom OR any keypress →
+  resume live. Alt-screen TUIs (vim/less): scrollback suppressed (today's behavior); wheel→paging
+  forwarding is a separate follow-up.
+- Perf: per-frame stays cheap; on very long sessions the lazy fetch + render of history is the cost,
+  paid only while reading. Virtualization (windowed render) is the documented follow-up if needed.
+
+## Steps (TDD, co-located *.test.ts)
+
+1. **Surface scroll state machine** (common): `userScrolledUp` flag + wheel/scroll listeners on the
+   surface root; `applyScrollMode` no-op while scrolled; scroll-anchor in `renderOutput` across
+   prepends; keypress/scroll-to-bottom resets. New `terminalTextSurface.test.ts`.
+2. **Bridge per-frame: `scrollbackRowCount` + `isAltScreen`** in the normalized snapshot
+   (`electron/ghostty-render-state-main.ts`), gated off alt-screen.
+3. **Bridge `READ_SCROLLBACK` channel**: styled scrollback cells from `formatHtml` (extend the HTML
+   walker to full styling; reuse without the viewport rowShift). New channel + handler + types.
+4. **Renderer IPC + service binding** for `READ_SCROLLBACK`
+   (`ghosttyNativeRenderStateBridge.ts` + service).
+5. **Surface renders fetched styled scrollback** above the viewport; combined scroll area;
+   throttled refresh; clears on bottom/keypress.
+6. **Alt-screen gating + end-to-end test** (`ghosttyInstance.test.ts`) + manual smoke.
+
+## Risks (from research)
+
+- jsdom has no layout → surface tests must stub `scrollHeight`/`clientHeight`/`scrollTop`.
+- Cursor + viewport cell rows must offset by `scrollbackRowCount` consistently.
+- `trimLeadingEmptyRows` must not rotate prepended scrollback.
+- Scroll-anchor must run every frozen frame (scrollback grows as live lines scroll off).
+- Async fetch vs live-frame race + scroll-anchor across the async boundary.
+- ≥10k-line sessions: lazy render may need virtualization (deferred).

--- a/docs/debug/2026-06-22-ghostty-scrollback-plan.md
+++ b/docs/debug/2026-06-22-ghostty-scrollback-plan.md
@@ -49,6 +49,21 @@ scroll-anchoring across an async boundary. This collapses the riskiest part of t
   `terminalTextSurface.test.ts`. (Note: a `git checkout` clobbered the WIP mid-step; recovered by
   re-applying via Edit — never `git checkout <file>` with uncommitted WIP.)
 
+## Step 2 DONE + Step 3 design (refined 2026-06-23)
+
+- **Step 2 DONE** — committed `a94a8a9b`. Bridge requests `snapshot({includeScrollback:true})`,
+  reports `scrollbackRowCount` (computed in main, lines stay there) + `isAltScreen`; suppressed
+  (count 0) on alt screen. 2 tests; bridge suite 39 green.
+- **Confirmed:** native `cells` are **viewport-only** (rows 0..viewport-1, never negative/scrollback);
+  `scrollbackLines` is text-only `{row,text}`. **The only styled source for scrollback is
+  `formatHtml`** — so Step 3 must parse it.
+- **Step 3 approach:** extend the existing HTML walker (`readReverseVideoRangesFromHtml` + its
+  `readTagCellStyle`) to emit **full styled cells** (text + fg/bg/bold/italic/underline), reuse the
+  existing `rowShift` anchor, and take the rows that map **outside** the viewport above
+  (`contentRow + rowShift < 0`) as scrollback, re-indexed 0-based top-down. Return them over a new
+  sync `READ_SCROLLBACK` channel. (libghostty gives no styled scrollback; `formatHtml` is per-frame
+  already, but READ_SCROLLBACK is called only on scroll-up so the parse cost is paid only then.)
+
 ## Steps (TDD, co-located *.test.ts)
 
 1. **Surface scroll state machine** (common): `userScrolledUp` flag + wheel/scroll listeners on the

--- a/docs/debug/2026-06-22-ghostty-scrollback-plan.md
+++ b/docs/debug/2026-06-22-ghostty-scrollback-plan.md
@@ -34,6 +34,21 @@ styled**. Because per-frame styled-scrollback over IPC would jank, styling is fe
 - Perf: per-frame stays cheap; on very long sessions the lazy fetch + render of history is the cost,
   paid only while reading. Virtualization (windowed render) is the documented follow-up if needed.
 
+## Architecture note (de-risked 2026-06-22)
+
+The render-state IPC is **synchronous** (`ipcRenderer.sendSync`, see
+`ghostty-render-state-preload`). So `READ_SCROLLBACK` is a **synchronous** channel: the surface
+fetches styled scrollback inline on scroll-up — no async fetch, no fetch/live-frame race, no
+scroll-anchoring across an async boundary. This collapses the riskiest part of the plan.
+
+## Progress
+
+- **Step 1 DONE** — committed `2e28d726`. Scroll state machine in `terminalTextSurface.ts`
+  (`userScrolledUp` + wheel/scroll listeners; `applyScrollMode` no-op while scrolled; scroll-anchor
+  in `renderOutput`; typing/scroll-to-bottom resumes). 6 mutation-checked tests in the new
+  `terminalTextSurface.test.ts`. (Note: a `git checkout` clobbered the WIP mid-step; recovered by
+  re-applying via Edit — never `git checkout <file>` with uncommitted WIP.)
+
 ## Steps (TDD, co-located *.test.ts)
 
 1. **Surface scroll state machine** (common): `userScrolledUp` flag + wheel/scroll listeners on the

--- a/docs/debug/2026-06-22-ghostty-scrollback-plan.md
+++ b/docs/debug/2026-06-22-ghostty-scrollback-plan.md
@@ -67,6 +67,7 @@ scroll-anchoring across an async boundary. This collapses the riskiest part of t
 ## Step 3 — codex verdict corrections (2026-06-23)
 
 Codex reviewed the design ("sound") with concrete corrections, adopted:
+
 1. **Shared tokenizer, two readers** — do NOT make the per-frame `readReverseVideoRangesFromHtml`
    emit styled cells (allocates scrollback-sized data every frame). Extract the tokenizer/style-stack
    walk once; keep `readReverseVideoRangesFromHtml` (per-frame bg) + add
@@ -95,6 +96,7 @@ scroll position. So "return {rows,cells} and the surface prepends them" describe
 not exist.
 
 **Consequence — revised steps:**
+
 - **Step 3 (main, low-risk, isolated):** `readScrollback` returns styled `{rows, cells}` (0-based,
   top-down). Corrections: extract a shared `computeRowShift(snapshot, rows, contentRowCount)` used by
   BOTH `normalizeSnapshot` and `readScrollback` (never recompute from a 2nd snapshot — desync). New
@@ -135,7 +137,7 @@ All steps done. Next: rebuild → user eyeball (scroll up shows styled history; 
 the bottom; typing/scroll-to-bottom resumes) → milestone PR `fix/ghostty-scrollback → umbrella`
 (auto-review/auto-approve).
 
-## Steps (TDD, co-located *.test.ts)
+## Steps (TDD, co-located \*.test.ts)
 
 1. **Surface scroll state machine** (common): `userScrolledUp` flag + wheel/scroll listeners on the
    surface root; `applyScrollMode` no-op while scrolled; scroll-anchor in `renderOutput` across

--- a/docs/debug/2026-06-22-ghostty-scrollback-plan.md
+++ b/docs/debug/2026-06-22-ghostty-scrollback-plan.md
@@ -64,6 +64,56 @@ scroll-anchoring across an async boundary. This collapses the riskiest part of t
   sync `READ_SCROLLBACK` channel. (libghostty gives no styled scrollback; `formatHtml` is per-frame
   already, but READ_SCROLLBACK is called only on scroll-up so the parse cost is paid only then.)
 
+## Step 3 — codex verdict corrections (2026-06-23)
+
+Codex reviewed the design ("sound") with concrete corrections, adopted:
+1. **Shared tokenizer, two readers** — do NOT make the per-frame `readReverseVideoRangesFromHtml`
+   emit styled cells (allocates scrollback-sized data every frame). Extract the tokenizer/style-stack
+   walk once; keep `readReverseVideoRangesFromHtml` (per-frame bg) + add
+   `readStyledScrollbackFromHtml` (lazy, scrollback only) on top.
+2. **Parse CSS declarations** (split on `;`), not a loose `color:` regex — else it matches inside
+   `background-color:`.
+3. **Convert fg + bg to HEX** (reuse `paletteIndexToHex`/`toHexColor`); do NOT pass
+   `var(--vt-palette-N)` through — `createGhosttyVtRenderSnapshotOutput` only encodes hex into SGR
+   sentinels and drops raw CSS vars before DOM styling.
+4. **Coalesce styled runs** into sparse cells (not one-per-char) — sync-IPC payload sanity at 10k.
+5. Return `{ rows, cells }`, omit cursor; **`rows.length = -rowShift`** (preserve internal blank
+   scrollback rows); cell `row` relative to returned rows.
+6. **Share the `rowShift`/`canAlign` helper** with `normalizeSnapshot` (no duplication); return empty
+   on alt-screen or when alignment is impossible. Test `/resume` + a trailing styled-blank row.
+
+(Awaiting the opus review of the surface-integration path before implementing.)
+
+## Opus review — CRITICAL finding (2026-06-23): the surface has no rows+cells path
+
+Both codex and opus return **GO-WITH-CHANGES** (design sound). But opus traced the full pipeline and
+found the brief's premise wrong: the surface does NOT render rows+cells. `createGhosttyVtRenderSnapshotOutput`
+collapses `{rows, cells}` into ONE flat string (SGR sentinels via `readStyledRowText`) →
+`displayDelta` `replace` → `TerminalDisplayBuffer.replace()` (clear+rewrite the whole buffer every
+frame) → flat `runs[]` → DOM. There is no viewport/scrollback region; `userScrolledUp` only moves
+scroll position. So "return {rows,cells} and the surface prepends them" describes a path that does
+not exist.
+
+**Consequence — revised steps:**
+- **Step 3 (main, low-risk, isolated):** `readScrollback` returns styled `{rows, cells}` (0-based,
+  top-down). Corrections: extract a shared `computeRowShift(snapshot, rows, contentRowCount)` used by
+  BOTH `normalizeSnapshot` and `readScrollback` (never recompute from a 2nd snapshot — desync). New
+  parallel `HtmlCellStyle` type + `readStyledCellsFromHtml` reusing the tokenizer primitives
+  (do NOT widen `ReverseVideoRange` helpers). fg+bg→HEX (`paletteIndexToHex`/`toHexColor`; raw
+  `var()` is dropped by `readSgrColorParameters`). Parse CSS declarations (split `;`). Coalesce runs.
+  `rows.length = -rowShift`. Clamp the `rowShift==-1` false-positive blank row. Bound payload
+  (bottom-N) + streaming `regex.exec`. Alt-screen → empty.
+- **Step 4 (plumbing, currently MISSING):** `scrollbackRowCount`/`isAltScreen` are dropped today at
+  `normalizeNativeSnapshot` AND the preload type — thread them through both so the renderer can gate.
+- **Step 5 (THE real integration, bigger than scoped):** on scroll-up, encode each scrollback row
+  via the existing `readStyledRowText` sentinel encoder, **concatenate ahead of the viewport
+  `displayText`** as one `replace`; handle `trimLeadingEmptyRows` (don't rotate history) + cursor
+  offset shift. Prototype against one real frame first.
+- **Step 6:** alt↔main transition reset + e2e.
+
+opus fallback if styling proves too costly: render text-only `scrollbackLines` unstyled above the
+viewport (content history now, styling later) — same integration risk, less walker work.
+
 ## Steps (TDD, co-located *.test.ts)
 
 1. **Surface scroll state machine** (common): `userScrolledUp` flag + wheel/scroll listeners on the

--- a/docs/debug/2026-06-22-ghostty-scrollback-plan.md
+++ b/docs/debug/2026-06-22-ghostty-scrollback-plan.md
@@ -122,12 +122,18 @@ viewport (content history now, styling later) — same integration risk, less wa
   fg/bg→hex, shared `computeRowShift`); real `/resume` capture = 118 styled rows verified.
 - **Step 4** ✅ `45563d04` — preload + renderer bridge plumbing (`readScrollback`,
   `scrollbackRowCount`/`isAltScreen` threaded). Full data path done + tested.
-- **Step 5** ⏭ THE risky composition. Plan (opus): encode scrollback `{rows,cells}` via the
-  existing `readStyledRowText` sentinel encoder → concatenate ahead of the viewport `displayText`
-  as one replace op; bypass `trimLeadingEmptyRows` for the scrollback prefix; shift the cursor
-  offset by the prepended text. Wire the surface↔driver back-channel (surface exposes
-  `isScrolledUp` / fetches `readScrollback`). **Prototype against one real frame first.**
-- **Step 6** — alt↔main transition reset + e2e → rebuild → eyeball → milestone PR.
+- **Step 5** ✅ `137226ea` — `encodeScrollback` + `prependScrollbackToOutput`; `flushOutput`
+  composes scrollback ahead of the viewport (cached on `scrollbackRowCount`, suppressed on alt
+  screen). No back-channel needed: scrollback is always in the DOM when it exists, so the step-1
+  scroll machine handles read/freeze/resume. Cursor shift = scrollback visible length + 1 (buffer
+  indexes cursor in visible space). Cursor math locked by unit test; prototyped on the real
+  `/resume` frame (148 rows = 118 scrollback + 30 viewport, composer at row 143).
+- **Step 6** ✅ alt↔main transition handled by the cache (alt → count 0 → suppress; exit →
+  re-fetch), locked by a test. Full terminal+bridge suite (1172) green. **Live rebuild = the e2e.**
+
+All steps done. Next: rebuild → user eyeball (scroll up shows styled history; live output flows at
+the bottom; typing/scroll-to-bottom resumes) → milestone PR `fix/ghostty-scrollback → umbrella`
+(auto-review/auto-approve).
 
 ## Steps (TDD, co-located *.test.ts)
 

--- a/docs/debug/2026-06-22-ghostty-scrollback-plan.md
+++ b/docs/debug/2026-06-22-ghostty-scrollback-plan.md
@@ -114,6 +114,21 @@ not exist.
 opus fallback if styling proves too costly: render text-only `scrollbackLines` unstyled above the
 viewport (content history now, styling later) — same integration risk, less walker work.
 
+## Progress (2026-06-23)
+
+- **Step 1** ✅ `2e28d726` — sticky-bottom scroll state machine (6 tests).
+- **Step 2** ✅ `a94a8a9b` — bridge `scrollbackRowCount` + `isAltScreen`.
+- **Step 3** ✅ `f663c34c` — `READ_SCROLLBACK` channel + styled `formatHtml` parser (coalesced cells,
+  fg/bg→hex, shared `computeRowShift`); real `/resume` capture = 118 styled rows verified.
+- **Step 4** ✅ `45563d04` — preload + renderer bridge plumbing (`readScrollback`,
+  `scrollbackRowCount`/`isAltScreen` threaded). Full data path done + tested.
+- **Step 5** ⏭ THE risky composition. Plan (opus): encode scrollback `{rows,cells}` via the
+  existing `readStyledRowText` sentinel encoder → concatenate ahead of the viewport `displayText`
+  as one replace op; bypass `trimLeadingEmptyRows` for the scrollback prefix; shift the cursor
+  offset by the prepended text. Wire the surface↔driver back-channel (surface exposes
+  `isScrolledUp` / fetches `readScrollback`). **Prototype against one real frame first.**
+- **Step 6** — alt↔main transition reset + e2e → rebuild → eyeball → milestone PR.
+
 ## Steps (TDD, co-located *.test.ts)
 
 1. **Surface scroll state machine** (common): `userScrolledUp` flag + wheel/scroll listeners on the

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -58,7 +58,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 29       | 11   | 2026-06-23   |
 | [Terminal DOM Rendering](patterns/terminal-dom-rendering.md)                                         | terminal           | 12       | 7    | 2026-06-24   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
-| [Terminal Render-State Driver Contract](patterns/terminal-render-state-driver-contract.md)           | terminal           | 39       | 15   | 2026-06-24   |
+| [Terminal Render-State Driver Contract](patterns/terminal-render-state-driver-contract.md)           | terminal           | 40       | 16   | 2026-06-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 88       | 27   | 2026-06-22   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 51       | 24   | 2026-06-18   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -58,7 +58,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 29       | 11   | 2026-06-23   |
 | [Terminal DOM Rendering](patterns/terminal-dom-rendering.md)                                         | terminal           | 12       | 7    | 2026-06-24   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
-| [Terminal Render-State Driver Contract](patterns/terminal-render-state-driver-contract.md)           | terminal           | 40       | 16   | 2026-06-24   |
+| [Terminal Render-State Driver Contract](patterns/terminal-render-state-driver-contract.md)           | terminal           | 41       | 16   | 2026-06-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 88       | 27   | 2026-06-22   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 51       | 24   | 2026-06-18   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -56,7 +56,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 1        | 0    | 2026-06-09   |
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 66       | 34   | 2026-06-20   |
 | [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 29       | 11   | 2026-06-23   |
-| [Terminal DOM Rendering](patterns/terminal-dom-rendering.md)                                         | terminal           | 11       | 7    | 2026-06-24   |
+| [Terminal DOM Rendering](patterns/terminal-dom-rendering.md)                                         | terminal           | 12       | 7    | 2026-06-24   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
 | [Terminal Render-State Driver Contract](patterns/terminal-render-state-driver-contract.md)           | terminal           | 36       | 13   | 2026-06-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 88       | 27   | 2026-06-22   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -50,15 +50,15 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 14       | 13   | 2026-06-13   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)                                             | cross-platform     | 6        | 3    | 2026-05-30   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                                                       | code-quality       | 7        | 0    | 2026-06-11   |
-| [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 10       | 6    | 2026-06-20   |
+| [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 11       | 7    | 2026-06-24   |
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 1        | 0    | 2026-06-09   |
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 66       | 34   | 2026-06-20   |
 | [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 29       | 11   | 2026-06-23   |
-| [Terminal DOM Rendering](patterns/terminal-dom-rendering.md)                                         | terminal           | 10       | 6    | 2026-06-21   |
+| [Terminal DOM Rendering](patterns/terminal-dom-rendering.md)                                         | terminal           | 11       | 7    | 2026-06-24   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
-| [Terminal Render-State Driver Contract](patterns/terminal-render-state-driver-contract.md)           | terminal           | 36       | 12   | 2026-06-23   |
+| [Terminal Render-State Driver Contract](patterns/terminal-render-state-driver-contract.md)           | terminal           | 36       | 13   | 2026-06-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 88       | 27   | 2026-06-22   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 51       | 24   | 2026-06-18   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -58,7 +58,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 29       | 11   | 2026-06-23   |
 | [Terminal DOM Rendering](patterns/terminal-dom-rendering.md)                                         | terminal           | 12       | 7    | 2026-06-24   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
-| [Terminal Render-State Driver Contract](patterns/terminal-render-state-driver-contract.md)           | terminal           | 36       | 13   | 2026-06-24   |
+| [Terminal Render-State Driver Contract](patterns/terminal-render-state-driver-contract.md)           | terminal           | 37       | 14   | 2026-06-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 88       | 27   | 2026-06-22   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 51       | 24   | 2026-06-18   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -58,7 +58,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 29       | 11   | 2026-06-23   |
 | [Terminal DOM Rendering](patterns/terminal-dom-rendering.md)                                         | terminal           | 12       | 7    | 2026-06-24   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
-| [Terminal Render-State Driver Contract](patterns/terminal-render-state-driver-contract.md)           | terminal           | 38       | 15   | 2026-06-24   |
+| [Terminal Render-State Driver Contract](patterns/terminal-render-state-driver-contract.md)           | terminal           | 39       | 15   | 2026-06-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 88       | 27   | 2026-06-22   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 51       | 24   | 2026-06-18   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -58,7 +58,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 29       | 11   | 2026-06-23   |
 | [Terminal DOM Rendering](patterns/terminal-dom-rendering.md)                                         | terminal           | 12       | 7    | 2026-06-24   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
-| [Terminal Render-State Driver Contract](patterns/terminal-render-state-driver-contract.md)           | terminal           | 37       | 14   | 2026-06-24   |
+| [Terminal Render-State Driver Contract](patterns/terminal-render-state-driver-contract.md)           | terminal           | 38       | 15   | 2026-06-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 88       | 27   | 2026-06-22   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 51       | 24   | 2026-06-18   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |

--- a/docs/reviews/patterns/derived-state-consistency.md
+++ b/docs/reviews/patterns/derived-state-consistency.md
@@ -2,8 +2,8 @@
 id: derived-state-consistency
 category: code-quality
 created: 2026-06-07
-last_updated: 2026-06-20
-ref_count: 6
+last_updated: 2026-06-24
+ref_count: 7
 ---
 
 # Derived State Consistency
@@ -139,4 +139,13 @@ base data is technically "correct."
 - **File:** `electron/ghostty-render-state-main.ts` L565
 - **Finding:** `resize()` updated the driver's cached `record.size` before calling the native terminal resize callback. If the native resize threw, a later reset recreated the terminal at the failed requested size rather than the still-active terminal size.
 - **Fix:** Moved the cached size assignment after `record.terminal.resize()` succeeds and added a regression test that verifies reset falls back to the previous dimensions after a resize failure.
+- **Commit:** same commit as this entry
+
+### 11. Derived scrollback counts should not require full line payloads
+
+- **Source:** github-claude | PR #615 round 1 | 2026-06-24
+- **Severity:** MEDIUM
+- **File:** `electron/ghostty-render-state-main.ts` L1639-L1642
+- **Finding:** `readSnapshot()` requested full scrollback line bodies only to derive `scrollbackRowCount` from their array length. On large histories this made every frame pay synchronous IPC allocation and transfer cost for data the renderer did not need.
+- **Fix:** Added an optional native `scrollbackRowCount()` hook and used it in the bridge when present, so per-frame snapshots request only viewport cells and carry the scalar count separately. Existing bindings without the hook keep the old full-snapshot fallback until their native package exposes the count API. Added a bridge regression for the count-only path.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/terminal-dom-rendering.md
+++ b/docs/reviews/patterns/terminal-dom-rendering.md
@@ -2,8 +2,8 @@
 id: terminal-dom-rendering
 category: terminal
 created: 2026-06-18
-last_updated: 2026-06-21
-ref_count: 6
+last_updated: 2026-06-24
+ref_count: 7
 ---
 
 # Terminal DOM Rendering
@@ -102,4 +102,13 @@ The terminal renderer translates a buffered text/runs model into DOM rows for di
 - **File:** `src/features/terminal/components/TerminalPane/terminalTextSurface.ts` L481-L485
 - **Finding:** Pinning every replace-operation delta to `scrollTop = 0` preserved full-screen TUI frames but could hide the active shell cursor when the cursor row still fit within the pane's visible row capacity.
 - **Fix:** Replace snapshots now derive the cursor row from the incoming replace operation and use cursor tracking when that row fits in the visible row capacity; snapshots whose cursor is below the pane remain top-pinned for TUI layouts. Added a Ghostty instance regression that proves a visible shell cursor scrolls into view while the TUI top-pin case stays unchanged.
+- **Commit:** same commit as this entry
+
+### 11. Sticky scroll state must be reset when content can no longer scroll
+
+- **Source:** github-claude + github-codex-connector | PR #615 round 1 | 2026-06-24
+- **Severity:** HIGH / P2
+- **File:** `src/features/terminal/components/TerminalPane/terminalTextSurface.ts`
+- **Finding:** The surface set `userScrolledUp` on wheel-up before confirming that the pane was actually scrollable, and `clear()` wiped the output/scrollback DOM without resetting the same sticky-scroll flag. Fresh panes could stop following new output after a no-op wheel, and a user who cleared while reading history could remain locked away from the live bottom.
+- **Fix:** Gate wheel-up freeze on real vertical scrollability, clear stale freeze state when the pane is no longer scrollable or is already at bottom, and reset `userScrolledUp` before rendering after `clear()`. Added regressions for no-op wheel-up and scroll-up-to-clear.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/terminal-dom-rendering.md
+++ b/docs/reviews/patterns/terminal-dom-rendering.md
@@ -112,3 +112,18 @@ The terminal renderer translates a buffered text/runs model into DOM rows for di
 - **Finding:** The surface set `userScrolledUp` on wheel-up before confirming that the pane was actually scrollable, and `clear()` wiped the output/scrollback DOM without resetting the same sticky-scroll flag. Fresh panes could stop following new output after a no-op wheel, and a user who cleared while reading history could remain locked away from the live bottom.
 - **Fix:** Gate wheel-up freeze on real vertical scrollability, clear stale freeze state when the pane is no longer scrollable or is already at bottom, and reset `userScrolledUp` before rendering after `clear()`. Added regressions for no-op wheel-up and scroll-up-to-clear.
 - **Commit:** same commit as this entry
+
+### 12. Null scrollback clears must reset sticky scroll state
+
+- **Source:** github-claude | PR #615 round 2 | 2026-06-24
+- **Severity:** HIGH
+- **File:** `src/features/terminal/components/TerminalPane/terminalTextSurface.ts`
+- **Finding:** `renderScrollback(null)` cleared the static history DOM for
+  alt-screen entry but left `userScrolledUp` set after a user had been
+  reading history. The next live render could then skip repositioning and
+  leave the active TUI frame below the visible area.
+- **Fix:** Reset `userScrolledUp` in the null scrollback branch before the
+  viewport render applies bottom-following. Added a regression that scrolls
+  up, sends a null scrollback payload, and verifies the viewport returns to
+  the bottom.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/terminal-render-state-driver-contract.md
+++ b/docs/reviews/patterns/terminal-render-state-driver-contract.md
@@ -3,7 +3,7 @@ id: terminal-render-state-driver-contract
 category: terminal
 created: 2026-06-19
 last_updated: 2026-06-24
-ref_count: 15
+ref_count: 16
 ---
 
 # Terminal Render-State Driver Contract
@@ -379,4 +379,13 @@ documented explicitly: effect callbacks must be invoked synchronously inside the
 - **File:** `src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts`
 - **Finding:** The empty-scrollback give-up branch cached a positive native row count but returned viewport output without a `scrollback` field. In the terminal surface contract, an omitted field means "preserve the current static region," so stale history could remain visible after the driver had decided that same count could not be delivered.
 - **Fix:** Return `scrollback: null` when the positive-count empty-retry budget is exhausted, clearing any stale static history region while still caching the count to suppress same-count retries. Updated the regression to assert retry frames preserve scrollback, the give-up frame clears it, and later same-count frames stop re-fetching.
+- **Commit:** same commit as this entry
+
+### 40. Lazy scrollback read failures must not escape the render flush
+
+- **Source:** github-codex-connector | PR #615 round 6 | 2026-06-24
+- **Severity:** P1 / HIGH
+- **File:** `src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts`
+- **Finding:** `attachScrollback()` called the native-backed `readScrollback()` path without a recovery boundary. Preload converts structured IPC failures into thrown errors, so a transient native scrollback read or formatter failure could throw through `flushOutput()` and stop the Ghostty pane's render updates instead of preserving the live viewport.
+- **Fix:** Wrap the lazy `readScrollback()` call in `try/catch` and return the viewport output with no `scrollback` field on failure. This preserves the existing static history region and does not advance the cached row count, so a later dirty frame can retry. Regression coverage asserts viewport rendering continues and recovered scrollback is attached on the next successful read.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/terminal-render-state-driver-contract.md
+++ b/docs/reviews/patterns/terminal-render-state-driver-contract.md
@@ -3,7 +3,7 @@ id: terminal-render-state-driver-contract
 category: terminal
 created: 2026-06-19
 last_updated: 2026-06-24
-ref_count: 14
+ref_count: 15
 ---
 
 # Terminal Render-State Driver Contract
@@ -361,4 +361,13 @@ documented explicitly: effect callbacks must be invoked synchronously inside the
 - **File:** `src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts` L106-L117
 - **Finding:** The VT render-state adapter wrote `cachedScrollbackRowCount = count` before verifying that `readScrollback()` returned a non-empty payload. A transient empty result with a positive native row count therefore emitted destructive `scrollback: null`, recorded the count as delivered, and caused later frames to omit the scrollback field forever until resize/reset.
 - **Fix:** Treat empty rows with `count > 0` as indeterminate: leave the output's scrollback field omitted and do not advance the cache. The cache now commits only for explicit clears (`count <= 0`) and successful non-empty payloads. The native renderer bridge contract now requires `readScrollback`, removing the silent empty fallback, and regression coverage verifies the retry path.
+- **Commit:** same commit as this entry
+
+### 38. Indeterminate scrollback retries need a same-count termination guard
+
+- **Source:** github-claude | PR #615 round 4 | 2026-06-24
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts` L99-L127
+- **Finding:** After fixing empty positive-count scrollback fetches to omit the payload and leave `cachedScrollbackRowCount` unchanged, persistent empty results for the same positive count retried `readScrollback()` on every dirty flush. That kept synchronous renderer/main-process IPC and scrollback parsing in the render path with no termination condition.
+- **Fix:** Track consecutive empty results per row count and, after a small same-count retry budget, mark that count as delivered-empty so later frames stop re-fetching until the count changes, resize invalidates the cache, or reset clears the adapter state. Regression coverage verifies persistent empty results stop retrying and a changed row count gets fresh retry attempts.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/terminal-render-state-driver-contract.md
+++ b/docs/reviews/patterns/terminal-render-state-driver-contract.md
@@ -371,3 +371,12 @@ documented explicitly: effect callbacks must be invoked synchronously inside the
 - **Finding:** After fixing empty positive-count scrollback fetches to omit the payload and leave `cachedScrollbackRowCount` unchanged, persistent empty results for the same positive count retried `readScrollback()` on every dirty flush. That kept synchronous renderer/main-process IPC and scrollback parsing in the render path with no termination condition.
 - **Fix:** Track consecutive empty results per row count and, after a small same-count retry budget, mark that count as delivered-empty so later frames stop re-fetching until the count changes, resize invalidates the cache, or reset clears the adapter state. Regression coverage verifies persistent empty results stop retrying and a changed row count gets fresh retry attempts.
 - **Commit:** same commit as this entry
+
+### 39. Retry give-up paths must respect tri-state render payload semantics
+
+- **Source:** github-claude | PR #615 round 5 | 2026-06-24
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts`
+- **Finding:** The empty-scrollback give-up branch cached a positive native row count but returned viewport output without a `scrollback` field. In the terminal surface contract, an omitted field means "preserve the current static region," so stale history could remain visible after the driver had decided that same count could not be delivered.
+- **Fix:** Return `scrollback: null` when the positive-count empty-retry budget is exhausted, clearing any stale static history region while still caching the count to suppress same-count retries. Updated the regression to assert retry frames preserve scrollback, the give-up frame clears it, and later same-count frames stop re-fetching.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/terminal-render-state-driver-contract.md
+++ b/docs/reviews/patterns/terminal-render-state-driver-contract.md
@@ -389,3 +389,12 @@ documented explicitly: effect callbacks must be invoked synchronously inside the
 - **Finding:** `attachScrollback()` called the native-backed `readScrollback()` path without a recovery boundary. Preload converts structured IPC failures into thrown errors, so a transient native scrollback read or formatter failure could throw through `flushOutput()` and stop the Ghostty pane's render updates instead of preserving the live viewport.
 - **Fix:** Wrap the lazy `readScrollback()` call in `try/catch` and return the viewport output with no `scrollback` field on failure. This preserves the existing static history region and does not advance the cached row count, so a later dirty frame can retry. Regression coverage asserts viewport rendering continues and recovered scrollback is attached on the next successful read.
 - **Commit:** same commit as this entry
+
+### 41. Exception retry paths need the same termination guard as empty results
+
+- **Source:** github-claude | PR #615 round 7 | 2026-06-24
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts`
+- **Finding:** The lazy scrollback exception path returned live viewport output without advancing or bounding the scrollback cache. A persistent native `readScrollback()` failure for a positive row count therefore retried the synchronous IPC read on every dirty output flush, even though the empty-result path already had a same-count give-up guard.
+- **Fix:** Route caught scrollback read failures through the same per-row-count retry helper used by empty scrollback responses. After the retry budget is exhausted, the adapter clears stale static scrollback, caches the current count, and suppresses further same-count reads until reset, resize, or row-count growth.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/terminal-render-state-driver-contract.md
+++ b/docs/reviews/patterns/terminal-render-state-driver-contract.md
@@ -3,7 +3,7 @@ id: terminal-render-state-driver-contract
 category: terminal
 created: 2026-06-19
 last_updated: 2026-06-24
-ref_count: 13
+ref_count: 14
 ---
 
 # Terminal Render-State Driver Contract
@@ -352,4 +352,13 @@ documented explicitly: effect callbacks must be invoked synchronously inside the
 - **File:** `src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts` L104
 - **Finding:** The VT render-state adapter cached the static scrollback payload only by row count. A terminal resize can reflow the same history into different line breaks without changing the native scrollback row count, leaving the surface's static history region rendered at stale geometry.
 - **Fix:** Invalidate the cached scrollback row count on every render-state driver resize so the next flushed frame re-fetches and re-attaches the static scrollback payload. Added a regression that keeps row count unchanged across resize and verifies the payload is fetched again.
+- **Commit:** same commit as this entry
+
+### 37. Static scrollback cache commits must follow successful payload delivery
+
+- **Source:** github-claude | PR #615 round 3 | 2026-06-24
+- **Severity:** HIGH
+- **File:** `src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts` L106-L117
+- **Finding:** The VT render-state adapter wrote `cachedScrollbackRowCount = count` before verifying that `readScrollback()` returned a non-empty payload. A transient empty result with a positive native row count therefore emitted destructive `scrollback: null`, recorded the count as delivered, and caused later frames to omit the scrollback field forever until resize/reset.
+- **Fix:** Treat empty rows with `count > 0` as indeterminate: leave the output's scrollback field omitted and do not advance the cache. The cache now commits only for explicit clears (`count <= 0`) and successful non-empty payloads. The native renderer bridge contract now requires `readScrollback`, removing the silent empty fallback, and regression coverage verifies the retry path.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/terminal-render-state-driver-contract.md
+++ b/docs/reviews/patterns/terminal-render-state-driver-contract.md
@@ -2,8 +2,8 @@
 id: terminal-render-state-driver-contract
 category: terminal
 created: 2026-06-19
-last_updated: 2026-06-23
-ref_count: 12
+last_updated: 2026-06-24
+ref_count: 13
 ---
 
 # Terminal Render-State Driver Contract
@@ -343,4 +343,13 @@ documented explicitly: effect callbacks must be invoked synchronously inside the
 - **File:** `electron/ghostty-render-state-main.ts` L1170
 - **Finding:** When a native viewport was fully blank, reverse-video range alignment still used a `rowShift` of `0`. Old styled rows from `formatHtml()` scrollback whose original rows fit inside the viewport could be synthesized into a blank snapshot during clear/redraw gaps.
 - **Fix:** Added an explicit alignment guard so formatter ranges are shifted and filtered only when the formatter has content rows and the native snapshot has a visible content anchor. Added a regression for a blank native viewport with stale highlighted formatter scrollback.
+- **Commit:** same commit as this entry
+
+### 36. Static scrollback caches must include terminal geometry invalidation
+
+- **Source:** github-codex-connector | PR #615 round 1 | 2026-06-24
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts` L104
+- **Finding:** The VT render-state adapter cached the static scrollback payload only by row count. A terminal resize can reflow the same history into different line breaks without changing the native scrollback row count, leaving the surface's static history region rendered at stale geometry.
+- **Fix:** Invalidate the cached scrollback row count on every render-state driver resize so the next flushed frame re-fetches and re-attaches the static scrollback payload. Added a regression that keeps row count unchanged across resize and verifies the payload is fetched again.
 - **Commit:** same commit as this entry

--- a/electron/ghostty-render-state-channels.ts
+++ b/electron/ghostty-render-state-channels.ts
@@ -9,6 +9,9 @@ export const GHOSTTY_RENDER_STATE_WRITE_BYTES =
 export const GHOSTTY_RENDER_STATE_READ_SNAPSHOT =
   'ghostty-render-state:read-snapshot'
 
+export const GHOSTTY_RENDER_STATE_READ_SCROLLBACK =
+  'ghostty-render-state:read-scrollback'
+
 export const GHOSTTY_RENDER_STATE_RESET = 'ghostty-render-state:reset'
 
 export const GHOSTTY_RENDER_STATE_RESIZE = 'ghostty-render-state:resize'

--- a/electron/ghostty-render-state-main.test.ts
+++ b/electron/ghostty-render-state-main.test.ts
@@ -267,7 +267,71 @@ describe('ghostty render-state main bridge', () => {
         ],
       },
     })
-    expect(terminals[0]?.snapshot).toHaveBeenCalledWith({ includeCells: true })
+
+    expect(terminals[0]?.snapshot).toHaveBeenCalledWith({
+      includeCells: true,
+      includeScrollback: true,
+    })
+  })
+
+  test('reports scrollbackRowCount from the native snapshot on the main screen', () => {
+    const bindings: GhosttyNativeBindings = {
+      createTerminal: () => ({
+        feed: vi.fn(),
+        resize: vi.fn(),
+        snapshot: () => ({
+          rows: 4,
+          cursorRow: 0,
+          cursorCol: 0,
+          isAltScreen: false,
+          visibleLines: [{ row: 0, text: 'prompt' }],
+          scrollbackLines: [
+            { row: 0, text: 'old line 1' },
+            { row: 1, text: 'old line 2' },
+            { row: 2, text: 'old line 3' },
+          ],
+        }),
+        dispose: vi.fn(),
+      }),
+    }
+    const bridge = new GhosttyRenderStateMainBridge('/app', bindings)
+    const event = createEvent()
+    const createResult = requireResult(bridge.createDriver(event))
+
+    const snapshot = requireResult(
+      bridge.readSnapshot(event.sender.id, { driverId: createResult.driverId })
+    )
+
+    expect(snapshot.scrollbackRowCount).toBe(3)
+    expect(snapshot.isAltScreen).toBeUndefined()
+  })
+
+  test('suppresses scrollback on the alt screen (full-screen TUIs own scrolling)', () => {
+    const bindings: GhosttyNativeBindings = {
+      createTerminal: () => ({
+        feed: vi.fn(),
+        resize: vi.fn(),
+        snapshot: () => ({
+          rows: 4,
+          cursorRow: 0,
+          cursorCol: 0,
+          isAltScreen: true,
+          visibleLines: [{ row: 0, text: 'vim' }],
+          scrollbackLines: [{ row: 0, text: 'stale history' }],
+        }),
+        dispose: vi.fn(),
+      }),
+    }
+    const bridge = new GhosttyRenderStateMainBridge('/app', bindings)
+    const event = createEvent()
+    const createResult = requireResult(bridge.createDriver(event))
+
+    const snapshot = requireResult(
+      bridge.readSnapshot(event.sender.id, { driverId: createResult.driverId })
+    )
+
+    expect(snapshot.scrollbackRowCount).toBeUndefined() // 0 → omitted
+    expect(snapshot.isAltScreen).toBe(true)
   })
 
   // Regression: codex's input composer is a full-width truecolor background bar

--- a/electron/ghostty-render-state-main.test.ts
+++ b/electron/ghostty-render-state-main.test.ts
@@ -23,6 +23,7 @@ import {
 interface TestNativeTerminal {
   feed: ReturnType<typeof vi.fn<(bytes: Uint8Array) => void>>
   resize: ReturnType<typeof vi.fn<(cols: number, rows: number) => void>>
+  scrollbackRowCount?: ReturnType<typeof vi.fn<() => number>>
   snapshot: ReturnType<
     typeof vi.fn<
       () => {
@@ -304,6 +305,40 @@ describe('ghostty render-state main bridge', () => {
 
     expect(snapshot.scrollbackRowCount).toBe(3)
     expect(snapshot.isAltScreen).toBeUndefined()
+  })
+
+  test('uses the native scrollback row count without fetching line bodies', () => {
+    const terminalSnapshot = vi.fn(() => ({
+      rows: 4,
+      cursorRow: 0,
+      cursorCol: 0,
+      isAltScreen: false,
+      visibleLines: [{ row: 0, text: 'prompt' }],
+    }))
+    const scrollbackRowCount = vi.fn(() => 3)
+
+    const bindings: GhosttyNativeBindings = {
+      createTerminal: () => ({
+        feed: vi.fn(),
+        resize: vi.fn(),
+        scrollbackRowCount,
+        snapshot: terminalSnapshot,
+        dispose: vi.fn(),
+      }),
+    }
+    const bridge = new GhosttyRenderStateMainBridge('/app', bindings)
+    const event = createEvent()
+    const createResult = requireResult(bridge.createDriver(event))
+
+    const snapshot = requireResult(
+      bridge.readSnapshot(event.sender.id, { driverId: createResult.driverId })
+    )
+
+    expect(snapshot.scrollbackRowCount).toBe(3)
+    expect(scrollbackRowCount).toHaveBeenCalledOnce()
+    expect(terminalSnapshot).toHaveBeenCalledWith({
+      includeCells: true,
+    })
   })
 
   test('suppresses scrollback on the alt screen (full-screen TUIs own scrolling)', () => {

--- a/electron/ghostty-render-state-main.test.ts
+++ b/electron/ghostty-render-state-main.test.ts
@@ -334,6 +334,177 @@ describe('ghostty render-state main bridge', () => {
     expect(snapshot.isAltScreen).toBe(true)
   })
 
+  const WRAPPER_OPEN =
+    '<div style="font-family: monospace; white-space: pre;">'
+
+  test('readScrollback returns styled scrollback rows above the viewport', () => {
+    // formatHtml: two scrollback rows (one red) then the viewport row. The
+    // viewport anchors to its last content row, so the scrollback maps above it.
+    const html = `${WRAPPER_OPEN}\n${[
+      '<div style="display: inline;color: rgb(255, 0, 0);">old line A</div>',
+      '<div style="display: inline;">old line B</div>',
+      '<div style="display: inline;">current output</div></div>',
+    ].join('\n')}`
+
+    const bindings: GhosttyNativeBindings = {
+      createTerminal: () => ({
+        feed: vi.fn(),
+        resize: vi.fn(),
+        snapshot: () => ({
+          rows: 5,
+          cursorRow: 0,
+          cursorCol: 0,
+          isAltScreen: false,
+          visibleLines: [
+            { row: 0, text: 'current output' },
+            { row: 1, text: '' },
+            { row: 2, text: '' },
+            { row: 3, text: '' },
+            { row: 4, text: '' },
+          ],
+          scrollbackLines: [
+            { row: 0, text: 'old line A' },
+            { row: 1, text: 'old line B' },
+          ],
+        }),
+        formatHtml: () => html,
+        dispose: vi.fn(),
+      }),
+    }
+    const bridge = new GhosttyRenderStateMainBridge('/app', bindings)
+    const event = createEvent()
+    const createResult = requireResult(bridge.createDriver(event))
+
+    const scrollback = requireResult(
+      bridge.readScrollback(event.sender.id, {
+        driverId: createResult.driverId,
+      })
+    )
+
+    expect(scrollback.rows).toEqual(['old line A', 'old line B'])
+    // one coalesced styled cell for the red run; the plain row carries no cell
+    expect(scrollback.cells).toEqual([
+      { row: 0, col: 0, text: 'old line A', width: 10, foreground: '#ff0000' },
+    ])
+  })
+
+  test('readScrollback returns empty on the alt screen', () => {
+    const bindings: GhosttyNativeBindings = {
+      createTerminal: () => ({
+        feed: vi.fn(),
+        resize: vi.fn(),
+        snapshot: () => ({
+          rows: 5,
+          cursorRow: 0,
+          cursorCol: 0,
+          isAltScreen: true,
+          visibleLines: [{ row: 0, text: 'vim' }],
+          scrollbackLines: [{ row: 0, text: 'history' }],
+        }),
+        formatHtml: () =>
+          `${WRAPPER_OPEN}\n<div style="display: inline;">vim</div></div>`,
+        dispose: vi.fn(),
+      }),
+    }
+    const bridge = new GhosttyRenderStateMainBridge('/app', bindings)
+    const event = createEvent()
+    const createResult = requireResult(bridge.createDriver(event))
+
+    const scrollback = requireResult(
+      bridge.readScrollback(event.sender.id, {
+        driverId: createResult.driverId,
+      })
+    )
+
+    expect(scrollback.rows).toEqual([])
+    expect(scrollback.cells).toEqual([])
+  })
+
+  test('readScrollback returns empty when there is no native scrollback', () => {
+    const bindings: GhosttyNativeBindings = {
+      createTerminal: () => ({
+        feed: vi.fn(),
+        resize: vi.fn(),
+        snapshot: () => ({
+          rows: 5,
+          cursorRow: 0,
+          cursorCol: 0,
+          isAltScreen: false,
+          visibleLines: [
+            { row: 0, text: 'prompt' },
+            { row: 1, text: '' },
+          ],
+        }),
+        formatHtml: () =>
+          `${WRAPPER_OPEN}\n<div style="display: inline;">prompt</div></div>`,
+        dispose: vi.fn(),
+      }),
+    }
+    const bridge = new GhosttyRenderStateMainBridge('/app', bindings)
+    const event = createEvent()
+    const createResult = requireResult(bridge.createDriver(event))
+
+    const scrollback = requireResult(
+      bridge.readScrollback(event.sender.id, {
+        driverId: createResult.driverId,
+      })
+    )
+
+    expect(scrollback.rows).toEqual([])
+    expect(scrollback.cells).toEqual([])
+  })
+
+  test('readScrollback resolves fg + bg colors and bold in coalesced cells', () => {
+    const html = `${WRAPPER_OPEN}\n${[
+      '<div style="display: inline;background-color: rgb(0, 0, 255);color: rgb(255, 255, 0);font-weight: bold;">WARN</div>',
+      '<div style="display: inline;">live</div></div>',
+    ].join('\n')}`
+
+    const bindings: GhosttyNativeBindings = {
+      createTerminal: () => ({
+        feed: vi.fn(),
+        resize: vi.fn(),
+        snapshot: () => ({
+          rows: 4,
+          cursorRow: 0,
+          cursorCol: 0,
+          isAltScreen: false,
+          visibleLines: [
+            { row: 0, text: 'live' },
+            { row: 1, text: '' },
+            { row: 2, text: '' },
+            { row: 3, text: '' },
+          ],
+          scrollbackLines: [{ row: 0, text: 'WARN' }],
+        }),
+        formatHtml: () => html,
+        dispose: vi.fn(),
+      }),
+    }
+    const bridge = new GhosttyRenderStateMainBridge('/app', bindings)
+    const event = createEvent()
+    const createResult = requireResult(bridge.createDriver(event))
+
+    const scrollback = requireResult(
+      bridge.readScrollback(event.sender.id, {
+        driverId: createResult.driverId,
+      })
+    )
+
+    expect(scrollback.rows).toEqual(['WARN'])
+    expect(scrollback.cells).toEqual([
+      {
+        row: 0,
+        col: 0,
+        text: 'WARN',
+        width: 4,
+        foreground: '#ffff00',
+        background: '#0000ff',
+        bold: true,
+      },
+    ])
+  })
+
   // Regression: codex's input composer is a full-width truecolor background bar
   // (rgb(57,57,71)) drawn over mostly-blank cells. libghostty's native snapshot
   // carries no color and omits blank cells, so the bar exists only in formatHtml.

--- a/electron/ghostty-render-state-main.test.ts
+++ b/electron/ghostty-render-state-main.test.ts
@@ -334,8 +334,7 @@ describe('ghostty render-state main bridge', () => {
     expect(snapshot.isAltScreen).toBe(true)
   })
 
-  const WRAPPER_OPEN =
-    '<div style="font-family: monospace; white-space: pre;">'
+  const WRAPPER_OPEN = '<div style="font-family: monospace; white-space: pre;">'
 
   test('readScrollback returns styled scrollback rows above the viewport', () => {
     // formatHtml: two scrollback rows (one red) then the viewport row. The

--- a/electron/ghostty-render-state-main.ts
+++ b/electron/ghostty-render-state-main.ts
@@ -1144,6 +1144,26 @@ const readSnapshotCells = (
   )
 }
 
+// Shared anchor for mapping formatHtml content rows onto the viewport-only
+// snapshot. formatHtml's LAST content row is the grid's last non-blank row, so
+// `contentRow + rowShift` is its viewport row; `< 0` is scrollback above the
+// viewport. normalizeSnapshot (bg synthesis) and readScrollback (styled history)
+// MUST use the identical shift — recomputing from a second snapshot() a frame
+// later can shift the last-styled-row anchor out of sync and move the boundary.
+const computeRowShift = (
+  snapshot: GhosttyNativeTerminalSnapshot,
+  rows: readonly string[],
+  contentRowCount: number
+): { rowShift: number; canAlign: boolean } => {
+  const lastContentRow = readLastSnapshotContentRow(snapshot, rows)
+  const canAlign = contentRowCount > 0 && lastContentRow >= 0
+
+  return {
+    canAlign,
+    rowShift: canAlign ? lastContentRow - (contentRowCount - 1) : 0,
+  }
+}
+
 const normalizeSnapshot = (
   snapshot: GhosttyNativeTerminalSnapshot,
   cursorVisible: boolean,
@@ -1177,12 +1197,11 @@ const normalizeSnapshot = (
   // snapshot row text trims empty. A fixed wrapper/leading offset cannot do
   // this: with scrollback the offset is the scrollback height (e.g. 118 rows on
   // /resume), without it it is 0 (fresh) or -1 (shell empty row 0).
-  const lastContentRow = readLastSnapshotContentRow(snapshot, rows)
-  const canAlign = reverseVideo.contentRowCount > 0 && lastContentRow >= 0
-
-  const rowShift = canAlign
-    ? lastContentRow - (reverseVideo.contentRowCount - 1)
-    : 0
+  const { rowShift, canAlign } = computeRowShift(
+    snapshot,
+    rows,
+    reverseVideo.contentRowCount
+  )
 
   const alignedRanges = canAlign
     ? reverseVideo.ranges

--- a/electron/ghostty-render-state-main.ts
+++ b/electron/ghostty-render-state-main.ts
@@ -118,6 +118,7 @@ interface GhosttyNativeTerminalSnapshot {
 interface GhosttyNativeTerminal {
   feed: (bytes: Uint8Array) => void
   resize: (cols: number, rows: number) => void
+  scrollbackRowCount?: () => number
   snapshot: (options?: {
     includeCells?: boolean
     includeScrollback?: boolean
@@ -1461,7 +1462,8 @@ const normalizeScrollback = (
 const normalizeSnapshot = (
   snapshot: GhosttyNativeTerminalSnapshot,
   cursorVisible: boolean,
-  reverseVideo: ReverseVideoRangesResult
+  reverseVideo: ReverseVideoRangesResult,
+  scrollbackRowCountOverride?: number
 ): GhosttyRenderStateBridgeSnapshot => {
   const rows = readSnapshotRows(snapshot)
 
@@ -1511,7 +1513,7 @@ const normalizeSnapshot = (
 
   const scrollbackRowCount = isAltScreen
     ? 0
-    : (snapshot.scrollbackLines?.length ?? 0)
+    : (scrollbackRowCountOverride ?? snapshot.scrollbackLines?.length ?? 0)
 
   return {
     rows,
@@ -1633,18 +1635,25 @@ export class GhosttyRenderStateMainBridge {
   }
 
   readSnapshot(ownerWebContentsId: number, payload: unknown): SnapshotResult {
-    return this.withDriver(ownerWebContentsId, payload, (record) =>
-      ok(
+    return this.withDriver(ownerWebContentsId, payload, (record) => {
+      const scrollbackRowCount = record.terminal.scrollbackRowCount?.()
+
+      const snapshot = record.terminal.snapshot({
+        includeCells: true,
+        ...(scrollbackRowCount === undefined
+          ? { includeScrollback: true }
+          : {}),
+      })
+
+      return ok(
         normalizeSnapshot(
-          record.terminal.snapshot({
-            includeCells: true,
-            includeScrollback: true,
-          }),
+          snapshot,
           record.cursorVisibilityScanner.readVisible(),
-          readTerminalReverseVideoRanges(record.terminal)
+          readTerminalReverseVideoRanges(record.terminal),
+          scrollbackRowCount
         )
       )
-    )
+    })
   }
 
   readScrollback(

--- a/electron/ghostty-render-state-main.ts
+++ b/electron/ghostty-render-state-main.ts
@@ -52,6 +52,11 @@ export interface GhosttyRenderStateBridgeSnapshot {
     visible?: boolean
   }
   cells?: readonly GhosttyRenderStateBridgeSnapshotCell[]
+  // Count of scrollback rows libghostty holds above the viewport (0 on the alt
+  // screen). The viewport rows/cells above stay viewport-only per frame; the
+  // styled scrollback itself is fetched lazily via readScrollback on scroll-up.
+  scrollbackRowCount?: number
+  isAltScreen?: boolean
 }
 
 export interface GhosttyRenderStateBridgeSnapshotCell extends GhosttyCellTraversalCell {
@@ -96,7 +101,9 @@ interface GhosttyNativeTerminalSnapshot {
   cursorRow: number
   cursorCol: number
   cursorVisible?: boolean
+  isAltScreen?: boolean
   visibleLines: readonly GhosttyNativeTerminalLine[]
+  scrollbackLines?: readonly GhosttyNativeTerminalLine[]
   cells?: readonly GhosttyNativeTerminalSnapshotCell[]
 }
 
@@ -105,6 +112,7 @@ interface GhosttyNativeTerminal {
   resize: (cols: number, rows: number) => void
   snapshot: (options?: {
     includeCells?: boolean
+    includeScrollback?: boolean
   }) => GhosttyNativeTerminalSnapshot
   dispose: () => void
   formatHtml?: () => string
@@ -1184,6 +1192,14 @@ const normalizeSnapshot = (
 
   const cells = readSnapshotCells(snapshot, rows, alignedRanges)
 
+  // Scrollback is meaningless on the alt screen (full-screen TUIs own their own
+  // scrolling), so report 0 there and let the renderer suppress history.
+  const isAltScreen = snapshot.isAltScreen === true
+
+  const scrollbackRowCount = isAltScreen
+    ? 0
+    : (snapshot.scrollbackLines?.length ?? 0)
+
   return {
     rows,
     cursor: {
@@ -1191,6 +1207,8 @@ const normalizeSnapshot = (
       ...(snapshotCursorVisible === false ? { visible: false } : {}),
     },
     ...(cells === undefined ? {} : { cells }),
+    ...(scrollbackRowCount > 0 ? { scrollbackRowCount } : {}),
+    ...(isAltScreen ? { isAltScreen: true } : {}),
   }
 }
 
@@ -1305,7 +1323,10 @@ export class GhosttyRenderStateMainBridge {
     return this.withDriver(ownerWebContentsId, payload, (record) =>
       ok(
         normalizeSnapshot(
-          record.terminal.snapshot({ includeCells: true }),
+          record.terminal.snapshot({
+            includeCells: true,
+            includeScrollback: true,
+          }),
           record.cursorVisibilityScanner.readVisible(),
           readTerminalReverseVideoRanges(record.terminal)
         )

--- a/electron/ghostty-render-state-main.ts
+++ b/electron/ghostty-render-state-main.ts
@@ -13,6 +13,7 @@ import { palette256ToRgb } from '../shared/ansiPalette'
 import {
   GHOSTTY_RENDER_STATE_CREATE,
   GHOSTTY_RENDER_STATE_DISPOSE,
+  GHOSTTY_RENDER_STATE_READ_SCROLLBACK,
   GHOSTTY_RENDER_STATE_READ_SNAPSHOT,
   GHOSTTY_RENDER_STATE_RESET,
   GHOSTTY_RENDER_STATE_RESIZE,
@@ -70,6 +71,13 @@ export interface GhosttyRenderStateBridgeSnapshotCell extends GhosttyCellTravers
   foreground?: string
   background?: string
   reverse?: boolean
+}
+
+export interface GhosttyRenderStateScrollback {
+  // Styled scrollback ABOVE the viewport, top-down, 0-based. `rows` carries the
+  // text; `cells` are coalesced styled spans (row relative to `rows`).
+  rows: readonly string[]
+  cells: readonly GhosttyRenderStateBridgeSnapshotCell[]
 }
 
 interface GhosttyNativeTerminalOptions {
@@ -170,6 +178,7 @@ type WriteBytesResult = IpcResult<{
   events: readonly GhosttyRenderStateEvent[]
 }>
 type SnapshotResult = IpcResult<GhosttyRenderStateBridgeSnapshot>
+type ScrollbackResult = IpcResult<GhosttyRenderStateScrollback>
 type EmptyResult = IpcResult<null>
 
 interface GhosttyRenderStateEvent {
@@ -790,6 +799,239 @@ const readTerminalReverseVideoRanges = (
   }
 }
 
+// Full cell style parsed from a formatHtml inline-style attribute. Parallel to
+// ReverseVideoRange's bg/reverse pick so the per-frame bg-synthesis helpers stay
+// untouched; this richer style is only used for the lazy styled-scrollback walk.
+interface HtmlCellStyle {
+  foreground?: string
+  background?: string
+  bold?: boolean
+  italic?: boolean
+  underline?: boolean
+  reverse?: boolean
+}
+
+const CSS_RGB_VALUE_PATTERN =
+  /^rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/i
+const CSS_PALETTE_VALUE_PATTERN = /^var\(--vt-palette-(\d{1,3})\)$/i
+
+// Resolve a CSS color VALUE (fg or bg) to hex. Must resolve `var(--vt-palette-N)`
+// to hex here: createGhosttyVtRenderSnapshotOutput only encodes hex cell colors
+// into SGR sentinels and drops raw CSS vars before DOM styling.
+const readCssColorValue = (value: string): string | undefined => {
+  const rgb = CSS_RGB_VALUE_PATTERN.exec(value)
+
+  if (rgb) {
+    return toHexColor(Number(rgb[1]), Number(rgb[2]), Number(rgb[3]))
+  }
+
+  const palette = CSS_PALETTE_VALUE_PATTERN.exec(value)
+
+  if (palette) {
+    return paletteIndexToHex(Number(palette[1]))
+  }
+
+  return undefined
+}
+
+// Parse declarations (split on `;`) rather than a loose `color:` regex, which
+// would also match inside `background-color:`.
+const readTagHtmlCellStyle = (token: string): HtmlCellStyle => {
+  const match = HTML_STYLE_ATTRIBUTE_PATTERN.exec(token)
+
+  if (!match) {
+    return {}
+  }
+
+  const style: HtmlCellStyle = {}
+
+  for (const declaration of match[1].split(';')) {
+    const separator = declaration.indexOf(':')
+
+    if (separator < 0) {
+      continue
+    }
+
+    const property = declaration.slice(0, separator).trim().toLowerCase()
+    const value = declaration.slice(separator + 1).trim()
+
+    if (property === 'color') {
+      const foreground = readCssColorValue(value)
+
+      if (foreground) {
+        style.foreground = foreground
+      }
+    } else if (property === 'background-color') {
+      const background = readCssColorValue(value)
+
+      if (background) {
+        style.background = background
+      }
+    } else if (property === 'font-weight' && value === 'bold') {
+      style.bold = true
+    } else if (property === 'font-style' && value === 'italic') {
+      style.italic = true
+    } else if (property === 'text-decoration' && /underline/i.test(value)) {
+      style.underline = true
+    } else if (property === 'filter' && /invert\(100%\)/i.test(value)) {
+      style.reverse = true
+    }
+  }
+
+  return style
+}
+
+const mergeHtmlCellStyle = (
+  parent: HtmlCellStyle,
+  child: HtmlCellStyle
+): HtmlCellStyle => {
+  const foreground = child.foreground ?? parent.foreground
+  const background = child.background ?? parent.background
+
+  return {
+    ...(foreground ? { foreground } : {}),
+    ...(background ? { background } : {}),
+    ...(parent.bold || child.bold ? { bold: true } : {}),
+    ...(parent.italic || child.italic ? { italic: true } : {}),
+    ...(parent.underline || child.underline ? { underline: true } : {}),
+    ...(parent.reverse || child.reverse ? { reverse: true } : {}),
+  }
+}
+
+const hasHtmlCellStyle = (style: HtmlCellStyle): boolean =>
+  style.foreground !== undefined ||
+  style.background !== undefined ||
+  style.bold === true ||
+  style.italic === true ||
+  style.underline === true ||
+  style.reverse === true
+
+const sameHtmlCellStyle = (left: HtmlCellStyle, right: HtmlCellStyle): boolean =>
+  left.foreground === right.foreground &&
+  left.background === right.background &&
+  left.bold === right.bold &&
+  left.italic === right.italic &&
+  left.underline === right.underline &&
+  left.reverse === right.reverse
+
+interface StyledHtmlParseResult {
+  readonly rows: readonly string[]
+  readonly cells: readonly GhosttyRenderStateBridgeSnapshotCell[]
+  readonly contentRowCount: number
+}
+
+interface StyledRun {
+  startColumn: number
+  text: string
+  style: HtmlCellStyle
+}
+
+const styledRunToCell = (
+  run: StyledRun,
+  row: number,
+  endColumn: number
+): GhosttyRenderStateBridgeSnapshotCell => ({
+  row,
+  col: run.startColumn,
+  text: run.text,
+  width: endColumn - run.startColumn,
+  ...run.style,
+})
+
+// Walk formatHtml into per-row text + coalesced styled-run cells (one cell per
+// contiguous same-style run; unstyled spans carry no cell — the row text
+// supplies them, matching how the viewport feeds readStyledRowText). Reuses the
+// same tokenizer/entity-decode/wrapper-skip as readReverseVideoRangesFromHtml.
+const readStyledCellsFromHtml = (html: string): StyledHtmlParseResult => {
+  const rows: string[] = []
+  const cells: GhosttyRenderStateBridgeSnapshotCell[] = []
+  const styleStack: HtmlCellStyle[] = [{}]
+  let row = 0
+  let column = 0
+  let rowText = ''
+  let run: StyledRun | null = null
+  let skippedWrapperNewline = false
+
+  const flushRun = (): void => {
+    if (run && hasHtmlCellStyle(run.style)) {
+      cells.push(styledRunToCell(run, row, column))
+    }
+    run = null
+  }
+
+  Array.from(html.matchAll(HTML_TOKEN_PATTERN)).forEach((match) => {
+    const token = match[0]
+
+    if (isOpeningHtmlTag(token)) {
+      styleStack.push(
+        mergeHtmlCellStyle(
+          styleStack[styleStack.length - 1] ?? {},
+          readTagHtmlCellStyle(token)
+        )
+      )
+
+      return
+    }
+
+    if (isClosingHtmlTag(token)) {
+      styleStack.pop()
+
+      return
+    }
+
+    if (isHtmlTag(token)) {
+      return
+    }
+
+    const style = styleStack[styleStack.length - 1] ?? {}
+
+    for (const character of decodeHtmlText(token)) {
+      if (character === '\n') {
+        if (!skippedWrapperNewline && row === 0 && column === 0) {
+          skippedWrapperNewline = true
+          continue
+        }
+
+        flushRun()
+        rows.push(rowText)
+        rowText = ''
+        row += 1
+        column = 0
+        continue
+      }
+
+      const width = readTextCellWidth(character)
+
+      if (width <= 0) {
+        continue
+      }
+
+      rowText += character
+
+      if (hasHtmlCellStyle(style)) {
+        if (run && sameHtmlCellStyle(run.style, style)) {
+          run.text += character
+        } else {
+          flushRun()
+          run = { startColumn: column, text: character, style }
+        }
+      } else {
+        flushRun()
+      }
+
+      column += width
+    }
+  })
+
+  flushRun()
+
+  if (rows.length > 0 || rowText.length > 0) {
+    rows.push(rowText)
+  }
+
+  return { rows, cells, contentRowCount: rows.length }
+}
+
 const hasSnapshotCellStyle = (
   cell: GhosttyRenderStateBridgeSnapshotCell
 ): boolean =>
@@ -1164,6 +1406,55 @@ const computeRowShift = (
   }
 }
 
+// Bound the styled-scrollback payload over sync IPC: return the bottom N rows
+// nearest the viewport (what the user sees first on scroll-up). Older history
+// paging is a follow-up.
+const MAX_SCROLLBACK_FETCH_ROWS = 2000
+
+const EMPTY_SCROLLBACK: GhosttyRenderStateScrollback = { rows: [], cells: [] }
+
+// Styled scrollback above the viewport, from formatHtml, using the SAME rowShift
+// anchor as normalizeSnapshot. Scrollback = content rows mapping above the
+// viewport (contentRow + rowShift < 0). Requires native scrollback to exist
+// (else a rowShift == -1 trimmed leading blank would masquerade as history),
+// and keeps the bottom MAX rows nearest the viewport.
+const normalizeScrollback = (
+  snapshot: GhosttyNativeTerminalSnapshot,
+  html: string
+): GhosttyRenderStateScrollback => {
+  if (snapshot.isAltScreen === true) {
+    return EMPTY_SCROLLBACK
+  }
+
+  const rows = readSnapshotRows(snapshot)
+  const parsed = readStyledCellsFromHtml(html)
+
+  const { rowShift, canAlign } = computeRowShift(
+    snapshot,
+    rows,
+    parsed.contentRowCount
+  )
+
+  if (!canAlign || rowShift >= 0) {
+    return EMPTY_SCROLLBACK
+  }
+
+  if ((snapshot.scrollbackLines?.length ?? 0) === 0) {
+    return EMPTY_SCROLLBACK
+  }
+
+  const scrollbackEnd = -rowShift // content rows [0, scrollbackEnd) are scrollback
+  const keep = Math.min(scrollbackEnd, MAX_SCROLLBACK_FETCH_ROWS)
+  const start = scrollbackEnd - keep
+
+  return {
+    rows: parsed.rows.slice(start, scrollbackEnd),
+    cells: parsed.cells
+      .filter((cell) => cell.row >= start && cell.row < scrollbackEnd)
+      .map((cell) => ({ ...cell, row: cell.row - start })),
+  }
+}
+
 const normalizeSnapshot = (
   snapshot: GhosttyNativeTerminalSnapshot,
   cursorVisible: boolean,
@@ -1353,6 +1644,28 @@ export class GhosttyRenderStateMainBridge {
     )
   }
 
+  readScrollback(ownerWebContentsId: number, payload: unknown): ScrollbackResult {
+    return this.withDriver(ownerWebContentsId, payload, (record) => {
+      if (!record.terminal.formatHtml) {
+        return ok(EMPTY_SCROLLBACK)
+      }
+
+      try {
+        return ok(
+          normalizeScrollback(
+            record.terminal.snapshot({
+              includeCells: true,
+              includeScrollback: true,
+            }),
+            record.terminal.formatHtml()
+          )
+        )
+      } catch (error) {
+        return fail(stringifyError(error))
+      }
+    })
+  }
+
   resize(ownerWebContentsId: number, payload: unknown): EmptyResult {
     try {
       const { driverId, size } = readSizePayload(payload)
@@ -1526,6 +1839,11 @@ export const setupGhosttyRenderStateIpc = (
       options.ipcMain,
       GHOSTTY_RENDER_STATE_READ_SNAPSHOT,
       (event, payload) => bridge.readSnapshot(event.sender.id, payload)
+    ),
+    registerSyncHandler(
+      options.ipcMain,
+      GHOSTTY_RENDER_STATE_READ_SCROLLBACK,
+      (event, payload) => bridge.readScrollback(event.sender.id, payload)
     ),
     registerSyncHandler(
       options.ipcMain,

--- a/electron/ghostty-render-state-main.ts
+++ b/electron/ghostty-render-state-main.ts
@@ -906,7 +906,10 @@ const hasHtmlCellStyle = (style: HtmlCellStyle): boolean =>
   style.underline === true ||
   style.reverse === true
 
-const sameHtmlCellStyle = (left: HtmlCellStyle, right: HtmlCellStyle): boolean =>
+const sameHtmlCellStyle = (
+  left: HtmlCellStyle,
+  right: HtmlCellStyle
+): boolean =>
   left.foreground === right.foreground &&
   left.background === right.background &&
   left.bold === right.bold &&
@@ -1644,7 +1647,10 @@ export class GhosttyRenderStateMainBridge {
     )
   }
 
-  readScrollback(ownerWebContentsId: number, payload: unknown): ScrollbackResult {
+  readScrollback(
+    ownerWebContentsId: number,
+    payload: unknown
+  ): ScrollbackResult {
     return this.withDriver(ownerWebContentsId, payload, (record) => {
       if (!record.terminal.formatHtml) {
         return ok(EMPTY_SCROLLBACK)

--- a/electron/ghostty-render-state-preload.ts
+++ b/electron/ghostty-render-state-preload.ts
@@ -3,6 +3,7 @@ import { ipcRenderer } from 'electron'
 import {
   GHOSTTY_RENDER_STATE_CREATE,
   GHOSTTY_RENDER_STATE_DISPOSE,
+  GHOSTTY_RENDER_STATE_READ_SCROLLBACK,
   GHOSTTY_RENDER_STATE_READ_SNAPSHOT,
   GHOSTTY_RENDER_STATE_RESET,
   GHOSTTY_RENDER_STATE_RESIZE,
@@ -27,6 +28,13 @@ export interface GhosttyRenderStateBridgeSnapshot {
     visible?: boolean
   }
   cells?: readonly GhosttyRenderStateBridgeSnapshotCell[]
+  scrollbackRowCount?: number
+  isAltScreen?: boolean
+}
+
+export interface GhosttyRenderStateBridgeScrollback {
+  rows: readonly string[]
+  cells: readonly GhosttyRenderStateBridgeSnapshotCell[]
 }
 
 export interface GhosttyRenderStateBridgeSnapshotCell {
@@ -45,6 +53,7 @@ export interface GhosttyRenderStateBridgeSnapshotCell {
 export interface GhosttyRenderStateBridgeDriver {
   writeBytes: (bytes: Uint8Array) => void
   readSnapshot: () => GhosttyRenderStateBridgeSnapshot
+  readScrollback: () => GhosttyRenderStateBridgeScrollback
   reset: () => void
   resize: (size: GhosttyRenderStateBridgeSize) => void
   dispose: () => void
@@ -151,6 +160,14 @@ export const createGhosttyRenderStateBridgeFromIpc =
 
           return readIpcResult<GhosttyRenderStateBridgeSnapshot>(
             GHOSTTY_RENDER_STATE_READ_SNAPSHOT,
+            { driverId }
+          )
+        },
+        readScrollback: (): GhosttyRenderStateBridgeScrollback => {
+          assertActive()
+
+          return readIpcResult<GhosttyRenderStateBridgeScrollback>(
+            GHOSTTY_RENDER_STATE_READ_SCROLLBACK,
             { driverId }
           )
         },

--- a/electron/sandbox.test.ts
+++ b/electron/sandbox.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest'
 import {
   VIMEFLOW_NO_SANDBOX_ENV,
+  VIMEFLOW_USER_DATA_DIR_ENV,
   electronStartupArgs,
   isElectronNoSandboxRequested,
 } from './sandbox'
@@ -25,5 +26,20 @@ describe('Electron sandbox startup args', () => {
         WAYLAND_DISPLAY: undefined,
       })
     ).toEqual(['.'])
+  })
+
+  test('isolates userData via --user-data-dir when requested', () => {
+    expect(
+      electronStartupArgs({ [VIMEFLOW_USER_DATA_DIR_ENV]: '/tmp/vimeflow-dev' })
+    ).toEqual(['.', '--user-data-dir=/tmp/vimeflow-dev'])
+  })
+
+  test('combines no-sandbox and an isolated userData dir', () => {
+    expect(
+      electronStartupArgs({
+        [VIMEFLOW_NO_SANDBOX_ENV]: '1',
+        [VIMEFLOW_USER_DATA_DIR_ENV]: '/tmp/vimeflow-dev',
+      })
+    ).toEqual(['.', '--no-sandbox', '--user-data-dir=/tmp/vimeflow-dev'])
   })
 })

--- a/electron/sandbox.ts
+++ b/electron/sandbox.ts
@@ -1,5 +1,10 @@
 export const VIMEFLOW_NO_SANDBOX_ENV = 'VIMEFLOW_NO_SANDBOX'
 
+// Run the dev build on an isolated userData dir so it never shares the default
+// `vibm` dir with an installed production app (which holds the Local Storage
+// lock). Off by default; opt in via the env var.
+export const VIMEFLOW_USER_DATA_DIR_ENV = 'VIMEFLOW_USER_DATA_DIR'
+
 type Env = Readonly<Record<string, string | undefined>>
 
 export const isElectronNoSandboxRequested = (env: Env = process.env): boolean =>
@@ -8,4 +13,7 @@ export const isElectronNoSandboxRequested = (env: Env = process.env): boolean =>
 export const electronStartupArgs = (env: Env = process.env): string[] => [
   '.',
   ...(isElectronNoSandboxRequested(env) ? ['--no-sandbox'] : []),
+  ...(env[VIMEFLOW_USER_DATA_DIR_ENV]
+    ? [`--user-data-dir=${env[VIMEFLOW_USER_DATA_DIR_ENV]}`]
+    : []),
 ]

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "electron:build:linux:x64": "node scripts/package-electron.mjs linux-x64",
     "electron:build:mac:arm64": "node scripts/package-electron.mjs mac-arm64",
     "electron:dev": "npm run generate:bindings && npm run backend:build && vite --mode electron",
+    "dev:ghostty": "bash scripts/dev-ghostty.sh",
     "prepare": "husky",
     "lint": "npm run generate:bindings:if-missing && eslint .",
     "lint:fix": "npm run generate:bindings:if-missing && eslint . --fix",

--- a/scripts/dev-ghostty.sh
+++ b/scripts/dev-ghostty.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Launch the Ghostty native dev build, ISOLATED from any installed production app.
+#
+# Why this exists
+# ---------------
+# The dev build and an installed /Applications/Vimeflow.app share the default
+# "vibm" Electron userData dir. If you run dev while the production app is open,
+# the two fight over the same Local Storage lock (or Electron's single-instance
+# behaviour hands the launch off to the already-open production window), so the
+# dev window silently shows production's code instead of yours. Pointing dev at
+# its OWN userData dir makes the two fully independent — and means you must NEVER
+# kill the production app just to test dev.
+#
+# The renderer defaults to xterm.js; the Ghostty native path is opt-in via the
+# two VITE_ vars below. Always go through electron:dev (regenerates bindings +
+# builds the Rust sidecar + vite); never run `npx vite --mode electron` directly.
+#
+# Usage:
+#   npm run dev:ghostty                          # normal launch
+#   VIMEFLOW_USER_DATA_DIR=/path npm run dev:ghostty   # custom isolated dir
+#
+# Reading logs: run this as a background task; the renderer console bridges to
+# stdout as `[renderer:info]`. For reliable debug telemetry, log from the MAIN
+# process (electron/*.ts) — it goes straight to stdout and survives the renderer's
+# flaky HMR. See .claude/skills/run-ghostty-dev/SKILL.md.
+set -euo pipefail
+
+export VITE_TERMINAL_RENDERER="${VITE_TERMINAL_RENDERER:-ghostty}"
+export VITE_GHOSTTY_RENDER_STATE_DRIVER_PROVIDER="${VITE_GHOSTTY_RENDER_STATE_DRIVER_PROVIDER:-native}"
+export VIMEFLOW_USER_DATA_DIR="${VIMEFLOW_USER_DATA_DIR:-${TMPDIR:-/tmp}/vimeflow-dev-userdata}"
+
+mkdir -p "$VIMEFLOW_USER_DATA_DIR"
+
+echo "[dev-ghostty] renderer=$VITE_TERMINAL_RENDERER driver=$VITE_GHOSTTY_RENDER_STATE_DRIVER_PROVIDER"
+echo "[dev-ghostty] userData=$VIMEFLOW_USER_DATA_DIR (isolated from the installed app)"
+echo "[dev-ghostty] launching electron:dev ..."
+
+exec npm run electron:dev

--- a/src/features/terminal/components/TerminalPane/ghosttyNativeRenderStateBridge.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyNativeRenderStateBridge.test.ts
@@ -234,6 +234,81 @@ describe('ghosttyNativeRenderStateBridge', () => {
     })
   })
 
+  test('threads scrollbackRowCount and isAltScreen onto the snapshot', () => {
+    installBridge({
+      createDriver: () => ({
+        writeBytes: vi.fn(),
+        readSnapshot: (): unknown => ({
+          rows: ['prompt'],
+          scrollbackRowCount: 7,
+          isAltScreen: false,
+        }),
+        readScrollback: (): unknown => ({ rows: [], cells: [] }),
+      }),
+    })
+
+    const driver = createGhosttyNativeRenderStateDriver({
+      onCwdChange: vi.fn(),
+    })
+
+    const snapshot = driver.readSnapshot()
+    expect(snapshot.scrollbackRowCount).toBe(7)
+    expect(snapshot.isAltScreen).toBeUndefined() // false → omitted
+  })
+
+  test('readScrollback normalizes the native styled scrollback', () => {
+    installBridge({
+      createDriver: () => ({
+        writeBytes: vi.fn(),
+        readSnapshot: (): unknown => ({ rows: [] }),
+        readScrollback: (): unknown => ({
+          rows: ['old A', 'old B'],
+          cells: [
+            {
+              row: 0,
+              col: 0,
+              text: 'old A',
+              width: 5,
+              foreground: 'var(--terminal-ansi-red)',
+            },
+          ],
+        }),
+      }),
+    })
+
+    const driver = createGhosttyNativeRenderStateDriver({
+      onCwdChange: vi.fn(),
+    })
+
+    expect(driver.readScrollback?.()).toEqual({
+      rows: ['old A', 'old B'],
+      cells: [
+        {
+          row: 0,
+          col: 0,
+          text: 'old A',
+          width: 5,
+          foreground: 'var(--terminal-ansi-red)',
+        },
+      ],
+    })
+  })
+
+  test('readScrollback returns empty when the bridge driver omits it', () => {
+    installBridge({
+      createDriver: () => ({
+        writeBytes: vi.fn(),
+        readSnapshot: (): unknown => ({ rows: [] }),
+      }),
+    })
+
+    const driver = createGhosttyNativeRenderStateDriver({
+      onCwdChange: vi.fn(),
+    })
+
+    expect(driver.readScrollback?.()).toEqual({ rows: [], cells: [] })
+  })
+
   test('does not pad a wide-glyph row that already reaches the cursor column', () => {
     installBridge({
       createDriver: () => ({

--- a/src/features/terminal/components/TerminalPane/ghosttyNativeRenderStateBridge.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyNativeRenderStateBridge.test.ts
@@ -105,6 +105,7 @@ describe('ghosttyNativeRenderStateBridge', () => {
               },
             ],
           }),
+          readScrollback: (): unknown => ({ rows: [], cells: [] }),
           reset,
           resize,
           dispose,
@@ -165,6 +166,7 @@ describe('ghosttyNativeRenderStateBridge', () => {
     installBridge({
       createDriver: () => ({
         writeBytes: vi.fn(),
+        readScrollback: (): unknown => ({ rows: [], cells: [] }),
         readSnapshot: (): unknown => ({
           rows: ['native prompt'],
           cursor: {
@@ -188,6 +190,7 @@ describe('ghosttyNativeRenderStateBridge', () => {
     installBridge({
       createDriver: () => ({
         writeBytes: vi.fn(),
+        readScrollback: (): unknown => ({ rows: [], cells: [] }),
         readSnapshot: (): unknown => ({
           rows: ['native prompt'],
           cursor: {
@@ -211,6 +214,7 @@ describe('ghosttyNativeRenderStateBridge', () => {
     installBridge({
       createDriver: () => ({
         writeBytes: vi.fn(),
+        readScrollback: (): unknown => ({ rows: [], cells: [] }),
         readSnapshot: (): unknown => ({
           rows: ['', 'abc'],
           cursor: {
@@ -294,25 +298,11 @@ describe('ghosttyNativeRenderStateBridge', () => {
     })
   })
 
-  test('readScrollback returns empty when the bridge driver omits it', () => {
-    installBridge({
-      createDriver: () => ({
-        writeBytes: vi.fn(),
-        readSnapshot: (): unknown => ({ rows: [] }),
-      }),
-    })
-
-    const driver = createGhosttyNativeRenderStateDriver({
-      onCwdChange: vi.fn(),
-    })
-
-    expect(driver.readScrollback?.()).toEqual({ rows: [], cells: [] })
-  })
-
   test('does not pad a wide-glyph row that already reaches the cursor column', () => {
     installBridge({
       createDriver: () => ({
         writeBytes: vi.fn(),
+        readScrollback: (): unknown => ({ rows: [], cells: [] }),
         readSnapshot: (): unknown => ({
           rows: ['界'],
           cursor: {
@@ -340,6 +330,7 @@ describe('ghosttyNativeRenderStateBridge', () => {
     installBridge({
       createDriver: () => ({
         writeBytes: vi.fn(),
+        readScrollback: (): unknown => ({ rows: [], cells: [] }),
         readSnapshot: (): unknown => ({
           rows: ['native prompt'],
           cells: [

--- a/src/features/terminal/components/TerminalPane/ghosttyNativeRenderStateBridge.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyNativeRenderStateBridge.ts
@@ -227,9 +227,7 @@ export const createGhosttyNativeRenderStateDriver: GhosttyVtRenderStateDriverFac
       readSnapshot: (): GhosttyVtRenderSnapshot =>
         normalizeNativeSnapshot(driver.readSnapshot()),
       readScrollback: (): GhosttyVtRenderScrollback =>
-        driver.readScrollback
-          ? normalizeNativeScrollback(driver.readScrollback())
-          : { rows: [], cells: [] },
+        normalizeNativeScrollback(driver.readScrollback()),
       reset: (): void => {
         driver.reset?.()
       },

--- a/src/features/terminal/components/TerminalPane/ghosttyNativeRenderStateBridge.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyNativeRenderStateBridge.ts
@@ -7,7 +7,10 @@ import type {
   GhosttyVtRenderStateDriver,
   GhosttyVtRenderStateDriverFactory,
 } from './ghosttyVtRenderStateDriver'
-import type { GhosttyVtRenderSnapshot } from './ghosttyVtRenderSnapshot'
+import type {
+  GhosttyVtRenderSnapshot,
+  GhosttyVtRenderScrollback,
+} from './ghosttyVtRenderSnapshot'
 import { readTextCellWidth } from './terminalDisplayBuffer'
 
 export const GHOSTTY_NATIVE_RENDER_STATE_DRIVER_PROVIDER_ID = 'native'
@@ -187,6 +190,25 @@ const normalizeNativeSnapshot = (
     rows: paddedRows,
     ...(cursor === undefined ? {} : { cursor }),
     ...(cells === undefined ? {} : { cells }),
+    ...(isNonNegativeInteger(snapshot.scrollbackRowCount)
+      ? { scrollbackRowCount: snapshot.scrollbackRowCount }
+      : {}),
+    ...(snapshot.isAltScreen === true ? { isAltScreen: true } : {}),
+  }
+}
+
+const normalizeNativeScrollback = (
+  scrollback: unknown
+): GhosttyVtRenderScrollback => {
+  if (!isRecord(scrollback)) {
+    throw new Error('Ghostty native render-state scrollback is invalid')
+  }
+
+  const rows = readSnapshotRows(scrollback)
+
+  return {
+    rows,
+    cells: readSnapshotCells(scrollback, rows.length) ?? [],
   }
 }
 
@@ -204,6 +226,10 @@ export const createGhosttyNativeRenderStateDriver: GhosttyVtRenderStateDriverFac
       },
       readSnapshot: (): GhosttyVtRenderSnapshot =>
         normalizeNativeSnapshot(driver.readSnapshot()),
+      readScrollback: (): GhosttyVtRenderScrollback =>
+        driver.readScrollback
+          ? normalizeNativeScrollback(driver.readScrollback())
+          : { rows: [], cells: [] },
       reset: (): void => {
         driver.reset?.()
       },

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.test.ts
@@ -1,7 +1,11 @@
 // cspell:ignore ghostty winoooops
 import { describe, expect, test } from 'vitest'
 import { TerminalDisplayBuffer } from './terminalDisplayBuffer'
-import { createGhosttyVtRenderSnapshotOutput } from './ghosttyVtRenderSnapshot'
+import {
+  createGhosttyVtRenderSnapshotOutput,
+  encodeScrollback,
+  prependScrollbackToOutput,
+} from './ghosttyVtRenderSnapshot'
 
 const TRUE_COLOR_PINK_HEX = ['#', 'f38ba8'].join('')
 const TRUE_COLOR_BASE_HEX = ['#', '181825'].join('')
@@ -673,5 +677,51 @@ describe('ghosttyVtRenderSnapshot', () => {
 
     expect(buffer.readVisibleText()).toBe(`${NERD_FONT_TERMINAL_ICON}xy`)
     expect(buffer.readCursorOffset()).toBe(`${NERD_FONT_TERMINAL_ICON}x`.length)
+  })
+})
+
+describe('scrollback composition', () => {
+  test('encodeScrollback renders plain rows verbatim and styled runs distinctly', () => {
+    expect(encodeScrollback({ rows: ['ab', 'cd'], cells: [] })).toEqual({
+      displayText: 'ab\ncd',
+      visibleText: 'ab\ncd',
+    })
+
+    const styled = encodeScrollback({
+      rows: ['x'],
+      cells: [{ row: 0, col: 0, text: 'x', width: 1, bold: true }],
+    })
+    expect(styled.visibleText).toBe('x')
+    // a styled run wraps the glyph in an SGR sentinel, so displayText differs
+    expect(styled.displayText).not.toBe('x')
+    expect(styled.displayText).toContain('x')
+  })
+
+  test('prependScrollbackToOutput stacks history above the viewport and shifts the cursor', () => {
+    const viewport = createGhosttyVtRenderSnapshotOutput({
+      rows: ['PROMPT'],
+      cursor: { rowIndex: 0, columnOffset: 3 },
+    })
+
+    const combined = prependScrollbackToOutput(viewport, {
+      displayText: 'history',
+      visibleText: 'history',
+    })
+
+    expect(combined.visibleText).toBe('history\nPROMPT')
+    expect(combined.displayDelta?.operations[0]).toEqual({
+      type: 'replace',
+      text: 'history\nPROMPT',
+      // 7 (scrollback visible) + 1 (newline) + 3 (viewport cursor) = 11
+      cursorOffset: 11,
+    })
+  })
+
+  test('prependScrollbackToOutput leaves an output without a replace delta untouched', () => {
+    const output = { visibleText: 'live' }
+
+    expect(
+      prependScrollbackToOutput(output, { displayText: 'h', visibleText: 'h' })
+    ).toBe(output)
   })
 })

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.test.ts
@@ -4,7 +4,6 @@ import { TerminalDisplayBuffer } from './terminalDisplayBuffer'
 import {
   createGhosttyVtRenderSnapshotOutput,
   encodeScrollback,
-  prependScrollbackToOutput,
 } from './ghosttyVtRenderSnapshot'
 
 const TRUE_COLOR_PINK_HEX = ['#', 'f38ba8'].join('')
@@ -695,33 +694,5 @@ describe('scrollback composition', () => {
     // a styled run wraps the glyph in an SGR sentinel, so displayText differs
     expect(styled.displayText).not.toBe('x')
     expect(styled.displayText).toContain('x')
-  })
-
-  test('prependScrollbackToOutput stacks history above the viewport and shifts the cursor', () => {
-    const viewport = createGhosttyVtRenderSnapshotOutput({
-      rows: ['PROMPT'],
-      cursor: { rowIndex: 0, columnOffset: 3 },
-    })
-
-    const combined = prependScrollbackToOutput(viewport, {
-      displayText: 'history',
-      visibleText: 'history',
-    })
-
-    expect(combined.visibleText).toBe('history\nPROMPT')
-    expect(combined.displayDelta?.operations[0]).toEqual({
-      type: 'replace',
-      text: 'history\nPROMPT',
-      // 7 (scrollback visible) + 1 (newline) + 3 (viewport cursor) = 11
-      cursorOffset: 11,
-    })
-  })
-
-  test('prependScrollbackToOutput leaves an output without a replace delta untouched', () => {
-    const output = { visibleText: 'live' }
-
-    expect(
-      prependScrollbackToOutput(output, { displayText: 'h', visibleText: 'h' })
-    ).toBe(output)
   })
 })

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.test.ts
@@ -683,14 +683,12 @@ describe('scrollback composition', () => {
   test('encodeScrollback renders plain rows verbatim and styled runs distinctly', () => {
     expect(encodeScrollback({ rows: ['ab', 'cd'], cells: [] })).toEqual({
       displayText: 'ab\ncd',
-      visibleText: 'ab\ncd',
     })
 
     const styled = encodeScrollback({
       rows: ['x'],
       cells: [{ row: 0, col: 0, text: 'x', width: 1, bold: true }],
     })
-    expect(styled.visibleText).toBe('x')
     // a styled run wraps the glyph in an SGR sentinel, so displayText differs
     expect(styled.displayText).not.toBe('x')
     expect(styled.displayText).toContain('x')

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.ts
@@ -450,6 +450,8 @@ export const prependScrollbackToOutput = (
     visibleText: `${encoded.visibleText}\n${output.visibleText}`,
     displayDelta: {
       ...delta,
+      // viewport/input is now below the prepended scrollback — follow the bottom
+      pinToBottom: true,
       operations: [
         {
           type: 'replace',

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.ts
@@ -410,22 +410,18 @@ export const createGhosttyVtRenderSnapshotOutput = (
   }
 }
 
-// Encode styled scrollback rows into the same SGR-sentinel displayText + plain
-// visibleText the viewport uses, so the surface can render it into its separate
-// STATIC history region. Scrollback is NOT trimmed (it is history, verbatim).
+// Encode styled scrollback rows into the same SGR-sentinel displayText the
+// viewport uses, so the surface can render it into its separate STATIC history
+// region. Scrollback is NOT trimmed (it is history, verbatim). The surface
+// derives visible text for selection from its own buffer, so we don't carry it.
 export const encodeScrollback = (
   scrollback: GhosttyVtRenderScrollback
-): { displayText: string; visibleText: string } => {
+): { displayText: string } => {
   const cellsByRow = readCellsByRow(scrollback.cells)
 
   return {
     displayText: scrollback.rows
       .map((row, rowIndex) => readStyledRowText(row, cellsByRow.get(rowIndex)))
-      .join('\n'),
-    visibleText: scrollback.rows
-      .map((row, rowIndex) =>
-        readCellRowVisibleText(row, cellsByRow.get(rowIndex))
-      )
       .join('\n'),
   }
 }

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.ts
@@ -409,3 +409,56 @@ export const createGhosttyVtRenderSnapshotOutput = (
     },
   }
 }
+
+// Encode styled scrollback rows into the same SGR-sentinel displayText + plain
+// visibleText the viewport uses, so it can be prepended to the viewport buffer.
+// Scrollback is NOT trimmed (it is history, rendered verbatim).
+export const encodeScrollback = (
+  scrollback: GhosttyVtRenderScrollback
+): { displayText: string; visibleText: string } => {
+  const cellsByRow = readCellsByRow(scrollback.cells)
+
+  return {
+    displayText: scrollback.rows
+      .map((row, rowIndex) => readStyledRowText(row, cellsByRow.get(rowIndex)))
+      .join('\n'),
+    visibleText: scrollback.rows
+      .map((row, rowIndex) =>
+        readCellRowVisibleText(row, cellsByRow.get(rowIndex))
+      )
+      .join('\n'),
+  }
+}
+
+// Prepend encoded scrollback ABOVE the viewport's replace op. Shifts the cursor
+// offset by the scrollback's VISIBLE length + 1 (the joining newline) because
+// the buffer indexes cursorOffset against visible text. Composing at the string
+// level keeps the viewport's leading-empty-row trim from rotating history.
+export const prependScrollbackToOutput = (
+  output: TerminalParserEngineOutput,
+  encoded: { displayText: string; visibleText: string }
+): TerminalParserEngineOutput => {
+  const delta = output.displayDelta
+  const operation = delta?.operations[0]
+
+  if (!delta || operation?.type !== 'replace') {
+    return output
+  }
+
+  return {
+    ...output,
+    visibleText: `${encoded.visibleText}\n${output.visibleText}`,
+    displayDelta: {
+      ...delta,
+      operations: [
+        {
+          type: 'replace',
+          text: `${encoded.displayText}\n${operation.text}`,
+          cursorOffset:
+            (operation.cursorOffset ?? 0) + encoded.visibleText.length + 1,
+        },
+        ...delta.operations.slice(1),
+      ],
+    },
+  }
+}

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.ts
@@ -411,8 +411,8 @@ export const createGhosttyVtRenderSnapshotOutput = (
 }
 
 // Encode styled scrollback rows into the same SGR-sentinel displayText + plain
-// visibleText the viewport uses, so it can be prepended to the viewport buffer.
-// Scrollback is NOT trimmed (it is history, rendered verbatim).
+// visibleText the viewport uses, so the surface can render it into its separate
+// STATIC history region. Scrollback is NOT trimmed (it is history, verbatim).
 export const encodeScrollback = (
   scrollback: GhosttyVtRenderScrollback
 ): { displayText: string; visibleText: string } => {
@@ -427,40 +427,5 @@ export const encodeScrollback = (
         readCellRowVisibleText(row, cellsByRow.get(rowIndex))
       )
       .join('\n'),
-  }
-}
-
-// Prepend encoded scrollback ABOVE the viewport's replace op. Shifts the cursor
-// offset by the scrollback's VISIBLE length + 1 (the joining newline) because
-// the buffer indexes cursorOffset against visible text. Composing at the string
-// level keeps the viewport's leading-empty-row trim from rotating history.
-export const prependScrollbackToOutput = (
-  output: TerminalParserEngineOutput,
-  encoded: { displayText: string; visibleText: string }
-): TerminalParserEngineOutput => {
-  const delta = output.displayDelta
-  const operation = delta?.operations[0]
-
-  if (!delta || operation?.type !== 'replace') {
-    return output
-  }
-
-  return {
-    ...output,
-    visibleText: `${encoded.visibleText}\n${output.visibleText}`,
-    displayDelta: {
-      ...delta,
-      // viewport/input is now below the prepended scrollback — follow the bottom
-      pinToBottom: true,
-      operations: [
-        {
-          type: 'replace',
-          text: `${encoded.displayText}\n${operation.text}`,
-          cursorOffset:
-            (operation.cursorOffset ?? 0) + encoded.visibleText.length + 1,
-        },
-        ...delta.operations.slice(1),
-      ],
-    },
   }
 }

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.ts
@@ -36,6 +36,15 @@ export interface GhosttyVtRenderSnapshot {
   readonly rows: readonly string[]
   readonly cursor?: GhosttyVtRenderSnapshotCursor
   readonly cells?: readonly GhosttyVtRenderSnapshotCell[]
+  // Count of scrollback rows the native terminal holds above the viewport (0 on
+  // the alt screen). Styled rows are fetched lazily via the driver's readScrollback.
+  readonly scrollbackRowCount?: number
+  readonly isAltScreen?: boolean
+}
+
+export interface GhosttyVtRenderScrollback {
+  readonly rows: readonly string[]
+  readonly cells: readonly GhosttyVtRenderSnapshotCell[]
 }
 
 interface SnapshotStyle {

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
@@ -165,6 +165,34 @@ describe('ghosttyVtRenderStateDriver', () => {
     expect(readScrollback).toHaveBeenCalledTimes(2) // count grew → re-fetch
   })
 
+  test('retries empty positive-count scrollback fetches without clearing', () => {
+    const readScrollback = vi
+      .fn()
+      .mockReturnValueOnce({ rows: [], cells: [] })
+      .mockReturnValueOnce({ rows: ['history'], cells: [] })
+
+    const adapter = createGhosttyVtRenderStateByteParserAdapter(
+      (): GhosttyVtRenderStateDriver => ({
+        writeBytes: vi.fn(),
+        readSnapshot: (): GhosttyVtRenderSnapshot => ({
+          rows: ['p'],
+          cursor: { rowIndex: 0, columnOffset: 0 },
+          scrollbackRowCount: 1,
+        }),
+        readScrollback,
+      })
+    )
+
+    adapter.parseBytes(createInput(new Uint8Array([0x61])))
+    expect(adapter.flushOutput?.()?.scrollback).toBeUndefined()
+
+    adapter.parseBytes(createInput(new Uint8Array([0x62])))
+    expect(adapter.flushOutput?.()?.scrollback).toEqual({
+      displayText: 'history',
+    })
+    expect(readScrollback).toHaveBeenCalledTimes(2)
+  })
+
   test('re-attaches scrollback after resize even when the row count is unchanged', () => {
     const readScrollback = vi
       .fn()

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
@@ -165,6 +165,39 @@ describe('ghosttyVtRenderStateDriver', () => {
     expect(readScrollback).toHaveBeenCalledTimes(2) // count grew → re-fetch
   })
 
+  test('re-attaches scrollback after resize even when the row count is unchanged', () => {
+    const readScrollback = vi
+      .fn()
+      .mockReturnValueOnce({ rows: ['wide history'], cells: [] })
+      .mockReturnValueOnce({ rows: ['narrow history'], cells: [] })
+
+    const adapter = createGhosttyVtRenderStateByteParserAdapter(
+      (): GhosttyVtRenderStateDriver => ({
+        writeBytes: vi.fn(),
+        readSnapshot: (): GhosttyVtRenderSnapshot => ({
+          rows: ['p'],
+          cursor: { rowIndex: 0, columnOffset: 0 },
+          scrollbackRowCount: 1,
+        }),
+        readScrollback,
+        resize: vi.fn(),
+      })
+    )
+
+    adapter.parseBytes(createInput(new Uint8Array([0x61])))
+    expect(adapter.flushOutput?.()?.scrollback).toEqual({
+      displayText: 'wide history',
+    })
+
+    adapter.resize?.({ cols: 40, rows: 24 })
+    adapter.parseBytes(createInput(new Uint8Array([0x62])))
+
+    expect(adapter.flushOutput?.()?.scrollback).toEqual({
+      displayText: 'narrow history',
+    })
+    expect(readScrollback).toHaveBeenCalledTimes(2)
+  })
+
   test('clears scrollback (null payload) on the alt screen without fetching', () => {
     const readScrollback = vi.fn(() => ({ rows: ['stale'], cells: [] }))
 

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
@@ -131,10 +131,7 @@ describe('ghosttyVtRenderStateDriver', () => {
     // The viewport follows the bottom while history sits above it.
     expect(output?.displayDelta?.pinToBottom).toBe(true)
     // History travels as a separate static payload for the surface's region.
-    expect(output?.scrollback).toEqual({
-      displayText: 'history line',
-      visibleText: 'history line',
-    })
+    expect(output?.scrollback).toEqual({ displayText: 'history line' })
     expect(readScrollback).toHaveBeenCalledOnce()
   })
 
@@ -155,10 +152,7 @@ describe('ghosttyVtRenderStateDriver', () => {
     )
 
     adapter.parseBytes(createInput(new Uint8Array([0x61])))
-    expect(adapter.flushOutput?.()?.scrollback).toEqual({
-      displayText: 'h',
-      visibleText: 'h',
-    })
+    expect(adapter.flushOutput?.()?.scrollback).toEqual({ displayText: 'h' })
 
     adapter.parseBytes(createInput(new Uint8Array([0x62])))
     // Count unchanged → no payload; the surface keeps its static region.
@@ -167,10 +161,7 @@ describe('ghosttyVtRenderStateDriver', () => {
 
     scrollbackRowCount = 2
     adapter.parseBytes(createInput(new Uint8Array([0x63])))
-    expect(adapter.flushOutput?.()?.scrollback).toEqual({
-      displayText: 'h',
-      visibleText: 'h',
-    })
+    expect(adapter.flushOutput?.()?.scrollback).toEqual({ displayText: 'h' })
     expect(readScrollback).toHaveBeenCalledTimes(2) // count grew → re-fetch
   })
 
@@ -225,10 +216,7 @@ describe('ghosttyVtRenderStateDriver', () => {
 
     const main1 = flush(0x61) // main screen: history attached
     expect(main1?.visibleText).toBe('p')
-    expect(main1?.scrollback).toEqual({
-      displayText: 'h1\nh2',
-      visibleText: 'h1\nh2',
-    })
+    expect(main1?.scrollback).toEqual({ displayText: 'h1\nh2' })
 
     isAltScreen = true
     const alt = flush(0x62) // alt screen: history cleared (null)
@@ -238,10 +226,7 @@ describe('ghosttyVtRenderStateDriver', () => {
     isAltScreen = false
     const main2 = flush(0x63) // back to main: history re-attached
     expect(main2?.visibleText).toBe('p')
-    expect(main2?.scrollback).toEqual({
-      displayText: 'h1\nh2',
-      visibleText: 'h1\nh2',
-    })
+    expect(main2?.scrollback).toEqual({ displayText: 'h1\nh2' })
 
     expect(readScrollback).toHaveBeenCalledTimes(2) // re-fetched on return
   })

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
@@ -220,6 +220,7 @@ describe('ghosttyVtRenderStateDriver', () => {
 
   test('retries empty scrollback fetches again when the row count changes', () => {
     let scrollbackRowCount = 1
+
     const readScrollback = vi
       .fn()
       .mockReturnValueOnce({ rows: [], cells: [] })

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
@@ -182,6 +182,37 @@ describe('ghosttyVtRenderStateDriver', () => {
     expect(readScrollback).not.toHaveBeenCalled()
   })
 
+  test('drops scrollback entering the alt screen and restores it on exit', () => {
+    let isAltScreen = false
+    const readScrollback = vi.fn(() => ({ rows: ['h1', 'h2'], cells: [] }))
+
+    const adapter = createGhosttyVtRenderStateByteParserAdapter(
+      (): GhosttyVtRenderStateDriver => ({
+        writeBytes: vi.fn(),
+        readSnapshot: (): GhosttyVtRenderSnapshot => ({
+          rows: ['p'],
+          cursor: { rowIndex: 0, columnOffset: 0 },
+          scrollbackRowCount: 2,
+          isAltScreen,
+        }),
+        readScrollback,
+      })
+    )
+
+    const flush = (byte: number): string | undefined => {
+      adapter.parseBytes(createInput(new Uint8Array([byte])))
+
+      return adapter.flushOutput?.()?.visibleText
+    }
+
+    expect(flush(0x61)).toBe('h1\nh2\np') // main screen: history shown
+    isAltScreen = true
+    expect(flush(0x62)).toBe('p') // alt screen: history dropped
+    isAltScreen = false
+    expect(flush(0x63)).toBe('h1\nh2\np') // back to main: history restored
+    expect(readScrollback).toHaveBeenCalledTimes(2) // re-fetched on return
+  })
+
   test('can be injected behind the Ghostty parser engine byte path', () => {
     const writeBytes = vi.fn()
 

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
@@ -193,7 +193,7 @@ describe('ghosttyVtRenderStateDriver', () => {
     expect(readScrollback).toHaveBeenCalledTimes(2)
   })
 
-  test('stops retrying persistent empty positive-count scrollback fetches', () => {
+  test('clears scrollback when persistent empty positive-count fetches give up', () => {
     const readScrollback = vi.fn(() => ({ rows: [], cells: [] }))
 
     const adapter = createGhosttyVtRenderStateByteParserAdapter(
@@ -208,10 +208,13 @@ describe('ghosttyVtRenderStateDriver', () => {
       })
     )
 
-    for (const byte of [0x61, 0x62, 0x63]) {
+    for (const byte of [0x61, 0x62]) {
       adapter.parseBytes(createInput(new Uint8Array([byte])))
       expect(adapter.flushOutput?.()?.scrollback).toBeUndefined()
     }
+
+    adapter.parseBytes(createInput(new Uint8Array([0x63])))
+    expect(adapter.flushOutput?.()?.scrollback).toBeNull()
 
     adapter.parseBytes(createInput(new Uint8Array([0x64])))
     expect(adapter.flushOutput?.()?.scrollback).toBeUndefined()
@@ -241,10 +244,13 @@ describe('ghosttyVtRenderStateDriver', () => {
       })
     )
 
-    for (const byte of [0x61, 0x62, 0x63]) {
+    for (const byte of [0x61, 0x62]) {
       adapter.parseBytes(createInput(new Uint8Array([byte])))
       expect(adapter.flushOutput?.()?.scrollback).toBeUndefined()
     }
+
+    adapter.parseBytes(createInput(new Uint8Array([0x63])))
+    expect(adapter.flushOutput?.()?.scrollback).toBeNull()
 
     scrollbackRowCount = 2
     adapter.parseBytes(createInput(new Uint8Array([0x64])))

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
@@ -199,6 +199,36 @@ describe('ghosttyVtRenderStateDriver', () => {
     expect(readScrollback).toHaveBeenCalledTimes(2)
   })
 
+  test('stops retrying persistent scrollback fetch failures for the same row count', () => {
+    const readScrollback = vi.fn(() => {
+      throw new Error('native read failed')
+    })
+
+    const adapter = createGhosttyVtRenderStateByteParserAdapter(
+      (): GhosttyVtRenderStateDriver => ({
+        writeBytes: vi.fn(),
+        readSnapshot: (): GhosttyVtRenderSnapshot => ({
+          rows: ['p'],
+          cursor: { rowIndex: 0, columnOffset: 0 },
+          scrollbackRowCount: 1,
+        }),
+        readScrollback,
+      })
+    )
+
+    for (const byte of [0x61, 0x62]) {
+      adapter.parseBytes(createInput(new Uint8Array([byte])))
+      expect(adapter.flushOutput?.()?.scrollback).toBeUndefined()
+    }
+
+    adapter.parseBytes(createInput(new Uint8Array([0x63])))
+    expect(adapter.flushOutput?.()?.scrollback).toBeNull()
+
+    adapter.parseBytes(createInput(new Uint8Array([0x64])))
+    expect(adapter.flushOutput?.()?.scrollback).toBeUndefined()
+    expect(readScrollback).toHaveBeenCalledTimes(3)
+  })
+
   test('retries empty positive-count scrollback fetches without clearing', () => {
     const readScrollback = vi
       .fn()

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
@@ -193,6 +193,69 @@ describe('ghosttyVtRenderStateDriver', () => {
     expect(readScrollback).toHaveBeenCalledTimes(2)
   })
 
+  test('stops retrying persistent empty positive-count scrollback fetches', () => {
+    const readScrollback = vi.fn(() => ({ rows: [], cells: [] }))
+
+    const adapter = createGhosttyVtRenderStateByteParserAdapter(
+      (): GhosttyVtRenderStateDriver => ({
+        writeBytes: vi.fn(),
+        readSnapshot: (): GhosttyVtRenderSnapshot => ({
+          rows: ['p'],
+          cursor: { rowIndex: 0, columnOffset: 0 },
+          scrollbackRowCount: 1,
+        }),
+        readScrollback,
+      })
+    )
+
+    for (const byte of [0x61, 0x62, 0x63]) {
+      adapter.parseBytes(createInput(new Uint8Array([byte])))
+      expect(adapter.flushOutput?.()?.scrollback).toBeUndefined()
+    }
+
+    adapter.parseBytes(createInput(new Uint8Array([0x64])))
+    expect(adapter.flushOutput?.()?.scrollback).toBeUndefined()
+    expect(readScrollback).toHaveBeenCalledTimes(3)
+  })
+
+  test('retries empty scrollback fetches again when the row count changes', () => {
+    let scrollbackRowCount = 1
+    const readScrollback = vi
+      .fn()
+      .mockReturnValueOnce({ rows: [], cells: [] })
+      .mockReturnValueOnce({ rows: [], cells: [] })
+      .mockReturnValueOnce({ rows: [], cells: [] })
+      .mockReturnValueOnce({ rows: [], cells: [] })
+      .mockReturnValueOnce({ rows: ['history'], cells: [] })
+
+    const adapter = createGhosttyVtRenderStateByteParserAdapter(
+      (): GhosttyVtRenderStateDriver => ({
+        writeBytes: vi.fn(),
+        readSnapshot: (): GhosttyVtRenderSnapshot => ({
+          rows: ['p'],
+          cursor: { rowIndex: 0, columnOffset: 0 },
+          scrollbackRowCount,
+        }),
+        readScrollback,
+      })
+    )
+
+    for (const byte of [0x61, 0x62, 0x63]) {
+      adapter.parseBytes(createInput(new Uint8Array([byte])))
+      expect(adapter.flushOutput?.()?.scrollback).toBeUndefined()
+    }
+
+    scrollbackRowCount = 2
+    adapter.parseBytes(createInput(new Uint8Array([0x64])))
+    expect(adapter.flushOutput?.()?.scrollback).toBeUndefined()
+
+    adapter.parseBytes(createInput(new Uint8Array([0x65])))
+    expect(adapter.flushOutput?.()?.scrollback).toEqual({
+      displayText: 'history',
+    })
+    expect(readScrollback).toHaveBeenCalledTimes(5)
+  })
+
   test('re-attaches scrollback after resize even when the row count is unchanged', () => {
     const readScrollback = vi
       .fn()

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
@@ -100,7 +100,7 @@ describe('ghosttyVtRenderStateDriver', () => {
     expect(snapshotReads).toBe(1)
   })
 
-  test('prepends scrollback above the viewport when the snapshot reports it', () => {
+  test('attaches scrollback as a separate field and keeps viewport output standalone', () => {
     const readScrollback = vi.fn(() => ({
       rows: ['history line'],
       cells: [],
@@ -121,17 +121,24 @@ describe('ghosttyVtRenderStateDriver', () => {
     adapter.parseBytes(createInput(new Uint8Array([0x61])))
     const output = adapter.flushOutput?.()
 
-    expect(output?.visibleText).toBe('history line\nprompt')
+    // The viewport output is standalone: no prepended history, no cursor shift.
+    expect(output?.visibleText).toBe('prompt')
     expect(output?.displayDelta?.operations[0]).toEqual({
       type: 'replace',
-      text: 'history line\nprompt',
-      // 12 (scrollback visible) + 1 (newline) + 2 (viewport cursor) = 15
-      cursorOffset: 15,
+      text: 'prompt',
+      cursorOffset: 2,
+    })
+    // The viewport follows the bottom while history sits above it.
+    expect(output?.displayDelta?.pinToBottom).toBe(true)
+    // History travels as a separate static payload for the surface's region.
+    expect(output?.scrollback).toEqual({
+      displayText: 'history line',
+      visibleText: 'history line',
     })
     expect(readScrollback).toHaveBeenCalledOnce()
   })
 
-  test('re-fetches scrollback only when the row count changes', () => {
+  test('attaches scrollback only when the row count changes', () => {
     let scrollbackRowCount = 1
     const readScrollback = vi.fn(() => ({ rows: ['h'], cells: [] }))
 
@@ -148,18 +155,26 @@ describe('ghosttyVtRenderStateDriver', () => {
     )
 
     adapter.parseBytes(createInput(new Uint8Array([0x61])))
-    adapter.flushOutput?.()
+    expect(adapter.flushOutput?.()?.scrollback).toEqual({
+      displayText: 'h',
+      visibleText: 'h',
+    })
+
     adapter.parseBytes(createInput(new Uint8Array([0x62])))
-    adapter.flushOutput?.()
-    expect(readScrollback).toHaveBeenCalledOnce() // count unchanged → cached
+    // Count unchanged → no payload; the surface keeps its static region.
+    expect(adapter.flushOutput?.()?.scrollback).toBeUndefined()
+    expect(readScrollback).toHaveBeenCalledOnce()
 
     scrollbackRowCount = 2
     adapter.parseBytes(createInput(new Uint8Array([0x63])))
-    adapter.flushOutput?.()
+    expect(adapter.flushOutput?.()?.scrollback).toEqual({
+      displayText: 'h',
+      visibleText: 'h',
+    })
     expect(readScrollback).toHaveBeenCalledTimes(2) // count grew → re-fetch
   })
 
-  test('suppresses scrollback on the alt screen', () => {
+  test('clears scrollback (null payload) on the alt screen without fetching', () => {
     const readScrollback = vi.fn(() => ({ rows: ['stale'], cells: [] }))
 
     const adapter = createGhosttyVtRenderStateByteParserAdapter(
@@ -179,10 +194,11 @@ describe('ghosttyVtRenderStateDriver', () => {
     const output = adapter.flushOutput?.()
 
     expect(output?.visibleText).toBe('vim')
+    expect(output?.scrollback).toBeNull()
     expect(readScrollback).not.toHaveBeenCalled()
   })
 
-  test('drops scrollback entering the alt screen and restores it on exit', () => {
+  test('clears scrollback entering the alt screen and re-attaches it on exit', () => {
     let isAltScreen = false
     const readScrollback = vi.fn(() => ({ rows: ['h1', 'h2'], cells: [] }))
 
@@ -199,17 +215,34 @@ describe('ghosttyVtRenderStateDriver', () => {
       })
     )
 
-    const flush = (byte: number): string | undefined => {
+    const flush = (
+      byte: number
+    ): ReturnType<NonNullable<typeof adapter.flushOutput>> => {
       adapter.parseBytes(createInput(new Uint8Array([byte])))
 
-      return adapter.flushOutput?.()?.visibleText
+      return adapter.flushOutput?.() ?? null
     }
 
-    expect(flush(0x61)).toBe('h1\nh2\np') // main screen: history shown
+    const main1 = flush(0x61) // main screen: history attached
+    expect(main1?.visibleText).toBe('p')
+    expect(main1?.scrollback).toEqual({
+      displayText: 'h1\nh2',
+      visibleText: 'h1\nh2',
+    })
+
     isAltScreen = true
-    expect(flush(0x62)).toBe('p') // alt screen: history dropped
+    const alt = flush(0x62) // alt screen: history cleared (null)
+    expect(alt?.visibleText).toBe('p')
+    expect(alt?.scrollback).toBeNull()
+
     isAltScreen = false
-    expect(flush(0x63)).toBe('h1\nh2\np') // back to main: history restored
+    const main2 = flush(0x63) // back to main: history re-attached
+    expect(main2?.visibleText).toBe('p')
+    expect(main2?.scrollback).toEqual({
+      displayText: 'h1\nh2',
+      visibleText: 'h1\nh2',
+    })
+
     expect(readScrollback).toHaveBeenCalledTimes(2) // re-fetched on return
   })
 

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
@@ -165,6 +165,40 @@ describe('ghosttyVtRenderStateDriver', () => {
     expect(readScrollback).toHaveBeenCalledTimes(2) // count grew → re-fetch
   })
 
+  test('keeps viewport rendering when scrollback fetch fails', () => {
+    const readScrollback = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        throw new Error('native read failed')
+      })
+      .mockReturnValueOnce({ rows: ['recovered history'], cells: [] })
+
+    const adapter = createGhosttyVtRenderStateByteParserAdapter(
+      (): GhosttyVtRenderStateDriver => ({
+        writeBytes: vi.fn(),
+        readSnapshot: (): GhosttyVtRenderSnapshot => ({
+          rows: ['p'],
+          cursor: { rowIndex: 0, columnOffset: 0 },
+          scrollbackRowCount: 1,
+        }),
+        readScrollback,
+      })
+    )
+
+    adapter.parseBytes(createInput(new Uint8Array([0x61])))
+    const failedOutput = adapter.flushOutput?.()
+
+    expect(failedOutput?.visibleText).toBe('p')
+    expect(failedOutput?.scrollback).toBeUndefined()
+    expect(failedOutput?.displayDelta?.pinToBottom).toBe(true)
+
+    adapter.parseBytes(createInput(new Uint8Array([0x62])))
+    expect(adapter.flushOutput?.()?.scrollback).toEqual({
+      displayText: 'recovered history',
+    })
+    expect(readScrollback).toHaveBeenCalledTimes(2)
+  })
+
   test('retries empty positive-count scrollback fetches without clearing', () => {
     const readScrollback = vi
       .fn()

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.test.ts
@@ -100,6 +100,88 @@ describe('ghosttyVtRenderStateDriver', () => {
     expect(snapshotReads).toBe(1)
   })
 
+  test('prepends scrollback above the viewport when the snapshot reports it', () => {
+    const readScrollback = vi.fn(() => ({
+      rows: ['history line'],
+      cells: [],
+    }))
+
+    const adapter = createGhosttyVtRenderStateByteParserAdapter(
+      (): GhosttyVtRenderStateDriver => ({
+        writeBytes: vi.fn(),
+        readSnapshot: (): GhosttyVtRenderSnapshot => ({
+          rows: ['prompt'],
+          cursor: { rowIndex: 0, columnOffset: 2 },
+          scrollbackRowCount: 1,
+        }),
+        readScrollback,
+      })
+    )
+
+    adapter.parseBytes(createInput(new Uint8Array([0x61])))
+    const output = adapter.flushOutput?.()
+
+    expect(output?.visibleText).toBe('history line\nprompt')
+    expect(output?.displayDelta?.operations[0]).toEqual({
+      type: 'replace',
+      text: 'history line\nprompt',
+      // 12 (scrollback visible) + 1 (newline) + 2 (viewport cursor) = 15
+      cursorOffset: 15,
+    })
+    expect(readScrollback).toHaveBeenCalledOnce()
+  })
+
+  test('re-fetches scrollback only when the row count changes', () => {
+    let scrollbackRowCount = 1
+    const readScrollback = vi.fn(() => ({ rows: ['h'], cells: [] }))
+
+    const adapter = createGhosttyVtRenderStateByteParserAdapter(
+      (): GhosttyVtRenderStateDriver => ({
+        writeBytes: vi.fn(),
+        readSnapshot: (): GhosttyVtRenderSnapshot => ({
+          rows: ['p'],
+          cursor: { rowIndex: 0, columnOffset: 0 },
+          scrollbackRowCount,
+        }),
+        readScrollback,
+      })
+    )
+
+    adapter.parseBytes(createInput(new Uint8Array([0x61])))
+    adapter.flushOutput?.()
+    adapter.parseBytes(createInput(new Uint8Array([0x62])))
+    adapter.flushOutput?.()
+    expect(readScrollback).toHaveBeenCalledOnce() // count unchanged → cached
+
+    scrollbackRowCount = 2
+    adapter.parseBytes(createInput(new Uint8Array([0x63])))
+    adapter.flushOutput?.()
+    expect(readScrollback).toHaveBeenCalledTimes(2) // count grew → re-fetch
+  })
+
+  test('suppresses scrollback on the alt screen', () => {
+    const readScrollback = vi.fn(() => ({ rows: ['stale'], cells: [] }))
+
+    const adapter = createGhosttyVtRenderStateByteParserAdapter(
+      (): GhosttyVtRenderStateDriver => ({
+        writeBytes: vi.fn(),
+        readSnapshot: (): GhosttyVtRenderSnapshot => ({
+          rows: ['vim'],
+          cursor: { rowIndex: 0, columnOffset: 0 },
+          scrollbackRowCount: 5,
+          isAltScreen: true,
+        }),
+        readScrollback,
+      })
+    )
+
+    adapter.parseBytes(createInput(new Uint8Array([0x61])))
+    const output = adapter.flushOutput?.()
+
+    expect(output?.visibleText).toBe('vim')
+    expect(readScrollback).not.toHaveBeenCalled()
+  })
+
   test('can be injected behind the Ghostty parser engine byte path', () => {
     const writeBytes = vi.fn()
 

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
@@ -103,18 +103,23 @@ export const createGhosttyVtRenderStateParserDriverFactory =
       if (count === cachedScrollbackRowCount) {
         return viewport
       }
-      cachedScrollbackRowCount = count
 
       if (count <= 0) {
+        cachedScrollbackRowCount = count
+
         return { ...viewport, scrollback: null }
       }
 
       const scrollback = renderStateDriver.readScrollback()
+      if (scrollback.rows.length === 0) {
+        return viewport
+      }
+
+      cachedScrollbackRowCount = count
 
       return {
         ...viewport,
-        scrollback:
-          scrollback.rows.length > 0 ? encodeScrollback(scrollback) : null,
+        scrollback: encodeScrollback(scrollback),
       }
     }
 

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
@@ -128,6 +128,8 @@ export const createGhosttyVtRenderStateParserDriverFactory =
           cachedScrollbackRowCount = count
           emptyScrollbackRetryRowCount = -1
           emptyScrollbackRetryCount = 0
+
+          return { ...viewport, scrollback: null }
         }
 
         return viewport

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
@@ -116,7 +116,13 @@ export const createGhosttyVtRenderStateParserDriverFactory =
         return { ...viewport, scrollback: null }
       }
 
-      const scrollback = renderStateDriver.readScrollback()
+      let scrollback: GhosttyVtRenderScrollback
+      try {
+        scrollback = renderStateDriver.readScrollback()
+      } catch {
+        return viewport
+      }
+
       if (scrollback.rows.length === 0) {
         emptyScrollbackRetryCount =
           count === emptyScrollbackRetryRowCount

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
@@ -161,6 +161,7 @@ export const createGhosttyVtRenderStateParserDriverFactory =
         renderStateDriver.reset?.()
       },
       resize: (size): void => {
+        cachedScrollbackRowCount = -1
         renderStateDriver.resize?.(size)
       },
       dispose: (): void => {

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
@@ -31,6 +31,8 @@ const EMPTY_RENDER_OUTPUT: TerminalParserEngineOutput = { visibleText: '' }
 // flushes, so a missed close marker can never freeze the surface.
 const MAX_HELD_FLUSHES = 8
 
+const MAX_EMPTY_SCROLLBACK_RETRIES = 2
+
 // The live viewport sits below the history region, so follow the bottom on each
 // frame (the surface's sticky-scroll freeze still wins while the user reads up).
 const pinViewportToBottom = (
@@ -84,6 +86,8 @@ export const createGhosttyVtRenderStateParserDriverFactory =
     // changes. This keeps the per-frame work viewport-sized; the heavy history
     // DOM is not re-parsed or re-rendered while the agent redraws the viewport.
     let cachedScrollbackRowCount = -1
+    let emptyScrollbackRetryRowCount = -1
+    let emptyScrollbackRetryCount = 0
 
     const attachScrollback = (
       snapshot: GhosttyVtRenderSnapshot,
@@ -106,16 +110,32 @@ export const createGhosttyVtRenderStateParserDriverFactory =
 
       if (count <= 0) {
         cachedScrollbackRowCount = count
+        emptyScrollbackRetryRowCount = -1
+        emptyScrollbackRetryCount = 0
 
         return { ...viewport, scrollback: null }
       }
 
       const scrollback = renderStateDriver.readScrollback()
       if (scrollback.rows.length === 0) {
+        emptyScrollbackRetryCount =
+          count === emptyScrollbackRetryRowCount
+            ? emptyScrollbackRetryCount + 1
+            : 1
+        emptyScrollbackRetryRowCount = count
+
+        if (emptyScrollbackRetryCount > MAX_EMPTY_SCROLLBACK_RETRIES) {
+          cachedScrollbackRowCount = count
+          emptyScrollbackRetryRowCount = -1
+          emptyScrollbackRetryCount = 0
+        }
+
         return viewport
       }
 
       cachedScrollbackRowCount = count
+      emptyScrollbackRetryRowCount = -1
+      emptyScrollbackRetryCount = 0
 
       return {
         ...viewport,
@@ -163,10 +183,14 @@ export const createGhosttyVtRenderStateParserDriverFactory =
         heldFlushes = 0
         dirty = false
         cachedScrollbackRowCount = -1
+        emptyScrollbackRetryRowCount = -1
+        emptyScrollbackRetryCount = 0
         renderStateDriver.reset?.()
       },
       resize: (size): void => {
         cachedScrollbackRowCount = -1
+        emptyScrollbackRetryRowCount = -1
+        emptyScrollbackRetryCount = 0
         renderStateDriver.resize?.(size)
       },
       dispose: (): void => {

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
@@ -89,6 +89,27 @@ export const createGhosttyVtRenderStateParserDriverFactory =
     let emptyScrollbackRetryRowCount = -1
     let emptyScrollbackRetryCount = 0
 
+    const noteMissingScrollback = (
+      count: number,
+      viewport: TerminalParserEngineOutput
+    ): TerminalParserEngineOutput => {
+      emptyScrollbackRetryCount =
+        count === emptyScrollbackRetryRowCount
+          ? emptyScrollbackRetryCount + 1
+          : 1
+      emptyScrollbackRetryRowCount = count
+
+      if (emptyScrollbackRetryCount > MAX_EMPTY_SCROLLBACK_RETRIES) {
+        cachedScrollbackRowCount = count
+        emptyScrollbackRetryRowCount = -1
+        emptyScrollbackRetryCount = 0
+
+        return { ...viewport, scrollback: null }
+      }
+
+      return viewport
+    }
+
     const attachScrollback = (
       snapshot: GhosttyVtRenderSnapshot,
       output: TerminalParserEngineOutput
@@ -120,25 +141,11 @@ export const createGhosttyVtRenderStateParserDriverFactory =
       try {
         scrollback = renderStateDriver.readScrollback()
       } catch {
-        return viewport
+        return noteMissingScrollback(count, viewport)
       }
 
       if (scrollback.rows.length === 0) {
-        emptyScrollbackRetryCount =
-          count === emptyScrollbackRetryRowCount
-            ? emptyScrollbackRetryCount + 1
-            : 1
-        emptyScrollbackRetryRowCount = count
-
-        if (emptyScrollbackRetryCount > MAX_EMPTY_SCROLLBACK_RETRIES) {
-          cachedScrollbackRowCount = count
-          emptyScrollbackRetryRowCount = -1
-          emptyScrollbackRetryCount = 0
-
-          return { ...viewport, scrollback: null }
-        }
-
-        return viewport
+        return noteMissingScrollback(count, viewport)
       }
 
       cachedScrollbackRowCount = count

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
@@ -14,6 +14,7 @@ import {
 import {
   createGhosttyVtRenderSnapshotOutput,
   type GhosttyVtRenderSnapshot,
+  type GhosttyVtRenderScrollback,
 } from './ghosttyVtRenderSnapshot'
 import {
   createSyncFrameParserState,
@@ -43,6 +44,9 @@ export interface GhosttyVtRenderStateDriver {
    */
   writeBytes: (bytes: Uint8Array) => void
   readSnapshot: () => GhosttyVtRenderSnapshot
+  // Lazily fetch the styled scrollback above the viewport (called on scroll-up,
+  // not per frame). Optional: non-native drivers may not support it.
+  readScrollback?: () => GhosttyVtRenderScrollback
   reset?: () => void
   resize?: (size: TerminalSize) => void
   dispose?: () => void

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
@@ -14,7 +14,6 @@ import {
 import {
   createGhosttyVtRenderSnapshotOutput,
   encodeScrollback,
-  prependScrollbackToOutput,
   type GhosttyVtRenderSnapshot,
   type GhosttyVtRenderScrollback,
 } from './ghosttyVtRenderSnapshot'
@@ -31,6 +30,18 @@ const EMPTY_RENDER_OUTPUT: TerminalParserEngineOutput = { visibleText: '' }
 // Failsafe: flush even while "inside" a 2026 frame after this many held
 // flushes, so a missed close marker can never freeze the surface.
 const MAX_HELD_FLUSHES = 8
+
+// The live viewport sits below the history region, so follow the bottom on each
+// frame (the surface's sticky-scroll freeze still wins while the user reads up).
+const pinViewportToBottom = (
+  output: TerminalParserEngineOutput
+): TerminalParserEngineOutput =>
+  output.displayDelta
+    ? {
+        ...output,
+        displayDelta: { ...output.displayDelta, pinToBottom: true },
+      }
+    : output
 
 export interface GhosttyVtRenderStateDriver {
   /**
@@ -67,38 +78,44 @@ export const createGhosttyVtRenderStateParserDriverFactory =
     let syncFrameState = createSyncFrameParserState()
     let heldFlushes = 0
     let dirty = false
-    // Cache the encoded styled scrollback; only re-fetch (sync IPC) when the
-    // native scrollback row count changes, then prepend it every frame so the
-    // history stays in the DOM and remains scrollable.
+    // History renders into the surface's SEPARATE static region, rebuilt only
+    // when it changes — so return viewport-only output every frame and attach
+    // the encoded scrollback (a sync-IPC fetch) ONLY when the native row count
+    // changes. This keeps the per-frame work viewport-sized; the heavy history
+    // DOM is not re-parsed or re-rendered while the agent redraws the viewport.
     let cachedScrollbackRowCount = -1
-    let cachedScrollback: { displayText: string; visibleText: string } | null =
-      null
 
-    const composeWithScrollback = (
+    const attachScrollback = (
       snapshot: GhosttyVtRenderSnapshot,
       output: TerminalParserEngineOutput
     ): TerminalParserEngineOutput => {
-      const count = snapshot.isAltScreen
-        ? 0
-        : (snapshot.scrollbackRowCount ?? 0)
-
-      if (count <= 0 || !renderStateDriver.readScrollback) {
-        cachedScrollbackRowCount = count
-        cachedScrollback = null
-
+      // Non-native drivers have no scrollback region: leave the output alone.
+      if (!renderStateDriver.readScrollback) {
         return output
       }
 
-      if (count !== cachedScrollbackRowCount) {
-        const scrollback = renderStateDriver.readScrollback()
-        cachedScrollback =
-          scrollback.rows.length > 0 ? encodeScrollback(scrollback) : null
-        cachedScrollbackRowCount = count
+      const count = snapshot.isAltScreen
+        ? 0
+        : (snapshot.scrollbackRowCount ?? 0)
+      const viewport = count > 0 ? pinViewportToBottom(output) : output
+
+      // Unchanged count → keep the surface's current static region (no field).
+      if (count === cachedScrollbackRowCount) {
+        return viewport
+      }
+      cachedScrollbackRowCount = count
+
+      if (count <= 0) {
+        return { ...viewport, scrollback: null }
       }
 
-      return cachedScrollback
-        ? prependScrollbackToOutput(output, cachedScrollback)
-        : output
+      const scrollback = renderStateDriver.readScrollback()
+
+      return {
+        ...viewport,
+        scrollback:
+          scrollback.rows.length > 0 ? encodeScrollback(scrollback) : null,
+      }
     }
 
     return {
@@ -130,7 +147,7 @@ export const createGhosttyVtRenderStateParserDriverFactory =
 
         const snapshot = renderStateDriver.readSnapshot()
 
-        return composeWithScrollback(
+        return attachScrollback(
           snapshot,
           createGhosttyVtRenderSnapshotOutput(snapshot)
         )
@@ -141,7 +158,6 @@ export const createGhosttyVtRenderStateParserDriverFactory =
         heldFlushes = 0
         dirty = false
         cachedScrollbackRowCount = -1
-        cachedScrollback = null
         renderStateDriver.reset?.()
       },
       resize: (size): void => {

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderStateDriver.ts
@@ -13,6 +13,8 @@ import {
 } from './ghosttyVtByteParserAdapter'
 import {
   createGhosttyVtRenderSnapshotOutput,
+  encodeScrollback,
+  prependScrollbackToOutput,
   type GhosttyVtRenderSnapshot,
   type GhosttyVtRenderScrollback,
 } from './ghosttyVtRenderSnapshot'
@@ -65,6 +67,39 @@ export const createGhosttyVtRenderStateParserDriverFactory =
     let syncFrameState = createSyncFrameParserState()
     let heldFlushes = 0
     let dirty = false
+    // Cache the encoded styled scrollback; only re-fetch (sync IPC) when the
+    // native scrollback row count changes, then prepend it every frame so the
+    // history stays in the DOM and remains scrollable.
+    let cachedScrollbackRowCount = -1
+    let cachedScrollback: { displayText: string; visibleText: string } | null =
+      null
+
+    const composeWithScrollback = (
+      snapshot: GhosttyVtRenderSnapshot,
+      output: TerminalParserEngineOutput
+    ): TerminalParserEngineOutput => {
+      const count = snapshot.isAltScreen
+        ? 0
+        : (snapshot.scrollbackRowCount ?? 0)
+
+      if (count <= 0 || !renderStateDriver.readScrollback) {
+        cachedScrollbackRowCount = count
+        cachedScrollback = null
+
+        return output
+      }
+
+      if (count !== cachedScrollbackRowCount) {
+        const scrollback = renderStateDriver.readScrollback()
+        cachedScrollback =
+          scrollback.rows.length > 0 ? encodeScrollback(scrollback) : null
+        cachedScrollbackRowCount = count
+      }
+
+      return cachedScrollback
+        ? prependScrollbackToOutput(output, cachedScrollback)
+        : output
+    }
 
     return {
       writeBytes: (bytes): TerminalParserEngineOutput => {
@@ -93,8 +128,11 @@ export const createGhosttyVtRenderStateParserDriverFactory =
         heldFlushes = 0
         dirty = false
 
-        return createGhosttyVtRenderSnapshotOutput(
-          renderStateDriver.readSnapshot()
+        const snapshot = renderStateDriver.readSnapshot()
+
+        return composeWithScrollback(
+          snapshot,
+          createGhosttyVtRenderSnapshotOutput(snapshot)
         )
       },
       hasPendingOutput: (): boolean => dirty,
@@ -102,6 +140,8 @@ export const createGhosttyVtRenderStateParserDriverFactory =
         syncFrameState = createSyncFrameParserState()
         heldFlushes = 0
         dirty = false
+        cachedScrollbackRowCount = -1
+        cachedScrollback = null
         renderStateDriver.reset?.()
       },
       resize: (size): void => {

--- a/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
+++ b/src/features/terminal/components/TerminalPane/terminalDisplayBuffer.ts
@@ -48,6 +48,10 @@ export type TerminalDisplayDeltaOperation =
 export interface TerminalDisplayDelta {
   readonly operations: readonly TerminalDisplayDeltaOperation[]
   readonly cursorVisible?: boolean
+  // The buffer carries prepended scrollback above the viewport, so the live
+  // viewport/input sits at the bottom — follow it instead of the replace
+  // snapshot's "show the top of a tall screen" heuristic.
+  readonly pinToBottom?: boolean
 }
 
 interface DisplayState {

--- a/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
+++ b/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
@@ -24,10 +24,7 @@ export interface TerminalParserEngineOutput {
   //   undefined = unchanged (keep the current region)
   //   object    = replace the region with this history
   //   null      = clear the region (alt screen / no history)
-  readonly scrollback?: {
-    readonly displayText: string
-    readonly visibleText: string
-  } | null
+  readonly scrollback?: { readonly displayText: string } | null
 }
 
 export type TerminalParserEngineInputMode = TerminalOutputInputMode

--- a/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
+++ b/src/features/terminal/components/TerminalPane/terminalParserEngine.ts
@@ -18,6 +18,16 @@ export interface TerminalParserEngineOutput {
   readonly visibleText: string
   readonly displayText?: string
   readonly displayDelta?: TerminalDisplayDelta
+  // Styled scrollback for the surface's separate, STATIC history region. The
+  // surface renders this once into its own buffer and leaves it alone, so the
+  // per-frame viewport render never rebuilds history. Tri-state:
+  //   undefined = unchanged (keep the current region)
+  //   object    = replace the region with this history
+  //   null      = clear the region (alt screen / no history)
+  readonly scrollback?: {
+    readonly displayText: string
+    readonly visibleText: string
+  } | null
 }
 
 export type TerminalParserEngineInputMode = TerminalOutputInputMode

--- a/src/features/terminal/components/TerminalPane/terminalRendererRegistry.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalRendererRegistry.test.ts
@@ -366,6 +366,7 @@ describe('terminalRendererRegistry', () => {
             columnOffset: 6,
           },
         }),
+        readScrollback: (): unknown => ({ rows: [], cells: [] }),
         reset: nativeReset,
         resize: nativeResize,
         dispose: nativeDispose,

--- a/src/features/terminal/components/TerminalPane/terminalTextSurface.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalTextSurface.test.ts
@@ -1,5 +1,5 @@
 // cspell:ignore ghostty
-import { afterEach, describe, expect, test } from 'vitest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
 import {
   TerminalTextSurface,
   type TerminalTextSurfaceOutput,
@@ -174,5 +174,14 @@ describe('TerminalTextSurface sticky-bottom scrolling', () => {
     })
 
     expect(root.scrollTop).toBe(400) // frozen, not pinned to the bottom
+  })
+
+  test('clicking focuses the input without scrolling it into view (no jump to top)', () => {
+    const { root, input } = mountSurface()
+    const focusSpy = vi.spyOn(input, 'focus')
+
+    root.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true })
   })
 })

--- a/src/features/terminal/components/TerminalPane/terminalTextSurface.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalTextSurface.test.ts
@@ -1,0 +1,142 @@
+// cspell:ignore ghostty
+import { afterEach, describe, expect, test } from 'vitest'
+import {
+  TerminalTextSurface,
+  type TerminalTextSurfaceOutput,
+} from './terminalTextSurface'
+
+// jsdom has no layout engine: scrollTop/scrollHeight/clientHeight are 0 and the
+// scroll geometry must be stubbed. These helpers give the surface root a
+// controllable, writable scrollTop plus fixed viewport/content heights so the
+// sticky-bottom scroll machine is observable.
+const stubScrollGeometry = (
+  root: HTMLElement,
+  { clientHeight, scrollHeight }: { clientHeight: number; scrollHeight: number }
+): void => {
+  let scrollTop = 0
+  Object.defineProperty(root, 'scrollTop', {
+    configurable: true,
+    get: () => scrollTop,
+    set: (value: number) => {
+      scrollTop = value
+    },
+  })
+
+  Object.defineProperty(root, 'clientHeight', {
+    configurable: true,
+    get: () => clientHeight,
+  })
+
+  Object.defineProperty(root, 'scrollHeight', {
+    configurable: true,
+    get: () => scrollHeight,
+  })
+}
+
+// deltaY isn't settable on a plain Event and jsdom may lack WheelEvent, so build
+// a 'wheel' event with a defined deltaY the handler can read.
+const dispatchWheel = (root: HTMLElement, deltaY: number): void => {
+  const event = new Event('wheel')
+  Object.defineProperty(event, 'deltaY', { value: deltaY })
+  root.dispatchEvent(event)
+}
+
+const surfaces: TerminalTextSurface[] = []
+
+const mountSurface = (
+  geometry = { clientHeight: 100, scrollHeight: 1000 }
+): { surface: TerminalTextSurface; root: HTMLElement; input: HTMLTextAreaElement } => {
+  const surface = new TerminalTextSurface({
+    rendererId: 'test',
+    transformOutput: (data): TerminalTextSurfaceOutput => ({
+      visibleText: data,
+    }),
+  })
+  surfaces.push(surface)
+  const container = document.createElement('div')
+  document.body.append(container)
+  surface.open(container)
+  const root = surface.element!
+  stubScrollGeometry(root, geometry)
+  const input = root.querySelector('textarea')!
+
+  return { surface, root, input }
+}
+
+afterEach(() => {
+  surfaces.splice(0).forEach((surface) => surface.dispose())
+  document.body.replaceChildren()
+})
+
+describe('TerminalTextSurface sticky-bottom scrolling', () => {
+  test('follows live output to the bottom by default', () => {
+    const { surface, root } = mountSurface()
+
+    surface.write('live output\n')
+
+    expect(root.scrollTop).toBe(root.scrollHeight)
+  })
+
+  test('freezes auto-scroll after the user wheels up', () => {
+    const { surface, root } = mountSurface()
+    root.scrollTop = root.scrollHeight // start stuck to the bottom
+
+    dispatchWheel(root, -50)
+    root.scrollTop = 400 // user reads history
+
+    surface.write('new live output arrives\n')
+
+    expect(root.scrollTop).toBe(400) // not yanked back to the bottom
+  })
+
+  test('resumes live scroll once the user returns to the bottom', () => {
+    const { surface, root } = mountSurface()
+    dispatchWheel(root, -50) // freeze
+
+    root.scrollTop = root.scrollHeight - root.clientHeight // back at the bottom
+    root.dispatchEvent(new Event('scroll'))
+
+    surface.write('more output\n')
+
+    expect(root.scrollTop).toBe(root.scrollHeight)
+  })
+
+  test('resumes live scroll when the user types', () => {
+    const { surface, root, input } = mountSurface()
+    dispatchWheel(root, -50) // freeze
+    root.scrollTop = 400
+
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true }))
+    surface.write('echoed input\n')
+
+    expect(root.scrollTop).toBe(root.scrollHeight)
+  })
+
+  test('anchors the reading position as content grows while frozen', () => {
+    const { surface, root } = mountSurface()
+    dispatchWheel(root, -50) // freeze
+    root.scrollTop = 400
+
+    // content grows by 200px across the next render (scrollback prepended / live
+    // output appended): the reading position must shift by the same delta.
+    const heights = [1000, 1200]
+    let read = 0
+    Object.defineProperty(root, 'scrollHeight', {
+      configurable: true,
+      get: () => heights[Math.min(read++, heights.length - 1)],
+    })
+
+    surface.write('appended\n')
+
+    expect(root.scrollTop).toBe(600) // 400 + (1200 - 1000)
+  })
+
+  test('does not scroll on a wheel-down (stays following the bottom)', () => {
+    const { surface, root } = mountSurface()
+
+    dispatchWheel(root, 50) // wheel down — no freeze
+    surface.write('live\n')
+
+    expect(root.scrollTop).toBe(root.scrollHeight)
+  })
+})

--- a/src/features/terminal/components/TerminalPane/terminalTextSurface.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalTextSurface.test.ts
@@ -293,6 +293,19 @@ describe('TerminalTextSurface static scrollback region', () => {
     expect(scrollback.textContent).toBe('')
   })
 
+  test('null scrollback resumes bottom-following after reading history', () => {
+    const { surface, root } = mountSurface()
+    writeWithScrollback(surface, {
+      displayText: 'history',
+    })
+    dispatchWheel(root, -50)
+    root.scrollTop = 400
+
+    writeWithScrollback(surface, null, 'vim')
+
+    expect(root.scrollTop).toBe(root.scrollHeight)
+  })
+
   test('select-all spans the history region and the viewport', () => {
     const { surface } = mountSurface()
     writeWithScrollback(surface, { displayText: 'history line' }, 'live prompt')

--- a/src/features/terminal/components/TerminalPane/terminalTextSurface.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalTextSurface.test.ts
@@ -45,7 +45,11 @@ const surfaces: TerminalTextSurface[] = []
 
 const mountSurface = (
   geometry = { clientHeight: 100, scrollHeight: 1000 }
-): { surface: TerminalTextSurface; root: HTMLElement; input: HTMLTextAreaElement } => {
+): {
+  surface: TerminalTextSurface
+  root: HTMLElement
+  input: HTMLTextAreaElement
+} => {
   const surface = new TerminalTextSurface({
     rendererId: 'test',
     transformOutput: (data): TerminalTextSurfaceOutput => ({
@@ -106,19 +110,23 @@ describe('TerminalTextSurface sticky-bottom scrolling', () => {
     dispatchWheel(root, -50) // freeze
     root.scrollTop = 400
 
-    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true }))
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'a', bubbles: true })
+    )
     surface.write('echoed input\n')
 
     expect(root.scrollTop).toBe(root.scrollHeight)
   })
 
-  test('anchors the reading position as content grows while frozen', () => {
+  test('holds the reading position as content grows below the frozen reader', () => {
     const { surface, root } = mountSurface()
     dispatchWheel(root, -50) // freeze
     root.scrollTop = 400
 
-    // content grows by 200px across the next render (scrollback prepended / live
-    // output appended): the reading position must shift by the same delta.
+    // Content grows by 200px across the next render. Terminal history grows at
+    // the bottom (below the reader), so the reading position must NOT move — the
+    // rows above scrollTop are unchanged. A height-delta anchor here was the
+    // regression that crept the reader to the bottom and snapped live.
     const heights = [1000, 1200]
     let read = 0
     Object.defineProperty(root, 'scrollHeight', {
@@ -128,7 +136,7 @@ describe('TerminalTextSurface sticky-bottom scrolling', () => {
 
     surface.write('appended\n')
 
-    expect(root.scrollTop).toBe(600) // 400 + (1200 - 1000)
+    expect(root.scrollTop).toBe(400) // held, not anchored to 600
   })
 
   test('does not scroll on a wheel-down (stays following the bottom)', () => {
@@ -145,7 +153,9 @@ describe('TerminalTextSurface sticky-bottom scrolling', () => {
     // 40 rows (scrollback + viewport) taller than the 100px pane; the cursor is
     // at the very end. Without pinToBottom the replace heuristic would jump to
     // the top (deep cursor row); pinToBottom must follow the bottom (the input).
-    const tallText = Array.from({ length: 40 }, (_, i) => `line ${i}`).join('\n')
+    const tallText = Array.from({ length: 40 }, (_, i) => `line ${i}`).join(
+      '\n'
+    )
 
     surface.writeParsedOutput({
       visibleText: tallText,

--- a/src/features/terminal/components/TerminalPane/terminalTextSurface.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalTextSurface.test.ts
@@ -148,6 +148,28 @@ describe('TerminalTextSurface sticky-bottom scrolling', () => {
     expect(root.scrollTop).toBe(root.scrollHeight)
   })
 
+  test('does not freeze auto-scroll when wheel-up cannot move content', () => {
+    const { surface, root } = mountSurface({
+      clientHeight: 100,
+      scrollHeight: 100,
+    })
+
+    dispatchWheel(root, -50)
+    surface.write('first overflow\n')
+
+    expect(root.scrollTop).toBe(root.scrollHeight)
+  })
+
+  test('clear resumes bottom-following after the user was reading history', () => {
+    const { surface, root } = mountSurface()
+    dispatchWheel(root, -50)
+    root.scrollTop = 400
+
+    surface.clear()
+
+    expect(root.scrollTop).toBe(root.scrollHeight)
+  })
+
   test('pins to the bottom on a scrollback render even when the cursor row is deep', () => {
     const { surface, root } = mountSurface()
 

--- a/src/features/terminal/components/TerminalPane/terminalTextSurface.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalTextSurface.test.ts
@@ -207,7 +207,7 @@ describe('TerminalTextSurface static scrollback region', () => {
 
   const writeWithScrollback = (
     surface: TerminalTextSurface,
-    scrollback: { displayText: string; visibleText: string } | null | undefined,
+    scrollback: { displayText: string } | null | undefined,
     viewportText = 'prompt>'
   ): void => {
     surface.writeParsedOutput({
@@ -231,7 +231,6 @@ describe('TerminalTextSurface static scrollback region', () => {
 
     writeWithScrollback(surface, {
       displayText: 'history one\nhistory two',
-      visibleText: 'history one\nhistory two',
     })
 
     const { scrollback, viewport } = readRegions(root)
@@ -247,7 +246,6 @@ describe('TerminalTextSurface static scrollback region', () => {
     const { surface, root } = mountSurface()
     writeWithScrollback(surface, {
       displayText: 'kept history',
-      visibleText: 'kept history',
     })
     const { scrollback } = readRegions(root)
     const firstRow = scrollback.firstChild
@@ -263,7 +261,6 @@ describe('TerminalTextSurface static scrollback region', () => {
     const { surface, root } = mountSurface()
     writeWithScrollback(surface, {
       displayText: 'history',
-      visibleText: 'history',
     })
     const { scrollback } = readRegions(root)
     expect(scrollback.style.display).toBe('block')
@@ -276,11 +273,7 @@ describe('TerminalTextSurface static scrollback region', () => {
 
   test('select-all spans the history region and the viewport', () => {
     const { surface } = mountSurface()
-    writeWithScrollback(
-      surface,
-      { displayText: 'history line', visibleText: 'history line' },
-      'live prompt'
-    )
+    writeWithScrollback(surface, { displayText: 'history line' }, 'live prompt')
 
     surface.selectAll()
 

--- a/src/features/terminal/components/TerminalPane/terminalTextSurface.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalTextSurface.test.ts
@@ -150,6 +150,7 @@ describe('TerminalTextSurface sticky-bottom scrolling', () => {
 
   test('pins to the bottom on a scrollback render even when the cursor row is deep', () => {
     const { surface, root } = mountSurface()
+
     // 40 rows (scrollback + viewport) taller than the 100px pane; the cursor is
     // at the very end. Without pinToBottom the replace heuristic would jump to
     // the top (deep cursor row); pinToBottom must follow the bottom (the input).
@@ -193,5 +194,98 @@ describe('TerminalTextSurface sticky-bottom scrolling', () => {
     root.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
 
     expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true })
+  })
+})
+
+describe('TerminalTextSurface static scrollback region', () => {
+  const readRegions = (
+    root: HTMLElement
+  ): { scrollback: HTMLElement; viewport: HTMLElement } => ({
+    scrollback: root.querySelector<HTMLElement>('[data-terminal-scrollback]')!,
+    viewport: root.querySelector<HTMLElement>('pre')!,
+  })
+
+  const writeWithScrollback = (
+    surface: TerminalTextSurface,
+    scrollback: { displayText: string; visibleText: string } | null | undefined,
+    viewportText = 'prompt>'
+  ): void => {
+    surface.writeParsedOutput({
+      visibleText: viewportText,
+      ...(scrollback === undefined ? {} : { scrollback }),
+      displayDelta: {
+        pinToBottom: true,
+        operations: [
+          {
+            type: 'replace',
+            text: viewportText,
+            cursorOffset: viewportText.length,
+          },
+        ],
+      },
+    })
+  }
+
+  test('renders history into the static region, separate from the viewport', () => {
+    const { surface, root } = mountSurface()
+
+    writeWithScrollback(surface, {
+      displayText: 'history one\nhistory two',
+      visibleText: 'history one\nhistory two',
+    })
+
+    const { scrollback, viewport } = readRegions(root)
+    expect(scrollback.style.display).toBe('block')
+    expect(scrollback.textContent).toContain('history one')
+    expect(scrollback.textContent).toContain('history two')
+    // The viewport pre holds only the live line, never the history.
+    expect(viewport.textContent).toContain('prompt>')
+    expect(viewport.textContent).not.toContain('history one')
+  })
+
+  test('does not rebuild history when the payload is absent (viewport-only frame)', () => {
+    const { surface, root } = mountSurface()
+    writeWithScrollback(surface, {
+      displayText: 'kept history',
+      visibleText: 'kept history',
+    })
+    const { scrollback } = readRegions(root)
+    const firstRow = scrollback.firstChild
+
+    // A frame with no scrollback field must leave the history DOM untouched.
+    writeWithScrollback(surface, undefined, 'prompt> typing')
+
+    expect(scrollback.textContent).toContain('kept history')
+    expect(scrollback.firstChild).toBe(firstRow) // same node, not rebuilt
+  })
+
+  test('clears the static region on a null payload (alt screen / no history)', () => {
+    const { surface, root } = mountSurface()
+    writeWithScrollback(surface, {
+      displayText: 'history',
+      visibleText: 'history',
+    })
+    const { scrollback } = readRegions(root)
+    expect(scrollback.style.display).toBe('block')
+
+    writeWithScrollback(surface, null)
+
+    expect(scrollback.style.display).toBe('none')
+    expect(scrollback.textContent).toBe('')
+  })
+
+  test('select-all spans the history region and the viewport', () => {
+    const { surface } = mountSurface()
+    writeWithScrollback(
+      surface,
+      { displayText: 'history line', visibleText: 'history line' },
+      'live prompt'
+    )
+
+    surface.selectAll()
+
+    // jsdom has no real selection geometry, so getSelection falls back to the
+    // combined visible text — which must include BOTH regions.
+    expect(surface.getSelection()).toBe('history line\nlive prompt')
   })
 })

--- a/src/features/terminal/components/TerminalPane/terminalTextSurface.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalTextSurface.test.ts
@@ -139,4 +139,40 @@ describe('TerminalTextSurface sticky-bottom scrolling', () => {
 
     expect(root.scrollTop).toBe(root.scrollHeight)
   })
+
+  test('pins to the bottom on a scrollback render even when the cursor row is deep', () => {
+    const { surface, root } = mountSurface()
+    // 40 rows (scrollback + viewport) taller than the 100px pane; the cursor is
+    // at the very end. Without pinToBottom the replace heuristic would jump to
+    // the top (deep cursor row); pinToBottom must follow the bottom (the input).
+    const tallText = Array.from({ length: 40 }, (_, i) => `line ${i}`).join('\n')
+
+    surface.writeParsedOutput({
+      visibleText: tallText,
+      displayDelta: {
+        pinToBottom: true,
+        operations: [
+          { type: 'replace', text: tallText, cursorOffset: tallText.length },
+        ],
+      },
+    })
+
+    expect(root.scrollTop).toBe(root.scrollHeight)
+  })
+
+  test('a scrollback render does not override the user scrolled-up freeze', () => {
+    const { surface, root } = mountSurface()
+    dispatchWheel(root, -50) // user reads history
+    root.scrollTop = 400
+
+    surface.writeParsedOutput({
+      visibleText: 'x\ny',
+      displayDelta: {
+        pinToBottom: true,
+        operations: [{ type: 'replace', text: 'x\ny', cursorOffset: 0 }],
+      },
+    })
+
+    expect(root.scrollTop).toBe(400) // frozen, not pinned to the bottom
+  })
 })

--- a/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
+++ b/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
@@ -468,7 +468,10 @@ export class TerminalTextSurface implements TerminalSurface {
   }
 
   focus(): void {
-    this.input.focus()
+    // The capture textarea sits at top:0; focusing it without preventScroll makes
+    // the browser scroll it into view — jumping a scrollback-tall buffer to the
+    // top on every click. preventScroll keeps the reading/live position.
+    this.input.focus({ preventScroll: true })
   }
 
   dispose(): void {

--- a/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
+++ b/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
@@ -69,10 +69,7 @@ export interface TerminalTextSurfaceOutput {
   readonly displayDelta?: TerminalDisplayDelta
   // Styled history for the separate static region. undefined = unchanged,
   // object = replace, null = clear. See TerminalParserEngineOutput.scrollback.
-  readonly scrollback?: {
-    readonly displayText: string
-    readonly visibleText: string
-  } | null
+  readonly scrollback?: { readonly displayText: string } | null
 }
 
 type RenderScrollMode = 'bottom' | 'cursor' | 'top'
@@ -1290,9 +1287,7 @@ export class TerminalTextSurface implements TerminalSurface {
     return rows
   }
 
-  private renderScrollback(
-    payload: { displayText: string; visibleText: string } | null
-  ): void {
+  private renderScrollback(payload: { displayText: string } | null): void {
     if (payload === null) {
       this.scrollbackBuffer.clear()
       this.scrollbackOutput.replaceChildren()

--- a/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
+++ b/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
@@ -1297,6 +1297,7 @@ export class TerminalTextSurface implements TerminalSurface {
       this.scrollbackBuffer.clear()
       this.scrollbackOutput.replaceChildren()
       this.scrollbackOutput.style.display = 'none'
+      this.userScrolledUp = false
 
       return
     }

--- a/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
+++ b/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
@@ -527,9 +527,11 @@ export class TerminalTextSurface implements TerminalSurface {
 
       this.outputBuffer.applyDelta(output.displayDelta)
 
-      const scrollMode: RenderScrollMode = hasReplaceOperation
-        ? this.readReplaceSnapshotScrollMode(replaceCursorRowIndex)
-        : 'bottom'
+      const scrollMode: RenderScrollMode = output.displayDelta.pinToBottom
+        ? 'bottom'
+        : hasReplaceOperation
+          ? this.readReplaceSnapshotScrollMode(replaceCursorRowIndex)
+          : 'bottom'
 
       this.renderOutput({ scrollMode })
       callback?.()

--- a/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
+++ b/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
@@ -1232,19 +1232,15 @@ export class TerminalTextSurface implements TerminalSurface {
       this.outputBuffer.readCursorVisible()
     )
 
-    const previousScrollTop = this.root.scrollTop
-    const previousScrollHeight = this.root.scrollHeight
-
     this.output.replaceChildren(...fragments)
 
-    if (this.userScrolledUp) {
-      // Anchor the reading position: replaceChildren rebuilds every row and the
-      // scrollback above may grow as live lines scroll off, so re-add the height
-      // delta to keep what the user is reading in place.
-      this.root.scrollTop =
-        previousScrollTop + (this.root.scrollHeight - previousScrollHeight)
-    }
-
+    // While the user is reading history we never reposition (applyScrollMode
+    // early-returns). Crucially we do NOT re-anchor scrollTop here: terminal
+    // history grows at the BOTTOM of scrollback (just above the viewport, below
+    // the reader), so a height-delta anchor would creep the reading position
+    // downward, fire a programmatic 'scroll', and let handleScroll flip the
+    // freeze off — snapping back to the bottom. Leaving scrollTop alone keeps
+    // the reading position put because the rows above it are unchanged.
     this.applyScrollMode(options.scrollMode ?? 'bottom', cursorRowIndex)
   }
 

--- a/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
+++ b/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
@@ -23,6 +23,10 @@ const MIN_ROWS = 1
 const APPROXIMATE_CHAR_WIDTH = 8
 const APPROXIMATE_LINE_HEIGHT = 18
 const MEASURED_CHAR_SAMPLE_LENGTH = 80
+// Within this many px of the bottom counts as "stuck to bottom" (live). The
+// epsilon absorbs fractional-pixel line heights so auto-scroll doesn't get
+// stuck one sub-pixel short of the end.
+const SCROLL_BOTTOM_THRESHOLD_PX = 8
 const BLOCK_ELEMENT_PATTERN = /[\u2580-\u2590\u2594-\u259f]/
 const BLOCK_ONE_EIGHTH = 12.5
 
@@ -373,6 +377,9 @@ export class TerminalTextSurface implements TerminalSurface {
     columns: DEFAULT_COLS,
   })
   private container: HTMLElement | null = null
+  // Sticky-bottom scroll state: while true the user has scrolled up to read
+  // history, so renders must NOT yank the view back to the bottom.
+  private userScrolledUp = false
   private colsValue = DEFAULT_COLS
   private rowsValue = DEFAULT_ROWS
   private cachedCharacterWidth: number | null = null
@@ -424,6 +431,8 @@ export class TerminalTextSurface implements TerminalSurface {
     this.input.setAttribute('aria-label', 'Terminal input')
     this.syncPtyViewportGeometry()
     this.root.addEventListener('mousedown', this.handlePointerDown)
+    this.root.addEventListener('wheel', this.handleWheel, { passive: true })
+    this.root.addEventListener('scroll', this.handleScroll, { passive: true })
     document.addEventListener('selectionchange', this.handleSelectionChange)
     this.input.addEventListener('keydown', this.handleKeyDown)
     this.input.addEventListener('paste', this.handlePaste)
@@ -465,6 +474,8 @@ export class TerminalTextSurface implements TerminalSurface {
   dispose(): void {
     this.disposed = true
     this.root.removeEventListener('mousedown', this.handlePointerDown)
+    this.root.removeEventListener('wheel', this.handleWheel)
+    this.root.removeEventListener('scroll', this.handleScroll)
     document.removeEventListener('selectionchange', this.handleSelectionChange)
     this.input.removeEventListener('keydown', this.handleKeyDown)
     this.input.removeEventListener('paste', this.handlePaste)
@@ -696,6 +707,29 @@ export class TerminalTextSurface implements TerminalSurface {
     this.focus()
   }
 
+  // Freeze auto-scroll the instant the user wheels up, before the resulting
+  // 'scroll' event/layout settles — otherwise the next render snaps to bottom.
+  private readonly handleWheel = (event: WheelEvent): void => {
+    if (event.deltaY < 0) {
+      this.userScrolledUp = true
+    }
+  }
+
+  // Source of truth for the sticky state: re-derive it from the scroll position
+  // after any scroll (user drag, wheel, or our own programmatic snap).
+  private readonly handleScroll = (): void => {
+    this.userScrolledUp = !this.isScrolledToBottom()
+  }
+
+  private isScrolledToBottom(): boolean {
+    return (
+      this.root.scrollTop >=
+      this.root.scrollHeight -
+        this.root.clientHeight -
+        SCROLL_BOTTOM_THRESHOLD_PX
+    )
+  }
+
   private readonly handleSelectionChange = (): void => {
     this.selectAllSelectionText = null
     const selectionText = this.readSelectionText()
@@ -739,6 +773,9 @@ export class TerminalTextSurface implements TerminalSurface {
     }
 
     event.preventDefault()
+    // Typing returns to the live prompt: drop the sticky-scroll freeze so the
+    // next render follows output to the bottom again.
+    this.userScrolledUp = false
     this.emitData(data)
   }
 
@@ -1190,7 +1227,19 @@ export class TerminalTextSurface implements TerminalSurface {
       this.outputBuffer.readCursorVisible()
     )
 
+    const previousScrollTop = this.root.scrollTop
+    const previousScrollHeight = this.root.scrollHeight
+
     this.output.replaceChildren(...fragments)
+
+    if (this.userScrolledUp) {
+      // Anchor the reading position: replaceChildren rebuilds every row and the
+      // scrollback above may grow as live lines scroll off, so re-add the height
+      // delta to keep what the user is reading in place.
+      this.root.scrollTop =
+        previousScrollTop + (this.root.scrollHeight - previousScrollHeight)
+    }
+
     this.applyScrollMode(options.scrollMode ?? 'bottom', cursorRowIndex)
   }
 
@@ -1198,6 +1247,11 @@ export class TerminalTextSurface implements TerminalSurface {
     scrollMode: RenderScrollMode,
     cursorRowIndex: number
   ): void {
+    // While the user is reading history, never reposition the viewport.
+    if (this.userScrolledUp) {
+      return
+    }
+
     if (scrollMode === 'bottom') {
       this.root.scrollTop = this.root.scrollHeight
 

--- a/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
+++ b/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
@@ -67,6 +67,12 @@ export interface TerminalTextSurfaceOutput {
   readonly visibleText: string
   readonly displayText?: string
   readonly displayDelta?: TerminalDisplayDelta
+  // Styled history for the separate static region. undefined = unchanged,
+  // object = replace, null = clear. See TerminalParserEngineOutput.scrollback.
+  readonly scrollback?: {
+    readonly displayText: string
+    readonly visibleText: string
+  } | null
 }
 
 type RenderScrollMode = 'bottom' | 'cursor' | 'top'
@@ -107,7 +113,8 @@ const getControlKeyData = (key: string): string | null => {
 
 const readContainedSelection = (
   root: HTMLElement,
-  output: HTMLElement,
+  contentStart: Node | null,
+  contentEnd: Node | null,
   selectAllText: string
 ): string => {
   const selection = window.getSelection()
@@ -129,15 +136,20 @@ const readContainedSelection = (
   }
 
   const range = selection.getRangeAt(0)
-  const outputRange = document.createRange()
-  outputRange.selectNodeContents(output)
 
-  const includesAllOutput =
-    range.compareBoundaryPoints(Range.START_TO_START, outputRange) <= 0 &&
-    range.compareBoundaryPoints(Range.END_TO_END, outputRange) >= 0
+  // The selectable content spans the history region + the viewport (two <pre>s).
+  if (contentStart && contentEnd) {
+    const contentRange = document.createRange()
+    contentRange.setStartBefore(contentStart)
+    contentRange.setEndAfter(contentEnd)
 
-  if (includesAllOutput) {
-    return selectAllText
+    const includesAllContent =
+      range.compareBoundaryPoints(Range.START_TO_START, contentRange) <= 0 &&
+      range.compareBoundaryPoints(Range.END_TO_END, contentRange) >= 0
+
+    if (includesAllContent) {
+      return selectAllText
+    }
   }
 
   return selection.toString()
@@ -367,6 +379,11 @@ const getKeyboardData = (event: KeyboardEvent): string | null => {
 
 export class TerminalTextSurface implements TerminalSurface {
   private readonly root = document.createElement('div')
+  // Static history region: rendered once when scrollback changes, then left
+  // alone. The viewport (this.output) re-renders per frame; history does not. A
+  // <div> (not <pre>) so `querySelector('pre')` still resolves the viewport; the
+  // row spans inside carry the monospace/pre layout regardless of the wrapper.
+  private readonly scrollbackOutput = document.createElement('div')
   private readonly output = document.createElement('pre')
   private readonly input = document.createElement('textarea')
   private readonly dataHandlers = new Set<(data: string) => void>()
@@ -374,6 +391,9 @@ export class TerminalTextSurface implements TerminalSurface {
   private readonly selectionHandlers = new Set<() => void>()
   private readonly keyHandlers = new Set<TerminalKeyEventHandler>()
   private readonly outputBuffer = new TerminalDisplayBuffer({
+    columns: DEFAULT_COLS,
+  })
+  private readonly scrollbackBuffer = new TerminalDisplayBuffer({
     columns: DEFAULT_COLS,
   })
   private container: HTMLElement | null = null
@@ -390,7 +410,7 @@ export class TerminalTextSurface implements TerminalSurface {
   constructor(private readonly options: TerminalTextSurfaceOptions) {
     this.root.dataset.terminalRenderer = options.rendererId
     this.root.tabIndex = -1
-    this.root.append(this.output, this.input)
+    this.root.append(this.scrollbackOutput, this.output, this.input)
 
     Object.assign(this.root.style, {
       height: '100%',
@@ -413,6 +433,25 @@ export class TerminalTextSurface implements TerminalSurface {
       minHeight: 'max(100%, var(--terminal-pty-viewport-height))',
       overflowX: 'hidden',
       padding: '8px',
+      whiteSpace: 'normal',
+      width: '100%',
+      wordBreak: 'normal',
+    })
+
+    // History region: same type metrics as the viewport, but its NATURAL height
+    // (no min-height fill) and no bottom padding so it abuts the viewport. Hidden
+    // until it holds history, so a fresh session has no extra top gap.
+    this.scrollbackOutput.dataset.terminalScrollback = 'true'
+    Object.assign(this.scrollbackOutput.style, {
+      boxSizing: 'border-box',
+      display: 'none',
+      fontFamily: TERMINAL_FONT_FAMILY,
+      fontSize: `${TERMINAL_FONT_SIZE}px`,
+      lineHeight: 'var(--terminal-line-height)',
+      margin: '0',
+      maxWidth: '100%',
+      overflowX: 'hidden',
+      padding: '8px 8px 0',
       whiteSpace: 'normal',
       width: '100%',
       wordBreak: 'normal',
@@ -495,6 +534,9 @@ export class TerminalTextSurface implements TerminalSurface {
 
   clear(): void {
     this.outputBuffer.clear()
+    this.scrollbackBuffer.clear()
+    this.scrollbackOutput.replaceChildren()
+    this.scrollbackOutput.style.display = 'none'
     this.renderOutput()
   }
 
@@ -520,6 +562,12 @@ export class TerminalTextSurface implements TerminalSurface {
       callback?.()
 
       return
+    }
+
+    // Update the static history region first (only when it changed) so the
+    // viewport render's scroll math below sees the combined height.
+    if (output.scrollback !== undefined) {
+      this.renderScrollback(output.scrollback)
     }
 
     if (output.displayDelta) {
@@ -588,14 +636,17 @@ export class TerminalTextSurface implements TerminalSurface {
   }
 
   selectAll(): void {
-    if (!this.output.firstChild) {
+    const { start, end } = this.readContentBoundaries()
+
+    if (!start || !end) {
       return
     }
 
-    this.selectAllSelectionText = this.outputBuffer.readVisibleText()
+    this.selectAllSelectionText = this.readCombinedVisibleText()
 
     const range = document.createRange()
-    range.selectNodeContents(this.output)
+    range.setStartBefore(start)
+    range.setEndAfter(end)
 
     const selection = window.getSelection()
     selection?.removeAllRanges()
@@ -699,6 +750,7 @@ export class TerminalTextSurface implements TerminalSurface {
     this.colsValue = nextCols
     this.rowsValue = nextRows
     this.outputBuffer.setColumns(nextCols)
+    this.scrollbackBuffer.setColumns(nextCols)
     this.syncPtyViewportGeometry()
     this.notifyResize()
   }
@@ -748,10 +800,13 @@ export class TerminalTextSurface implements TerminalSurface {
   }
 
   private readSelectionText(): string {
+    const { start, end } = this.readContentBoundaries()
+
     const nativeSelectionText = readContainedSelection(
       this.root,
-      this.output,
-      this.outputBuffer.readVisibleText()
+      start,
+      end,
+      this.readCombinedVisibleText()
     )
 
     if (nativeSelectionText.length > 0) {
@@ -759,6 +814,26 @@ export class TerminalTextSurface implements TerminalSurface {
     }
 
     return this.selectAllSelectionText ?? ''
+  }
+
+  // The selectable content spans the history region (if present) then the
+  // viewport, so selection + select-all reach across both <pre> elements.
+  private readContentBoundaries(): {
+    start: Node | null
+    end: Node | null
+  } {
+    return {
+      start: this.scrollbackOutput.firstChild ?? this.output.firstChild,
+      end: this.output.lastChild ?? this.scrollbackOutput.lastChild,
+    }
+  }
+
+  private readCombinedVisibleText(): string {
+    const viewport = this.outputBuffer.readVisibleText()
+
+    return this.scrollbackOutput.firstChild
+      ? `${this.scrollbackBuffer.readVisibleText()}\n${viewport}`
+      : viewport
   }
 
   private readonly handleKeyDown = (event: KeyboardEvent): void => {
@@ -1213,6 +1288,35 @@ export class TerminalTextSurface implements TerminalSurface {
     }
 
     return rows
+  }
+
+  private renderScrollback(
+    payload: { displayText: string; visibleText: string } | null
+  ): void {
+    if (payload === null) {
+      this.scrollbackBuffer.clear()
+      this.scrollbackOutput.replaceChildren()
+      this.scrollbackOutput.style.display = 'none'
+
+      return
+    }
+
+    this.scrollbackBuffer.applyDelta({
+      operations: [
+        { type: 'replace', text: payload.displayText, cursorOffset: 0 },
+      ],
+    })
+
+    // History has no cursor: render the styled runs only. This is the ONLY place
+    // the history DOM is built — never in the per-frame viewport render.
+    this.scrollbackOutput.replaceChildren(
+      ...this.createOutputFragments(
+        this.scrollbackBuffer.readStyledRuns(),
+        0,
+        false
+      )
+    )
+    this.scrollbackOutput.style.display = 'block'
   }
 
   private renderOutput(options: { scrollMode?: RenderScrollMode } = {}): void {

--- a/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
+++ b/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
@@ -534,6 +534,7 @@ export class TerminalTextSurface implements TerminalSurface {
     this.scrollbackBuffer.clear()
     this.scrollbackOutput.replaceChildren()
     this.scrollbackOutput.style.display = 'none'
+    this.userScrolledUp = false
     this.renderOutput()
   }
 
@@ -764,7 +765,7 @@ export class TerminalTextSurface implements TerminalSurface {
   // Freeze auto-scroll the instant the user wheels up, before the resulting
   // 'scroll' event/layout settles — otherwise the next render snaps to bottom.
   private readonly handleWheel = (event: WheelEvent): void => {
-    if (event.deltaY < 0) {
+    if (event.deltaY < 0 && this.canScrollVertically()) {
       this.userScrolledUp = true
     }
   }
@@ -782,6 +783,10 @@ export class TerminalTextSurface implements TerminalSurface {
         this.root.clientHeight -
         SCROLL_BOTTOM_THRESHOLD_PX
     )
+  }
+
+  private canScrollVertically(): boolean {
+    return this.root.scrollHeight > this.root.clientHeight
   }
 
   private readonly handleSelectionChange = (): void => {
@@ -1349,7 +1354,11 @@ export class TerminalTextSurface implements TerminalSurface {
   ): void {
     // While the user is reading history, never reposition the viewport.
     if (this.userScrolledUp) {
-      return
+      if (!this.canScrollVertically() || this.isScrolledToBottom()) {
+        this.userScrolledUp = false
+      } else {
+        return
+      }
     }
 
     if (scrollMode === 'bottom') {

--- a/src/lib/backend.ts
+++ b/src/lib/backend.ts
@@ -25,7 +25,7 @@ export interface GhosttyRenderStateBridgeSize {
 export interface GhosttyRenderStateBridgeDriver {
   writeBytes: (bytes: Uint8Array) => void
   readSnapshot: () => unknown
-  readScrollback?: () => unknown
+  readScrollback: () => unknown
   reset?: () => void
   resize?: (size: GhosttyRenderStateBridgeSize) => void
   dispose?: () => void

--- a/src/lib/backend.ts
+++ b/src/lib/backend.ts
@@ -25,6 +25,7 @@ export interface GhosttyRenderStateBridgeSize {
 export interface GhosttyRenderStateBridgeDriver {
   writeBytes: (bytes: Uint8Array) => void
   readSnapshot: () => unknown
+  readScrollback?: () => unknown
   reset?: () => void
   resize?: (size: GhosttyRenderStateBridgeSize) => void
   dispose?: () => void


### PR DESCRIPTION
## Summary

Brings scroll-up-to-see-history to the Ghostty native terminal for **normal-buffer** sessions (shell, codex). Styled scrollback renders into a **separate static DOM region**, so the per-frame viewport render never rebuilds history, and the sticky-bottom scroll machine holds your reading position while output streams.

## What changed

- **Styled scrollback pipeline** (steps 1–6): native `READ_SCROLLBACK` channel → preload → renderer bridge → encoded SGR-sentinel rows; bridge exposes `scrollbackRowCount` + `isAltScreen`.
- **Static history region** (`terminalTextSurface`): a separate `<div>` + buffer rendered **only when scrollback changes**; the viewport `<pre>` re-renders per frame. Cursor stays in the viewport (no offset shift); selection / select-all span both regions.
- **Scroll-machine fixes**: removed the height-delta anchor that crept the reader toward the bottom (restores scroll-up); `focus({ preventScroll: true })` so clicking the canvas no longer jumps to the top; the viewport pins to the bottom only while the user is **not** scrolled up.
- **Driver**: returns viewport-only output every frame and attaches scrollback as a tri-state payload (unchanged / replace / clear) only on row-count change.
- **Dev tooling**: `npm run dev:ghostty` (isolated-userData launcher, so dev never collides with an installed app) + a `run-ghostty-dev` project skill capturing the run/debug workflow.

## Verified

- Real app (ghostty native dev build): **shell + codex scroll their history correctly** — confirmed by manual smoke.
- **4076 frontend tests pass** (3 skipped); lint, prettier, and type-check are green repo-wide.

## Scope & follow-ups

- **Claude can't be terminal-scrolled because it runs on the alternate screen** — the alt screen has no terminal scrollback by design (confirmed via telemetry: `isAltScreen=true`, `scrollbackRowCount=0`, while shell/codex are normal-buffer). Giving claude scroll requires forwarding the wheel to the app, tracked in **VIM-223**.
- Perf optimizations from the codex review (gate scrollback fetch/render on actual scroll-up): **VIM-224**.
- First-keystroke input responsiveness in the ghostty build: **VIM-222**.

Closes VIM-216

🤖 Generated with [Claude Code](https://claude.com/claude-code)
