### PR TITLE
fix(terminal): render faint/dim cells so agent placeholders dim correctly (VIM-230)

### DIFF
--- a/crates/backend/src/terminal/ghostty.rs
+++ b/crates/backend/src/terminal/ghostty.rs
@@ -277,6 +277,7 @@ impl GhosttyTerminalState {
 
                     if !text.is_empty()
                         || style.bold
+                        || style.faint
                         || style.italic
                         || style.underline != Underline::None
                         || style.inverse
@@ -289,6 +290,7 @@ impl GhosttyTerminalState {
                             text,
                             width: cell_width,
                             bold: style.bold.then_some(true),
+                            dim: style.faint.then_some(true),
                             italic: style.italic.then_some(true),
                             underline: (style.underline != Underline::None).then_some(true),
                             foreground,
@@ -463,6 +465,32 @@ mod tests {
             "ANSI colors must resolve to RGB hex, got fg={:?} bg={:?}",
             styled.foreground,
             styled.background
+        );
+    }
+
+    #[test]
+    fn snapshot_captures_faint_cells_as_dim() {
+        // codex/ratatui draw placeholder & hint text with SGR 2 (faint). The
+        // snapshot must carry it as `dim` so the frontend renders it dimmed
+        // instead of at full brightness, where it reads like real input (VIM-230).
+        let mut state = make_state(80, 24);
+        state
+            .write(b"\x1b[2mhint\x1b[0m")
+            .expect("write faint text");
+        let snapshot = state.snapshot().expect("snapshot");
+
+        let cell = snapshot
+            .cells
+            .as_ref()
+            .expect("styled cells")
+            .iter()
+            .find(|cell| cell.text == "h")
+            .expect("the 'h' cell");
+        assert_eq!(
+            cell.dim,
+            Some(true),
+            "faint (SGR 2) must surface as dim, got {:?}",
+            cell
         );
     }
 

--- a/crates/backend/src/terminal/types.rs
+++ b/crates/backend/src/terminal/types.rs
@@ -157,6 +157,9 @@ pub struct GhosttyVtRenderSnapshotCell {
     pub bold: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(test, ts(optional))]
+    pub dim: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(test, ts(optional))]
     pub italic: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(test, ts(optional))]

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -54,9 +54,9 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 10       | 6    | 2026-06-25   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 7        | 1    | 2026-06-03   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 1        | 0    | 2026-06-09   |
-| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 67       | 35   | 2026-06-25   |
+| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 68       | 36   | 2026-06-25   |
 | [Terminal Control Sequence Handling](patterns/terminal-control-sequence-handling.md)                 | terminal           | 30       | 12   | 2026-06-25   |
-| [Terminal DOM Rendering](patterns/terminal-dom-rendering.md)                                         | terminal           | 11       | 6    | 2026-06-25   |
+| [Terminal DOM Rendering](patterns/terminal-dom-rendering.md)                                         | terminal           | 12       | 7    | 2026-06-25   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 12       | 3    | 2026-06-25   |
 | [Terminal Render-State Driver Contract](patterns/terminal-render-state-driver-contract.md)           | terminal           | 35       | 10   | 2026-06-25   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 85       | 25   | 2026-06-08   |

--- a/docs/reviews/patterns/terminal-dom-rendering.md
+++ b/docs/reviews/patterns/terminal-dom-rendering.md
@@ -3,7 +3,7 @@ id: terminal-dom-rendering
 category: terminal
 created: 2026-06-18
 last_updated: 2026-06-25
-ref_count: 6
+ref_count: 7
 ---
 
 # Terminal DOM Rendering
@@ -111,4 +111,13 @@ The terminal renderer translates a buffered text/runs model into DOM rows for di
 - **File:** `src/features/terminal/components/TerminalPane/terminalTextSurface.ts` L1409-L1413
 - **Finding:** While a user held a terminal text selection, each deferred `renderOutput` call replaced the pending render options wholesale. A replace snapshot that explicitly requested top/cursor positioning could be followed by live output with default options, causing the flush after selection clear to jump to the bottom.
 - **Fix:** Split deferred render state into a pending-render flag plus a separately retained `pendingScrollMode`. Later renders only overwrite the pending scroll mode when they carry an explicit mode, so live output can coalesce content without discarding the user's history-positioning intent. Added a regression that holds a selection across a top-pinned replace snapshot and later live output.
