### PR TITLE
feat(diff): add split-side keyboard toggles

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -59,7 +59,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 86       | 40   | 2026-06-29   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 5        | 3    | 2026-06-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 93       | 90   | 2026-06-25   |
-| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 84       | 82   | 2026-06-29   |
+| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 85       | 83   | 2026-06-29   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 71       | 70   | 2026-06-26   |
 | [Canonical Path Dedupe](patterns/canonical-path-dedupe.md)                                           | correctness        | 2        | 0    | 2026-06-14   |
@@ -81,7 +81,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 24       | 10   | 2026-06-19   |
 | [Module Boundaries](patterns/module-boundaries.md)                                                   | code-quality       | 17       | 3    | 2026-06-25   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 13       | 3    | 2026-06-15   |
-| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 27       | 5    | 2026-06-28   |
+| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 28       | 6    | 2026-06-29   |
 | [Verify Render Target](patterns/verify-render-target.md)                                             | code-quality       | 2        | 0    | 2026-05-24   |
 | [UI Visual Regression](patterns/ui-visual-regression.md)                                             | code-quality       | 15       | 9    | 2026-06-20   |
 | [Status Indicator Display](patterns/status-indicator-display.md)                                     | code-quality       | 3        | 0    | 2026-05-26   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -59,7 +59,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 86       | 40   | 2026-06-29   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 5        | 3    | 2026-06-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 93       | 90   | 2026-06-25   |
-| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 85       | 83   | 2026-06-29   |
+| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 86       | 84   | 2026-06-29   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 71       | 70   | 2026-06-26   |
 | [Canonical Path Dedupe](patterns/canonical-path-dedupe.md)                                           | correctness        | 2        | 0    | 2026-06-14   |
@@ -109,6 +109,6 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Vite HMR Static Dependencies](patterns/vite-hmr-static-deps.md)                                     | code-quality       | 3        | 2    | 2026-06-18   |
 | [Custom Pane Layout Preservation](patterns/custom-pane-layout-preservation.md)                       | correctness        | 13       | 5    | 2026-06-22   |
 | [Pane Slot Identity](patterns/pane-slot-identity.md)                                                 | correctness        | 3        | 1    | 2026-06-22   |
-| [Transient UI Side Effects](patterns/transient-ui-side-effects.md)                                   | react-patterns     | 9        | 4    | 2026-06-29   |
+| [Transient UI Side Effects](patterns/transient-ui-side-effects.md)                                   | react-patterns     | 10       | 5    | 2026-06-29   |
 | [Async Global State Mutation](patterns/async-global-state-mutation.md)                               | backend            | 1        | 0    | 2026-06-19   |
 | [Boolean Sentinel Consistency](patterns/boolean-sentinel-consistency.md)                             | code-quality       | 2        | 1    | 2026-06-22   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -109,6 +109,6 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Vite HMR Static Dependencies](patterns/vite-hmr-static-deps.md)                                     | code-quality       | 3        | 2    | 2026-06-18   |
 | [Custom Pane Layout Preservation](patterns/custom-pane-layout-preservation.md)                       | correctness        | 13       | 5    | 2026-06-22   |
 | [Pane Slot Identity](patterns/pane-slot-identity.md)                                                 | correctness        | 3        | 1    | 2026-06-22   |
-| [Transient UI Side Effects](patterns/transient-ui-side-effects.md)                                   | react-patterns     | 8        | 4    | 2026-06-26   |
+| [Transient UI Side Effects](patterns/transient-ui-side-effects.md)                                   | react-patterns     | 9        | 4    | 2026-06-29   |
 | [Async Global State Mutation](patterns/async-global-state-mutation.md)                               | backend            | 1        | 0    | 2026-06-19   |
 | [Boolean Sentinel Consistency](patterns/boolean-sentinel-consistency.md)                             | code-quality       | 2        | 1    | 2026-06-22   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -56,10 +56,10 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 8        | 2    | 2026-06-19   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 4        | 0    | 2026-06-21   |
-| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 85       | 39   | 2026-06-27   |
+| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 86       | 40   | 2026-06-29   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 5        | 3    | 2026-06-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 93       | 90   | 2026-06-25   |
-| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 82       | 81   | 2026-06-28   |
+| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 84       | 82   | 2026-06-29   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 71       | 70   | 2026-06-26   |
 | [Canonical Path Dedupe](patterns/canonical-path-dedupe.md)                                           | correctness        | 2        | 0    | 2026-06-14   |

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -3,7 +3,7 @@ id: accessibility
 category: a11y
 created: 2026-04-09
 last_updated: 2026-06-29
-ref_count: 83
+ref_count: 84
 ---
 
 # Accessibility
@@ -790,3 +790,18 @@ handlers must not trap focus without implementing the promised behavior.
 - **Finding:** The hunk/file keyboard-confirm popover passed `className="focus-visible:ring-0"` to both `Button` actions, overriding the shared primitive's only visible keyboard focus indicator.
 - **Fix:** Removed the local ring suppression so the shared `Button` focus styles apply, and added co-located regression assertions for the `No (n)` and `Yes (y)` actions.
 - **Commit:** same commit as this entry
+
+### 78. Primary finish-feedback actions relied on brightness-only focus
+
+- **Source:** github-claude | PR #633 round 3 | 2026-06-29
+- **Severity:** MEDIUM
+- **File:** `src/features/diff/components/FinishFeedbackPopover.tsx`
+- **Finding:** Finish-feedback Confirm and multi-agent Send buttons suppressed
+  outlines and rings while using only `focus-visible:brightness-110` as the
+  keyboard focus cue. The saturated primary fill made that cue too weak for
+  keyboard-only and low-vision users, especially in the multi-agent list where
+  Tab is the selection path.
+- **Fix:** Replaced the brightness-only primary focus class with a visible
+  token-backed focus ring and updated co-located tests to reject the old
+  brightness/ring-0 treatment.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -2,8 +2,8 @@
 id: accessibility
 category: a11y
 created: 2026-04-09
-last_updated: 2026-06-28
-ref_count: 81
+last_updated: 2026-06-29
+ref_count: 82
 ---
 
 # Accessibility
@@ -762,4 +762,22 @@ handlers must not trap focus without implementing the promised behavior.
 - **File:** `src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.tsx`
 - **Finding:** `LayoutSwitcher` reused the “Focus active pane” accessible name and tooltip for every `single` layout option, including the New Session dialog where the control selects a “Single” template rather than focusing an active pane.
 - **Fix:** Made the focus-action label and shortcut chip opt-in via `labelSingleAsFocusAction`, enabled it only in workspace chrome, and kept generic pickers on the plain “Single” label.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 75. Popover action buttons suppressed keyboard focus indication
+
+- **Source:** github-codex-connector | PR #633 round 1 | 2026-06-29
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/diff/components/FinishFeedbackPopover.tsx`
+- **Finding:** Finish-feedback Cancel and Confirm buttons removed the browser focus ring with `focus:outline-none focus-visible:outline-none` without replacing it, so keyboard users could not tell which action was focused before activating it.
+- **Fix:** Added the shared button focus-ring treatment (`focus-visible:ring-1 focus-visible:ring-primary`) to the popover action class and updated co-located tests to assert the visible focus styles.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 76. Multi-agent send choices had no visible Tab focus
+
+- **Source:** github-claude | PR #633 round 1 | 2026-06-29
+- **Severity:** MEDIUM
+- **File:** `src/features/diff/components/FinishFeedbackPopover.tsx`
+- **Finding:** The multi-agent finish-feedback branch suppressed `focus-visible` outlines on each Send button even though those choices have no shortcut fallback, making Tab navigation through the agent list ambiguous.
+- **Fix:** Routed the Send buttons through the same explicit popover action focus class and added a regression assertion that multi-agent Send buttons include the visible focus ring.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -3,7 +3,7 @@ id: accessibility
 category: a11y
 created: 2026-04-09
 last_updated: 2026-06-29
-ref_count: 82
+ref_count: 83
 ---
 
 # Accessibility
@@ -781,3 +781,12 @@ handlers must not trap focus without implementing the promised behavior.
 - **Finding:** The multi-agent finish-feedback branch suppressed `focus-visible` outlines on each Send button even though those choices have no shortcut fallback, making Tab navigation through the agent list ambiguous.
 - **Fix:** Routed the Send buttons through the same explicit popover action focus class and added a regression assertion that multi-agent Send buttons include the visible focus ring.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 77. Confirm popover buttons suppressed the shared focus ring
+
+- **Source:** github-codex-connector + github-claude | PR #633 round 2 | 2026-06-29
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/diff/components/DiffPanelContent.tsx`
+- **Finding:** The hunk/file keyboard-confirm popover passed `className="focus-visible:ring-0"` to both `Button` actions, overriding the shared primitive's only visible keyboard focus indicator.
+- **Fix:** Removed the local ring suppression so the shared `Button` focus styles apply, and added co-located regression assertions for the `No (n)` and `Yes (y)` actions.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/keyboard-shortcut-guards.md
+++ b/docs/reviews/patterns/keyboard-shortcut-guards.md
@@ -2,8 +2,8 @@
 id: keyboard-shortcut-guards
 category: keyboard-shortcuts
 created: 2026-05-18
-last_updated: 2026-06-28
-ref_count: 5
+last_updated: 2026-06-29
+ref_count: 6
 ---
 
 # Keyboard Shortcut Guards
@@ -363,3 +363,12 @@ against three classes of false-fire:
   before applying the next layout. Added regression coverage for the cycle-away-then-single
   path so `Mod+Z` returns to the single-layout no-op behavior.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 28. Unified diff navigation reused split-row skipping
