### PR TITLE
feat(workspace): add active-pane focus toggle

### DIFF
--- a/docs/design/UNIFIED.md
+++ b/docs/design/UNIFIED.md
@@ -532,7 +532,7 @@ Rules:
 ## 6. Interactions & keyboard shortcuts
 
 - **Streaming:** terminal output is raw PTY. Agent structured output prefixes `∴` in `primary-container`; one event every ~1.3–2s while `running`, stopping the instant state leaves `running`.
-- **Shortcuts:** `Mod+1–4` focus panes · `Mod+\` cycle layout · `Mod+E` Editor · `Mod+G` Diff · `Mod+0` toggle dock · `Mod+B` (mac) / `Ctrl+Shift+B` toggle sidebar · `Ctrl/Cmd+;` command palette · `Ctrl/Cmd+L` browser address bar · `Esc` closes overlays.
+- **Shortcuts:** `Mod+1–4` focus panes · `Mod+\` cycle layout · `Mod+Z` toggle active-pane focus · `Mod+E` Editor · `Mod+G` Diff · `Mod+0` toggle dock · `Mod+B` (mac) / `Ctrl+Shift+B` toggle sidebar · `Ctrl/Cmd+;` command palette · `Ctrl/Cmd+L` browser address bar · `Esc` closes overlays.
 - **Approval:** `awaiting` surfaces an approval card (Approve gradient / Deny ghost); approving snaps to `running` and prepends a `user` event.
 - **Focus model:** `activeContainerId` routes shortcuts to the terminal vs the dock; the sidebar toggle has a focus guard so compact-close never drops focus to `<body>`.
 

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -59,7 +59,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 85       | 39   | 2026-06-27   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 5        | 3    | 2026-06-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 93       | 90   | 2026-06-25   |
-| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 81       | 32   | 2026-06-22   |
+| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 82       | 81   | 2026-06-28   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 71       | 70   | 2026-06-26   |
 | [Canonical Path Dedupe](patterns/canonical-path-dedupe.md)                                           | correctness        | 2        | 0    | 2026-06-14   |
@@ -81,7 +81,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 24       | 10   | 2026-06-19   |
 | [Module Boundaries](patterns/module-boundaries.md)                                                   | code-quality       | 17       | 3    | 2026-06-25   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 13       | 3    | 2026-06-15   |
-| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 24       | 3    | 2026-06-26   |
+| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 26       | 4    | 2026-06-28   |
 | [Verify Render Target](patterns/verify-render-target.md)                                             | code-quality       | 2        | 0    | 2026-05-24   |
 | [UI Visual Regression](patterns/ui-visual-regression.md)                                             | code-quality       | 15       | 9    | 2026-06-20   |
 | [Status Indicator Display](patterns/status-indicator-display.md)                                     | code-quality       | 3        | 0    | 2026-05-26   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -45,7 +45,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | ---------------------------------------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md)                                                     | security           | 28       | 7    | 2026-06-22   |
 | [Native Surface Occlusion](patterns/native-surface-occlusion.md)                                     | correctness        | 3        | 0    | 2026-06-15   |
-| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 59       | 62   | 2026-06-27   |
+| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 59       | 63   | 2026-06-27   |
 | [Imperative Animation Ownership](patterns/imperative-animation-ownership.md)                         | react-patterns     | 7        | 3    | 2026-06-17   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Fixed-Position Portals](patterns/fixed-position-portals.md)                                         | react-patterns     | 2        | 1    | 2026-06-22   |
@@ -81,7 +81,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 24       | 10   | 2026-06-19   |
 | [Module Boundaries](patterns/module-boundaries.md)                                                   | code-quality       | 17       | 3    | 2026-06-25   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 13       | 3    | 2026-06-15   |
-| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 26       | 4    | 2026-06-28   |
+| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 26       | 5    | 2026-06-28   |
 | [Verify Render Target](patterns/verify-render-target.md)                                             | code-quality       | 2        | 0    | 2026-05-24   |
 | [UI Visual Regression](patterns/ui-visual-regression.md)                                             | code-quality       | 15       | 9    | 2026-06-20   |
 | [Status Indicator Display](patterns/status-indicator-display.md)                                     | code-quality       | 3        | 0    | 2026-05-26   |
@@ -99,8 +99,8 @@ When appending findings to a pattern file, label the source so future readers ca
 | [String Construction Hygiene](patterns/string-construction-hygiene.md)                               | code-quality       | 2        | 1    | 2026-06-19   |
 | [Agent-State Guards](patterns/agent-state-guards.md)                                                 | correctness        | 10       | 7    | 2026-06-22   |
 | [React Prop Contracts](patterns/react-prop-contracts.md)                                             | react-patterns     | 8        | 6    | 2026-06-22   |
-| [Stale Retained Interactions](patterns/stale-retained-interactions.md)                               | react-patterns     | 2        | 1    | 2026-06-15   |
-| [Retained State Identity](patterns/retained-state-identity.md)                                       | react-patterns     | 1        | 1    | 2026-06-15   |
+| [Stale Retained Interactions](patterns/stale-retained-interactions.md)                               | react-patterns     | 2        | 2    | 2026-06-15   |
+| [Retained State Identity](patterns/retained-state-identity.md)                                       | react-patterns     | 2        | 2    | 2026-06-28   |
 | [Authoritative Completion Guard](patterns/authoritative-completion-guard.md)                         | correctness        | 6        | 2    | 2026-06-27   |
 | [Equality Guard Completeness](patterns/equality-guard-completeness.md)                               | correctness        | 2        | 0    | 2026-06-17   |
 | [Resizable Layout Bounds](patterns/resizable-layout-bounds.md)                                       | correctness        | 3        | 1    | 2026-06-18   |
@@ -109,6 +109,6 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Vite HMR Static Dependencies](patterns/vite-hmr-static-deps.md)                                     | code-quality       | 3        | 2    | 2026-06-18   |
 | [Custom Pane Layout Preservation](patterns/custom-pane-layout-preservation.md)                       | correctness        | 13       | 5    | 2026-06-22   |
 | [Pane Slot Identity](patterns/pane-slot-identity.md)                                                 | correctness        | 3        | 1    | 2026-06-22   |
-| [Transient UI Side Effects](patterns/transient-ui-side-effects.md)                                   | react-patterns     | 8        | 3    | 2026-06-26   |
+| [Transient UI Side Effects](patterns/transient-ui-side-effects.md)                                   | react-patterns     | 8        | 4    | 2026-06-26   |
 | [Async Global State Mutation](patterns/async-global-state-mutation.md)                               | backend            | 1        | 0    | 2026-06-19   |
 | [Boolean Sentinel Consistency](patterns/boolean-sentinel-consistency.md)                             | code-quality       | 2        | 1    | 2026-06-22   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -81,7 +81,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 24       | 10   | 2026-06-19   |
 | [Module Boundaries](patterns/module-boundaries.md)                                                   | code-quality       | 17       | 3    | 2026-06-25   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 13       | 3    | 2026-06-15   |
-| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 26       | 5    | 2026-06-28   |
+| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 27       | 5    | 2026-06-28   |
 | [Verify Render Target](patterns/verify-render-target.md)                                             | code-quality       | 2        | 0    | 2026-05-24   |
 | [UI Visual Regression](patterns/ui-visual-regression.md)                                             | code-quality       | 15       | 9    | 2026-06-20   |
 | [Status Indicator Display](patterns/status-indicator-display.md)                                     | code-quality       | 3        | 0    | 2026-05-26   |

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -2,8 +2,8 @@
 id: accessibility
 category: a11y
 created: 2026-04-09
-last_updated: 2026-06-22
-ref_count: 80
+last_updated: 2026-06-28
+ref_count: 81
 ---
 
 # Accessibility
@@ -754,3 +754,12 @@ handlers must not trap focus without implementing the promised behavior.
 - **Finding:** The browser-pane drag handle was promoted to `role="button"` and `tabIndex={0}`, but still only implemented pointer drag handlers. Keyboard and screen-reader users could focus a control announced as a button, then press Enter or Space with no activation path.
 - **Fix:** Removed the button role and tab stop from the browser-pane drag handle until keyboard-driven pane reorder exists. Added regression coverage that the handle remains draggable but is not exposed as a keyboard-focusable button.
 - **Commit:** same commit as this entry
+
+### 74. Generic layout picker announced workspace-only focus action
+
+- **Source:** github-codex-connector | PR #631 round 1 | 2026-06-28
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.tsx`
+- **Finding:** `LayoutSwitcher` reused the “Focus active pane” accessible name and tooltip for every `single` layout option, including the New Session dialog where the control selects a “Single” template rather than focusing an active pane.
+- **Fix:** Made the focus-action label and shortcut chip opt-in via `labelSingleAsFocusAction`, enabled it only in workspace chrome, and kept generic pickers on the plain “Single” label.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/keyboard-shortcut-guards.md
+++ b/docs/reviews/patterns/keyboard-shortcut-guards.md
@@ -349,3 +349,17 @@ against three classes of false-fire:
 - **Finding:** The `KeyZ` branch did not mirror the digit-shortcut container guard, so `Ctrl+Z` / `Cmd+Z` from the focused editor dock toggled the terminal layout instead of reaching the dock.
 - **Fix:** Added an `isTerminalContainerActiveRef.current === false` pass-through before the branch can prevent default, with regression coverage for dock focus.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 27. Manual layout cycle left stale Mod+Z restore state
