### PR TITLE
fix(terminal): Show burner terminal context menu above overlay

### DIFF
--- a/src/components/Menu.test.tsx
+++ b/src/components/Menu.test.tsx
@@ -678,6 +678,23 @@ describe('Menu.Context', () => {
     expect(screen.getByRole('menuitem', { name: 'Paste' })).toBeInTheDocument()
   })
 
+  test('renders above z-100 overlays like the burner terminal popup', () => {
+    render(
+      <Menu.Context
+        position={{ x: 50, y: 60 }}
+        open
+        onOpenChange={vi.fn()}
+        aria-label="Terminal actions"
+      >
+        <Menu.Item onSelect={vi.fn()}>Paste</Menu.Item>
+      </Menu.Context>
+    )
+
+    expect(
+      screen.getByRole('menu', { name: 'Terminal actions' }).className
+    ).toContain('z-[110]')
+  })
+
   test('requests close via onOpenChange on Escape', async () => {
     const user = userEvent.setup()
     const onOpenChange = vi.fn<(open: boolean) => void>()

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -68,7 +68,7 @@ const useMenuContext = (): MenuContextValue => {
 const MENU_BODY_CLASSES = 'py-1 min-w-52 max-h-[28rem] overflow-auto'
 
 const CONTEXT_MENU_SURFACE_CLASSES =
-  'z-50 overflow-hidden rounded-md border border-outline-variant/30 bg-surface-container-high shadow-lg outline-none focus:outline-none focus-visible:outline-none'
+  'z-[110] overflow-hidden rounded-md border border-outline-variant/30 bg-surface-container-high shadow-lg outline-none focus:outline-none focus-visible:outline-none'
 
 const CONTEXT_MENU_BODY_CLASSES = 'min-w-0 max-h-[28rem] overflow-auto'
 


### PR DESCRIPTION
## Summary
- Raise cursor-anchored context menus above the burner terminal overlay.
- Add a regression test that pins the context-menu layer above z-100 dialogs.

## Root cause
The burner popup renders at `z-[100]`, while `Menu.Context` used `z-50`, so the terminal copy/paste menu opened behind the burner overlay.

## Validation
- `npm test -- Menu.test.tsx --run`
- `npx eslint src/components/Menu.tsx src/components/Menu.test.tsx`
- `npx prettier --check src/components/Menu.tsx src/components/Menu.test.tsx`

Refs VIM-233