### PR TITLE
[codex] Refine terminal context menu image paste

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -57,7 +57,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 8        | 2    | 2026-06-19   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 4        | 0    | 2026-06-21   |
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 83       | 37   | 2026-06-22   |
-| [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 4        | 2    | 2026-05-24   |
+| [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 5        | 3    | 2026-06-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 92       | 90   | 2026-06-22   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 81       | 32   | 2026-06-22   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
@@ -81,7 +81,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 24       | 10   | 2026-06-19   |
 | [Module Boundaries](patterns/module-boundaries.md)                                                   | code-quality       | 16       | 3    | 2026-06-15   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 13       | 3    | 2026-06-15   |
-| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 20       | 1    | 2026-06-18   |
+| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 22       | 2    | 2026-06-24   |
 | [Verify Render Target](patterns/verify-render-target.md)                                             | code-quality       | 2        | 0    | 2026-05-24   |
 | [UI Visual Regression](patterns/ui-visual-regression.md)                                             | code-quality       | 15       | 9    | 2026-06-20   |
 | [Status Indicator Display](patterns/status-indicator-display.md)                                     | code-quality       | 3        | 0    | 2026-05-26   |
@@ -109,6 +109,6 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Vite HMR Static Dependencies](patterns/vite-hmr-static-deps.md)                                     | code-quality       | 3        | 2    | 2026-06-18   |
 | [Custom Pane Layout Preservation](patterns/custom-pane-layout-preservation.md)                       | correctness        | 13       | 5    | 2026-06-22   |
 | [Pane Slot Identity](patterns/pane-slot-identity.md)                                                 | correctness        | 3        | 1    | 2026-06-22   |
-| [Transient UI Side Effects](patterns/transient-ui-side-effects.md)                                   | react-patterns     | 5        | 1    | 2026-06-20   |
+| [Transient UI Side Effects](patterns/transient-ui-side-effects.md)                                   | react-patterns     | 6        | 2    | 2026-06-24   |
 | [Async Global State Mutation](patterns/async-global-state-mutation.md)                               | backend            | 1        | 0    | 2026-06-19   |
 | [Boolean Sentinel Consistency](patterns/boolean-sentinel-consistency.md)                             | code-quality       | 2        | 1    | 2026-06-22   |

--- a/docs/reviews/patterns/keyboard-shortcut-guards.md
+++ b/docs/reviews/patterns/keyboard-shortcut-guards.md
@@ -2,8 +2,8 @@
 id: keyboard-shortcut-guards
 category: keyboard-shortcuts
 created: 2026-05-18
-last_updated: 2026-06-18
-ref_count: 1
+last_updated: 2026-06-24
+ref_count: 2
 ---
 
 # Keyboard Shortcut Guards
@@ -291,4 +291,22 @@ against three classes of false-fire:
   right panes unreachable by keyboard.
 - **Fix:** Extended the regex from `^Digit([1-4])$` to `^Digit([1-6])$` and
   added a test covering `Ctrl+5` / `Ctrl+6` focus in a `grid3x2` session.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 21. Image paste shortcut stole shifted macOS text paste
+
+- **Source:** github-codex-connector | PR #618 round 1 | 2026-06-24
+- **Severity:** P2
+- **File:** `src/features/terminal/hooks/useTerminalClipboard.ts`
+- **Finding:** The macOS image-paste shortcut matched `Cmd+Shift+V` because it did not require `!event.shiftKey`. In agent panes with image paste enabled, this branch ran before the normal text-paste shortcut and regressed the shifted terminal paste chord.
+- **Fix:** Required `!event.shiftKey` for the macOS image-paste shortcut so `Cmd+Shift+V` continues through the normal text paste path. Added a regression test with image paste enabled and an image-capable clipboard.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 22. Duplicate macOS shortcut chips for semantically different paste rows
+
+- **Source:** github-claude | PR #618 round 1 | 2026-06-24
+- **Severity:** LOW
+- **File:** `src/features/terminal/components/TerminalContextMenu.tsx`
+- **Finding:** On macOS, both the Paste and Paste Image context-menu rows rendered the same shortcut chip, making the menu look contradictory even though the image path has priority only when the clipboard contains an image.
+- **Fix:** Made the Paste Image shortcut chip platform-aware and omitted it on macOS while keeping the distinct `Ctrl+V` chip on non-mac platforms. Added a macOS module-load regression test for the rendered row.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/terminal-input-handling.md
+++ b/docs/reviews/patterns/terminal-input-handling.md
@@ -2,8 +2,8 @@
 id: terminal-input-handling
 category: terminal
 created: 2026-04-09
-last_updated: 2026-05-24
-ref_count: 2
+last_updated: 2026-06-24
+ref_count: 3
 ---
 
 # Terminal Input Handling
@@ -52,3 +52,12 @@ double execution, and paste failures.
 - **Finding:** The `:rename-pane` command path wrote the trimmed raw argument into `userLabel` without the validation used by the chord modal. Control characters and overlong titles could persist locally; for agent panes, frontend state could diverge from the backend-sanitized `/rename` value.
 - **Fix:** Route command rename arguments through `validateTitle` before any local label or backend rename write. Control characters and over-200-byte titles are rejected consistently; valid whitespace is collapsed before both local and agent rename calls. Regression tests cover control-character rejection, byte-length rejection, and sanitized whitespace.
 - **Commit:** _(see git log for the PR #265 review-fix commit)_
+
+### 5. Clipboard image paste had no payload size cap
+
+- **Source:** github-claude | PR #618 round 1 | 2026-06-24
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/hooks/useTerminalClipboard.ts`
+- **Finding:** `pasteImageIfAvailable` converted the top clipboard image to a data URL and pasted it into the PTY without checking byte size. Large screenshots can expand to multi-megabyte base64 input, freezing the terminal and overflowing coding-agent context windows.
+- **Fix:** Added a 512 KB pre-encoding cap for clipboard image paste, clears the image-paste affordance when exceeded, surfaces an error through `onPasteError`, and covers the rejection path with a regression test.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/transient-ui-side-effects.md
+++ b/docs/reviews/patterns/transient-ui-side-effects.md
@@ -2,8 +2,8 @@
 id: transient-ui-side-effects
 category: react-patterns
 created: 2026-06-20
-last_updated: 2026-06-20
-ref_count: 1
+last_updated: 2026-06-24
+ref_count: 2
 ---
 
 # Transient UI Side Effects
@@ -87,3 +87,12 @@ to persistent state through a separate, explicit path.
   reset timer on a true result. Added regression coverage for both successful
   async feedback and the failure path that keeps the copy glyph visible.
 - **Commit:** same commit as this entry
+
+### 6. Context menu opened before async clipboard-derived state settled
+
+- **Source:** github-claude | PR #618 round 1 | 2026-06-24
+- **Severity:** LOW
+- **File:** `src/features/terminal/hooks/useTerminalClipboard.ts`
+- **Finding:** The terminal context menu reset `canPasteImage` to false and opened immediately while the clipboard image-type read was still pending. Fast reads produced a visible disabled-to-enabled transition for the Paste Image row.
+- **Fix:** Deferred menu open until a fast clipboard image check resolves, with a short fallback timer for slow or permission-gated reads. Cleanup now cancels pending fallback timers, and a regression test asserts the fast-read path opens with image state already settled.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -557,10 +557,10 @@ const MenuRow = ({
       aria-disabled={disabled ? true : undefined}
       aria-label={label}
       className={className}
-      onKeyDownCapture={handleKeyDownCapture}
       {...menu.getItemProps({
         onClick: handleClick,
         onKeyDown: handleKeyDown,
+        onKeyDownCapture: handleKeyDownCapture,
       })}
     >
       {children}

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -67,6 +67,11 @@ const useMenuContext = (): MenuContextValue => {
 
 const MENU_BODY_CLASSES = 'py-1 min-w-52 max-h-[28rem] overflow-auto'
 
+const CONTEXT_MENU_SURFACE_CLASSES =
+  'z-50 overflow-hidden rounded-md border border-outline-variant/30 bg-surface-container-high shadow-lg outline-none focus:outline-none focus-visible:outline-none'
+
+const CONTEXT_MENU_BODY_CLASSES = 'min-w-0 max-h-[28rem] overflow-auto'
+
 const SECTION_HEADER_CLASSES =
   'text-[0.65rem] font-bold uppercase tracking-wider text-on-surface-variant px-2.5 pt-2 pb-1'
 
@@ -127,6 +132,8 @@ interface MenuBodyProps {
   listRef: MutableRefObject<(HTMLElement | null)[]>
   labelsRef: MutableRefObject<(string | null)[]>
   width?: number
+  surfaceClassName?: string
+  bodyClassName?: string
   ariaLabel?: string
   focus?: false | { modal?: boolean }
   contextValue: MenuContextValue
@@ -146,6 +153,8 @@ const MenuBody = ({
   listRef,
   labelsRef,
   width = undefined,
+  surfaceClassName = undefined,
+  bodyClassName = MENU_BODY_CLASSES,
   ariaLabel = undefined,
   focus = false,
   contextValue,
@@ -157,10 +166,11 @@ const MenuBody = ({
     context={context}
     width={width}
     focus={focus}
+    className={surfaceClassName}
     aria-label={ariaLabel}
     {...floatingProps}
   >
-    <div className={MENU_BODY_CLASSES}>
+    <div className={bodyClassName}>
       <MenuContext.Provider value={contextValue}>
         <FloatingList elementsRef={listRef} labelsRef={labelsRef}>
           {children}
@@ -911,6 +921,8 @@ const MenuContextMenu = ({
       labelsRef={labelsRef}
       ariaLabel={ariaLabel}
       focus={{ modal: false }}
+      surfaceClassName={CONTEXT_MENU_SURFACE_CLASSES}
+      bodyClassName={CONTEXT_MENU_BODY_CLASSES}
       contextValue={contextValue}
     >
       {children}

--- a/src/components/base/floating/SurfacePanel.tsx
+++ b/src/components/base/floating/SurfacePanel.tsx
@@ -13,9 +13,9 @@ export interface SurfacePanelProps {
   width?: number
   // FloatingFocusManager config; an object turns focus management on. Default off.
   focus?: false | { initialFocus?: number; modal?: boolean }
+  className?: string
   children: ReactNode
-  // getFloatingProps() output is spread through; NO arbitrary className —
-  // GLASS_SURFACE is the single chrome so the glass panel cannot drift.
+  // getFloatingProps() output is spread through.
   [prop: string]: unknown
 }
 
@@ -29,6 +29,7 @@ export const SurfacePanel = ({
   context,
   width = undefined,
   focus = false,
+  className = GLASS_SURFACE,
   children,
   ...floatingProps
 }: SurfacePanelProps): ReactElement => {
@@ -37,7 +38,7 @@ export const SurfacePanel = ({
       ref={setFloating}
       style={{ ...style, width }}
       {...floatingProps}
-      className={GLASS_SURFACE}
+      className={className}
     >
       {children}
     </div>

--- a/src/features/terminal/components/TerminalContextMenu.test.tsx
+++ b/src/features/terminal/components/TerminalContextMenu.test.tsx
@@ -7,7 +7,10 @@ const baseProps = {
   onClose: vi.fn(),
   onCopy: vi.fn(),
   onPaste: vi.fn(),
+  onPasteImage: vi.fn(),
   canCopy: true,
+  canPasteImage: false,
+  showPasteImage: true,
 }
 
 const closed = false
@@ -21,6 +24,21 @@ test('renders null when isOpen is false', () => {
   expect(container).toBeEmptyDOMElement()
 })
 
+test('hides Paste Image outside coding agent sessions', () => {
+  render(
+    <TerminalContextMenu
+      {...baseProps}
+      {...{ showPasteImage: false }}
+      isOpen
+      position={{ x: 50, y: 60 }}
+    />
+  )
+
+  expect(
+    screen.queryByRole('menuitem', { name: 'Paste Image' })
+  ).not.toBeInTheDocument()
+})
+
 test('renders a menu with Copy and Paste items when isOpen and canCopy', () => {
   render(
     <TerminalContextMenu {...baseProps} isOpen position={{ x: 50, y: 60 }} />
@@ -31,6 +49,11 @@ test('renders a menu with Copy and Paste items when isOpen and canCopy', () => {
   ).toBeInTheDocument()
   expect(screen.getByRole('menuitem', { name: 'Copy' })).toBeInTheDocument()
   expect(screen.getByRole('menuitem', { name: 'Paste' })).toBeInTheDocument()
+
+  expect(
+    screen.getByRole('menuitem', { name: 'Paste Image' })
+  ).toBeInTheDocument()
+
   expect(
     screen.queryByRole('menuitem', { name: 'Select All' })
   ).not.toBeInTheDocument()
@@ -40,6 +63,45 @@ test('renders a menu with Copy and Paste items when isOpen and canCopy', () => {
   ).not.toBeInTheDocument()
 })
 
+test('Paste Image item is disabled when the top clipboard item is not an image', () => {
+  render(
+    <TerminalContextMenu {...baseProps} isOpen position={{ x: 50, y: 60 }} />
+  )
+
+  expect(screen.getByRole('menuitem', { name: 'Paste Image' })).toHaveAttribute(
+    'aria-disabled',
+    'true'
+  )
+})
+
+test('clicking Paste Image when enabled fires onPasteImage then onClose', async () => {
+  const user = userEvent.setup()
+  const order: string[] = []
+
+  const onPasteImage = vi.fn(() => {
+    order.push('paste-image')
+  })
+
+  const onClose = vi.fn(() => {
+    order.push('close')
+  })
+
+  render(
+    <TerminalContextMenu
+      {...baseProps}
+      onPasteImage={onPasteImage}
+      onClose={onClose}
+      canPasteImage
+      isOpen
+      position={{ x: 0, y: 0 }}
+    />
+  )
+
+  await user.click(screen.getByRole('menuitem', { name: 'Paste Image' }))
+
+  expect(order).toEqual(['paste-image', 'close'])
+})
+
 test('renders shortcut chips beside Copy and Paste', () => {
   render(
     <TerminalContextMenu {...baseProps} isOpen position={{ x: 50, y: 60 }} />
@@ -47,6 +109,7 @@ test('renders shortcut chips beside Copy and Paste', () => {
 
   expect(screen.getByText('Ctrl+Shift+C')).toBeInTheDocument()
   expect(screen.getByText('Ctrl+Shift+V')).toBeInTheDocument()
+  expect(screen.getByText('Ctrl+V')).toBeInTheDocument()
 })
 
 test('Copy item has aria-disabled="true" when canCopy is false', () => {

--- a/src/features/terminal/components/TerminalContextMenu.test.tsx
+++ b/src/features/terminal/components/TerminalContextMenu.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { expect, test, vi } from 'vitest'
 import { TerminalContextMenu } from './TerminalContextMenu'
@@ -110,6 +110,47 @@ test('renders shortcut chips beside Copy and Paste', () => {
   expect(screen.getByText('Ctrl+Shift+C')).toBeInTheDocument()
   expect(screen.getByText('Ctrl+Shift+V')).toBeInTheDocument()
   expect(screen.getByText('Ctrl+V')).toBeInTheDocument()
+})
+
+test('omits duplicate Paste Image shortcut chip on macOS', async () => {
+  const originalPlatform = Object.getOwnPropertyDescriptor(
+    window.navigator,
+    'platform'
+  )
+
+  Object.defineProperty(window.navigator, 'platform', {
+    configurable: true,
+    value: 'MacIntel',
+  })
+  vi.resetModules()
+
+  try {
+    const { TerminalContextMenu: MacTerminalContextMenu } = await import(
+      './TerminalContextMenu'
+    )
+
+    render(
+      <MacTerminalContextMenu
+        {...baseProps}
+        canPasteImage
+        isOpen
+        position={{ x: 50, y: 60 }}
+      />
+    )
+
+    const pasteRow = screen.getByRole('menuitem', { name: 'Paste' })
+    const pasteImageRow = screen.getByRole('menuitem', { name: 'Paste Image' })
+
+    expect(within(pasteRow).getByText(/V$/)).toBeInTheDocument()
+    expect(within(pasteImageRow).queryByText(/V$/)).not.toBeInTheDocument()
+  } finally {
+    if (originalPlatform === undefined) {
+      delete (window.navigator as unknown as { platform?: string }).platform
+    } else {
+      Object.defineProperty(window.navigator, 'platform', originalPlatform)
+    }
+    vi.resetModules()
+  }
 })
 
 test('Copy item has aria-disabled="true" when canCopy is false', () => {

--- a/src/features/terminal/components/TerminalContextMenu.test.tsx
+++ b/src/features/terminal/components/TerminalContextMenu.test.tsx
@@ -125,9 +125,8 @@ test('omits duplicate Paste Image shortcut chip on macOS', async () => {
   vi.resetModules()
 
   try {
-    const { TerminalContextMenu: MacTerminalContextMenu } = await import(
-      './TerminalContextMenu'
-    )
+    const { TerminalContextMenu: MacTerminalContextMenu } =
+      await import('./TerminalContextMenu')
 
     render(
       <MacTerminalContextMenu

--- a/src/features/terminal/components/TerminalContextMenu.tsx
+++ b/src/features/terminal/components/TerminalContextMenu.tsx
@@ -32,7 +32,7 @@ const PASTE_SHORTCUT: ShortcutInput = IS_MAC
   ? ['Mod', 'V']
   : ['Ctrl', 'Shift', 'V']
 
-const PASTE_IMAGE_SHORTCUT: ShortcutInput = ['Mod', 'V']
+const PASTE_IMAGE_SHORTCUT: ShortcutInput | null = IS_MAC ? null : ['Ctrl', 'V']
 
 const TERMINAL_MENU_ROW_CLASSES =
   'flex min-h-7 w-40 items-center justify-between gap-6 px-2.5 py-1 ' +
@@ -110,9 +110,11 @@ export const TerminalContextMenu = ({
           }}
         >
           <span>Paste Image</span>
-          <kbd className={TERMINAL_MENU_SHORTCUT_CLASSES} aria-hidden="true">
-            {formatShortcut(PASTE_IMAGE_SHORTCUT)}
-          </kbd>
+          {PASTE_IMAGE_SHORTCUT === null ? null : (
+            <kbd className={TERMINAL_MENU_SHORTCUT_CLASSES} aria-hidden="true">
+              {formatShortcut(PASTE_IMAGE_SHORTCUT)}
+            </kbd>
+          )}
         </Menu.Row>
       ) : null}
     </Menu.Context>

--- a/src/features/terminal/components/TerminalContextMenu.tsx
+++ b/src/features/terminal/components/TerminalContextMenu.tsx
@@ -1,6 +1,10 @@
 import { type ReactElement } from 'react'
 import { Menu } from '@/components/Menu'
-import { isMacPlatform, type ShortcutInput } from '../../../lib/formatShortcut'
+import {
+  formatShortcut,
+  isMacPlatform,
+  type ShortcutInput,
+} from '../../../lib/formatShortcut'
 
 export interface TerminalContextMenuProps {
   isOpen: boolean
@@ -8,7 +12,10 @@ export interface TerminalContextMenuProps {
   onClose: () => void
   onCopy: () => void
   onPaste: () => void
+  onPasteImage: () => void
   canCopy: boolean
+  canPasteImage: boolean
+  showPasteImage: boolean
 }
 
 // Chips reflect the active platform's handled terminal clipboard shortcuts:
@@ -25,13 +32,30 @@ const PASTE_SHORTCUT: ShortcutInput = IS_MAC
   ? ['Mod', 'V']
   : ['Ctrl', 'Shift', 'V']
 
+const PASTE_IMAGE_SHORTCUT: ShortcutInput = ['Mod', 'V']
+
+const TERMINAL_MENU_ROW_CLASSES =
+  'flex min-h-7 w-40 items-center justify-between gap-6 px-2.5 py-1 ' +
+  'text-left text-xs text-on-surface outline-none hover:bg-on-surface/10 ' +
+  'focus:bg-on-surface/10'
+
+const TERMINAL_MENU_DISABLED_ROW_CLASSES =
+  'aria-disabled:cursor-default aria-disabled:text-on-surface-variant/45 ' +
+  'aria-disabled:hover:bg-transparent aria-disabled:focus:bg-transparent'
+
+const TERMINAL_MENU_SHORTCUT_CLASSES =
+  'shrink-0 font-mono text-[10px] text-on-surface-variant'
+
 export const TerminalContextMenu = ({
   isOpen,
   position,
   onClose,
   onCopy,
   onPaste,
+  onPasteImage,
   canCopy,
+  canPasteImage,
+  showPasteImage,
 }: TerminalContextMenuProps): ReactElement | null => {
   if (position === null) {
     return null
@@ -48,12 +72,49 @@ export const TerminalContextMenu = ({
       }}
       aria-label="Terminal actions"
     >
-      <Menu.Item disabled={!canCopy} shortcut={COPY_SHORTCUT} onSelect={onCopy}>
-        Copy
-      </Menu.Item>
-      <Menu.Item shortcut={PASTE_SHORTCUT} onSelect={onPaste}>
-        Paste
-      </Menu.Item>
+      <Menu.Row
+        label="Copy"
+        disabled={!canCopy}
+        className={`${TERMINAL_MENU_ROW_CLASSES} ${TERMINAL_MENU_DISABLED_ROW_CLASSES}`}
+        onSelect={(): void => {
+          onCopy()
+          onClose()
+        }}
+      >
+        <span>Copy</span>
+        <kbd className={TERMINAL_MENU_SHORTCUT_CLASSES} aria-hidden="true">
+          {formatShortcut(COPY_SHORTCUT)}
+        </kbd>
+      </Menu.Row>
+      <Menu.Row
+        label="Paste"
+        className={TERMINAL_MENU_ROW_CLASSES}
+        onSelect={(): void => {
+          onPaste()
+          onClose()
+        }}
+      >
+        <span>Paste</span>
+        <kbd className={TERMINAL_MENU_SHORTCUT_CLASSES} aria-hidden="true">
+          {formatShortcut(PASTE_SHORTCUT)}
+        </kbd>
+      </Menu.Row>
+      {showPasteImage ? (
+        <Menu.Row
+          label="Paste Image"
+          disabled={!canPasteImage}
+          className={`${TERMINAL_MENU_ROW_CLASSES} ${TERMINAL_MENU_DISABLED_ROW_CLASSES}`}
+          onSelect={(): void => {
+            onPasteImage()
+            onClose()
+          }}
+        >
+          <span>Paste Image</span>
+          <kbd className={TERMINAL_MENU_SHORTCUT_CLASSES} aria-hidden="true">
+            {formatShortcut(PASTE_IMAGE_SHORTCUT)}
+          </kbd>
+        </Menu.Row>
+      ) : null}
     </Menu.Context>
   )
 }

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -199,6 +199,11 @@ export interface BodyProps {
    * dragged. The final size is fitted when this flips back to false.
    */
   deferFit?: boolean
+
+  /**
+   * Enables coding-agent-only clipboard image paste controls.
+   */
+  enableImagePaste?: boolean
 }
 
 export interface BodyHandle {
@@ -220,6 +225,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     onPtyStatusChange = undefined,
     onFocusChange = undefined,
     deferFit = false,
+    enableImagePaste = false,
   },
   ref
 ): ReactElement {
@@ -975,6 +981,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
 
   const clipboard = useTerminalClipboard({
     terminal,
+    enableImagePaste,
     // TODO: surface clipboard failures via a visible status/error channel.
     onCopyError: (): void => undefined,
     onPasteError: (): void => undefined,
@@ -1001,7 +1008,12 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
         onPaste={(): void => {
           void clipboard.paste()
         }}
+        onPasteImage={(): void => {
+          void clipboard.pasteImage()
+        }}
         canCopy={clipboard.hasSelection}
+        canPasteImage={clipboard.canPasteImage}
+        showPasteImage={enableImagePaste}
       />
     </div>
   )

--- a/src/features/terminal/components/TerminalPane/index.tsx
+++ b/src/features/terminal/components/TerminalPane/index.tsx
@@ -210,6 +210,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
     )
 
     const isAwaitingRestart = mode === 'awaiting-restart'
+    const enableImagePaste = pane.agentType !== 'generic'
 
     const footerPlaceholder = isAwaitingRestart
       ? `session ended — restart to resume ${agent.short.toLowerCase()}`
@@ -297,6 +298,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
               mode={mode}
               onPtyStatusChange={setPtyStatus}
               deferFit={deferFit}
+              enableImagePaste={enableImagePaste}
             />
           </div>
         )}

--- a/src/features/terminal/hooks/useTerminalClipboard.test.ts
+++ b/src/features/terminal/hooks/useTerminalClipboard.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import type { IDisposable, Terminal } from '@xterm/xterm'
 import { expect, test, vi } from 'vitest'
 import { useTerminalClipboard } from './useTerminalClipboard'
@@ -62,6 +62,12 @@ const installClipboardMock = (
   overrides: {
     writeText?: () => Promise<void>
     readText?: () => Promise<string>
+    read?: () => Promise<
+      {
+        types: readonly string[]
+        getType: (type: string) => Promise<Blob>
+      }[]
+    >
   } = {}
 ): ClipboardMockControls => {
   const writeTextMock = vi.fn(
@@ -71,10 +77,18 @@ const installClipboardMock = (
   const readTextMock = vi.fn(
     overrides.readText ?? ((): Promise<string> => Promise.resolve(''))
   )
+
+  const readMock =
+    overrides.read === undefined ? undefined : vi.fn(overrides.read)
+
   const original = window.navigator.clipboard
 
   Object.defineProperty(window.navigator, 'clipboard', {
-    value: { writeText: writeTextMock, readText: readTextMock },
+    value: {
+      writeText: writeTextMock,
+      readText: readTextMock,
+      ...(readMock === undefined ? {} : { read: readMock }),
+    },
     configurable: true,
     writable: true,
   })
@@ -483,6 +497,92 @@ test('right-click on terminal.element sets isOpen=true, openAt={x,y}, and calls 
   expect(result.current.isOpen).toBe(true)
   expect(result.current.openAt).toEqual({ x: 100, y: 200 })
   expect(preventDefaultSpy).toHaveBeenCalledOnce()
+})
+
+test('right-click enables image paste only when the top clipboard item is an image', async () => {
+  const mock = createMockTerminal()
+
+  const clipboard = installClipboardMock({
+    read: () =>
+      Promise.resolve([
+        {
+          types: ['image/png'],
+          getType: (): Promise<Blob> =>
+            Promise.resolve(new Blob(['png'], { type: 'image/png' })),
+        },
+      ]),
+  })
+
+  try {
+    const { result } = renderHook(() =>
+      useTerminalClipboard({
+        terminal: mock.terminal,
+        enableImagePaste: true,
+      })
+    )
+
+    await act(async () => {
+      mock.element.dispatchEvent(
+        new MouseEvent('contextmenu', {
+          bubbles: true,
+          cancelable: true,
+          clientX: 100,
+          clientY: 200,
+        })
+      )
+      await flushMicrotasks()
+    })
+
+    await waitFor(() => {
+      expect(result.current.canPasteImage).toBe(true)
+    })
+  } finally {
+    clipboard.restore()
+  }
+})
+
+test('right-click does not enable image paste for copied image-path text', async () => {
+  const mock = createMockTerminal()
+
+  const clipboard = installClipboardMock({
+    read: () =>
+      Promise.resolve([
+        {
+          types: ['text/plain'],
+          getType: (): Promise<Blob> =>
+            Promise.resolve(
+              new Blob(['/tmp/codex-clipboard-image.png'], {
+                type: 'text/plain',
+              })
+            ),
+        },
+      ]),
+  })
+
+  try {
+    const { result } = renderHook(() =>
+      useTerminalClipboard({
+        terminal: mock.terminal,
+        enableImagePaste: true,
+      })
+    )
+
+    await act(async () => {
+      mock.element.dispatchEvent(
+        new MouseEvent('contextmenu', {
+          bubbles: true,
+          cancelable: true,
+          clientX: 100,
+          clientY: 200,
+        })
+      )
+      await flushMicrotasks()
+    })
+
+    expect(result.current.canPasteImage).toBe(false)
+  } finally {
+    clipboard.restore()
+  }
 })
 
 test('close() resets isOpen and openAt and is idempotent', () => {

--- a/src/features/terminal/hooks/useTerminalClipboard.test.ts
+++ b/src/features/terminal/hooks/useTerminalClipboard.test.ts
@@ -541,6 +541,66 @@ test('right-click enables image paste only when the top clipboard item is an ima
   }
 })
 
+test('right-click waits for a fast image clipboard read before opening', async () => {
+  const mock = createMockTerminal()
+  let resolveRead:
+    | ((
+        items: {
+          types: readonly string[]
+          getType: (type: string) => Promise<Blob>
+        }[]
+      ) => void)
+    | null = null
+
+  const clipboard = installClipboardMock({
+    read: () =>
+      new Promise((resolve) => {
+        resolveRead = resolve
+      }),
+  })
+
+  try {
+    const { result } = renderHook(() =>
+      useTerminalClipboard({
+        terminal: mock.terminal,
+        enableImagePaste: true,
+      })
+    )
+
+    act(() => {
+      mock.element.dispatchEvent(
+        new MouseEvent('contextmenu', {
+          bubbles: true,
+          cancelable: true,
+          clientX: 100,
+          clientY: 200,
+        })
+      )
+    })
+
+    expect(result.current.isOpen).toBe(false)
+
+    await act(async () => {
+      resolveRead?.([
+        {
+          types: ['image/png'],
+          getType: (): Promise<Blob> =>
+            Promise.resolve(new Blob(['png'], { type: 'image/png' })),
+        },
+      ])
+      await flushMicrotasks()
+    })
+
+    await waitFor(() => {
+      expect(result.current.isOpen).toBe(true)
+      expect(result.current.canPasteImage).toBe(true)
+      expect(result.current.openAt).toEqual({ x: 100, y: 200 })
+    })
+  } finally {
+    clipboard.restore()
+  }
+})
+
 test('right-click does not enable image paste for copied image-path text', async () => {
   const mock = createMockTerminal()
 
@@ -580,6 +640,47 @@ test('right-click does not enable image paste for copied image-path text', async
     })
 
     expect(result.current.canPasteImage).toBe(false)
+  } finally {
+    clipboard.restore()
+  }
+})
+
+test('pasteImage() rejects clipboard images above the paste size cap', async () => {
+  const mock = createMockTerminal()
+  const pasteSpy = vi.spyOn(mock.terminal, 'paste')
+  const onPasteError = vi.fn()
+
+  const clipboard = installClipboardMock({
+    read: () =>
+      Promise.resolve([
+        {
+          types: ['image/png'],
+          getType: (): Promise<Blob> =>
+            Promise.resolve(
+              new Blob([new Uint8Array(512 * 1024 + 1)], {
+                type: 'image/png',
+              })
+            ),
+        },
+      ]),
+  })
+
+  try {
+    const { result } = renderHook(() =>
+      useTerminalClipboard({
+        terminal: mock.terminal,
+        enableImagePaste: true,
+        onPasteError,
+      })
+    )
+
+    await result.current.pasteImage()
+
+    expect(pasteSpy).not.toHaveBeenCalled()
+    expect(onPasteError).toHaveBeenCalledOnce()
+    expect((onPasteError.mock.calls[0][0] as Error).message).toBe(
+      'Clipboard image is too large to paste'
+    )
   } finally {
     clipboard.restore()
   }
@@ -874,6 +975,45 @@ test('preferModifier="meta" + Cmd+Shift+V suppresses and pastes', async () => {
 
     expect(result).toBe(false)
     expect(pasteSpy).toHaveBeenCalledWith('pasted')
+  } finally {
+    clipboard.restore()
+  }
+})
+
+test('preferModifier="meta" + Cmd+Shift+V still text-pastes when image paste is enabled', async () => {
+  const mock = createMockTerminal()
+  const pasteSpy = vi.spyOn(mock.terminal, 'paste')
+
+  const clipboard = installClipboardMock({
+    readText: () => Promise.resolve('pasted text'),
+    read: () =>
+      Promise.resolve([
+        {
+          types: ['image/png'],
+          getType: (): Promise<Blob> =>
+            Promise.resolve(new Blob(['png'], { type: 'image/png' })),
+        },
+      ]),
+  })
+
+  try {
+    renderHook(() =>
+      useTerminalClipboard({
+        terminal: mock.terminal,
+        preferModifier: 'meta',
+        enableImagePaste: true,
+      })
+    )
+    const handler = captureKeyHandler(mock)
+
+    const result = handler(
+      keyboardEvent({ code: 'KeyV', metaKey: true, shiftKey: true })
+    )
+    await flushMicrotasks()
+
+    expect(result).toBe(false)
+    expect(clipboard.readTextMock).toHaveBeenCalledOnce()
+    expect(pasteSpy).toHaveBeenCalledWith('pasted text')
   } finally {
     clipboard.restore()
   }

--- a/src/features/terminal/hooks/useTerminalClipboard.ts
+++ b/src/features/terminal/hooks/useTerminalClipboard.ts
@@ -60,6 +60,9 @@ const writeViaTextarea = (text: string): boolean => {
 
 const noopAsync = (): Promise<void> => Promise.resolve()
 
+const MAX_PASTE_IMAGE_BYTES = 512 * 1024
+const IMAGE_CLIPBOARD_OPEN_DELAY_MS = 50
+
 interface ClipboardImageItem {
   types: readonly string[]
   getType: (type: string) => Promise<Blob>
@@ -228,6 +231,15 @@ export const useTerminalClipboard = ({
         return false
       }
 
+      if (image.size > MAX_PASTE_IMAGE_BYTES) {
+        setCanPasteImage(false)
+        onPasteErrorRef.current?.(
+          new Error('Clipboard image is too large to paste')
+        )
+
+        return false
+      }
+
       terminal.paste(await blobToDataUrl(image))
 
       return true
@@ -267,6 +279,8 @@ export const useTerminalClipboard = ({
 
     let isDragging = false
     let pendingSelection = false
+    let disposed = false
+    const pendingOpenTimers = new Set<number>()
 
     const handleMouseDown = (event: MouseEvent): void => {
       if (event.button !== 0) {
@@ -306,20 +320,35 @@ export const useTerminalClipboard = ({
       event.preventDefault()
       event.stopPropagation()
       setCanPasteImage(false)
-      if (!enableImagePaste) {
+
+      const openMenu = (): void => {
+        if (disposed) {
+          return
+        }
+
         setIsOpen(true)
         setOpenAt({ x: event.clientX, y: event.clientY })
+      }
+
+      if (!enableImagePaste) {
+        openMenu()
 
         return
       }
 
       const itemsPromise = readClipboardItems()
       if (itemsPromise === null) {
-        setIsOpen(true)
-        setOpenAt({ x: event.clientX, y: event.clientY })
+        openMenu()
 
         return
       }
+
+      const fallbackOpenTimer = window.setTimeout(() => {
+        pendingOpenTimers.delete(fallbackOpenTimer)
+        openMenu()
+      }, IMAGE_CLIPBOARD_OPEN_DELAY_MS)
+
+      pendingOpenTimers.add(fallbackOpenTimer)
 
       void (async (): Promise<void> => {
         try {
@@ -328,10 +357,15 @@ export const useTerminalClipboard = ({
           )
         } catch {
           setCanPasteImage(false)
+        } finally {
+          const timerPending = pendingOpenTimers.delete(fallbackOpenTimer)
+          window.clearTimeout(fallbackOpenTimer)
+
+          if (timerPending) {
+            openMenu()
+          }
         }
       })()
-      setIsOpen(true)
-      setOpenAt({ x: event.clientX, y: event.clientY })
     }
 
     const isMac = preferModifier === 'meta'
@@ -373,7 +407,7 @@ export const useTerminalClipboard = ({
 
       if (event.code === 'KeyV') {
         const imagePasteShortcut = isMac
-          ? event.metaKey && !event.ctrlKey && !event.altKey
+          ? event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey
           : event.ctrlKey && !event.shiftKey && !event.metaKey && !event.altKey
 
         if (enableImagePaste && imagePasteShortcut) {
@@ -417,6 +451,12 @@ export const useTerminalClipboard = ({
     })
 
     return (): void => {
+      disposed = true
+      pendingOpenTimers.forEach((timerId) => {
+        window.clearTimeout(timerId)
+      })
+      pendingOpenTimers.clear()
+
       try {
         selectionDisposable.dispose()
       } catch {

--- a/src/features/terminal/hooks/useTerminalClipboard.ts
+++ b/src/features/terminal/hooks/useTerminalClipboard.ts
@@ -6,17 +6,20 @@ export type ClipboardModifier = 'meta' | 'ctrl'
 export interface UseTerminalClipboardOptions {
   terminal: Terminal | null
   preferModifier?: ClipboardModifier
+  enableImagePaste?: boolean
   onCopyError?: (error: unknown) => void
   onPasteError?: (error: unknown) => void
 }
 
 export interface UseTerminalClipboardResult {
   hasSelection: boolean
+  canPasteImage: boolean
   isOpen: boolean
   openAt: { x: number; y: number } | null
   close: () => void
   copy: () => Promise<void>
   paste: () => Promise<void>
+  pasteImage: () => Promise<void>
   selectAll: () => void
   clear: () => void
 }
@@ -57,15 +60,88 @@ const writeViaTextarea = (text: string): boolean => {
 
 const noopAsync = (): Promise<void> => Promise.resolve()
 
+interface ClipboardImageItem {
+  types: readonly string[]
+  getType: (type: string) => Promise<Blob>
+}
+
+const readClipboardItems = (): Promise<ClipboardImageItem[]> | null => {
+  const clipboard = window.navigator.clipboard as
+    | { read?: () => Promise<ClipboardImageItem[]> }
+    | undefined
+
+  if (clipboard?.read === undefined) {
+    return null
+  }
+
+  return clipboard.read()
+}
+
+const firstClipboardItem = (
+  items: readonly ClipboardImageItem[]
+): ClipboardImageItem | null => (items.length === 0 ? null : items[0])
+
+const imageTypeOfTopClipboardItem = (
+  items: readonly ClipboardImageItem[]
+): string | null => {
+  const topItem = firstClipboardItem(items)
+  if (topItem === null) {
+    return null
+  }
+
+  const imageType = topItem.types.find((type) => type.startsWith('image/'))
+
+  return imageType ?? null
+}
+
+const readTopClipboardImage = async (): Promise<Blob | null> => {
+  const items = await readClipboardItems()
+  if (items === null) {
+    return null
+  }
+
+  const topItem = firstClipboardItem(items)
+  if (topItem === null) {
+    return null
+  }
+
+  const imageType = imageTypeOfTopClipboardItem(items)
+
+  return imageType === null ? null : topItem.getType(imageType)
+}
+
+const blobToDataUrl = (blob: Blob): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader()
+
+    reader.onload = (): void => {
+      if (typeof reader.result === 'string') {
+        resolve(reader.result)
+
+        return
+      }
+
+      reject(new Error('Clipboard image read failed'))
+    }
+
+    reader.onerror = (): void => {
+      reject(reader.error ?? new Error('Clipboard image read failed'))
+    }
+
+    reader.readAsDataURL(blob)
+  })
+
 export const useTerminalClipboard = ({
   terminal,
   preferModifier: preferredModifier = undefined,
+  enableImagePaste = false,
   onCopyError = undefined,
   onPasteError = undefined,
 }: UseTerminalClipboardOptions): UseTerminalClipboardResult => {
   const preferModifier = preferredModifier ?? detectModifier()
 
   const [hasSelection, setHasSelection] = useState(false)
+  const [canPasteImage, setCanPasteImage] = useState(false)
   const [isOpen, setIsOpen] = useState(false)
   const [openAt, setOpenAt] = useState<{ x: number; y: number } | null>(null)
 
@@ -73,6 +149,10 @@ export const useTerminalClipboard = ({
   const onPasteErrorRef = useRef(onPasteError)
   const copyRef = useRef<() => Promise<void>>(noopAsync)
   const pasteRef = useRef<() => Promise<void>>(noopAsync)
+
+  const pasteImageIfAvailableRef = useRef<() => Promise<boolean>>(() =>
+    Promise.resolve(false)
+  )
 
   onCopyErrorRef.current = onCopyError
   onPasteErrorRef.current = onPasteError
@@ -131,6 +211,33 @@ export const useTerminalClipboard = ({
     }
   }
 
+  const pasteImage = async (): Promise<void> => {
+    await pasteImageIfAvailable()
+  }
+
+  const pasteImageIfAvailable = async (): Promise<boolean> => {
+    if (!terminal || !enableImagePaste) {
+      return false
+    }
+
+    try {
+      const image = await readTopClipboardImage()
+      if (image === null) {
+        setCanPasteImage(false)
+
+        return false
+      }
+
+      terminal.paste(await blobToDataUrl(image))
+
+      return true
+    } catch (error: unknown) {
+      onPasteErrorRef.current?.(error)
+
+      return false
+    }
+  }
+
   const selectAll = (): void => {
     terminal?.selectAll()
   }
@@ -146,6 +253,7 @@ export const useTerminalClipboard = ({
 
   copyRef.current = copy
   pasteRef.current = paste
+  pasteImageIfAvailableRef.current = pasteImageIfAvailable
 
   useEffect(() => {
     if (!terminal) {
@@ -197,6 +305,31 @@ export const useTerminalClipboard = ({
     const handleContextMenu = (event: MouseEvent): void => {
       event.preventDefault()
       event.stopPropagation()
+      setCanPasteImage(false)
+      if (!enableImagePaste) {
+        setIsOpen(true)
+        setOpenAt({ x: event.clientX, y: event.clientY })
+
+        return
+      }
+
+      const itemsPromise = readClipboardItems()
+      if (itemsPromise === null) {
+        setIsOpen(true)
+        setOpenAt({ x: event.clientX, y: event.clientY })
+
+        return
+      }
+
+      void (async (): Promise<void> => {
+        try {
+          setCanPasteImage(
+            imageTypeOfTopClipboardItem(await itemsPromise) !== null
+          )
+        } catch {
+          setCanPasteImage(false)
+        }
+      })()
       setIsOpen(true)
       setOpenAt({ x: event.clientX, y: event.clientY })
     }
@@ -239,6 +372,23 @@ export const useTerminalClipboard = ({
       }
 
       if (event.code === 'KeyV') {
+        const imagePasteShortcut = isMac
+          ? event.metaKey && !event.ctrlKey && !event.altKey
+          : event.ctrlKey && !event.shiftKey && !event.metaKey && !event.altKey
+
+        if (enableImagePaste && imagePasteShortcut) {
+          event.preventDefault()
+
+          void (async (): Promise<void> => {
+            const pasted = await pasteImageIfAvailableRef.current()
+            if (!pasted) {
+              await pasteRef.current()
+            }
+          })()
+
+          return false
+        }
+
         const matched = isMac
           ? event.metaKey && !event.ctrlKey && !event.altKey
           : event.ctrlKey && event.shiftKey && !event.metaKey && !event.altKey
@@ -287,16 +437,19 @@ export const useTerminalClipboard = ({
       setIsOpen(false)
       setOpenAt(null)
       setHasSelection(false)
+      setCanPasteImage(false)
     }
-  }, [terminal, preferModifier])
+  }, [terminal, preferModifier, enableImagePaste])
 
   return {
     hasSelection,
+    canPasteImage,
     isOpen,
     openAt,
     close,
     copy,
     paste,
+    pasteImage,
     selectAll,
     clear,
   }


### PR DESCRIPTION
## Summary
- Restyles the terminal right-click menu into a compact context menu variant without glass/pill shortcut chrome.
- Adds agent-only Paste Image support gated on the top clipboard item's image MIME type.
- Shows platform-aware shortcut hints for paste actions and keeps copied image file paths treated as text.

## Validation
- npx vitest run src/features/terminal/components/TerminalContextMenu.test.tsx src/features/terminal/hooks/useTerminalClipboard.test.ts
- npm run type-check
- pre-commit hook: ESLint, Prettier, tsc --noEmit
- pre-push hook: npm test

Refs VIM-226