### PR TITLE
[codex] Enable terminal clipboard in OpenCode

### DIFF
--- a/src/features/terminal/components/TerminalContextMenu.tsx
+++ b/src/features/terminal/components/TerminalContextMenu.tsx
@@ -11,8 +11,8 @@ export interface TerminalContextMenuProps {
   canCopy: boolean
 }
 
-// Chips reflect the active platform's actual binding (see spec §4 table):
-//   macOS:        Cmd+C copy / Cmd+Shift+V paste     → renders ⌘C / ⌘⇧V
+// Chips reflect the active platform's handled terminal clipboard shortcuts:
+//   macOS:        Cmd+C copy / Cmd+V paste           → renders ⌘C / ⌘V
 //   Linux/Win:    Ctrl+Shift+C / Ctrl+Shift+V        → renders Ctrl+Shift+C / Ctrl+Shift+V
 // Computed at module load — there's no live platform-flip use case.
 const IS_MAC = isMacPlatform()
@@ -22,7 +22,7 @@ const COPY_SHORTCUT: ShortcutInput = IS_MAC
   : ['Ctrl', 'Shift', 'C']
 
 const PASTE_SHORTCUT: ShortcutInput = IS_MAC
-  ? ['Mod', 'Shift', 'V']
+  ? ['Mod', 'V']
   : ['Ctrl', 'Shift', 'V']
 
 export const TerminalContextMenu = ({

--- a/src/features/terminal/components/TerminalPane/Body.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.test.tsx
@@ -279,6 +279,7 @@ describe('Body', () => {
           cursorBlink: true,
           fontSize: 14,
           fontFamily: TERMINAL_FONT_FAMILY,
+          macOptionClickForcesSelection: true,
         })
       )
     })

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -668,6 +668,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
         theme: toXtermTheme(themeService.current().terminal),
         scrollback: 10000,
         allowProposedApi: true,
+        macOptionClickForcesSelection: true,
       })
 
       // Create and load fit addon

--- a/src/features/terminal/hooks/useTerminalClipboard.test.ts
+++ b/src/features/terminal/hooks/useTerminalClipboard.test.ts
@@ -779,6 +779,33 @@ test('preferModifier="meta" + Cmd+Shift+V suppresses and pastes', async () => {
   }
 })
 
+test('preferModifier="meta" + Cmd+V suppresses and pastes', async () => {
+  const mock = createMockTerminal()
+  const pasteSpy = vi.spyOn(mock.terminal, 'paste')
+
+  const clipboard = installClipboardMock({
+    readText: () => Promise.resolve('pasted'),
+  })
+
+  try {
+    renderHook(() =>
+      useTerminalClipboard({
+        terminal: mock.terminal,
+        preferModifier: 'meta',
+      })
+    )
+    const handler = captureKeyHandler(mock)
+
+    const result = handler(keyboardEvent({ code: 'KeyV', metaKey: true }))
+    await flushMicrotasks()
+
+    expect(result).toBe(false)
+    expect(pasteSpy).toHaveBeenCalledWith('pasted')
+  } finally {
+    clipboard.restore()
+  }
+})
+
 test('unrelated key passes through unchanged', () => {
   const mock = createMockTerminal()
   renderHook(() => useTerminalClipboard({ terminal: mock.terminal }))

--- a/src/features/terminal/hooks/useTerminalClipboard.ts
+++ b/src/features/terminal/hooks/useTerminalClipboard.ts
@@ -240,7 +240,7 @@ export const useTerminalClipboard = ({
 
       if (event.code === 'KeyV') {
         const matched = isMac
-          ? event.metaKey && event.shiftKey && !event.ctrlKey && !event.altKey
+          ? event.metaKey && !event.ctrlKey && !event.altKey
           : event.ctrlKey && event.shiftKey && !event.metaKey && !event.altKey
 
         if (matched) {


### PR DESCRIPTION
## Summary
- Enable xterm's macOS selection override so Option-drag can select text while OpenCode has mouse tracking active.
- Handle Cmd+V in the terminal clipboard hook and keep Cmd+Shift+V working.
- Update the terminal context-menu paste shortcut hint and add focused regression coverage.

## Root cause
OpenCode enables terminal mouse tracking, which makes xterm route normal drag gestures to the PTY instead of starting local selection. The terminal also only handled Cmd+Shift+V explicitly on macOS, so the common Cmd+V path depended on browser/native paste behavior instead of Vimeflow's terminal clipboard hook.

## Validation
- `npx vitest run src/features/terminal/hooks/useTerminalClipboard.test.ts src/features/terminal/components/TerminalPane/Body.test.tsx src/features/terminal/components/TerminalContextMenu.test.tsx`
- `npm run type-check:generated`
- `npx eslint src/features/terminal/components/TerminalPane/Body.tsx src/features/terminal/hooks/useTerminalClipboard.ts src/features/terminal/components/TerminalContextMenu.tsx src/features/terminal/components/TerminalPane/Body.test.tsx src/features/terminal/hooks/useTerminalClipboard.test.ts src/features/terminal/components/TerminalContextMenu.test.tsx`
- pre-push `npm run test` (342 files, 4245 passed, 3 skipped)

Refs VIM-225