+
+- **Source:** github-claude | PR #631 round 2 | 2026-06-28
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/hooks/usePaneShortcuts.ts`
+- **Finding:** The per-session Mod+Z restore map was cleared on restore and failed-restore
+  paths, but not when `Mod+\` manually changed the same session's layout. A user could
+  enter single-pane focus with `Mod+Z`, cycle away with `Mod+\`, later return to single,
+  and have the next `Mod+Z` consume the stale restore entry.
+- **Fix:** Clear the active session's restore entry in the `Backslash` layout-cycle branch
+  before applying the next layout. Added regression coverage for the cycle-away-then-single
+  path so `Mod+Z` returns to the single-layout no-op behavior.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/keyboard-shortcut-guards.md
+++ b/docs/reviews/patterns/keyboard-shortcut-guards.md
@@ -2,8 +2,8 @@
 id: keyboard-shortcut-guards
 category: keyboard-shortcuts
 created: 2026-05-18
-last_updated: 2026-06-26
-ref_count: 3
+last_updated: 2026-06-28
+ref_count: 4
 ---
 
 # Keyboard Shortcut Guards
@@ -331,3 +331,21 @@ against three classes of false-fire:
 - **Fix:** Stop propagation for keyboard events that originate from nested focusable
   controls while preserving the row's own Enter/Space activation.
 - **Commit:** same commit as this entry
+
+### 25. Mod+Z focus toggle captured terminal and editor undo controls
+
+- **Source:** github-codex-connector | PR #631 round 1 | 2026-06-28
+- **Severity:** P1 / HIGH
+- **File:** `src/features/terminal/hooks/usePaneShortcuts.ts`
+- **Finding:** The new document-level `Mod+Z` layout toggle consumed the event before focused controls could handle it, stealing terminal `Ctrl+Z` job suspension and editor/dock undo behavior.
+- **Fix:** Guarded the shortcut so it passes through when the terminal container is inactive or focus is inside editable/xterm input. Added regression coverage for focused dock and xterm helper textarea cases.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 26. Mod+Z focus toggle lacked terminal-container ownership guard
+
+- **Source:** github-claude | PR #631 round 1 | 2026-06-28
+- **Severity:** HIGH
+- **File:** `src/features/terminal/hooks/usePaneShortcuts.ts`
+- **Finding:** The `KeyZ` branch did not mirror the digit-shortcut container guard, so `Ctrl+Z` / `Cmd+Z` from the focused editor dock toggled the terminal layout instead of reaching the dock.
+- **Fix:** Added an `isTerminalContainerActiveRef.current === false` pass-through before the branch can prevent default, with regression coverage for dock focus.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/keyboard-shortcut-guards.md
+++ b/docs/reviews/patterns/keyboard-shortcut-guards.md
@@ -3,7 +3,7 @@ id: keyboard-shortcut-guards
 category: keyboard-shortcuts
 created: 2026-05-18
 last_updated: 2026-06-28
-ref_count: 4
+ref_count: 5
 ---
 
 # Keyboard Shortcut Guards

--- a/docs/reviews/patterns/react-lifecycle.md
+++ b/docs/reviews/patterns/react-lifecycle.md
@@ -3,7 +3,7 @@ id: react-lifecycle
 category: react-patterns
 created: 2026-04-09
 last_updated: 2026-06-27
-ref_count: 62
+ref_count: 63
 ---
 
 # React Lifecycle

--- a/docs/reviews/patterns/retained-state-identity.md
+++ b/docs/reviews/patterns/retained-state-identity.md
@@ -2,8 +2,8 @@
 id: retained-state-identity
 category: react-patterns
 created: 2026-06-15
-last_updated: 2026-06-15
-ref_count: 1
+last_updated: 2026-06-28
+ref_count: 2
 ---
 
 # Retained State Identity
@@ -22,3 +22,18 @@ When a React component renders retained (stale) content while fresh data for a n
 - **Finding:** During retained-body fetching, `bodySnapshotKey` referred to the previously rendered/source pane while `snapshotKey` referred to the current target pane. The `handleScroll` callback wrote user scroll events to `bodySnapshotKey`, so scrolling retained content during the refresh window overwrote the source pane's saved scroll position and caused it to reopen at the wrong offset later.
 - **Fix:** Added an identity guard before `writeStatusScrollAnchor` that returns early when `bodySnapshotKey !== snapshotKey`, and added `snapshotKey` to the `handleScroll` `useCallback` dependencies.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 2. Single focus-toggle restore slot is shared across sessions
+
+- **Source:** github-claude | PR #631 round 1 | 2026-06-28
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/hooks/usePaneShortcuts.ts`
+- **Finding:** The Mod+Z single-pane focus toggle stored the previous layout in
+  one ref for the whole hook. Toggling session A to focus and then toggling
+  session B overwrote A's restore layout, so returning to A left the keyboard
+  restore path as a silent no-op.
+- **Fix:** Replaced the single restore slot with a ref-held `Map` keyed by
+  session id, storing, reading, and deleting only the active session's restore
+  layout. Added a regression test covering two sessions toggled to focus mode
+  independently.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/stale-retained-interactions.md
+++ b/docs/reviews/patterns/stale-retained-interactions.md
@@ -3,7 +3,7 @@ id: stale-retained-interactions
 category: react-patterns
 created: 2026-06-15
 last_updated: 2026-06-15