+- **Commit:** same commit as this entry
+
+### 12. Custom block glyph foreground transforms must reach rect fills
+
+- **Source:** github-codex-connector | PR #623 round 1 | 2026-06-25
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/terminalTextSurface.ts` L1158
+- **Finding:** The SGR 2 dim path changed only `element.style.color`, but custom block glyphs paint their visible foreground through child rectangle `backgroundColor` values and then set the wrapper text color to `transparent`. Dimmed block glyphs therefore stayed full brightness after replacing whole-element opacity with foreground-only mixing.
+- **Fix:** Centralized the dim color expression and applied it inside `readBlockGlyphColors` so block-glyph rect fills receive the same foreground dimming as normal text. Added a regression that asserts dimmed block glyph fill color uses `color-mix` while the cell background remains unfaded.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -3,7 +3,7 @@ id: testing-gaps
 category: testing
 created: 2026-04-09
 last_updated: 2026-06-25
-ref_count: 35
+ref_count: 36
 ---
 
 # Testing Gaps
@@ -674,4 +674,13 @@ filesystem scope restrictions).
 - **File:** `src/features/terminal/hooks/useTerminal.test.ts` L945-989
 - **Finding:** The Ghostty OSC color-query work covered the formatter/scanner layer and background hook path, but the hook-level foreground path depends on the string literal `--terminal-foreground`. A token-name drift would silently skip the `OSC 10` response without a hook integration failure.
 - **Fix:** Kept the restored-buffered `OSC 10` hook test that mocks `--terminal-foreground` and expects the foreground color response, then made its exact RGB assertion CSpell-clean so the Code Quality lint gate passes.
+- **Commit:** same commit as this entry
+
+### 68. Added style branches need direct branch coverage
+
+- **Source:** github-claude | PR #623 round 1 | 2026-06-25
+- **Severity:** LOW
+- **File:** `src/features/terminal/components/TerminalPane/terminalTextSurface.ts` L1150-L1159
+- **Finding:** The new SGR 2 dim rendering branch selected a different foreground source when `style.reverse` was true, but the added tests only covered the non-reverse foreground path. A future edit could swap the reverse/non-reverse arms and leave reverse+dim cells with the wrong color while tests stayed green.
+- **Fix:** Added a focused `TerminalTextSurface` regression using `getSgrStyleSentinel([0, 7, 2])` that asserts reverse+dim text mixes from `var(--terminal-background)`, the swapped foreground source.
 - **Commit:** same commit as this entry

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.test.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.test.ts
@@ -289,6 +289,37 @@ describe('ghosttyVtRenderSnapshot', () => {
     ])
   })
 
+  test('emits SGR 2 for a faint/dim native cell so it renders dimmed', () => {
+    const output = createGhosttyVtRenderSnapshotOutput({
+      rows: ['hint'],
+      cursor: {
+        rowIndex: 0,
+        columnOffset: 4,
+      },
+      cells: [
+        {
+          row: 0,
+          col: 0,
+          text: 'hint',
+          width: 4,
+          dim: true,
+        },
+      ],
+    })
+    const operation = output.displayDelta?.operations[0]
+    const buffer = new TerminalDisplayBuffer()
+
+    if (operation?.type !== 'replace') {
+      throw new Error('Expected replace operation')
+    }
+
+    buffer.applyDelta({ operations: [operation] })
+
+    expect(buffer.readStyledRuns()).toEqual([
+      { text: 'hint', style: { dim: true } },
+    ])
+  })
+
   test('preserves fallback gaps before sparse styled cells', () => {
     const output = createGhosttyVtRenderSnapshotOutput({
       rows: ['plain red'],

--- a/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.ts
+++ b/src/features/terminal/components/TerminalPane/ghosttyVtRenderSnapshot.ts
@@ -28,6 +28,7 @@ export interface GhosttyVtRenderSnapshotCell extends GhosttyCellTraversalCell {
   readonly text: string
   readonly width: number
   readonly bold?: boolean
+  readonly dim?: boolean
   readonly italic?: boolean
   readonly underline?: boolean
   readonly foreground?: string
@@ -48,6 +49,7 @@ export interface GhosttyVtRenderSnapshot {
 
 interface SnapshotStyle {
   readonly bold?: boolean
+  readonly dim?: boolean
   readonly italic?: boolean
   readonly underline?: boolean
   readonly foreground?: string
@@ -84,6 +86,7 @@ const readSgrColorParameters = (
 
 const readCellStyle = (cell: GhosttyVtRenderSnapshotCell): SnapshotStyle => ({
   ...(cell.bold === true ? { bold: true } : {}),
+  ...(cell.dim === true ? { dim: true } : {}),
   ...(cell.italic === true ? { italic: true } : {}),
   ...(cell.underline === true ? { underline: true } : {}),
   ...(cell.foreground ? { foreground: cell.foreground } : {}),
@@ -94,6 +97,7 @@ const readCellStyle = (cell: GhosttyVtRenderSnapshotCell): SnapshotStyle => ({
 const readStyleKey = (style: SnapshotStyle): string =>
   [
     style.bold === true ? '1' : '',
+    style.dim === true ? '2' : '',
     style.italic === true ? '3' : '',
     style.underline === true ? '4' : '',
     style.foreground ?? '',
@@ -106,6 +110,7 @@ const EMPTY_STYLE_KEY = readStyleKey({})
 const readStyleParameters = (style: SnapshotStyle): readonly number[] => [
   0,
   ...(style.bold === true ? [1] : []),
+  ...(style.dim === true ? [2] : []),
   ...(style.italic === true ? [3] : []),
   ...(style.underline === true ? [4] : []),
   ...(style.reverse === true ? [7] : []),
@@ -319,6 +324,7 @@ const PROMPT_MARKER_PATTERN = /^\s*>/
 
 const hasCellStyle = (cell: GhosttyVtRenderSnapshotCell): boolean =>
   cell.bold === true ||
+  cell.dim === true ||
   cell.italic === true ||
   cell.underline === true ||
   cell.foreground !== undefined ||

--- a/src/features/terminal/components/TerminalPane/terminalTextSurface.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalTextSurface.test.ts
@@ -4,6 +4,7 @@ import {
   TerminalTextSurface,
   type TerminalTextSurfaceOutput,
 } from './terminalTextSurface'
+import { getSgrStyleSentinel } from './terminalControlParser'
 
 // jsdom has no layout engine: scrollTop/scrollHeight/clientHeight are 0 and the
 // scroll geometry must be stubbed. These helpers give the surface root a
@@ -497,5 +498,33 @@ describe('TerminalTextSurface selection preservation', () => {
 
     expect(root.textContent).toContain('live output')
     expect(root.scrollTop).toBe(0)
+  })
+})
+
+describe('TerminalTextSurface dim rendering', () => {
+  test('dims faint text via foreground alpha, preserving the cell background', () => {
+    const { surface, root } = mountSurface()
+
+    // A faint cell that also has a background (e.g. codex's grey composer box
+    // behind dim placeholder text): dim must fade the text only, never darken
+    // the cell background via a whole-element opacity.
+    const styledText =
+      getSgrStyleSentinel([0, 2, 48, 2, 24, 24, 37]) +
+      'hint' +
+      getSgrStyleSentinel([0])
+    surface.writeParsedOutput({
+      visibleText: 'hint',
+      displayDelta: {
+        operations: [{ type: 'replace', text: styledText, cursorOffset: 4 }],
+      },
+    })
+
+    const span = root.querySelector<HTMLElement>(
+      '[data-terminal-style-run="true"]'
+    )!
+
+    expect(span.style.backgroundColor).not.toBe('') // background preserved
+    expect(span.style.opacity).toBe('') // not via whole-element opacity
+    expect(span.style.color).toContain('color-mix') // foreground dimmed instead
   })
 })

--- a/src/features/terminal/components/TerminalPane/terminalTextSurface.test.ts
+++ b/src/features/terminal/components/TerminalPane/terminalTextSurface.test.ts
@@ -527,4 +527,56 @@ describe('TerminalTextSurface dim rendering', () => {
     expect(span.style.opacity).toBe('') // not via whole-element opacity
     expect(span.style.color).toContain('color-mix') // foreground dimmed instead
   })
+
+  test('dims reverse-video text from the swapped foreground source', () => {
+    const { surface, root } = mountSurface()
+
+    const styledText =
+      getSgrStyleSentinel([0, 7, 2]) + 'hint' + getSgrStyleSentinel([0])
+    surface.writeParsedOutput({
+      visibleText: 'hint',
+      displayDelta: {
+        operations: [{ type: 'replace', text: styledText, cursorOffset: 4 }],
+      },
+    })
+
+    const span = root.querySelector<HTMLElement>(
+      '[data-terminal-style-run="true"]'
+    )!
+
+    expect(span.style.backgroundColor).toBe('var(--terminal-foreground)')
+    expect(span.style.opacity).toBe('')
+    expect(span.style.color).toBe(
+      'color-mix(in srgb, var(--terminal-background) 72%, transparent)'
+    )
+  })
+
+  test('dims custom block glyph fills without fading the cell background', () => {
+    const { surface, root } = mountSurface()
+
+    const styledText =
+      getSgrStyleSentinel([0, 2, 38, 2, 243, 139, 168, 48, 2, 24, 24, 37]) +
+      '█' +
+      getSgrStyleSentinel([0])
+    surface.writeParsedOutput({
+      visibleText: '█',
+      displayDelta: {
+        operations: [{ type: 'replace', text: styledText, cursorOffset: 1 }],
+      },
+    })
+
+    const glyph = root.querySelector<HTMLElement>(
+      '[data-terminal-custom-glyph="block"]'
+    )!
+
+    const rect = glyph.querySelector<HTMLElement>(
+      '[data-terminal-custom-glyph-rect="true"]'
+    )!
+
+    expect(glyph.style.backgroundColor).not.toBe('')
+    expect(glyph.style.opacity).toBe('')
+    expect(rect.style.backgroundColor).toContain('color-mix')
+    expect(rect.style.backgroundColor).toContain('243, 139, 168')
+    expect(rect.style.backgroundColor).toContain('72%')
+  })
 })

--- a/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
+++ b/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
@@ -53,6 +53,9 @@ interface BlockGlyphColors {
   readonly foreground: string
 }
 
+const dimTerminalForeground = (foreground: string): string =>
+  `color-mix(in srgb, ${foreground} 72%, transparent)`
+
 const KEYBOARD_SEQUENCES = new Map<string, string>([
   ['ArrowUp', '\x1b[A'],
   ['ArrowDown', '\x1b[B'],
@@ -92,15 +95,19 @@ const readBlockGlyphColors = (
   style: TerminalDisplayStyle
 ): BlockGlyphColors => {
   if (style.reverse) {
+    const foreground = style.background ?? 'var(--terminal-background)'
+
     return {
       background: style.foreground ?? 'var(--terminal-foreground)',
-      foreground: style.background ?? 'var(--terminal-background)',
+      foreground: style.dim ? dimTerminalForeground(foreground) : foreground,
     }
   }
 
+  const foreground = style.foreground ?? 'var(--terminal-foreground)'
+
   return {
     background: style.background ?? 'transparent',
-    foreground: style.foreground ?? 'var(--terminal-foreground)',
+    foreground: style.dim ? dimTerminalForeground(foreground) : foreground,
   }
 }
 
@@ -1155,7 +1162,7 @@ export class TerminalTextSurface implements TerminalSurface {
       const dimForeground = style.reverse
         ? (style.background ?? 'var(--terminal-background)')
         : (style.foreground ?? 'var(--terminal-foreground)')
-      element.style.color = `color-mix(in srgb, ${dimForeground} 72%, transparent)`
+      element.style.color = dimTerminalForeground(dimForeground)
     }
 
     if (style.underline) {

--- a/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
+++ b/src/features/terminal/components/TerminalPane/terminalTextSurface.ts
@@ -1133,10 +1133,6 @@ export class TerminalTextSurface implements TerminalSurface {
       element.style.fontWeight = '700'
     }
 
-    if (style.dim) {
-      element.style.opacity = '0.72'
-    }
-
     if (style.foreground) {
       element.style.color = style.foreground
     }
@@ -1149,6 +1145,17 @@ export class TerminalTextSurface implements TerminalSurface {
       element.style.backgroundColor =
         style.foreground ?? 'var(--terminal-foreground)'
       element.style.color = style.background ?? 'var(--terminal-background)'
+    }
+
+    if (style.dim) {
+      // Faint (SGR 2): fade the foreground only. A whole-element opacity would
+      // also darken the cell background (e.g. the grey codex composer box behind
+      // dim placeholder text), so blend the foreground toward transparent and
+      // leave the background intact.
+      const dimForeground = style.reverse
+        ? (style.background ?? 'var(--terminal-background)')
+        : (style.foreground ?? 'var(--terminal-foreground)')
+      element.style.color = `color-mix(in srgb, ${dimForeground} 72%, transparent)`
     }
 
     if (style.underline) {


### PR DESCRIPTION
## Summary

Agent placeholder / hint text (e.g. codex's `Run /review...`) rendered at full brightness on the Ghostty path — looking like real typed input — because the snapshot dropped the SGR 2 (faint) attribute.

- **Backend** — capture libghostty's `style.faint` into the snapshot cell as `dim` (`ghostty.rs`, `types.rs`).
- **Frontend snapshot** — emit SGR 2 for a dim cell (`ghosttyVtRenderSnapshot.ts`); the display buffer already maps SGR 2 → `dim` and the surface already renders `dim`. The whole dim pipeline existed — only the ghostty path's two ends were unwired.
- **Render fix** — dim by fading the **foreground only** (`color-mix` alpha) instead of a whole-element `opacity`, which previously darkened the cell background too (a dark patch behind dim text on the grey codex composer box).

## Tests

- Backend `snapshot_captures_faint_cells_as_dim` (faint → `dim`).
- Frontend: dim cell → SGR 2 through the display buffer; surface renders dim via foreground alpha with the background preserved.
- 489 TerminalPane tests pass; `type-check:generated` + eslint + prettier clean. (`src/bindings` regenerates in CI; the placeholder is faint/SGR 2 — the separate palette-colour gap noted in VIM-230 wasn't needed here.)

Closes VIM-230. Part of VIM-139 (Ghostty Terminal Migration — M4 renderer fidelity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