+
+- **Source:** github-codex-connector | PR #633 round 2 | 2026-06-29
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/diff/components/DiffPanelContent.tsx`
+- **Finding:** The `j`/`k` line shortcuts always skipped sibling targets with the same split-row index, even when the active renderer was unified and `h`/`l` side navigation was disabled.
+- **Fix:** Kept same-row skipping and same-side preservation only for split mode; unified mode now steps target-by-target and uses per-line scroll indexing. Added a regression that reaches the added side of a replacement hunk in unified view.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -2,8 +2,8 @@
 id: testing-gaps
 category: testing
 created: 2026-04-09
-last_updated: 2026-06-27
-ref_count: 39
+last_updated: 2026-06-29
+ref_count: 40
 ---
 
 # Testing Gaps
@@ -835,3 +835,12 @@ filesystem scope restrictions).
 - **Finding:** The new-session button path had coverage that a click appended a session, but no replacement assertion for the removed `onCreated` callback contract that terminal focus is claimed after creating the session. A future regression could call `createSession` without returning focus to the terminal.
 - **Fix:** Extended the switcher-row New session integration test to assert that the terminal zone receives focus after the button creates the new session, pinning the composed create-and-claim behavior.
 - **Commit:** same commit as this entry
+
+### 86. Split-side toggle test used selectors shared by both CSS branches
+
+- **Source:** github-claude | PR #633 round 1 | 2026-06-29
+- **Severity:** LOW
+- **File:** `src/features/diff/components/DiffPanelContent.test.tsx`
+- **Finding:** The `h` and `l` split-side toggle assertions checked selectors and `display: none` strings that appear in both hide-origin and hide-new CSS blocks, so swapping the two constants would still pass.
+- **Fix:** Added unique border-adjustment assertions for each branch: `border-left: 0` after hiding origin and `border-right: 0` after hiding the new side.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/transient-ui-side-effects.md
+++ b/docs/reviews/patterns/transient-ui-side-effects.md
@@ -3,7 +3,7 @@ id: transient-ui-side-effects
 category: react-patterns
 created: 2026-06-20
 last_updated: 2026-06-29
-ref_count: 4
+ref_count: 5
 ---
 
 # Transient UI Side Effects
@@ -137,4 +137,19 @@ to persistent state through a separate, explicit path.
 - **Fix:** Added an early return when resolved keyboard navigation is a no-op,
   before focus and scroll side effects run. Added a regression test covering a
   single-row split replacement from the deletion side.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 10. Split side navigation reused vertical scroll positioning
+
+- **Source:** github-claude | PR #633 round 3 | 2026-06-29
+- **Severity:** MEDIUM
+- **File:** `src/features/diff/components/DiffPanelContent.tsx`
+- **Finding:** Split-mode `h`/`l` side navigation passed `delta=0` through
+  scroll positioning written for `j`/`k`. The helper treated non-positive
+  deltas as upward navigation, so lateral moves on the only, first, or last
+  visual row could snap the viewport even though the user did not move
+  vertically.
+- **Fix:** Added an explicit `delta === 0` path that uses nearest-block
+  scrolling and sticky-header reveal without previous-row reservation. Added a
+  regression assertion for lateral movement on a single split replacement row.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/transient-ui-side-effects.md
+++ b/docs/reviews/patterns/transient-ui-side-effects.md
@@ -2,7 +2,7 @@
 id: transient-ui-side-effects
 category: react-patterns
 created: 2026-06-20
-last_updated: 2026-06-26
+last_updated: 2026-06-29
 ref_count: 4
 ---
 
@@ -123,4 +123,18 @@ to persistent state through a separate, explicit path.
   suppresses the status bar and threaded it through `Header` to `HeaderActions`.
   Added regression coverage for the awaiting-restart pane and header forwarding
   behavior.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 9. Split diff row navigation scrolled on no-op movement
+
+- **Source:** github-codex-connector | PR #633 round 1 | 2026-06-29
+- **Severity:** MEDIUM
+- **File:** `src/features/diff/components/DiffPanelContent.tsx`
+- **Finding:** Split-mode `j` navigation skipped paired deletion/addition
+  targets by row, but a single-row replacement diff could resolve the next
+  target back to the current deletion target. The selection did not move, yet
+  the scroll side effect still ran with a downward movement delta.
+- **Fix:** Added an early return when resolved keyboard navigation is a no-op,
+  before focus and scroll side effects run. Added a regression test covering a
+  single-row split replacement from the deletion side.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/src/features/diff/components/DiffPanelContent.test.tsx
+++ b/src/features/diff/components/DiffPanelContent.test.tsx
@@ -2919,6 +2919,7 @@ describe('DiffPanelContent', () => {
       fireEvent.keyDown(diff, { key: 'h' })
       expect(diff.getAttribute('data-unsafe-css')).toContain('[data-deletions]')
       expect(diff.getAttribute('data-unsafe-css')).toContain('display: none')
+      expect(diff.getAttribute('data-unsafe-css')).toContain('border-left: 0')
 
       fireEvent.keyDown(diff, { key: 'h' })
       expect(diff).not.toHaveAttribute('data-unsafe-css')
@@ -2926,6 +2927,7 @@ describe('DiffPanelContent', () => {
       fireEvent.keyDown(diff, { key: 'l' })
       expect(diff.getAttribute('data-unsafe-css')).toContain('[data-additions]')
       expect(diff.getAttribute('data-unsafe-css')).toContain('display: none')
+      expect(diff.getAttribute('data-unsafe-css')).toContain('border-right: 0')
     })
 
     test('preserves comment draft text across a same-file diff refresh remount', async (): Promise<void> => {

--- a/src/features/diff/components/DiffPanelContent.test.tsx
+++ b/src/features/diff/components/DiffPanelContent.test.tsx
@@ -2723,6 +2723,77 @@ describe('DiffPanelContent', () => {
       expect(scrollBody.scrollTop).toBe(68)
     })
 
+    test('j does not scroll when split replacement navigation cannot leave the current row', (): void => {
+      const changedFileDiff: FileDiff = {
+        filePath: 'src/foo.ts',
+        oldPath: 'src/foo.ts',
+        newPath: 'src/foo.ts',
+        hunks: [
+          {
+            id: 'hunk-0',
+            header: '@@ -1 +1 @@',
+            oldStart: 1,
+            oldLines: 1,
+            newStart: 1,
+            newLines: 1,
+            lines: [
+              { type: 'removed', oldLineNumber: 1, content: 'old beta' },
+              { type: 'added', newLineNumber: 1, content: 'new beta' },
+            ],
+          },
+        ],
+      }
+
+      vi.spyOn(useFileDiffModule, 'useFileDiff').mockReturnValue(
+        fileDiffMock({
+          diff: changedFileDiff,
+          loading: false,
+          error: null,
+          oldText: 'old beta\n',
+          newText: 'new beta\n',
+          rawDiff: '',
+        })
+      )
+
+      render(
+        <DiffPanelContent
+          cwd="/repo"
+          selectedFile={{ path: 'src/foo.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+        />
+      )
+
+      setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
+
+      const scrollBody = screen.getByTestId('diff-scroll-body')
+      const host = document.createElement('diffs-container')
+      const shadowRoot = host.attachShadow({ mode: 'open' })
+      const deletions = document.createElement('div')
+      const deletionLine = document.createElement('div')
+      const scrollDeletionIntoView = vi.fn()
+
+      deletions.setAttribute('data-deletions', '')
+      deletionLine.setAttribute('data-line-type', 'change-deletion')
+      deletionLine.setAttribute('data-line', '1')
+      Object.defineProperty(deletionLine, 'scrollIntoView', {
+        configurable: true,
+        value: scrollDeletionIntoView,
+      })
+      deletions.append(deletionLine)
+      shadowRoot.append(deletions)
+      scrollBody.append(host)
+
+      const diff = screen.getByTestId('multi-file-diff')
+      fireEvent.keyDown(diff, { key: 'h' })
+      scrollDeletionIntoView.mockClear()
+
+      fireEvent.keyDown(diff, { key: 'j' })
+
+      expect(diff).toHaveAttribute('data-selected-lines-start', '1')
+      expect(diff).toHaveAttribute('data-selected-lines-side', 'deletions')
+      expect(scrollDeletionIntoView).not.toHaveBeenCalled()
+    })
+
     test('i opens the inline comment editor on the keyboard-selected line', (): void => {
       render(
         <DiffPanelContent

--- a/src/features/diff/components/DiffPanelContent.test.tsx
+++ b/src/features/diff/components/DiffPanelContent.test.tsx
@@ -83,7 +83,6 @@ vi.mock('@pierre/diffs/react', () => ({
       diffStyle?: string
       theme?: string
       lineDiffType?: string
-      unsafeCSS?: string
       enableGutterUtility?: boolean
     }
     selectedLines?: {
@@ -124,7 +123,6 @@ vi.mock('@pierre/diffs/react', () => ({
       data-diff-style={options.diffStyle}
       data-theme={options.theme}
       data-line-diff-type={options.lineDiffType}
-      data-unsafe-css={options.unsafeCSS}
       data-selected-lines-start={
         selectedLines != null ? String(selectedLines.start) : undefined
       }
@@ -2647,15 +2645,45 @@ describe('DiffPanelContent', () => {
       const shadowRoot = host.attachShadow({ mode: 'open' })
       const additions = document.createElement('div')
       additions.setAttribute('data-additions', '')
+      const stickyHeader = document.createElement('div')
+      stickyHeader.setAttribute('data-diffs-header', 'default')
+      stickyHeader.setAttribute('data-sticky', '')
       const firstLine = document.createElement('div')
       const secondLine = document.createElement('div')
       const scrollFirstIntoView = vi.fn()
       const scrollSecondIntoView = vi.fn()
 
+      const rect = (top: number, bottom: number): DOMRect => ({
+        bottom,
+        height: bottom - top,
+        left: 0,
+        right: 0,
+        top,
+        width: 0,
+        x: 0,
+        y: top,
+        toJSON: () => ({}),
+      })
+
       firstLine.setAttribute('data-line-type', 'context')
       firstLine.setAttribute('data-line', '1')
       secondLine.setAttribute('data-line-type', 'context')
       secondLine.setAttribute('data-line', '2')
+      Object.defineProperty(scrollBody, 'getBoundingClientRect', {
+        configurable: true,
+        value: () => rect(0, 400),
+      })
+
+      Object.defineProperty(stickyHeader, 'getBoundingClientRect', {
+        configurable: true,
+        value: () => rect(0, 28),
+      })
+
+      Object.defineProperty(firstLine, 'getBoundingClientRect', {
+        configurable: true,
+        value: () => rect(20, 40),
+      })
+
       Object.defineProperty(firstLine, 'scrollIntoView', {
         configurable: true,
         value: scrollFirstIntoView,
@@ -2666,7 +2694,7 @@ describe('DiffPanelContent', () => {
         value: scrollSecondIntoView,
       })
       additions.append(firstLine, secondLine)
-      shadowRoot.append(additions)
+      shadowRoot.append(stickyHeader, additions)
       scrollBody.append(host)
 
       const diff = screen.getByTestId('multi-file-diff')
@@ -2677,11 +2705,14 @@ describe('DiffPanelContent', () => {
         inline: 'nearest',
       })
 
+      scrollBody.scrollTop = 100
+
       fireEvent.keyDown(diff, { key: 'k' })
       expect(scrollFirstIntoView).toHaveBeenCalledWith({
         block: 'start',
         inline: 'nearest',
       })
+      expect(scrollBody.scrollTop).toBe(68)
     })
 
     test('i opens the inline comment editor on the keyboard-selected line', (): void => {
@@ -2902,7 +2933,44 @@ describe('DiffPanelContent', () => {
       expect(diff).toHaveAttribute('data-diff-style', 'unified')
     })
 
-    test('h and l toggle split origin and new sections', (): void => {
+    test('j/k move rows and h/l move the keyboard-selected comment target between split sides', (): void => {
+      const changedFileDiff: FileDiff = {
+        filePath: 'src/foo.ts',
+        oldPath: 'src/foo.ts',
+        newPath: 'src/foo.ts',
+        hunks: [
+          {
+            id: 'hunk-0',
+            header: '@@ -1,2 +1,2 @@',
+            oldStart: 1,
+            oldLines: 2,
+            newStart: 1,
+            newLines: 2,
+            lines: [
+              { type: 'removed', oldLineNumber: 1, content: 'old beta' },
+              { type: 'added', newLineNumber: 1, content: 'new beta' },
+              {
+                type: 'context',
+                oldLineNumber: 2,
+                newLineNumber: 2,
+                content: 'tail',
+              },
+            ],
+          },
+        ],
+      }
+
+      vi.spyOn(useFileDiffModule, 'useFileDiff').mockReturnValue(
+        fileDiffMock({
+          diff: changedFileDiff,
+          loading: false,
+          error: null,
+          oldText: 'old beta\ntail\n',
+          newText: 'new beta\ntail\n',
+          rawDiff: '',
+        })
+      )
+
       render(
         <DiffPanelContent
           cwd="/repo"
@@ -2914,20 +2982,31 @@ describe('DiffPanelContent', () => {
       setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
 
       const diff = screen.getByTestId('multi-file-diff')
-      expect(diff).not.toHaveAttribute('data-unsafe-css')
+
+      fireEvent.keyDown(diff, { key: 'j' })
+      expect(diff).toHaveAttribute('data-selected-lines-start', '2')
+      expect(diff).toHaveAttribute('data-selected-lines-side', 'additions')
+
+      fireEvent.keyDown(diff, { key: 'k' })
+      expect(diff).toHaveAttribute('data-selected-lines-start', '1')
+      expect(diff).toHaveAttribute('data-selected-lines-side', 'additions')
 
       fireEvent.keyDown(diff, { key: 'h' })
-      expect(diff.getAttribute('data-unsafe-css')).toContain('[data-deletions]')
-      expect(diff.getAttribute('data-unsafe-css')).toContain('display: none')
-      expect(diff.getAttribute('data-unsafe-css')).toContain('border-left: 0')
-
-      fireEvent.keyDown(diff, { key: 'h' })
-      expect(diff).not.toHaveAttribute('data-unsafe-css')
+      expect(diff).toHaveAttribute('data-selected-lines-start', '1')
+      expect(diff).toHaveAttribute('data-selected-lines-side', 'deletions')
 
       fireEvent.keyDown(diff, { key: 'l' })
-      expect(diff.getAttribute('data-unsafe-css')).toContain('[data-additions]')
-      expect(diff.getAttribute('data-unsafe-css')).toContain('display: none')
-      expect(diff.getAttribute('data-unsafe-css')).toContain('border-right: 0')
+      expect(diff).toHaveAttribute('data-selected-lines-start', '1')
+      expect(diff).toHaveAttribute('data-selected-lines-side', 'additions')
+
+      fireEvent.keyDown(diff, { key: 'h' })
+      expect(diff).toHaveAttribute('data-selected-lines-start', '1')
+      expect(diff).toHaveAttribute('data-selected-lines-side', 'deletions')
+
+      fireEvent.keyDown(diff, { key: 'i' })
+      expect(
+        screen.getByRole('dialog', { name: /Comment on line L1/ })
+      ).toBeInTheDocument()
     })
 
     test('preserves comment draft text across a same-file diff refresh remount', async (): Promise<void> => {

--- a/src/features/diff/components/DiffPanelContent.test.tsx
+++ b/src/features/diff/components/DiffPanelContent.test.tsx
@@ -1604,8 +1604,16 @@ describe('DiffPanelContent', () => {
         name: 'Stage hunk?',
       })
       expect(stageFile).not.toHaveBeenCalled()
+      const noButton = within(confirm).getByRole('button', { name: 'No (n)' })
+      const yesButton = within(confirm).getByRole('button', { name: 'Yes (y)' })
+      expect(noButton).toHaveClass('focus-visible:ring-1')
+      expect(noButton).toHaveClass('focus-visible:ring-primary')
+      expect(noButton).not.toHaveClass('focus-visible:ring-0')
+      expect(yesButton).toHaveClass('focus-visible:ring-1')
+      expect(yesButton).toHaveClass('focus-visible:ring-primary')
+      expect(yesButton).not.toHaveClass('focus-visible:ring-0')
 
-      await user.click(within(confirm).getByRole('button', { name: 'Yes (y)' }))
+      await user.click(yesButton)
 
       await waitFor(() => expect(stageFile).toHaveBeenCalledTimes(1))
     })
@@ -3007,6 +3015,71 @@ describe('DiffPanelContent', () => {
       expect(
         screen.getByRole('dialog', { name: /Comment on line L1/ })
       ).toBeInTheDocument()
+    })
+
+    test('j/k step through both replacement lines in unified view', (): void => {
+      const changedFileDiff: FileDiff = {
+        filePath: 'src/foo.ts',
+        oldPath: 'src/foo.ts',
+        newPath: 'src/foo.ts',
+        hunks: [
+          {
+            id: 'hunk-0',
+            header: '@@ -1,2 +1,2 @@',
+            oldStart: 1,
+            oldLines: 2,
+            newStart: 1,
+            newLines: 2,
+            lines: [
+              { type: 'removed', oldLineNumber: 1, content: 'old beta' },
+              { type: 'added', newLineNumber: 1, content: 'new beta' },
+              {
+                type: 'context',
+                oldLineNumber: 2,
+                newLineNumber: 2,
+                content: 'tail',
+              },
+            ],
+          },
+        ],
+      }
+
+      vi.spyOn(useFileDiffModule, 'useFileDiff').mockReturnValue(
+        fileDiffMock({
+          diff: changedFileDiff,
+          loading: false,
+          error: null,
+          oldText: 'old beta\ntail\n',
+          newText: 'new beta\ntail\n',
+          rawDiff: '',
+        })
+      )
+
+      render(
+        <DiffPanelContent
+          cwd="/repo"
+          selectedFile={{ path: 'src/foo.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+        />
+      )
+
+      setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
+
+      const diff = screen.getByTestId('multi-file-diff')
+      fireEvent.keyDown(diff, { key: 't' })
+      expect(diff).toHaveAttribute('data-diff-style', 'unified')
+
+      fireEvent.keyDown(diff, { key: 'j' })
+      expect(diff).toHaveAttribute('data-selected-lines-start', '1')
+      expect(diff).toHaveAttribute('data-selected-lines-side', 'additions')
+
+      fireEvent.keyDown(diff, { key: 'j' })
+      expect(diff).toHaveAttribute('data-selected-lines-start', '2')
+      expect(diff).toHaveAttribute('data-selected-lines-side', 'additions')
+
+      fireEvent.keyDown(diff, { key: 'k' })
+      expect(diff).toHaveAttribute('data-selected-lines-start', '1')
+      expect(diff).toHaveAttribute('data-selected-lines-side', 'additions')
     })
 
     test('preserves comment draft text across a same-file diff refresh remount', async (): Promise<void> => {

--- a/src/features/diff/components/DiffPanelContent.test.tsx
+++ b/src/features/diff/components/DiffPanelContent.test.tsx
@@ -83,6 +83,7 @@ vi.mock('@pierre/diffs/react', () => ({
       diffStyle?: string
       theme?: string
       lineDiffType?: string
+      unsafeCSS?: string
       enableGutterUtility?: boolean
     }
     selectedLines?: {
@@ -123,6 +124,7 @@ vi.mock('@pierre/diffs/react', () => ({
       data-diff-style={options.diffStyle}
       data-theme={options.theme}
       data-line-diff-type={options.lineDiffType}
+      data-unsafe-css={options.unsafeCSS}
       data-selected-lines-start={
         selectedLines != null ? String(selectedLines.start) : undefined
       }
@@ -2898,6 +2900,32 @@ describe('DiffPanelContent', () => {
       fireEvent.keyDown(diff, { key: 't' })
 
       expect(diff).toHaveAttribute('data-diff-style', 'unified')
+    })
+
+    test('h and l toggle split origin and new sections', (): void => {
+      render(
+        <DiffPanelContent
+          cwd="/repo"
+          selectedFile={{ path: 'src/foo.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+        />
+      )
+
+      setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
+
+      const diff = screen.getByTestId('multi-file-diff')
+      expect(diff).not.toHaveAttribute('data-unsafe-css')
+
+      fireEvent.keyDown(diff, { key: 'h' })
+      expect(diff.getAttribute('data-unsafe-css')).toContain('[data-deletions]')
+      expect(diff.getAttribute('data-unsafe-css')).toContain('display: none')
+
+      fireEvent.keyDown(diff, { key: 'h' })
+      expect(diff).not.toHaveAttribute('data-unsafe-css')
+
+      fireEvent.keyDown(diff, { key: 'l' })
+      expect(diff.getAttribute('data-unsafe-css')).toContain('[data-additions]')
+      expect(diff.getAttribute('data-unsafe-css')).toContain('display: none')
     })
 
     test('preserves comment draft text across a same-file diff refresh remount', async (): Promise<void> => {

--- a/src/features/diff/components/DiffPanelContent.test.tsx
+++ b/src/features/diff/components/DiffPanelContent.test.tsx
@@ -2769,21 +2769,39 @@ describe('DiffPanelContent', () => {
       const host = document.createElement('diffs-container')
       const shadowRoot = host.attachShadow({ mode: 'open' })
       const deletions = document.createElement('div')
+      const additions = document.createElement('div')
       const deletionLine = document.createElement('div')
+      const additionLine = document.createElement('div')
       const scrollDeletionIntoView = vi.fn()
+      const scrollAdditionIntoView = vi.fn()
 
       deletions.setAttribute('data-deletions', '')
+      additions.setAttribute('data-additions', '')
       deletionLine.setAttribute('data-line-type', 'change-deletion')
       deletionLine.setAttribute('data-line', '1')
+      additionLine.setAttribute('data-line-type', 'change-addition')
+      additionLine.setAttribute('data-line', '1')
       Object.defineProperty(deletionLine, 'scrollIntoView', {
         configurable: true,
         value: scrollDeletionIntoView,
       })
+
+      Object.defineProperty(additionLine, 'scrollIntoView', {
+        configurable: true,
+        value: scrollAdditionIntoView,
+      })
       deletions.append(deletionLine)
-      shadowRoot.append(deletions)
+      additions.append(additionLine)
+      shadowRoot.append(deletions, additions)
       scrollBody.append(host)
 
       const diff = screen.getByTestId('multi-file-diff')
+      fireEvent.keyDown(diff, { key: 'l' })
+      expect(scrollAdditionIntoView).toHaveBeenCalledWith({
+        block: 'nearest',
+        inline: 'nearest',
+      })
+
       fireEvent.keyDown(diff, { key: 'h' })
       scrollDeletionIntoView.mockClear()
 

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -1648,12 +1648,16 @@ export const DiffPanelContent = ({
       scrollLineElementIntoView(
         node,
         line,
-        keyboardRowIndexForTarget(keyboardLineTargets, targetIndex),
-        keyboardRowCountForTargets(keyboardLineTargets),
+        effectiveDiffStyle === 'split'
+          ? keyboardRowIndexForTarget(keyboardLineTargets, targetIndex)
+          : targetIndex,
+        effectiveDiffStyle === 'split'
+          ? keyboardRowCountForTargets(keyboardLineTargets)
+          : keyboardLineTargets.length,
         delta
       )
     },
-    [keyboardLineTargets]
+    [effectiveDiffStyle, keyboardLineTargets]
   )
 
   // Hunk jumps reveal the hunk top, then include the end only when it fits.
@@ -1708,25 +1712,32 @@ export const DiffPanelContent = ({
       setKeyboardLineIndex((prev) => {
         const currentIndex = Math.min(prev, keyboardLineTargets.length - 1)
         const currentTarget = keyboardLineTargets[currentIndex]
-        let rowTargetIndex = currentIndex
+        let rowTargetIndex = currentIndex + delta
 
-        while (
-          rowTargetIndex + delta >= 0 &&
-          rowTargetIndex + delta < keyboardLineTargets.length
+        if (
+          rowTargetIndex < 0 ||
+          rowTargetIndex >= keyboardLineTargets.length
         ) {
-          rowTargetIndex += delta
-
-          const rowTarget = keyboardLineTargets[rowTargetIndex]
-          if (
-            rowTarget.hunkIndex !== currentTarget.hunkIndex ||
-            rowTarget.splitRowIndex !== currentTarget.splitRowIndex
-          ) {
-            break
-          }
+          return currentIndex
         }
 
-        if (rowTargetIndex === currentIndex) {
-          return currentIndex
+        if (effectiveDiffStyle === 'split') {
+          rowTargetIndex = currentIndex
+
+          while (
+            rowTargetIndex + delta >= 0 &&
+            rowTargetIndex + delta < keyboardLineTargets.length
+          ) {
+            rowTargetIndex += delta
+
+            const rowTarget = keyboardLineTargets[rowTargetIndex]
+            if (
+              rowTarget.hunkIndex !== currentTarget.hunkIndex ||
+              rowTarget.splitRowIndex !== currentTarget.splitRowIndex
+            ) {
+              break
+            }
+          }
         }
 
         const rowTarget = keyboardLineTargets[rowTargetIndex]
@@ -1738,7 +1749,10 @@ export const DiffPanelContent = ({
             target.side === currentTarget.side
         )
 
-        const next = sameSideIndex === -1 ? rowTargetIndex : sameSideIndex
+        const next =
+          effectiveDiffStyle === 'split' && sameSideIndex !== -1
+            ? sameSideIndex
+            : rowTargetIndex
         const nextTarget = keyboardLineTargets[next]
         setFocusedHunkIndex(nextTarget.hunkIndex)
         scrollKeyboardTargetIntoView(nextTarget, next, delta)
@@ -1749,6 +1763,7 @@ export const DiffPanelContent = ({
     },
     [
       clearNavSelectionTimer,
+      effectiveDiffStyle,
       focusDiffRoot,
       keyboardLineTargets,
       scrollKeyboardTargetIntoView,
@@ -2289,7 +2304,6 @@ export const DiffPanelContent = ({
                   <Button
                     size="sm"
                     variant="ghost"
-                    className="focus-visible:ring-0"
                     aria-keyshortcuts="n"
                     onClick={cancelKeyboardConfirm}
                   >
@@ -2298,7 +2312,6 @@ export const DiffPanelContent = ({
                   <Button
                     size="sm"
                     variant={keyboardConfirm.variant}
-                    className="focus-visible:ring-0"
                     aria-keyshortcuts="y"
                     onClick={confirmKeyboardAction}
                   >

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -66,11 +66,88 @@ type DiffStyle = NonNullable<BaseDiffOptions['diffStyle']>
 type DiffIndicators = NonNullable<BaseDiffOptions['diffIndicators']>
 type Overflow = NonNullable<BaseDiffOptions['overflow']>
 type LineDiffType = NonNullable<BaseDiffOptions['lineDiffType']>
+type HiddenSplitSide = 'origin' | 'new'
 
 const DIFF_NATIVE_FOCUS_SELECTOR =
   'button, input, textarea, select, [contenteditable], [role="textbox"]'
 
 const PIERRE_DIFF_CONTAINER_SELECTOR = 'diffs-container'
+
+const HIDE_ORIGIN_SPLIT_CSS = `
+[data-diff-type="split"][data-overflow="scroll"] {
+  grid-template-columns: 1fr;
+}
+
+[data-diff-type="split"][data-overflow="scroll"] [data-deletions] {
+  display: none;
+}
+
+[data-diff-type="split"][data-overflow="scroll"] [data-additions] {
+  border-left: 0;
+}
+
+[data-diff-type="split"][data-overflow="wrap"] {
+  grid-template-columns: var(--diffs-code-grid);
+}
+
+[data-diff-type="split"][data-overflow="wrap"] [data-deletions] {
+  display: none;
+}
+
+:is([data-diff-type="split"][data-overflow="wrap"] [data-additions]) [data-gutter] {
+  border-left: 0;
+  grid-column: 1;
+}
+
+:is([data-diff-type="split"][data-overflow="wrap"] [data-additions]) [data-content] {
+  grid-column: 2;
+}
+`.trim()
+
+const HIDE_NEW_SPLIT_CSS = `
+[data-diff-type="split"][data-overflow="scroll"] {
+  grid-template-columns: 1fr;
+}
+
+[data-diff-type="split"][data-overflow="scroll"] [data-additions] {
+  display: none;
+}
+
+[data-diff-type="split"][data-overflow="scroll"] [data-deletions] {
+  border-right: 0;
+}
+
+[data-diff-type="split"][data-overflow="wrap"] {
+  grid-template-columns: var(--diffs-code-grid);
+}
+
+[data-diff-type="split"][data-overflow="wrap"] [data-additions] {
+  display: none;
+}
+
+:is([data-diff-type="split"][data-overflow="wrap"] [data-deletions]) [data-content] {
+  border-right: 0;
+}
+`.trim()
+
+const splitSideCSSFor = (
+  hiddenSide: HiddenSplitSide | null,
+  diffStyle: DiffStyle
+): string | undefined => {
+  if (diffStyle !== 'split') {
+    return undefined
+  }
+
+  if (hiddenSide === 'origin') {
+    return HIDE_ORIGIN_SPLIT_CSS
+  }
+
+  if (hiddenSide === 'new') {
+    return HIDE_NEW_SPLIT_CSS
+  }
+
+  return undefined
+}
 
 // The subset of Pierre options the worker pool OWNS once a pool is active:
 // the Shiki `theme` and the intra-line word-diff algorithm (`lineDiffType`).
@@ -1272,6 +1349,9 @@ export const DiffPanelContent = ({
   const [disableFileHeader, setDisableFileHeader] = useState(false)
   const [stickyHeader, setStickyHeader] = useState(true)
 
+  const [hiddenSplitSide, setHiddenSplitSide] =
+    useState<HiddenSplitSide | null>(null)
+
   // Pool-owned render options, gated behind the worker-pool sync below so the
   // diff remount waits until the pool actually accepts the new value.
   // `renderedTheme` / `renderedLineDiffType` read from HERE (not from `theme` /
@@ -1413,6 +1493,7 @@ export const DiffPanelContent = ({
     hasMeasuredPane && diffStyle === 'split' && paneWidth < SPLIT_MIN_WIDTH_PX
   const effectiveDiffStyle: DiffStyle = splitForced ? 'unified' : diffStyle
   const tooNarrow = hasMeasuredPane && paneWidth < DIFF_MIN_WIDTH_PX
+  const splitSideCSS = splitSideCSSFor(hiddenSplitSide, effectiveDiffStyle)
 
   const handleDiffStyleChange = useCallback(
     (next: DiffStyle): void => {
@@ -1712,6 +1793,17 @@ export const DiffPanelContent = ({
     handleDiffStyleChange(diffStyle === 'split' ? 'unified' : 'split')
   }, [diffStyle, handleDiffStyleChange])
 
+  const toggleSplitSide = useCallback(
+    (side: HiddenSplitSide): void => {
+      if (effectiveDiffStyle !== 'split') {
+        return
+      }
+
+      setHiddenSplitSide((current) => (current === side ? null : side))
+    },
+    [effectiveDiffStyle]
+  )
+
   // Opens the y/n guard for destructive or staging keyboard actions.
   const openKeyboardConfirm = useCallback(
     (action: KeyboardConfirmAction): void => {
@@ -1856,6 +1948,8 @@ export const DiffPanelContent = ({
     onDiscardHunk: (): void => openKeyboardConfirm('discard-hunk'),
     onDiscardFile: (): void => openKeyboardConfirm('discard-file'),
     onToggleView: toggleDiffStyle,
+    onToggleOriginSection: (): void => toggleSplitSide('origin'),
+    onToggleNewSection: (): void => toggleSplitSide('new'),
     onConfirm: confirmKeyboardAction,
     onCancelConfirm: cancelKeyboardConfirm,
   })
@@ -2169,6 +2263,7 @@ export const DiffPanelContent = ({
                   disableBackground,
                   disableFileHeader,
                   stickyHeader,
+                  unsafeCSS: splitSideCSS,
                   enableGutterUtility: true,
                 }}
                 renderGutterUtility={(getHoveredLine): ReactElement => (

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -1753,6 +1753,10 @@ export const DiffPanelContent = ({
           effectiveDiffStyle === 'split' && sameSideIndex !== -1
             ? sameSideIndex
             : rowTargetIndex
+        if (next === currentIndex) {
+          return currentIndex
+        }
+
         const nextTarget = keyboardLineTargets[next]
         setFocusedHunkIndex(nextTarget.hunkIndex)
         scrollKeyboardTargetIntoView(nextTarget, next, delta)

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -481,6 +481,13 @@ const scrollLineElementIntoView = (
   targetCount: number,
   delta: number
 ): void => {
+  if (delta === 0) {
+    line.scrollIntoView({ block: 'nearest', inline: 'nearest' })
+    revealLineBelowStickyHeader(container, line, false)
+
+    return
+  }
+
   if (targetCount === 1) {
     line.scrollIntoView({
       block: delta > 0 ? 'end' : 'start',

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -66,88 +66,12 @@ type DiffStyle = NonNullable<BaseDiffOptions['diffStyle']>
 type DiffIndicators = NonNullable<BaseDiffOptions['diffIndicators']>
 type Overflow = NonNullable<BaseDiffOptions['overflow']>
 type LineDiffType = NonNullable<BaseDiffOptions['lineDiffType']>
-type HiddenSplitSide = 'origin' | 'new'
 
 const DIFF_NATIVE_FOCUS_SELECTOR =
   'button, input, textarea, select, [contenteditable], [role="textbox"]'
 
 const PIERRE_DIFF_CONTAINER_SELECTOR = 'diffs-container'
-
-const HIDE_ORIGIN_SPLIT_CSS = `
-[data-diff-type="split"][data-overflow="scroll"] {
-  grid-template-columns: 1fr;
-}
-
-[data-diff-type="split"][data-overflow="scroll"] [data-deletions] {
-  display: none;
-}
-
-[data-diff-type="split"][data-overflow="scroll"] [data-additions] {
-  border-left: 0;
-}
-
-[data-diff-type="split"][data-overflow="wrap"] {
-  grid-template-columns: var(--diffs-code-grid);
-}
-
-[data-diff-type="split"][data-overflow="wrap"] [data-deletions] {
-  display: none;
-}
-
-:is([data-diff-type="split"][data-overflow="wrap"] [data-additions]) [data-gutter] {
-  border-left: 0;
-  grid-column: 1;
-}
-
-:is([data-diff-type="split"][data-overflow="wrap"] [data-additions]) [data-content] {
-  grid-column: 2;
-}
-`.trim()
-
-const HIDE_NEW_SPLIT_CSS = `
-[data-diff-type="split"][data-overflow="scroll"] {
-  grid-template-columns: 1fr;
-}
-
-[data-diff-type="split"][data-overflow="scroll"] [data-additions] {
-  display: none;
-}
-
-[data-diff-type="split"][data-overflow="scroll"] [data-deletions] {
-  border-right: 0;
-}
-
-[data-diff-type="split"][data-overflow="wrap"] {
-  grid-template-columns: var(--diffs-code-grid);
-}
-
-[data-diff-type="split"][data-overflow="wrap"] [data-additions] {
-  display: none;
-}
-
-:is([data-diff-type="split"][data-overflow="wrap"] [data-deletions]) [data-content] {
-  border-right: 0;
-}
-`.trim()
-
-const splitSideCSSFor = (
-  hiddenSide: HiddenSplitSide | null,
-  diffStyle: DiffStyle
-): string | undefined => {
-  if (diffStyle !== 'split') {
-    return undefined
-  }
-
-  if (hiddenSide === 'origin') {
-    return HIDE_ORIGIN_SPLIT_CSS
-  }
-
-  if (hiddenSide === 'new') {
-    return HIDE_NEW_SPLIT_CSS
-  }
-
-  return undefined
-}
+const STICKY_HEADER_SCROLL_GAP_PX = 4
 
 // The subset of Pierre options the worker pool OWNS once a pool is active:
 // the Shiki `theme` and the intra-line word-diff algorithm (`lineDiffType`).
@@ -217,6 +141,7 @@ interface KeyboardLineTarget {
   lineNumber: number
   side: AnnotationSide
   hunkIndex: number
+  splitRowIndex: number
   changed: boolean
 }
 
@@ -279,12 +204,40 @@ const keyboardLineTargetsForDiff = (
   fileDiff.hunks.forEach((hunk, hunkIndex) => {
     let oldLine = hunk.oldStart
     let newLine = hunk.newStart
+    let splitRowIndex = 0
+    let pendingDeletions: KeyboardLineTarget[] = []
+    let pendingAdditions: KeyboardLineTarget[] = []
+
+    const flushChangedRows = (): void => {
+      const rowCount = Math.max(
+        pendingDeletions.length,
+        pendingAdditions.length
+      )
+
+      for (let rowOffset = 0; rowOffset < rowCount; rowOffset += 1) {
+        const rowIndex = splitRowIndex + rowOffset
+        if (rowOffset < pendingDeletions.length) {
+          const deletion = pendingDeletions[rowOffset]
+          targets.push({ ...deletion, splitRowIndex: rowIndex })
+        }
+
+        if (rowOffset < pendingAdditions.length) {
+          const addition = pendingAdditions[rowOffset]
+          targets.push({ ...addition, splitRowIndex: rowIndex })
+        }
+      }
+
+      splitRowIndex += rowCount
+      pendingDeletions = []
+      pendingAdditions = []
+    }
 
     if (hunk.lines.length === 0) {
       targets.push({
         lineNumber: hunk.newLines === 0 ? hunk.oldStart : hunk.newStart,
         side: hunk.newLines === 0 ? 'deletions' : 'additions',
         hunkIndex,
+        splitRowIndex,
         changed: true,
       })
 
@@ -300,20 +253,38 @@ const keyboardLineTargetsForDiff = (
 
       if (line.type === 'removed') {
         if (oldLineNumber !== undefined) {
-          targets.push({
+          pendingDeletions.push({
             lineNumber: oldLineNumber,
             side: 'deletions',
             hunkIndex,
+            splitRowIndex,
             changed: true,
           })
         }
-      } else if (newLineNumber !== undefined) {
-        targets.push({
-          lineNumber: newLineNumber,
-          side: 'additions',
-          hunkIndex,
-          changed: line.type === 'added',
-        })
+      } else if (line.type === 'added') {
+        if (newLineNumber !== undefined) {
+          pendingAdditions.push({
+            lineNumber: newLineNumber,
+            side: 'additions',
+            hunkIndex,
+            splitRowIndex,
+            changed: true,
+          })
+        }
+      } else {
+        flushChangedRows()
+
+        if (newLineNumber !== undefined) {
+          targets.push({
+            lineNumber: newLineNumber,
+            side: 'additions',
+            hunkIndex,
+            splitRowIndex,
+            changed: false,
+          })
+        }
+
+        splitRowIndex += 1
       }
 
       if (line.type !== 'added') {
@@ -324,10 +295,39 @@ const keyboardLineTargetsForDiff = (
         newLine += 1
       }
     }
+
+    flushChangedRows()
   })
 
   return targets
 }
+
+const sameKeyboardRow = (
+  left: KeyboardLineTarget,
+  right: KeyboardLineTarget
+): boolean =>
+  left.hunkIndex === right.hunkIndex &&
+  left.splitRowIndex === right.splitRowIndex
+
+const keyboardRowIndexForTarget = (
+  targets: KeyboardLineTarget[],
+  targetIndex: number
+): number => {
+  let rowIndex = 0
+
+  for (let index = 1; index <= targetIndex; index += 1) {
+    if (!sameKeyboardRow(targets[index - 1], targets[index])) {
+      rowIndex += 1
+    }
+  }
+
+  return rowIndex
+}
+
+const keyboardRowCountForTargets = (targets: KeyboardLineTarget[]): number =>
+  targets.length === 0
+    ? 0
+    : keyboardRowIndexForTarget(targets, targets.length - 1) + 1
 
 // Matches Pierre's rendered rows/gutters for the current keyboard target.
 const lineSelectorForKeyboardTarget = (target: KeyboardLineTarget): string => {
@@ -429,7 +429,53 @@ const lineRangeFitsContainer = (
   return bottom - top <= container.clientHeight
 }
 
+const stickyHeaderOffsetForDiffRoot = (root: HTMLElement): number => {
+  const headers = [
+    ...root.querySelectorAll<HTMLElement>('[data-diffs-header][data-sticky]'),
+  ]
+
+  for (const container of root.querySelectorAll<HTMLElement>(
+    PIERRE_DIFF_CONTAINER_SELECTOR
+  )) {
+    if (container.shadowRoot !== null) {
+      headers.push(
+        ...container.shadowRoot.querySelectorAll<HTMLElement>(
+          '[data-diffs-header][data-sticky]'
+        )
+      )
+    }
+  }
+
+  const height = Math.max(
+    0,
+    ...headers.map((header) => header.getBoundingClientRect().height)
+  )
+
+  return height === 0 ? 0 : height + STICKY_HEADER_SCROLL_GAP_PX
+}
+
+const revealLineBelowStickyHeader = (
+  container: HTMLElement,
+  line: HTMLElement,
+  reservePreviousRow: boolean
+): void => {
+  const stickyOffset = stickyHeaderOffsetForDiffRoot(container)
+  if (stickyOffset === 0) {
+    return
+  }
+
+  const containerTop = container.getBoundingClientRect().top
+  const lineRect = line.getBoundingClientRect()
+  const rowOffset = reservePreviousRow ? lineRect.height : 0
+  const overlap = containerTop + stickyOffset + rowOffset - lineRect.top
+
+  if (overlap > 0) {
+    container.scrollTop = Math.max(0, container.scrollTop - Math.ceil(overlap))
+  }
+}
+
 const scrollLineElementIntoView = (
+  container: HTMLElement,
   line: HTMLElement,
   targetIndex: number,
   targetCount: number,
@@ -440,23 +486,27 @@ const scrollLineElementIntoView = (
       block: delta > 0 ? 'end' : 'start',
       inline: 'nearest',
     })
+    revealLineBelowStickyHeader(container, line, delta < 0)
 
     return
   }
 
   if (targetIndex === 0) {
     line.scrollIntoView({ block: 'start', inline: 'nearest' })
+    revealLineBelowStickyHeader(container, line, delta < 0)
 
     return
   }
 
   if (targetIndex === targetCount - 1) {
     line.scrollIntoView({ block: 'end', inline: 'nearest' })
+    revealLineBelowStickyHeader(container, line, false)
 
     return
   }
 
   line.scrollIntoView({ block: 'nearest', inline: 'nearest' })
+  revealLineBelowStickyHeader(container, line, delta < 0)
 }
 
 const keyboardConfirmCopy = (
@@ -1349,9 +1399,6 @@ export const DiffPanelContent = ({
   const [disableFileHeader, setDisableFileHeader] = useState(false)
   const [stickyHeader, setStickyHeader] = useState(true)
 
-  const [hiddenSplitSide, setHiddenSplitSide] =
-    useState<HiddenSplitSide | null>(null)
-
   // Pool-owned render options, gated behind the worker-pool sync below so the
   // diff remount waits until the pool actually accepts the new value.
   // `renderedTheme` / `renderedLineDiffType` read from HERE (not from `theme` /
@@ -1493,7 +1540,6 @@ export const DiffPanelContent = ({
     hasMeasuredPane && diffStyle === 'split' && paneWidth < SPLIT_MIN_WIDTH_PX
   const effectiveDiffStyle: DiffStyle = splitForced ? 'unified' : diffStyle
   const tooNarrow = hasMeasuredPane && paneWidth < DIFF_MIN_WIDTH_PX
-  const splitSideCSS = splitSideCSSFor(hiddenSplitSide, effectiveDiffStyle)
 
   const handleDiffStyleChange = useCallback(
     (next: DiffStyle): void => {
@@ -1588,12 +1634,7 @@ export const DiffPanelContent = ({
 
   // Keeps j/k line navigation visible without changing the selected target.
   const scrollKeyboardTargetIntoView = useCallback(
-    (
-      target: KeyboardLineTarget,
-      targetIndex: number,
-      targetCount: number,
-      delta: number
-    ): void => {
+    (target: KeyboardLineTarget, targetIndex: number, delta: number): void => {
       const node = diffScrollBodyRef.current
       if (node === null) {
         return
@@ -1604,9 +1645,15 @@ export const DiffPanelContent = ({
         return
       }
 
-      scrollLineElementIntoView(line, targetIndex, targetCount, delta)
+      scrollLineElementIntoView(
+        node,
+        line,
+        keyboardRowIndexForTarget(keyboardLineTargets, targetIndex),
+        keyboardRowCountForTargets(keyboardLineTargets),
+        delta
+      )
     },
-    []
+    [keyboardLineTargets]
   )
 
   // Hunk jumps reveal the hunk top, then include the end only when it fits.
@@ -1659,18 +1706,42 @@ export const DiffPanelContent = ({
       setNavSelection(null)
       setKeyboardLineActive(true)
       setKeyboardLineIndex((prev) => {
-        const next = Math.min(
-          Math.max(prev + delta, 0),
-          keyboardLineTargets.length - 1
+        const currentIndex = Math.min(prev, keyboardLineTargets.length - 1)
+        const currentTarget = keyboardLineTargets[currentIndex]
+        let rowTargetIndex = currentIndex
+
+        while (
+          rowTargetIndex + delta >= 0 &&
+          rowTargetIndex + delta < keyboardLineTargets.length
+        ) {
+          rowTargetIndex += delta
+
+          const rowTarget = keyboardLineTargets[rowTargetIndex]
+          if (
+            rowTarget.hunkIndex !== currentTarget.hunkIndex ||
+            rowTarget.splitRowIndex !== currentTarget.splitRowIndex
+          ) {
+            break
+          }
+        }
+
+        if (rowTargetIndex === currentIndex) {
+          return currentIndex
+        }
+
+        const rowTarget = keyboardLineTargets[rowTargetIndex]
+
+        const sameSideIndex = keyboardLineTargets.findIndex(
+          (target) =>
+            target.hunkIndex === rowTarget.hunkIndex &&
+            target.splitRowIndex === rowTarget.splitRowIndex &&
+            target.side === currentTarget.side
         )
+
+        const next = sameSideIndex === -1 ? rowTargetIndex : sameSideIndex
         const nextTarget = keyboardLineTargets[next]
         setFocusedHunkIndex(nextTarget.hunkIndex)
-        scrollKeyboardTargetIntoView(
-          nextTarget,
-          next,
-          keyboardLineTargets.length,
-          delta
-        )
+        scrollKeyboardTargetIntoView(nextTarget, next, delta)
 
         return next
       })
@@ -1726,12 +1797,7 @@ export const DiffPanelContent = ({
       setKeyboardLineIndex(targetIndex)
       setFocusedHunkIndex(next)
       if (!scrollHunkIntoView(next)) {
-        scrollKeyboardTargetIntoView(
-          target,
-          targetIndex,
-          keyboardLineTargets.length,
-          delta
-        )
+        scrollKeyboardTargetIntoView(target, targetIndex, delta)
       }
       focusDiffRoot()
     },
@@ -1793,15 +1859,41 @@ export const DiffPanelContent = ({
     handleDiffStyleChange(diffStyle === 'split' ? 'unified' : 'split')
   }, [diffStyle, handleDiffStyleChange])
 
-  const toggleSplitSide = useCallback(
-    (side: HiddenSplitSide): void => {
-      if (effectiveDiffStyle !== 'split') {
+  const moveKeyboardLineSide = useCallback(
+    (side: AnnotationSide): void => {
+      if (effectiveDiffStyle !== 'split' || keyboardLineTarget === null) {
         return
       }
 
-      setHiddenSplitSide((current) => (current === side ? null : side))
+      const nextIndex = keyboardLineTargets.findIndex(
+        (target) =>
+          target.hunkIndex === keyboardLineTarget.hunkIndex &&
+          target.splitRowIndex === keyboardLineTarget.splitRowIndex &&
+          target.side === side
+      )
+
+      if (nextIndex === -1 || nextIndex === keyboardLineIndex) {
+        return
+      }
+
+      const nextTarget = keyboardLineTargets[nextIndex]
+      clearNavSelectionTimer()
+      setNavSelection(null)
+      setKeyboardLineActive(true)
+      setKeyboardLineIndex(nextIndex)
+      setFocusedHunkIndex(nextTarget.hunkIndex)
+      scrollKeyboardTargetIntoView(nextTarget, nextIndex, 0)
+      focusDiffRoot()
     },
-    [effectiveDiffStyle]
+    [
+      clearNavSelectionTimer,
+      effectiveDiffStyle,
+      focusDiffRoot,
+      keyboardLineIndex,
+      keyboardLineTarget,
+      keyboardLineTargets,
+      scrollKeyboardTargetIntoView,
+    ]
   )
 
   // Opens the y/n guard for destructive or staging keyboard actions.
@@ -1948,8 +2040,7 @@ export const DiffPanelContent = ({
     onDiscardHunk: (): void => openKeyboardConfirm('discard-hunk'),
     onDiscardFile: (): void => openKeyboardConfirm('discard-file'),
     onToggleView: toggleDiffStyle,
-    onToggleOriginSection: (): void => toggleSplitSide('origin'),
-    onToggleNewSection: (): void => toggleSplitSide('new'),
+    onMoveLineSide: moveKeyboardLineSide,
     onConfirm: confirmKeyboardAction,
     onCancelConfirm: cancelKeyboardConfirm,
   })
@@ -2198,6 +2289,7 @@ export const DiffPanelContent = ({
                   <Button
                     size="sm"
                     variant="ghost"
+                    className="focus-visible:ring-0"
                     aria-keyshortcuts="n"
                     onClick={cancelKeyboardConfirm}
                   >
@@ -2206,6 +2298,7 @@ export const DiffPanelContent = ({
                   <Button
                     size="sm"
                     variant={keyboardConfirm.variant}
+                    className="focus-visible:ring-0"
                     aria-keyshortcuts="y"
                     onClick={confirmKeyboardAction}
                   >
@@ -2263,7 +2356,6 @@ export const DiffPanelContent = ({
                   disableBackground,
                   disableFileHeader,
                   stickyHeader,
-                  unsafeCSS: splitSideCSS,
                   enableGutterUtility: true,
                 }}
                 renderGutterUtility={(getHoveredLine): ReactElement => (

--- a/src/features/diff/components/FinishFeedbackPopover.test.tsx
+++ b/src/features/diff/components/FinishFeedbackPopover.test.tsx
@@ -94,7 +94,7 @@ test('kind one shows pane info, correct copy, and buttons work', async () => {
   anchor.remove()
 })
 
-test('kind one confirmation buttons render visible keyboard focus styles', () => {
+test('kind one confirmation buttons render borderless keyboard focus styles', () => {
   const anchor = createAnchor()
   const pane = makePane()
 
@@ -111,16 +111,16 @@ test('kind one confirmation buttons render visible keyboard focus styles', () =>
 
   expect(screen.getByRole('button', { name: 'Cancel (n)' })).toHaveClass(
     'focus:outline-none',
+    'focus-visible:bg-surface-container-high',
     'focus-visible:outline-none',
-    'focus-visible:ring-1',
-    'focus-visible:ring-primary'
+    'focus-visible:ring-0'
   )
 
   expect(screen.getByRole('button', { name: 'Confirm (Y)' })).toHaveClass(
     'focus:outline-none',
+    'focus-visible:brightness-110',
     'focus-visible:outline-none',
-    'focus-visible:ring-1',
-    'focus-visible:ring-primary'
+    'focus-visible:ring-0'
   )
 
   anchor.remove()
@@ -193,8 +193,8 @@ test('kind many renders row per candidate and sends to correct pane', async () =
   const sendButtons = screen.getAllByRole('button', { name: 'Send' })
   expect(sendButtons).toHaveLength(2)
   expect(sendButtons[0]).toHaveClass(
-    'focus-visible:ring-1',
-    'focus-visible:ring-primary'
+    'focus-visible:brightness-110',
+    'focus-visible:ring-0'
   )
 
   await user.click(sendButtons[1])

--- a/src/features/diff/components/FinishFeedbackPopover.test.tsx
+++ b/src/features/diff/components/FinishFeedbackPopover.test.tsx
@@ -94,7 +94,7 @@ test('kind one shows pane info, correct copy, and buttons work', async () => {
   anchor.remove()
 })
 
-test('kind one confirmation buttons do not render focus outlines', () => {
+test('kind one confirmation buttons render visible keyboard focus styles', () => {
   const anchor = createAnchor()
   const pane = makePane()
 
@@ -111,12 +111,16 @@ test('kind one confirmation buttons do not render focus outlines', () => {
 
   expect(screen.getByRole('button', { name: 'Cancel (n)' })).toHaveClass(
     'focus:outline-none',
-    'focus-visible:outline-none'
+    'focus-visible:outline-none',
+    'focus-visible:ring-1',
+    'focus-visible:ring-primary'
   )
 
   expect(screen.getByRole('button', { name: 'Confirm (Y)' })).toHaveClass(
     'focus:outline-none',
-    'focus-visible:outline-none'
+    'focus-visible:outline-none',
+    'focus-visible:ring-1',
+    'focus-visible:ring-primary'
   )
 
   anchor.remove()
@@ -188,6 +192,10 @@ test('kind many renders row per candidate and sends to correct pane', async () =
 
   const sendButtons = screen.getAllByRole('button', { name: 'Send' })
   expect(sendButtons).toHaveLength(2)
+  expect(sendButtons[0]).toHaveClass(
+    'focus-visible:ring-1',
+    'focus-visible:ring-primary'
+  )
 
   await user.click(sendButtons[1])
   expect(onSend).toHaveBeenCalledTimes(1)

--- a/src/features/diff/components/FinishFeedbackPopover.test.tsx
+++ b/src/features/diff/components/FinishFeedbackPopover.test.tsx
@@ -94,6 +94,34 @@ test('kind one shows pane info, correct copy, and buttons work', async () => {
   anchor.remove()
 })
 
+test('kind one confirmation buttons do not render focus outlines', () => {
+  const anchor = createAnchor()
+  const pane = makePane()
+
+  render(
+    <FinishFeedbackPopover
+      anchor={anchor}
+      result={{ kind: 'one', pane } as ResolveResult}
+      commentCount={1}
+      fileCount={1}
+      onSend={vi.fn()}
+      onCancel={vi.fn()}
+    />
+  )
+
+  expect(screen.getByRole('button', { name: 'Cancel (n)' })).toHaveClass(
+    'focus:outline-none',
+    'focus-visible:outline-none'
+  )
+
+  expect(screen.getByRole('button', { name: 'Confirm (Y)' })).toHaveClass(
+    'focus:outline-none',
+    'focus-visible:outline-none'
+  )
+
+  anchor.remove()
+})
+
 test('kind one accepts Y to confirm and n to cancel', async () => {
   const user = userEvent.setup()
   const anchor = createAnchor()

--- a/src/features/diff/components/FinishFeedbackPopover.test.tsx
+++ b/src/features/diff/components/FinishFeedbackPopover.test.tsx
@@ -94,7 +94,7 @@ test('kind one shows pane info, correct copy, and buttons work', async () => {
   anchor.remove()
 })
 
-test('kind one confirmation buttons render borderless keyboard focus styles', () => {
+test('kind one confirmation buttons render visible keyboard focus styles', () => {
   const anchor = createAnchor()
   const pane = makePane()
 
@@ -118,8 +118,15 @@ test('kind one confirmation buttons render borderless keyboard focus styles', ()
 
   expect(screen.getByRole('button', { name: 'Confirm (Y)' })).toHaveClass(
     'focus:outline-none',
-    'focus-visible:brightness-110',
     'focus-visible:outline-none',
+    'focus-visible:ring-2',
+    'focus-visible:ring-primary',
+    'focus-visible:ring-offset-2',
+    'focus-visible:ring-offset-surface-container'
+  )
+
+  expect(screen.getByRole('button', { name: 'Confirm (Y)' })).not.toHaveClass(
+    'focus-visible:brightness-110',
     'focus-visible:ring-0'
   )
 
@@ -193,6 +200,13 @@ test('kind many renders row per candidate and sends to correct pane', async () =
   const sendButtons = screen.getAllByRole('button', { name: 'Send' })
   expect(sendButtons).toHaveLength(2)
   expect(sendButtons[0]).toHaveClass(
+    'focus-visible:ring-2',
+    'focus-visible:ring-primary',
+    'focus-visible:ring-offset-2',
+    'focus-visible:ring-offset-surface-container'
+  )
+
+  expect(sendButtons[0]).not.toHaveClass(
     'focus-visible:brightness-110',
     'focus-visible:ring-0'
   )

--- a/src/features/diff/components/FinishFeedbackPopover.tsx
+++ b/src/features/diff/components/FinishFeedbackPopover.tsx
@@ -2,6 +2,9 @@ import { useEffect, type ReactElement } from 'react'
 import { Popover } from '@/components/Popover'
 import type { PaneCandidate, ResolveResult } from '../services/activePanePicker'
 
+const popoverActionFocusClass =
+  'focus:outline-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary'
+
 interface FinishFeedbackPopoverProps {
   anchor: HTMLElement
   result: ResolveResult
@@ -84,7 +87,7 @@ export const FinishFeedbackPopover = ({
               type="button"
               aria-keyshortcuts="n"
               onClick={(): void => onCancel()}
-              className="rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface focus:outline-none focus-visible:outline-none"
+              className={`rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface ${popoverActionFocusClass}`}
             >
               Dismiss (n)
             </button>
@@ -103,7 +106,7 @@ export const FinishFeedbackPopover = ({
               type="button"
               aria-keyshortcuts="n"
               onClick={(): void => onCancel()}
-              className="rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface focus:outline-none focus-visible:outline-none"
+              className={`rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface ${popoverActionFocusClass}`}
             >
               Cancel (n)
             </button>
@@ -111,7 +114,7 @@ export const FinishFeedbackPopover = ({
               type="button"
               aria-keyshortcuts="Y"
               onClick={(): void => onSend(result.pane)}
-              className="rounded-md bg-primary px-3 py-1 text-xs text-on-primary hover:bg-primary/80 focus:outline-none focus-visible:outline-none"
+              className={`rounded-md bg-primary px-3 py-1 text-xs text-on-primary hover:bg-primary/80 ${popoverActionFocusClass}`}
             >
               Confirm (Y)
             </button>
@@ -136,7 +139,7 @@ export const FinishFeedbackPopover = ({
                 <button
                   type="button"
                   onClick={(): void => onSend(pane)}
-                  className="rounded-md bg-primary px-3 py-1 text-xs text-on-primary hover:bg-primary/80 focus:outline-none focus-visible:outline-none"
+                  className={`rounded-md bg-primary px-3 py-1 text-xs text-on-primary hover:bg-primary/80 ${popoverActionFocusClass}`}
                 >
                   Send
                 </button>
@@ -148,7 +151,7 @@ export const FinishFeedbackPopover = ({
               type="button"
               aria-keyshortcuts="n"
               onClick={(): void => onCancel()}
-              className="rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface focus:outline-none focus-visible:outline-none"
+              className={`rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface ${popoverActionFocusClass}`}
             >
               Cancel (n)
             </button>

--- a/src/features/diff/components/FinishFeedbackPopover.tsx
+++ b/src/features/diff/components/FinishFeedbackPopover.tsx
@@ -84,7 +84,7 @@ export const FinishFeedbackPopover = ({
               type="button"
               aria-keyshortcuts="n"
               onClick={(): void => onCancel()}
-              className="rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface"
+              className="rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface focus:outline-none focus-visible:outline-none"
             >
               Dismiss (n)
             </button>
@@ -103,7 +103,7 @@ export const FinishFeedbackPopover = ({
               type="button"
               aria-keyshortcuts="n"
               onClick={(): void => onCancel()}
-              className="rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface"
+              className="rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface focus:outline-none focus-visible:outline-none"
             >
               Cancel (n)
             </button>
@@ -111,7 +111,7 @@ export const FinishFeedbackPopover = ({
               type="button"
               aria-keyshortcuts="Y"
               onClick={(): void => onSend(result.pane)}
-              className="rounded-md bg-primary px-3 py-1 text-xs text-on-primary hover:bg-primary/80"
+              className="rounded-md bg-primary px-3 py-1 text-xs text-on-primary hover:bg-primary/80 focus:outline-none focus-visible:outline-none"
             >
               Confirm (Y)
             </button>
@@ -136,7 +136,7 @@ export const FinishFeedbackPopover = ({
                 <button
                   type="button"
                   onClick={(): void => onSend(pane)}
-                  className="rounded-md bg-primary px-3 py-1 text-xs text-on-primary hover:bg-primary/80"
+                  className="rounded-md bg-primary px-3 py-1 text-xs text-on-primary hover:bg-primary/80 focus:outline-none focus-visible:outline-none"
                 >
                   Send
                 </button>
@@ -148,7 +148,7 @@ export const FinishFeedbackPopover = ({
               type="button"
               aria-keyshortcuts="n"
               onClick={(): void => onCancel()}
-              className="rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface"
+              className="rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface focus:outline-none focus-visible:outline-none"
             >
               Cancel (n)
             </button>

--- a/src/features/diff/components/FinishFeedbackPopover.tsx
+++ b/src/features/diff/components/FinishFeedbackPopover.tsx
@@ -6,7 +6,7 @@ const popoverGhostActionFocusClass =
   'ring-0 focus:outline-none focus-visible:bg-surface-container-high focus-visible:text-on-surface focus-visible:outline-none focus-visible:ring-0'
 
 const popoverPrimaryActionFocusClass =
-  'ring-0 focus:outline-none focus-visible:brightness-110 focus-visible:outline-none focus-visible:ring-0'
+  'ring-0 focus:outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface-container'
 
 interface FinishFeedbackPopoverProps {
   anchor: HTMLElement

--- a/src/features/diff/components/FinishFeedbackPopover.tsx
+++ b/src/features/diff/components/FinishFeedbackPopover.tsx
@@ -2,8 +2,11 @@ import { useEffect, type ReactElement } from 'react'
 import { Popover } from '@/components/Popover'
 import type { PaneCandidate, ResolveResult } from '../services/activePanePicker'
 
-const popoverActionFocusClass =
-  'focus:outline-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary'
+const popoverGhostActionFocusClass =
+  'ring-0 focus:outline-none focus-visible:bg-surface-container-high focus-visible:text-on-surface focus-visible:outline-none focus-visible:ring-0'
+
+const popoverPrimaryActionFocusClass =
+  'ring-0 focus:outline-none focus-visible:brightness-110 focus-visible:outline-none focus-visible:ring-0'
 
 interface FinishFeedbackPopoverProps {
   anchor: HTMLElement
@@ -87,7 +90,7 @@ export const FinishFeedbackPopover = ({
               type="button"
               aria-keyshortcuts="n"
               onClick={(): void => onCancel()}
-              className={`rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface ${popoverActionFocusClass}`}
+              className={`rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface ${popoverGhostActionFocusClass}`}
             >
               Dismiss (n)
             </button>
@@ -106,7 +109,7 @@ export const FinishFeedbackPopover = ({
               type="button"
               aria-keyshortcuts="n"
               onClick={(): void => onCancel()}
-              className={`rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface ${popoverActionFocusClass}`}
+              className={`rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface ${popoverGhostActionFocusClass}`}
             >
               Cancel (n)
             </button>
@@ -114,7 +117,7 @@ export const FinishFeedbackPopover = ({
               type="button"
               aria-keyshortcuts="Y"
               onClick={(): void => onSend(result.pane)}
-              className={`rounded-md bg-primary px-3 py-1 text-xs text-on-primary hover:bg-primary/80 ${popoverActionFocusClass}`}
+              className={`rounded-md bg-primary px-3 py-1 text-xs text-on-primary hover:bg-primary/80 ${popoverPrimaryActionFocusClass}`}
             >
               Confirm (Y)
             </button>
@@ -139,7 +142,7 @@ export const FinishFeedbackPopover = ({
                 <button
                   type="button"
                   onClick={(): void => onSend(pane)}
-                  className={`rounded-md bg-primary px-3 py-1 text-xs text-on-primary hover:bg-primary/80 ${popoverActionFocusClass}`}
+                  className={`rounded-md bg-primary px-3 py-1 text-xs text-on-primary hover:bg-primary/80 ${popoverPrimaryActionFocusClass}`}
                 >
                   Send
                 </button>
@@ -151,7 +154,7 @@ export const FinishFeedbackPopover = ({
               type="button"
               aria-keyshortcuts="n"
               onClick={(): void => onCancel()}
-              className={`rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface ${popoverActionFocusClass}`}
+              className={`rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface ${popoverGhostActionFocusClass}`}
             >
               Cancel (n)
             </button>

--- a/src/features/diff/hooks/useDiffKeyboard.test.ts
+++ b/src/features/diff/hooks/useDiffKeyboard.test.ts
@@ -77,8 +77,7 @@ const renderKeyboard = (
     onDiscardHunk: vi.fn(),
     onDiscardFile: vi.fn(),
     onToggleView: vi.fn(),
-    onToggleOriginSection: vi.fn(),
-    onToggleNewSection: vi.fn(),
+    onMoveLineSide: vi.fn(),
     onConfirm: vi.fn(),
     onCancelConfirm: vi.fn(),
     ...overrides,
@@ -174,14 +173,14 @@ describe('useDiffKeyboard', () => {
     expect(props.onToggleView).toHaveBeenCalledOnce()
   })
 
-  test('h and l toggle split origin and new sections', () => {
+  test('h and l move the keyboard line between split sides', () => {
     const { props } = renderKeyboard()
 
     dispatch('h')
     dispatch('l')
 
-    expect(props.onToggleOriginSection).toHaveBeenCalledOnce()
-    expect(props.onToggleNewSection).toHaveBeenCalledOnce()
+    expect(props.onMoveLineSide).toHaveBeenNthCalledWith(1, 'deletions')
+    expect(props.onMoveLineSide).toHaveBeenNthCalledWith(2, 'additions')
   })
 
   test('Ctrl+D and Ctrl+U scroll the current file', () => {
@@ -324,8 +323,7 @@ describe('useDiffKeyboard', () => {
       onDiscardHunk: vi.fn(),
       onDiscardFile: vi.fn(),
       onToggleView: vi.fn(),
-      onToggleOriginSection: vi.fn(),
-      onToggleNewSection: vi.fn(),
+      onMoveLineSide: vi.fn(),
       onConfirm: vi.fn(),
       onCancelConfirm: vi.fn(),
     }

--- a/src/features/diff/hooks/useDiffKeyboard.test.ts
+++ b/src/features/diff/hooks/useDiffKeyboard.test.ts
@@ -77,6 +77,8 @@ const renderKeyboard = (
     onDiscardHunk: vi.fn(),
     onDiscardFile: vi.fn(),
     onToggleView: vi.fn(),
+    onToggleOriginSection: vi.fn(),
+    onToggleNewSection: vi.fn(),
     onConfirm: vi.fn(),
     onCancelConfirm: vi.fn(),
     ...overrides,
@@ -170,6 +172,16 @@ describe('useDiffKeyboard', () => {
     dispatch('t')
 
     expect(props.onToggleView).toHaveBeenCalledOnce()
+  })
+
+  test('h and l toggle split origin and new sections', () => {
+    const { props } = renderKeyboard()
+
+    dispatch('h')
+    dispatch('l')
+
+    expect(props.onToggleOriginSection).toHaveBeenCalledOnce()
+    expect(props.onToggleNewSection).toHaveBeenCalledOnce()
   })
 
   test('Ctrl+D and Ctrl+U scroll the current file', () => {
@@ -312,6 +324,8 @@ describe('useDiffKeyboard', () => {
       onDiscardHunk: vi.fn(),
       onDiscardFile: vi.fn(),
       onToggleView: vi.fn(),
+      onToggleOriginSection: vi.fn(),
+      onToggleNewSection: vi.fn(),
       onConfirm: vi.fn(),
       onCancelConfirm: vi.fn(),
     }

--- a/src/features/diff/hooks/useDiffKeyboard.ts
+++ b/src/features/diff/hooks/useDiffKeyboard.ts
@@ -22,8 +22,7 @@ export interface UseDiffKeyboardOptions {
   onDiscardHunk: () => void
   onDiscardFile: () => void
   onToggleView: () => void
-  onToggleOriginSection: () => void
-  onToggleNewSection: () => void
+  onMoveLineSide: (side: 'deletions' | 'additions') => void
   onConfirm: () => void
   onCancelConfirm: () => void
 }
@@ -65,8 +64,7 @@ export const useDiffKeyboard = (options: UseDiffKeyboardOptions): void => {
     onDiscardHunk,
     onDiscardFile,
     onToggleView,
-    onToggleOriginSection,
-    onToggleNewSection,
+    onMoveLineSide,
     onConfirm,
     onCancelConfirm,
   } = options
@@ -160,8 +158,8 @@ export const useDiffKeyboard = (options: UseDiffKeyboardOptions): void => {
         d: onDiscardHunk,
         D: onDiscardFile,
         t: onToggleView,
-        h: onToggleOriginSection,
-        l: onToggleNewSection,
+        h: () => onMoveLineSide('deletions'),
+        l: () => onMoveLineSide('additions'),
       }
 
       const handler = handlers[event.key]
@@ -195,8 +193,7 @@ export const useDiffKeyboard = (options: UseDiffKeyboardOptions): void => {
     onDiscardHunk,
     onDiscardFile,
     onToggleView,
-    onToggleOriginSection,
-    onToggleNewSection,
+    onMoveLineSide,
     onConfirm,
     onCancelConfirm,
   ])

--- a/src/features/diff/hooks/useDiffKeyboard.ts
+++ b/src/features/diff/hooks/useDiffKeyboard.ts
@@ -22,6 +22,8 @@ export interface UseDiffKeyboardOptions {
   onDiscardHunk: () => void
   onDiscardFile: () => void
   onToggleView: () => void
+  onToggleOriginSection: () => void
+  onToggleNewSection: () => void
   onConfirm: () => void
   onCancelConfirm: () => void
 }
@@ -63,6 +65,8 @@ export const useDiffKeyboard = (options: UseDiffKeyboardOptions): void => {
     onDiscardHunk,
     onDiscardFile,
     onToggleView,
+    onToggleOriginSection,
+    onToggleNewSection,
     onConfirm,
     onCancelConfirm,
   } = options
@@ -156,6 +160,8 @@ export const useDiffKeyboard = (options: UseDiffKeyboardOptions): void => {
         d: onDiscardHunk,
         D: onDiscardFile,
         t: onToggleView,
+        h: onToggleOriginSection,
+        l: onToggleNewSection,
       }
 
       const handler = handlers[event.key]
@@ -189,6 +195,8 @@ export const useDiffKeyboard = (options: UseDiffKeyboardOptions): void => {
     onDiscardHunk,
     onDiscardFile,
     onToggleView,
+    onToggleOriginSection,
+    onToggleNewSection,
     onConfirm,
     onCancelConfirm,
   ])


### PR DESCRIPTION
## Summary
- add split-mode DiffView keyboard behavior where `j`/`k` move by rendered rows and `h`/`l` move the active comment target between old/new sides on the same row
- keep keyboard-selected lines visible around Pierre sticky headers, including upward `k` navigation near the first visible row
- remove the visible focus ring from finish/confirmation popover actions while keeping borderless focus-visible feedback
- note the narrow VIM-252 slice in this PR; the larger single-file search and unchanged-code collapse scope remains open

## Verification
- `npm exec eslint -- src/features/diff/hooks/useDiffKeyboard.ts src/features/diff/hooks/useDiffKeyboard.test.ts src/features/diff/components/DiffPanelContent.tsx src/features/diff/components/DiffPanelContent.test.tsx src/features/diff/components/FinishFeedbackPopover.tsx src/features/diff/components/FinishFeedbackPopover.test.tsx`
- `npm exec vitest run src/features/diff/hooks/useDiffKeyboard.test.ts src/features/diff/components/DiffPanelContent.test.tsx src/features/diff/components/FinishFeedbackPopover.test.tsx`
- `npm test` (pre-push hook)