-ref_count: 1
+ref_count: 2
 ---
 
 # Stale Retained Interactions

--- a/docs/reviews/patterns/transient-ui-side-effects.md
+++ b/docs/reviews/patterns/transient-ui-side-effects.md
@@ -3,7 +3,7 @@ id: transient-ui-side-effects
 category: react-patterns
 created: 2026-06-20
 last_updated: 2026-06-26
-ref_count: 3
+ref_count: 4
 ---
 
 # Transient UI Side Effects

--- a/src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.test.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.test.tsx
@@ -29,9 +29,7 @@ describe('LayoutSwitcher', () => {
     const active = screen.getByRole('button', { name: 'Vertical split' })
     expect(active).toHaveAttribute('data-active', 'true')
 
-    const inactive = screen.getByRole('button', {
-      name: SINGLE_PANE_FOCUS_LABEL,
-    })
+    const inactive = screen.getByRole('button', { name: 'Single' })
     expect(inactive).not.toHaveAttribute('data-active')
   })
 
@@ -62,9 +60,7 @@ describe('LayoutSwitcher', () => {
     )
 
     expect(screen.getAllByRole('button')).toHaveLength(3)
-    expect(
-      screen.getByRole('button', { name: SINGLE_PANE_FOCUS_LABEL })
-    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Single' })).toBeInTheDocument()
 
     expect(
       screen.getByRole('button', { name: 'Main + 2 stack' })
@@ -210,9 +206,32 @@ describe('LayoutSwitcher', () => {
     expect(screen.getByTestId('layout-switcher')).toHaveClass('vf-app-no-drag')
   })
 
-  test('layout tooltips show a shortcut chip only for active-pane focus', async () => {
+  test('generic layout pickers keep the single layout name without a shortcut chip', async () => {
     const user = userEvent.setup()
     render(<LayoutSwitcher activeLayoutId="single" onPick={vi.fn()} />)
+
+    const singleButton = screen.getByRole('button', { name: 'Single' })
+    await user.hover(singleButton)
+    const singleTip = await screen.findByRole('tooltip')
+    expect(singleTip).toHaveTextContent('Single')
+    expect(within(singleTip).queryByTestId('tooltip-shortcut')).toBeNull()
+    await user.unhover(singleButton)
+
+    await user.hover(screen.getByRole('button', { name: 'Quad' }))
+    const quadTip = await screen.findByRole('tooltip')
+    expect(quadTip).toHaveTextContent('Quad')
+    expect(within(quadTip).queryByTestId('tooltip-shortcut')).toBeNull()
+  })
+
+  test('workspace focus mode labels single layout as an active-pane action', async () => {
+    const user = userEvent.setup()
+    render(
+      <LayoutSwitcher
+        activeLayoutId="single"
+        onPick={vi.fn()}
+        labelSingleAsFocusAction
+      />
+    )
 
     const focusButton = screen.getByRole('button', {
       name: SINGLE_PANE_FOCUS_LABEL,
@@ -223,11 +242,5 @@ describe('LayoutSwitcher', () => {
     expect(within(focusTip).getByTestId('tooltip-shortcut')).toHaveTextContent(
       'Z'
     )
-    await user.unhover(focusButton)
-
-    await user.hover(screen.getByRole('button', { name: 'Quad' }))
-    const quadTip = await screen.findByRole('tooltip')
-    expect(quadTip).toHaveTextContent('Quad')
-    expect(within(quadTip).queryByTestId('tooltip-shortcut')).toBeNull()
   })
 })

--- a/src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.test.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, test, vi } from 'vitest'
+import { SINGLE_PANE_FOCUS_LABEL } from '../../layout-registry'
 import { LayoutSwitcher } from './LayoutSwitcher'
 
 describe('LayoutSwitcher', () => {
@@ -27,7 +28,10 @@ describe('LayoutSwitcher', () => {
 
     const active = screen.getByRole('button', { name: 'Vertical split' })
     expect(active).toHaveAttribute('data-active', 'true')
-    const inactive = screen.getByRole('button', { name: 'Single' })
+
+    const inactive = screen.getByRole('button', {
+      name: SINGLE_PANE_FOCUS_LABEL,
+    })
     expect(inactive).not.toHaveAttribute('data-active')
   })
 
@@ -58,7 +62,10 @@ describe('LayoutSwitcher', () => {
     )
 
     expect(screen.getAllByRole('button')).toHaveLength(3)
-    expect(screen.getByRole('button', { name: 'Single' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: SINGLE_PANE_FOCUS_LABEL })
+    ).toBeInTheDocument()
+
     expect(
       screen.getByRole('button', { name: 'Main + 2 stack' })
     ).toBeInTheDocument()
@@ -203,20 +210,24 @@ describe('LayoutSwitcher', () => {
     expect(screen.getByTestId('layout-switcher')).toHaveClass('vf-app-no-drag')
   })
 
-  // Layout buttons render the layout name only — no shortcut chip.
-  // `Mod+\` cycles to the NEXT layout (usePaneShortcuts), not to any
-  // specific one, so attaching the chip to individual layout buttons
-  // would advertise a per-layout shortcut that doesn't exist (Claude
-  // review on PR #224 cycle 3, MEDIUM finding). If a future refactor
-  // introduces per-layout shortcuts (e.g. Mod+1..Mod+5 picker keys),
-  // re-add the chip and flip this assertion.
-  test('hovering a layout button shows a plain tooltip (no shortcut chip)', async () => {
+  test('layout tooltips show a shortcut chip only for active-pane focus', async () => {
     const user = userEvent.setup()
     render(<LayoutSwitcher activeLayoutId="single" onPick={vi.fn()} />)
 
-    await user.hover(screen.getByRole('button', { name: 'Single' }))
-    const tip = await screen.findByRole('tooltip')
-    expect(tip).toHaveTextContent('Single')
-    expect(within(tip).queryByTestId('tooltip-shortcut')).toBeNull()
+    const focusButton = screen.getByRole('button', {
+      name: SINGLE_PANE_FOCUS_LABEL,
+    })
+    await user.hover(focusButton)
+    const focusTip = await screen.findByRole('tooltip')
+    expect(focusTip).toHaveTextContent(SINGLE_PANE_FOCUS_LABEL)
+    expect(within(focusTip).getByTestId('tooltip-shortcut')).toHaveTextContent(
+      'Z'
+    )
+    await user.unhover(focusButton)
+
+    await user.hover(screen.getByRole('button', { name: 'Quad' }))
+    const quadTip = await screen.findByRole('tooltip')
+    expect(quadTip).toHaveTextContent('Quad')
+    expect(within(quadTip).queryByTestId('tooltip-shortcut')).toBeNull()
   })
 })

--- a/src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.tsx
@@ -34,6 +34,11 @@ export interface LayoutSwitcherProps {
    * narrow Layout column. Arrow Up/Down already drive selection either way.
    */
   vertical?: boolean
+  /**
+   * Workspace chrome treats the `single` layout as the active-pane focus
+   * toggle. Generic layout pickers keep the plain layout name.
+   */
+  labelSingleAsFocusAction?: boolean
 }
 
 export const LayoutSwitcher = ({
@@ -46,6 +51,7 @@ export const LayoutSwitcher = ({
   onPick,
   trailing = undefined,
   vertical = false,
+  labelSingleAsFocusAction = false,
 }: LayoutSwitcherProps): ReactElement => {
   const layoutIds = useMemo(() => layouts.map((layout) => layout.id), [layouts])
 
@@ -97,7 +103,7 @@ export const LayoutSwitcher = ({
 
           const label = disabled
             ? `Reduce panes to switch to ${name}`
-            : isSingleFocus
+            : isSingleFocus && labelSingleAsFocusAction
               ? SINGLE_PANE_FOCUS_LABEL
               : name
 
@@ -109,7 +115,10 @@ export const LayoutSwitcher = ({
             // readers and on hover when the layout is blocked.
             ariaLabel: label,
             tooltip: label,
-            shortcut: isSingleFocus ? ['Mod', 'Z'] : undefined,
+            shortcut:
+              isSingleFocus && labelSingleAsFocusAction
+                ? ['Mod', 'Z']
+                : undefined,
             disabled,
           }
         })}

--- a/src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.tsx
@@ -2,6 +2,8 @@ import { useMemo, type ReactElement, type ReactNode } from 'react'
 import type { PaneLayoutId } from '../../../sessions/types'
 import {
   BUILTIN_PANE_LAYOUT_REGISTRY,
+  SINGLE_PANE_FOCUS_LABEL,
+  SINGLE_PANE_FOCUS_LAYOUT_ID,
   type LayoutShape,
 } from '../../layout-registry'
 import { LayoutGlyph } from './LayoutGlyph'
@@ -53,7 +55,9 @@ export const LayoutSwitcher = ({
   )
 
   const normalizedVisibleLayoutIds = layoutIds.filter(
-    (layoutId) => layoutId === 'single' || visibleLayoutIds.includes(layoutId)
+    (layoutId) =>
+      layoutId === SINGLE_PANE_FOCUS_LAYOUT_ID ||
+      visibleLayoutIds.includes(layoutId)
   )
 
   const renderedLayoutIds = layoutIds.filter(
@@ -86,10 +90,16 @@ export const LayoutSwitcher = ({
         value={activeLayoutId}
         options={renderedLayoutIds.map((layoutId) => {
           const name = layoutById.get(layoutId)?.name ?? layoutId
+          const isSingleFocus = layoutId === SINGLE_PANE_FOCUS_LAYOUT_ID
 
           const disabled =
             blockedLayoutIds.includes(layoutId) && layoutId !== activeLayoutId
-          const label = disabled ? `Reduce panes to switch to ${name}` : name
+
+          const label = disabled
+            ? `Reduce panes to switch to ${name}`
+            : isSingleFocus
+              ? SINGLE_PANE_FOCUS_LABEL
+              : name
 
           return {
             value: layoutId,
@@ -99,6 +109,7 @@ export const LayoutSwitcher = ({
             // readers and on hover when the layout is blocked.
             ariaLabel: label,
             tooltip: label,
+            shortcut: isSingleFocus ? ['Mod', 'Z'] : undefined,
             disabled,
           }
         })}

--- a/src/features/terminal/hooks/usePaneShortcuts.test.ts
+++ b/src/features/terminal/hooks/usePaneShortcuts.test.ts
@@ -187,6 +187,72 @@ describe('usePaneShortcuts', () => {
     })
   })
 
+  test('Mod+Z keeps separate restore layouts for each session', () => {
+    const setSessionLayout = vi.fn()
+
+    const { rerender } = renderHook(
+      ({ sessions, activeSessionId }) =>
+        usePaneShortcuts({
+          sessions,
+          activeSessionId,
+          setSessionActivePane: vi.fn(),
+          setSessionLayout,
+        }),
+      {
+        initialProps: {
+          sessions: [
+            makeSession('s1', 'grid3x2', ['s1-p0', 's1-p1', 's1-p2'], 1),
+            makeSession('s2', 'vsplit', ['s2-p0', 's2-p1'], 0),
+          ],
+          activeSessionId: 's1',
+        },
+      }
+    )
+
+    fire('z', shortcutModifiersFor('ctrl'))
+    expect(setSessionLayout).toHaveBeenLastCalledWith(
+      's1',
+      SINGLE_PANE_FOCUS_LAYOUT_ID
+    )
+
+    rerender({
+      sessions: [
+        makeSession(
+          's1',
+          SINGLE_PANE_FOCUS_LAYOUT_ID,
+          ['s1-p0', 's1-p1', 's1-p2'],
+          1
+        ),
+        makeSession('s2', 'vsplit', ['s2-p0', 's2-p1'], 0),
+      ],
+      activeSessionId: 's2',
+    })
+
+    fire('z', shortcutModifiersFor('ctrl'))
+    expect(setSessionLayout).toHaveBeenLastCalledWith(
+      's2',
+      SINGLE_PANE_FOCUS_LAYOUT_ID
+    )
+
+    rerender({
+      sessions: [
+        makeSession(
+          's1',
+          SINGLE_PANE_FOCUS_LAYOUT_ID,
+          ['s1-p0', 's1-p1', 's1-p2'],
+          1
+        ),
+        makeSession('s2', SINGLE_PANE_FOCUS_LAYOUT_ID, ['s2-p0', 's2-p1'], 0),
+      ],
+      activeSessionId: 's1',
+    })
+
+    const restoreEvent = fire('z', shortcutModifiersFor('ctrl'))
+
+    expect(setSessionLayout).toHaveBeenLastCalledWith('s1', 'grid3x2')
+    expect(restoreEvent.preventDefaultSpy).toHaveBeenCalled()
+  })
+
   test('Mod+Z restore falls through when the previous layout no longer fits', () => {
     const setSessionLayout = vi.fn()
 

--- a/src/features/terminal/hooks/usePaneShortcuts.test.ts
+++ b/src/features/terminal/hooks/usePaneShortcuts.test.ts
@@ -659,6 +659,55 @@ describe('usePaneShortcuts container reclaim extensions', () => {
     removeFakeDock(dockElement)
   })
 
+  test('Mod+Z from focused dock passes through to focused controls', () => {
+    const setSessionLayout = vi.fn()
+    const dockElement = attachFakeDock()
+
+    renderHook(() =>
+      usePaneShortcuts({
+        sessions: [makeSession('s1', 'vsplit', ['p0', 'p1'])],
+        activeSessionId: 's1',
+        setSessionActivePane: vi.fn(),
+        setSessionLayout,
+        isTerminalContainerActive: false,
+        onTerminalZoneFocus: vi.fn(),
+      })
+    )
+
+    const event = fire('z', shortcutModifiersFor('ctrl'))
+
+    expect(setSessionLayout).not.toHaveBeenCalled()
+    expect(event.preventDefaultSpy).not.toHaveBeenCalled()
+
+    removeFakeDock(dockElement)
+  })
+
+  test('Mod+Z inside xterm helper textarea passes through to terminal input', () => {
+    const setSessionLayout = vi.fn()
+    const textarea = document.createElement('textarea')
+    textarea.className = 'xterm-helper-textarea'
+    document.body.appendChild(textarea)
+    textarea.focus()
+
+    renderHook(() =>
+      usePaneShortcuts({
+        sessions: [makeSession('s1', 'vsplit', ['p0', 'p1'])],
+        activeSessionId: 's1',
+        setSessionActivePane: vi.fn(),
+        setSessionLayout,
+        isTerminalContainerActive: true,
+        onTerminalZoneFocus: vi.fn(),
+      })
+    )
+
+    const event = fire('z', shortcutModifiersFor('ctrl'))
+
+    expect(setSessionLayout).not.toHaveBeenCalled()
+    expect(event.preventDefaultSpy).not.toHaveBeenCalled()
+
+    document.body.removeChild(textarea)
+  })
+
   test('Ctrl+1 from stale dock state outside dock passes through', () => {
     const onTerminalZoneFocus = vi.fn()
     blurActiveElement()

--- a/src/features/terminal/hooks/usePaneShortcuts.test.ts
+++ b/src/features/terminal/hooks/usePaneShortcuts.test.ts
@@ -5,9 +5,10 @@ import { emptyActivity } from '../../sessions/constants'
 import type { PaneLayoutId, Session } from '../../sessions/types'
 import {
   PaneLayoutRegistry,
+  SINGLE_PANE_FOCUS_LAYOUT_ID,
   type PaneLayoutDefinition,
 } from '../layout-registry'
-import { usePaneShortcuts } from './usePaneShortcuts'
+import { usePaneShortcuts, type PaneShortcutModifier } from './usePaneShortcuts'
 
 const makeSession = (
   id: string,
@@ -47,6 +48,9 @@ const codeFor = (key: string): string | undefined => {
   if (key === '\\') {
     return 'Backslash'
   }
+  if (key.toLowerCase() === 'z') {
+    return 'KeyZ'
+  }
 
   return undefined
 }
@@ -69,6 +73,30 @@ const fire = (
 
   return Object.assign(event, { preventDefaultSpy })
 }
+
+const modZPlatforms: readonly {
+  readonly label: string
+  readonly preferModifier: PaneShortcutModifier
+}[] = [
+  {
+    label: 'Linux',
+    preferModifier: 'ctrl',
+  },
+  {
+    label: 'macOS',
+    preferModifier: 'meta',
+  },
+]
+
+const shortcutModifiersFor = (
+  preferModifier: PaneShortcutModifier
+): Partial<KeyboardEventInit> =>
+  preferModifier === 'meta' ? { metaKey: true } : { ctrlKey: true }
+
+const oppositeModifiersFor = (
+  preferModifier: PaneShortcutModifier
+): Partial<KeyboardEventInit> =>
+  preferModifier === 'meta' ? { ctrlKey: true } : { metaKey: true }
 
 describe('usePaneShortcuts', () => {
   test('Ctrl+\\ from single cycles to vsplit and prevents default (default modifier)', () => {
@@ -104,6 +132,135 @@ describe('usePaneShortcuts', () => {
 
     expect(setSessionLayout).toHaveBeenCalledOnce()
     expect(setSessionLayout).toHaveBeenCalledWith('s1', 'single')
+  })
+
+  modZPlatforms.forEach(({ label, preferModifier }) => {
+    test(`${label}: Mod+Z toggles a multi-pane layout to single and back`, () => {
+      const setSessionLayout = vi.fn()
+      const shortcutModifiers = shortcutModifiersFor(preferModifier)
+      const oppositeModifiers = oppositeModifiersFor(preferModifier)
+
+      const { rerender } = renderHook(
+        ({ session }) =>
+          usePaneShortcuts({
+            sessions: [session],
+            activeSessionId: 's1',
+            setSessionActivePane: vi.fn(),
+            setSessionLayout,
+            preferModifier,
+          }),
+        {
+          initialProps: {
+            session: makeSession('s1', 'grid3x2', ['p0', 'p1', 'p2'], 2),
+          },
+        }
+      )
+
+      const oppositeEvent = fire('z', oppositeModifiers)
+      expect(setSessionLayout).not.toHaveBeenCalled()
+      expect(oppositeEvent.preventDefaultSpy).not.toHaveBeenCalled()
+
+      const event = fire('z', shortcutModifiers)
+
+      expect(setSessionLayout).toHaveBeenCalledOnce()
+      expect(setSessionLayout).toHaveBeenCalledWith(
+        's1',
+        SINGLE_PANE_FOCUS_LAYOUT_ID
+      )
+      expect(event.preventDefaultSpy).toHaveBeenCalled()
+
+      setSessionLayout.mockClear()
+      rerender({
+        session: makeSession(
+          's1',
+          SINGLE_PANE_FOCUS_LAYOUT_ID,
+          ['p0', 'p1', 'p2'],
+          2
+        ),
+      })
+
+      const restoreEvent = fire('z', shortcutModifiers)
+
+      expect(setSessionLayout).toHaveBeenCalledOnce()
+      expect(setSessionLayout).toHaveBeenCalledWith('s1', 'grid3x2')
+      expect(restoreEvent.preventDefaultSpy).toHaveBeenCalled()
+    })
+  })
+
+  test('Mod+Z restore falls through when the previous layout no longer fits', () => {
+    const setSessionLayout = vi.fn()
+
+    const { rerender } = renderHook(
+      ({ session }) =>
+        usePaneShortcuts({
+          sessions: [session],
+          activeSessionId: 's1',
+          setSessionActivePane: vi.fn(),
+          setSessionLayout,
+        }),
+      {
+        initialProps: {
+          session: makeSession('s1', 'vsplit', ['p0', 'p1'], 1),
+        },
+      }
+    )
+
+    fire('z', shortcutModifiersFor('ctrl'))
+    expect(setSessionLayout).toHaveBeenCalledWith(
+      's1',
+      SINGLE_PANE_FOCUS_LAYOUT_ID
+    )
+
+    setSessionLayout.mockClear()
+    rerender({
+      session: makeSession(
+        's1',
+        SINGLE_PANE_FOCUS_LAYOUT_ID,
+        ['p0', 'p1', 'p2'],
+        2
+      ),
+    })
+
+    const event = fire('z', shortcutModifiersFor('ctrl'))
+
+    expect(setSessionLayout).not.toHaveBeenCalled()
+    expect(event.preventDefaultSpy).not.toHaveBeenCalled()
+  })
+
+  test('Mod+Z on single layout is a no-op and lets the event propagate', () => {
+    const setSessionLayout = vi.fn()
+    renderHook(() =>
+      usePaneShortcuts({
+        sessions: [
+          makeSession('s1', SINGLE_PANE_FOCUS_LAYOUT_ID, ['p0', 'p1'], 1),
+        ],
+        activeSessionId: 's1',
+        setSessionActivePane: vi.fn(),
+        setSessionLayout,
+      })
+    )
+
+    const event = fire('z', shortcutModifiersFor('ctrl'))
+
+    expect(setSessionLayout).not.toHaveBeenCalled()
+    expect(event.preventDefaultSpy).not.toHaveBeenCalled()
+  })
+
+  test('Shift+Mod+Z does not switch layout', () => {
+    const setSessionLayout = vi.fn()
+    renderHook(() =>
+      usePaneShortcuts({
+        sessions: [makeSession('s1', 'grid3x2', ['p0', 'p1'])],
+        activeSessionId: 's1',
+        setSessionActivePane: vi.fn(),
+        setSessionLayout,
+      })
+    )
+
+    const event = fire('z', { ...shortcutModifiersFor('ctrl'), shiftKey: true })
+
+    expect(setSessionLayout).not.toHaveBeenCalled()
+    expect(event.preventDefaultSpy).not.toHaveBeenCalled()
   })
 
   test('Ctrl+2 with only one pane is a no-op AND lets the event propagate', () => {

--- a/src/features/terminal/hooks/usePaneShortcuts.test.ts
+++ b/src/features/terminal/hooks/usePaneShortcuts.test.ts
@@ -312,6 +312,57 @@ describe('usePaneShortcuts', () => {
     expect(event.preventDefaultSpy).not.toHaveBeenCalled()
   })
 
+  test('Mod+\\ clears pending Mod+Z restore state for the active session', () => {
+    const setSessionLayout = vi.fn()
+
+    const { rerender } = renderHook(
+      ({ session }) =>
+        usePaneShortcuts({
+          sessions: [session],
+          activeSessionId: 's1',
+          setSessionActivePane: vi.fn(),
+          setSessionLayout,
+        }),
+      {
+        initialProps: {
+          session: makeSession('s1', 'grid3x2', ['p0', 'p1', 'p2'], 2),
+        },
+      }
+    )
+
+    fire('z', shortcutModifiersFor('ctrl'))
+    expect(setSessionLayout).toHaveBeenCalledWith(
+      's1',
+      SINGLE_PANE_FOCUS_LAYOUT_ID
+    )
+
+    rerender({
+      session: makeSession(
+        's1',
+        SINGLE_PANE_FOCUS_LAYOUT_ID,
+        ['p0', 'p1', 'p2'],
+        2
+      ),
+    })
+    fire('\\', shortcutModifiersFor('ctrl'))
+    expect(setSessionLayout).toHaveBeenLastCalledWith('s1', 'vsplit')
+
+    setSessionLayout.mockClear()
+    rerender({
+      session: makeSession(
+        's1',
+        SINGLE_PANE_FOCUS_LAYOUT_ID,
+        ['p0', 'p1', 'p2'],
+        2
+      ),
+    })
+
+    const event = fire('z', shortcutModifiersFor('ctrl'))
+
+    expect(setSessionLayout).not.toHaveBeenCalled()
+    expect(event.preventDefaultSpy).not.toHaveBeenCalled()
+  })
+
   test('Shift+Mod+Z does not switch layout', () => {
     const setSessionLayout = vi.fn()
     renderHook(() =>

--- a/src/features/terminal/hooks/usePaneShortcuts.ts
+++ b/src/features/terminal/hooks/usePaneShortcuts.ts
@@ -52,10 +52,9 @@ export const usePaneShortcuts = ({
   const isTerminalContainerActiveRef = useRef(isTerminalContainerActive)
   const layoutRegistryRef = useRef(layoutRegistry)
 
-  const lastSingleToggleLayoutRef = useRef<{
-    readonly sessionId: string
-    readonly layoutId: PaneLayoutId
-  } | null>(null)
+  const lastSingleToggleLayoutBySessionRef = useRef(
+    new Map<string, PaneLayoutId>()
+  )
 
   sessionsRef.current = sessions
   activeSessionIdRef.current = activeSessionId
@@ -120,9 +119,8 @@ export const usePaneShortcuts = ({
 
         if (activeSession.layout === SINGLE_PANE_FOCUS_LAYOUT_ID) {
           const previousLayoutId =
-            lastSingleToggleLayoutRef.current?.sessionId === activeSession.id
-              ? lastSingleToggleLayoutRef.current.layoutId
-              : null
+            lastSingleToggleLayoutBySessionRef.current.get(activeSession.id) ??
+            null
 
           const previousLayout =
             previousLayoutId === null
@@ -133,14 +131,14 @@ export const usePaneShortcuts = ({
             previousLayout === null ||
             activeSession.panes.length > previousLayout.capacity
           ) {
-            lastSingleToggleLayoutRef.current = null
+            lastSingleToggleLayoutBySessionRef.current.delete(activeSession.id)
 
             return
           }
 
           event.preventDefault()
           event.stopPropagation()
-          lastSingleToggleLayoutRef.current = null
+          lastSingleToggleLayoutBySessionRef.current.delete(activeSession.id)
           setSessionLayout(activeSession.id, previousLayout.id)
 
           return
@@ -155,10 +153,10 @@ export const usePaneShortcuts = ({
 
         event.preventDefault()
         event.stopPropagation()
-        lastSingleToggleLayoutRef.current = {
-          sessionId: activeSession.id,
-          layoutId: currentLayout.id,
-        }
+        lastSingleToggleLayoutBySessionRef.current.set(
+          activeSession.id,
+          currentLayout.id
+        )
         setSessionLayout(activeSession.id, SINGLE_PANE_FOCUS_LAYOUT_ID)
 
         return

--- a/src/features/terminal/hooks/usePaneShortcuts.ts
+++ b/src/features/terminal/hooks/usePaneShortcuts.ts
@@ -275,6 +275,7 @@ export const usePaneShortcuts = ({
         event.preventDefault()
         event.stopPropagation()
         const nextIndex = (currentIndex + 1) % LAYOUT_CYCLE.length
+        lastSingleToggleLayoutBySessionRef.current.delete(activeSession.id)
         setSessionLayout(activeSession.id, LAYOUT_CYCLE[nextIndex])
       }
     }

--- a/src/features/terminal/hooks/usePaneShortcuts.ts
+++ b/src/features/terminal/hooks/usePaneShortcuts.ts
@@ -3,6 +3,7 @@ import type { PaneLayoutId, Session } from '../../sessions/types'
 import {
   BUILTIN_PANE_LAYOUT_REGISTRY,
   LAYOUT_CYCLE,
+  SINGLE_PANE_FOCUS_LAYOUT_ID,
   type PaneLayoutRegistry,
   isKnownLayoutId,
 } from '../layout-registry/layoutRegistry'
@@ -50,6 +51,12 @@ export const usePaneShortcuts = ({
   const onTerminalZoneFocusRef = useRef(onTerminalZoneFocus)
   const isTerminalContainerActiveRef = useRef(isTerminalContainerActive)
   const layoutRegistryRef = useRef(layoutRegistry)
+
+  const lastSingleToggleLayoutRef = useRef<{
+    readonly sessionId: string
+    readonly layoutId: PaneLayoutId
+  } | null>(null)
+
   sessionsRef.current = sessions
   activeSessionIdRef.current = activeSessionId
   preferModifierRef.current = preferModifier
@@ -90,6 +97,57 @@ export const usePaneShortcuts = ({
         (session) => session.id === activeId
       )
       if (!activeSession) {
+        return
+      }
+
+      if (event.code === 'KeyZ' && !event.altKey && !event.shiftKey) {
+        if (document.querySelector(DIALOG_SELECTOR)) {
+          return
+        }
+
+        if (activeSession.layout === SINGLE_PANE_FOCUS_LAYOUT_ID) {
+          const previousLayoutId =
+            lastSingleToggleLayoutRef.current?.sessionId === activeSession.id
+              ? lastSingleToggleLayoutRef.current.layoutId
+              : null
+
+          const previousLayout =
+            previousLayoutId === null
+              ? null
+              : layoutRegistryRef.current.getLayout(previousLayoutId)
+
+          if (
+            previousLayout === null ||
+            activeSession.panes.length > previousLayout.capacity
+          ) {
+            lastSingleToggleLayoutRef.current = null
+
+            return
+          }
+
+          event.preventDefault()
+          event.stopPropagation()
+          lastSingleToggleLayoutRef.current = null
+          setSessionLayout(activeSession.id, previousLayout.id)
+
+          return
+        }
+
+        const currentLayout = layoutRegistryRef.current.getLayout(
+          activeSession.layout
+        )
+        if (currentLayout === null) {
+          return
+        }
+
+        event.preventDefault()
+        event.stopPropagation()
+        lastSingleToggleLayoutRef.current = {
+          sessionId: activeSession.id,
+          layoutId: currentLayout.id,
+        }
+        setSessionLayout(activeSession.id, SINGLE_PANE_FOCUS_LAYOUT_ID)
+
         return
       }
 

--- a/src/features/terminal/hooks/usePaneShortcuts.ts
+++ b/src/features/terminal/hooks/usePaneShortcuts.ts
@@ -105,6 +105,19 @@ export const usePaneShortcuts = ({
           return
         }
 
+        if (isTerminalContainerActiveRef.current === false) {
+          return
+        }
+
+        const activeElement = document.activeElement
+        if (
+          activeElement?.closest(
+            'input, textarea, select, [contenteditable=""], [contenteditable="true"], .xterm-helper-textarea'
+          )
+        ) {
+          return
+        }
+
         if (activeSession.layout === SINGLE_PANE_FOCUS_LAYOUT_ID) {
           const previousLayoutId =
             lastSingleToggleLayoutRef.current?.sessionId === activeSession.id

--- a/src/features/terminal/layout-registry/index.ts
+++ b/src/features/terminal/layout-registry/index.ts
@@ -4,8 +4,11 @@ export {
   LAYOUTS,
   MAX_BUILTIN_PANE_COUNT,
   PaneLayoutRegistry,
+  SINGLE_PANE_FOCUS_LABEL,
+  SINGLE_PANE_FOCUS_LAYOUT_ID,
   VISIBLE_LAYOUTS,
   autoShrinkLayoutFor,
+  canSelectLayoutOverCapacity,
   isKnownLayoutId,
   type RuntimePaneLayoutRegistrySnapshot,
 } from './layoutRegistry'

--- a/src/features/terminal/layout-registry/layoutRegistry.ts
+++ b/src/features/terminal/layout-registry/layoutRegistry.ts
@@ -19,6 +19,13 @@ export { LAYOUTS }
 
 export const LAYOUT_CYCLE: readonly LayoutId[] = LAYOUT_IDS
 
+export const SINGLE_PANE_FOCUS_LAYOUT_ID = 'single' satisfies LayoutId
+
+export const SINGLE_PANE_FOCUS_LABEL = 'Focus active pane'
+
+export const canSelectLayoutOverCapacity = (layoutId: PaneLayoutId): boolean =>
+  layoutId === SINGLE_PANE_FOCUS_LAYOUT_ID
+
 export interface RuntimePaneLayoutRegistrySnapshot {
   readonly layouts: readonly LayoutShape[]
   readonly rejected: readonly RejectedPaneLayoutDefinition[]

--- a/src/features/workspace/WorkspaceView.top-chrome.test.tsx
+++ b/src/features/workspace/WorkspaceView.top-chrome.test.tsx
@@ -16,6 +16,8 @@ import type { Session, SessionStatus, PaneLayoutId } from '../sessions/types'
 import {
   BUILTIN_PANE_LAYOUT_REGISTRY,
   PaneLayoutRegistry,
+  SINGLE_PANE_FOCUS_LABEL,
+  SINGLE_PANE_FOCUS_LAYOUT_ID,
   type PaneLayoutDefinition,
 } from '../terminal/layout-registry'
 import {
@@ -834,8 +836,10 @@ describe('WorkspaceView – top chrome (main-stage handoff J2–J6)', () => {
   })
 
   test('an over-capacity checked layout renders as a disabled pill instead of vanishing', async () => {
+    const user = userEvent.setup()
+
     const baseSession = createMockSession('session-1', 'auth refactor', {
-      layout: 'single',
+      layout: 'grid3x2',
     })
 
     // Five panes exceed Quad's capacity (4) but fit 3x2 grid (6): Quad is
@@ -855,7 +859,7 @@ describe('WorkspaceView – top chrome (main-stage handoff J2–J6)', () => {
     await setupSessionManager([fivePaneSession], 'session-1')
     window.localStorage.setItem(
       SHOWN_LAYOUTS_STORAGE_KEY,
-      JSON.stringify(['single', 'quad', 'grid3x2'])
+      JSON.stringify([SINGLE_PANE_FOCUS_LAYOUT_ID, 'quad', 'grid3x2'])
     )
     render(<WorkspaceView />)
 
@@ -868,10 +872,21 @@ describe('WorkspaceView – top chrome (main-stage handoff J2–J6)', () => {
     })
     expect(quad).toHaveAttribute('aria-disabled', 'true')
 
+    const single = within(switcher).getByRole('button', {
+      name: SINGLE_PANE_FOCUS_LABEL,
+    })
+    expect(single).not.toHaveAttribute('aria-disabled', 'true')
+
     // A layout that DOES fit the pane count stays enabled.
     expect(
       within(switcher).getByRole('button', { name: '3x2 grid' })
     ).not.toHaveAttribute('aria-disabled', 'true')
+
+    await user.click(single)
+    expect(mockSessionManager.setSessionLayout).toHaveBeenCalledWith(
+      'session-1',
+      SINGLE_PANE_FOCUS_LAYOUT_ID
+    )
   })
 
   test('the layout display menu can hide a non-active layout pill from the pillar', async () => {

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -96,6 +96,7 @@ import { findActivePane } from '../sessions/utils/activeSessionPane'
 import { isShellPane } from '../sessions/utils/paneKind'
 import { selectVisiblePanes } from '../terminal/components/SplitView'
 import {
+  canSelectLayoutOverCapacity,
   getPaneLayoutCapacity,
   type PaneLayoutDefinition,
 } from '../terminal/layout-registry'
@@ -538,7 +539,7 @@ const WorkspaceViewContent = (): ReactElement => {
 
     return layoutRegistry.layouts
       .filter((layout) => {
-        if (layout.id === 'single') {
+        if (canSelectLayoutOverCapacity(layout.id)) {
           return true
         }
 
@@ -558,6 +559,7 @@ const WorkspaceViewContent = (): ReactElement => {
         : layoutRegistry.layouts
             .filter(
               (layout) =>
+                !canSelectLayoutOverCapacity(layout.id) &&
                 layout.id !== activeSession.layout &&
                 activeSession.panes.length > layout.capacity
             )
@@ -1312,7 +1314,10 @@ const WorkspaceViewContent = (): ReactElement => {
         return false
       }
 
-      if (activeSession.panes.length > layoutRegistry.capacityFor(layoutId)) {
+      if (
+        !canSelectLayoutOverCapacity(layoutId) &&
+        activeSession.panes.length > layoutRegistry.capacityFor(layoutId)
+      ) {
         return false
       }
 

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -2741,6 +2741,7 @@ const WorkspaceViewContent = (): ReactElement => {
               layouts={layoutRegistry.layouts}
               blockedLayoutIds={blockedLayoutIds}
               onPick={handlePickLayout}
+              labelSingleAsFocusAction
               trailing={
                 <LayoutDisplayMenu
                   activeLayoutId={activeSession.layout}

--- a/src/features/workspace/commands/buildWorkspaceCommands.test.ts
+++ b/src/features/workspace/commands/buildWorkspaceCommands.test.ts
@@ -8,6 +8,10 @@ import {
 import type { Command } from '../../command-palette/registry/types'
 import { fuzzyMatch } from '../../command-palette/registry/fuzzyMatch'
 import { isMacPlatform } from '../../command-palette/shortcutConfig'
+import {
+  SINGLE_PANE_FOCUS_LABEL,
+  SINGLE_PANE_FOCUS_LAYOUT_ID,
+} from '../../terminal/layout-registry'
 import { themeService } from '../../../theme'
 
 vi.mock('../../command-palette/shortcutConfig', async (importActual) => {
@@ -1631,7 +1635,7 @@ describe('buildWorkspaceCommands - layout and dock-position namespaces', () => {
       ...baseDeps(),
       pickLayout,
       availableLayouts: [
-        { id: 'single', title: 'Single' },
+        { id: SINGLE_PANE_FOCUS_LAYOUT_ID, title: 'Single' },
         { id: 'vsplit', title: 'Vertical Split' },
       ],
     })
@@ -1639,7 +1643,7 @@ describe('buildWorkspaceCommands - layout and dock-position namespaces', () => {
     const layout = commands.find((c) => c.id === 'layout')
     expect(layout?.label).toBe(':layout')
     expect(layout?.children?.map((c) => c.label)).toEqual([
-      'Single',
+      SINGLE_PANE_FOCUS_LABEL,
       'Vertical Split',
     ])
 
@@ -1655,15 +1659,45 @@ describe('buildWorkspaceCommands - layout and dock-position namespaces', () => {
       ...baseDeps(),
       notifyInfo,
       pickLayout,
-      availableLayouts: [{ id: 'single', title: 'Single' }],
+      availableLayouts: [{ id: SINGLE_PANE_FOCUS_LAYOUT_ID, title: 'Single' }],
     })
+
+    const singleLayoutCommandId = `layout-${SINGLE_PANE_FOCUS_LAYOUT_ID}`
 
     commands
       .find((c) => c.id === 'layout')
-      ?.children?.find((c) => c.id === 'layout-single')
+      ?.children?.find((c) => c.id === singleLayoutCommandId)
       ?.execute?.('')
 
     expect(notifyInfo).toHaveBeenCalledWith("Layout 'Single' needs fewer panes")
+  })
+
+  test(':layout single child advertises the active-pane focus shortcut', () => {
+    vi.mocked(isMacPlatform).mockReturnValue(false)
+
+    const commands = buildWorkspaceCommands({
+      ...baseDeps(),
+      pickLayout: vi.fn(() => true),
+      availableLayouts: [
+        { id: SINGLE_PANE_FOCUS_LAYOUT_ID, title: 'Single' },
+        { id: 'vsplit', title: 'Vertical Split' },
+      ],
+    })
+
+    const layout = commands.find((c) => c.id === 'layout')
+    const singleLayoutCommandId = `layout-${SINGLE_PANE_FOCUS_LAYOUT_ID}`
+
+    expect(
+      layout?.children?.find((c) => c.id === singleLayoutCommandId)?.shortcut
+    ).toEqual(['Ctrl', 'Z'])
+
+    expect(
+      layout?.children?.find((c) => c.id === singleLayoutCommandId)?.description
+    ).toBe('Toggle active-pane focus')
+
+    expect(
+      layout?.children?.find((c) => c.id === 'layout-vsplit')?.shortcut
+    ).toBeUndefined()
   })
 
   test(':dock-position children move the dock and mark the current edge', () => {

--- a/src/features/workspace/commands/buildWorkspaceCommands.ts
+++ b/src/features/workspace/commands/buildWorkspaceCommands.ts
@@ -4,6 +4,10 @@ import { isExpectedLocalOnlyRenameFailure } from '../../sessions/utils/agentRena
 import type { Command } from '../../command-palette/registry/types'
 import { fuzzyMatch } from '../../command-palette/registry/fuzzyMatch'
 import { isMacPlatform } from '../../command-palette/shortcutConfig'
+import {
+  SINGLE_PANE_FOCUS_LABEL,
+  SINGLE_PANE_FOCUS_LAYOUT_ID,
+} from '../../terminal/layout-registry'
 import { themeService } from '../../../theme'
 
 export type DockPositionCommandArg = 'bottom' | 'top' | 'left' | 'right'
@@ -283,9 +287,21 @@ export const buildWorkspaceCommands = (
           icon: 'grid_view',
           children: availableLayouts.map((layout) => ({
             id: `layout-${layout.id}`,
-            label: layout.title,
-            description: `Switch to the ${layout.title} layout`,
+            label:
+              layout.id === SINGLE_PANE_FOCUS_LAYOUT_ID
+                ? SINGLE_PANE_FOCUS_LABEL
+                : layout.title,
+            description:
+              layout.id === SINGLE_PANE_FOCUS_LAYOUT_ID
+                ? 'Toggle active-pane focus'
+                : `Switch to the ${layout.title} layout`,
             icon: 'grid_view',
+            shortcut:
+              layout.id === SINGLE_PANE_FOCUS_LAYOUT_ID
+                ? isMac
+                  ? ['⌘', 'Z']
+                  : ['Ctrl', 'Z']
+                : undefined,
             execute: (): void => {
               // `false` means the active session has more panes than this layout holds.
               if (pickLayout(layout.id) === false) {


### PR DESCRIPTION
## Summary
- add `Mod+Z` active-pane focus toggle that restores the previous layout on second press
- keep the focus layout selectable over capacity and label it as “Focus active pane”
- surface the shortcut in the layout pill tooltip and command palette
- track the broader layout-registry cleanup as Linear issue VIM-254

## Validation
- `npm test -- --run src/features/terminal/hooks/usePaneShortcuts.test.ts src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.test.tsx src/features/workspace/WorkspaceView.top-chrome.test.tsx src/features/workspace/commands/buildWorkspaceCommands.test.ts`
- `npx eslint src/features/terminal/hooks/usePaneShortcuts.ts src/features/terminal/hooks/usePaneShortcuts.test.ts src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.tsx src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.test.tsx src/features/workspace/WorkspaceView.tsx src/features/workspace/WorkspaceView.top-chrome.test.tsx src/features/workspace/commands/buildWorkspaceCommands.ts src/features/workspace/commands/buildWorkspaceCommands.test.ts src/features/terminal/layout-registry/index.ts src/features/terminal/layout-registry/layoutRegistry.ts --max-warnings=0`
- `npm run type-check`
- `npx prettier --check docs/design/UNIFIED.md src/features/terminal/hooks/usePaneShortcuts.ts src/features/terminal/hooks/usePaneShortcuts.test.ts src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.tsx src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.test.tsx src/features/workspace/WorkspaceView.tsx src/features/workspace/WorkspaceView.top-chrome.test.tsx src/features/workspace/commands/buildWorkspaceCommands.ts src/features/workspace/commands/buildWorkspaceCommands.test.ts src/features/terminal/layout-registry/index.ts src/features/terminal/layout-registry/layoutRegistry.ts`
- `git diff --check`

Note: the workspace top-chrome test run still prints existing React `act(...)` warnings.
