### PR TITLE
VIM-258: Track unfinished diff review batches

### DIFF
--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -284,6 +284,7 @@ interface MenuProps {
   variant?: 'default' | 'compact'
   // Opt out of scroll-dismiss where a consumer's behavior differs (spec §5.3).
   middleware?: { ancestorScroll?: boolean }
+  bodyClassName?: string
   'aria-label'?: string
   onOpenChange?: (open: boolean) => void
   children: ReactNode
@@ -306,6 +307,7 @@ const MenuRoot = ({
   width = undefined,
   variant = 'default',
   middleware = undefined,
+  bodyClassName = undefined,
   'aria-label': ariaLabel = undefined,
   onOpenChange = undefined,
   children,
@@ -465,7 +467,8 @@ const MenuRoot = ({
             variant === 'compact' ? CONTEXT_MENU_SURFACE_CLASSES : undefined
           }
           bodyClassName={
-            variant === 'compact' ? CONTEXT_MENU_BODY_CLASSES : undefined
+            bodyClassName ??
+            (variant === 'compact' ? CONTEXT_MENU_BODY_CLASSES : undefined)
           }
           ariaLabel={ariaLabel}
           contextValue={contextValue}
@@ -712,6 +715,7 @@ interface MenuItemProps {
   /** Rich leading visual (brand SVG / accent chip) for when a material-symbol `icon` isn't enough. */
   leadingIcon?: ReactNode
   shortcut?: ShortcutInput
+  active?: boolean
   disabled?: boolean
   onSelect: () => void
   children: ReactNode
@@ -721,6 +725,7 @@ const MenuItem = ({
   icon = undefined,
   leadingIcon = undefined,
   shortcut = undefined,
+  active = false,
   disabled = false,
   onSelect,
   children,
@@ -735,8 +740,11 @@ const MenuItem = ({
       role="menuitem"
       ref={ref}
       tabIndex={menu.activeIndex === index ? 0 : -1}
+      aria-current={active ? 'true' : undefined}
       aria-disabled={disabled ? true : undefined}
-      className={`${ITEM_CLASSES} ${DISABLED_ITEM_CLASSES}`}
+      className={`${ITEM_CLASSES} ${
+        active ? 'bg-primary-container/15' : ''
+      } ${DISABLED_ITEM_CLASSES}`}
       {...menu.getItemProps({
         onClick: (): void => {
           if (disabled) {
@@ -748,7 +756,7 @@ const MenuItem = ({
         },
       })}
     >
-      <span className="flex items-center gap-2.5">
+      <span className="flex min-w-0 flex-1 items-center gap-2.5">
         {leadingIcon}
         {icon !== undefined ? (
           <span aria-hidden="true" className={ITEM_ICON_CLASSES}>

--- a/src/features/diff/components/DiffPanelContent.test.tsx
+++ b/src/features/diff/components/DiffPanelContent.test.tsx
@@ -24,8 +24,14 @@ import type { GitService } from '../services/gitService'
 import * as gitServiceModule from '../services/gitService'
 import * as pierreAdapterModule from '../services/pierreAdapter'
 import * as useFeedbackBatchModule from '../hooks/useFeedbackBatch'
+import {
+  makeBatchKey,
+  type ReviewComment,
+  type UseFeedbackBatchReturn,
+} from '../hooks/useFeedbackBatch'
 import type { MockInstance } from 'vitest'
 import type { PaneCandidate } from '../services/activePanePicker'
+import type { DiffLineAnnotation } from '@pierre/diffs'
 
 // Mock the hooks
 vi.mock('../hooks/useGitStatus')
@@ -299,6 +305,76 @@ describe('DiffPanelContent', () => {
     const panel = screen.getByTestId('diff-empty-panel')
     expect(panel).toHaveClass('items-center')
     expect(panel).toHaveClass('justify-center')
+  })
+
+  test('keeps feedback actions available in the empty state', async (): Promise<void> => {
+    const user = userEvent.setup()
+    const clearBatch = vi.fn()
+
+    const annotation: DiffLineAnnotation<ReviewComment> = {
+      side: 'additions',
+      lineNumber: 1,
+      metadata: {
+        id: 'comment-1',
+        text: 'Needs review',
+        author: 'self',
+        createdAt: 1000,
+      },
+    }
+
+    const batch = new Map([
+      [makeBatchKey('/repo/old', 'src/foo.ts', false), [annotation]],
+    ])
+
+    const feedbackBatch: UseFeedbackBatchReturn = {
+      batch,
+      annotationsForFile: () => [],
+      addAnnotation: () => 'ok',
+      updateAnnotation: vi.fn(),
+      removeAnnotation: vi.fn(),
+      clearBatch,
+      totalAnnotations: () => 1,
+    }
+
+    vi.spyOn(useGitStatusModule, 'useGitStatus').mockReturnValue({
+      files: [],
+      filesCwd: '/repo/current',
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+      idle: false,
+    })
+
+    vi.spyOn(useFileDiffModule, 'useFileDiff').mockReturnValue(
+      fileDiffMock({
+        diff: null,
+        loading: false,
+        error: null,
+      })
+    )
+
+    render(
+      <DiffPanelContent cwd="/repo/current" feedbackBatch={feedbackBatch} />
+    )
+
+    expect(screen.getByTestId('diff-empty-state')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /finish feedback \(1\)/i })
+    ).toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole('button', { name: /discard all feedback/i })
+    )
+
+    expect(clearBatch).toHaveBeenCalledOnce()
+
+    await user.click(
+      screen.getByRole('button', { name: /finish feedback \(1\)/i })
+    )
+
+    expect(
+      await screen.findByRole('dialog', { name: 'Finish feedback' })
+    ).toBeInTheDocument()
   })
 
   test('renders ChangedFilesList and Pierre MultiFileDiff when changes exist', (): void => {

--- a/src/features/diff/components/DiffPanelContent.tsx
+++ b/src/features/diff/components/DiffPanelContent.tsx
@@ -103,6 +103,7 @@ type DiffPanelSelectionControl =
 
 export interface FeedbackRepoRootRef {
   current: string
+  repoRootForCwd?: (cwd: string) => string
 }
 
 interface DiffPanelContentBaseProps {
@@ -762,7 +763,7 @@ export const DiffPanelContent = ({
   const { clearBatch: clearLocalFeedbackBatch } = localFeedback
   const hasParentFeedbackBatch = feedbackBatch !== undefined
   const feedback: UseFeedbackBatchReturn = feedbackBatch ?? localFeedback
-  const localRepoRootRef = useRef('')
+  const localRepoRootRef = useRef('') as FeedbackRepoRootRef
   const repoRootRef = feedbackRepoRootRef ?? localRepoRootRef
 
   // Track cwd transitions that invalidate per-repo derived state. The
@@ -1006,8 +1007,23 @@ export const DiffPanelContent = ({
         // into the payload so an `MM` file (staged + unstaged both commented)
         // stays disambiguated.
         for (const [key, annotations] of feedback.batch) {
-          const { filePath: relPath, staged } = parseBatchKey(key)
-          const filePath = repoRoot ? `${repoRoot}/${relPath}` : relPath
+          const {
+            cwd: entryCwd,
+            filePath: relPath,
+            staged,
+          } = parseBatchKey(key)
+
+          const entryRepoRoot =
+            'repoRootForCwd' in repoRootRef
+              ? repoRootRef.repoRootForCwd?.(entryCwd)
+              : undefined
+
+          const resolvedRepoRoot =
+            entryRepoRoot && entryRepoRoot.length > 0 ? entryRepoRoot : repoRoot
+
+          const filePath = resolvedRepoRoot
+            ? `${resolvedRepoRoot}/${relPath}`
+            : relPath
           entries.push({ filePath, staged, annotations })
         }
 
@@ -2134,6 +2150,21 @@ export const DiffPanelContent = ({
     onStickyHeaderChange: setStickyHeader,
   }
 
+  const finishFeedbackPopover: ReactElement | null =
+    finishOpen && toolbarShellRef.current !== null ? (
+      <FinishFeedbackPopover
+        anchor={toolbarShellRef.current}
+        result={resolveCandidatePanes({
+          allPanes: feedbackDispatch?.candidates ?? [],
+          diffCwd: cwd,
+        })}
+        commentCount={feedback.totalAnnotations()}
+        fileCount={feedback.batch.size}
+        onCancel={(): void => setFinishOpen(false)}
+        onSend={handleSendFeedback}
+      />
+    ) : null
+
   // Empty state (no changes): keep a DORMANT toolbar (only the settings
   // dropdowns stay live — nav arrows, tool-well + actions render disabled /
   // placeholder) above a calm "no changes" panel, so the chrome stays put when
@@ -2147,13 +2178,21 @@ export const DiffPanelContent = ({
         onPointerDownCapture={handleDiffRootPointerDown}
         className="flex h-full w-full min-h-0 flex-col overflow-hidden text-on-surface-variant focus:outline-none"
       >
-        <div className="shrink-0">
+        <div
+          ref={toolbarShellRef}
+          data-testid="diff-toolbar-shell"
+          className="shrink-0"
+        >
           <DiffChipToolbar
             {...toolbarSettingsProps}
             diffMode="unstaged"
             currentFileIndex={-1}
             totalFiles={0}
+            feedbackCount={feedback.totalAnnotations()}
+            onDiscardFeedback={feedback.clearBatch}
+            onFinishFeedback={(): void => setFinishOpen(true)}
           />
+          {finishFeedbackPopover}
         </div>
         <div
           data-testid="diff-empty-panel"
@@ -2276,19 +2315,7 @@ export const DiffPanelContent = ({
               </span>
             </div>
           ) : null}
-          {finishOpen && toolbarShellRef.current !== null ? (
-            <FinishFeedbackPopover
-              anchor={toolbarShellRef.current}
-              result={resolveCandidatePanes({
-                allPanes: feedbackDispatch?.candidates ?? [],
-                diffCwd: cwd,
-              })}
-              commentCount={feedback.totalAnnotations()}
-              fileCount={feedback.batch.size}
-              onCancel={(): void => setFinishOpen(false)}
-              onSend={handleSendFeedback}
-            />
-          ) : null}
+          {finishFeedbackPopover}
           {keyboardConfirm !== null && toolbarShellRef.current !== null ? (
             <Popover
               anchor={toolbarShellRef.current}

--- a/src/features/diff/hooks/useFeedbackBatch.test.ts
+++ b/src/features/diff/hooks/useFeedbackBatch.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import {
   useFeedbackBatch,
+  useFeedbackBatchStore,
   makeBatchKey,
   parseBatchKey,
 } from './useFeedbackBatch'
@@ -255,5 +256,153 @@ describe('useFeedbackBatch', () => {
       const key = makeBatchKey(expected.cwd, expected.filePath, expected.staged)
       expect(parseBatchKey(key)).toEqual(expected)
     }
+  })
+})
+
+describe('useFeedbackBatchStore', () => {
+  test('stores unfinished reviews separately per owner key', () => {
+    const { result, rerender } = renderHook(
+      ({ ownerKey, cwd }) => useFeedbackBatchStore(ownerKey, cwd),
+      { initialProps: { ownerKey: 'session-a:p0', cwd: '/repo-a' } }
+    )
+
+    act(() => {
+      result.current.feedbackBatch.addAnnotation(
+        '/repo-a',
+        'src/a.ts',
+        false,
+        makeAnnotation('owner-a')
+      )
+    })
+
+    expect(result.current.feedbackBatch.totalAnnotations()).toBe(1)
+    rerender({ ownerKey: 'session-b:p0', cwd: '/repo-b' })
+
+    expect(result.current.feedbackBatch.totalAnnotations()).toBe(0)
+
+    act(() => {
+      result.current.feedbackBatch.addAnnotation(
+        '/repo-b',
+        'src/b.ts',
+        false,
+        makeAnnotation('owner-b')
+      )
+    })
+
+    expect(result.current.feedbackBatch.totalAnnotations()).toBe(1)
+    rerender({ ownerKey: 'session-a:p0', cwd: '/repo-a' })
+
+    expect(result.current.feedbackBatch.totalAnnotations()).toBe(1)
+    expect(
+      result.current.feedbackBatch.annotationsForFile(
+        '/repo-a',
+        'src/a.ts',
+        false
+      )[0].metadata.id
+    ).toBe('owner-a')
+  })
+
+  test('keeps an owner batch when the same terminal changes cwd', () => {
+    const { result, rerender } = renderHook(
+      ({ cwd }) => useFeedbackBatchStore('session-a:p0', cwd),
+      { initialProps: { cwd: '/repo-a' } }
+    )
+
+    act(() => {
+      result.current.feedbackBatch.addAnnotation(
+        '/repo-a',
+        'src/a.ts',
+        false,
+        makeAnnotation('cwd-a')
+      )
+    })
+
+    rerender({ cwd: '/repo-b' })
+
+    expect(result.current.feedbackBatch.totalAnnotations()).toBe(1)
+    expect(
+      result.current.feedbackBatch.annotationsForFile(
+        '/repo-a',
+        'src/a.ts',
+        false
+      )[0].metadata.id
+    ).toBe('cwd-a')
+  })
+
+  test('tracks repo roots per owner and cwd', () => {
+    const { result, rerender } = renderHook(
+      ({ ownerKey, cwd }) => useFeedbackBatchStore(ownerKey, cwd),
+      { initialProps: { ownerKey: 'session-a:p0', cwd: '/repo-a' } }
+    )
+
+    act(() => {
+      result.current.feedbackRepoRootRef.current = '/repo-a-root'
+    })
+
+    rerender({ ownerKey: 'session-a:p0', cwd: '/repo-b' })
+
+    expect(result.current.feedbackRepoRootRef.current).toBe('')
+
+    act(() => {
+      result.current.feedbackRepoRootRef.current = '/repo-b-root'
+    })
+
+    expect(result.current.feedbackRepoRootRef.repoRootForCwd('/repo-a')).toBe(
+      '/repo-a-root'
+    )
+
+    expect(result.current.feedbackRepoRootRef.repoRootForCwd('/repo-b')).toBe(
+      '/repo-b-root'
+    )
+
+    rerender({ ownerKey: 'session-b:p0', cwd: '/repo-a' })
+
+    expect(result.current.feedbackRepoRootRef.current).toBe('')
+  })
+
+  test('prunes batches and repo roots for closed owners', () => {
+    const { result, rerender } = renderHook(
+      ({ ownerKey, cwd }) => useFeedbackBatchStore(ownerKey, cwd),
+      { initialProps: { ownerKey: 'session-a:p0', cwd: '/repo-a' } }
+    )
+
+    act(() => {
+      result.current.feedbackBatch.addAnnotation(
+        '/repo-a',
+        'src/a.ts',
+        false,
+        makeAnnotation('owner-a')
+      )
+      result.current.feedbackRepoRootRef.current = '/repo-a-root'
+    })
+
+    rerender({ ownerKey: 'session-b:p0', cwd: '/repo-b' })
+
+    act(() => {
+      result.current.feedbackBatch.addAnnotation(
+        '/repo-b',
+        'src/b.ts',
+        false,
+        makeAnnotation('owner-b')
+      )
+      result.current.feedbackRepoRootRef.current = '/repo-b-root'
+    })
+
+    expect(result.current.summaries.map((summary) => summary.ownerKey)).toEqual(
+      ['session-a:p0', 'session-b:p0']
+    )
+
+    act(() => {
+      result.current.pruneOwners(new Set(['session-b:p0']))
+    })
+
+    expect(result.current.summaries.map((summary) => summary.ownerKey)).toEqual(
+      ['session-b:p0']
+    )
+
+    rerender({ ownerKey: 'session-a:p0', cwd: '/repo-a' })
+
+    expect(result.current.feedbackBatch.totalAnnotations()).toBe(0)
+    expect(result.current.feedbackRepoRootRef.current).toBe('')
   })
 })

--- a/src/features/diff/hooks/useFeedbackBatch.ts
+++ b/src/features/diff/hooks/useFeedbackBatch.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { DiffLineAnnotation } from '@pierre/diffs'
 
 export interface ReviewComment {
@@ -138,6 +138,19 @@ const removeAnnotationFromBatch = (
 const EMPTY: DiffLineAnnotation<ReviewComment>[] = []
 Object.freeze(EMPTY)
 
+const EMPTY_BATCH: FeedbackBatch = new Map()
+Object.freeze(EMPTY_BATCH)
+
+const REPO_ROOT_KEY_SEP = '\0'
+
+const makeRepoRootKey = (ownerKey: string, cwd: string): string =>
+  `${ownerKey}${REPO_ROOT_KEY_SEP}${cwd}`
+
+const ownerKeyFromRepoRootKey = (key: string): string =>
+  key.split(REPO_ROOT_KEY_SEP)[0] ?? ''
+
+const LOCAL_FEEDBACK_OWNER_KEY = '__local_feedback__'
+
 export interface UseFeedbackBatchReturn {
   batch: FeedbackBatch
   annotationsForFile: (
@@ -168,14 +181,43 @@ export interface UseFeedbackBatchReturn {
   totalAnnotations: () => number
 }
 
-export const useFeedbackBatch = (): UseFeedbackBatchReturn => {
-  const [batch, setBatch] = useState<FeedbackBatch>(() => new Map())
-  const optimisticBatchRef = useRef<FeedbackBatch>(batch)
+export interface FeedbackBatchSummary {
+  ownerKey: string
+  fileCount: number
+  commentCount: number
+}
+
+export interface FeedbackRepoRootStoreRef {
+  current: string
+  repoRootForCwd: (cwd: string) => string
+}
+
+export interface UseFeedbackBatchStoreReturn {
+  feedbackBatch: UseFeedbackBatchReturn
+  feedbackRepoRootRef: FeedbackRepoRootStoreRef
+  summaries: FeedbackBatchSummary[]
+  pruneOwners: (liveOwnerKeys: ReadonlySet<string>) => void
+}
+
+export const useFeedbackBatchStore = (
+  ownerKey: string,
+  cwd: string
+): UseFeedbackBatchStoreReturn => {
+  const [batchesByOwner, setBatchesByOwner] = useState<
+    Map<string, FeedbackBatch>
+  >(() => new Map())
+
+  // Mirrors review batches for synchronous optimistic mutations before React
+  // commits state; this is the user-visible comment data.
+  const optimisticBatchesRef = useRef(batchesByOwner)
+  const repoRootsRef = useRef<Map<string, string>>(new Map())
   const addAnnotationResultRef = useRef<'ok' | 'cap-reached'>('ok')
 
   useEffect(() => {
-    optimisticBatchRef.current = batch
-  }, [batch])
+    optimisticBatchesRef.current = batchesByOwner
+  }, [batchesByOwner])
+
+  const batch = batchesByOwner.get(ownerKey) ?? EMPTY_BATCH
 
   const totalAnnotations = useCallback(
     (): number => countAnnotationsInBatch(batch),
@@ -184,11 +226,11 @@ export const useFeedbackBatch = (): UseFeedbackBatchReturn => {
 
   const annotationsForFile = useCallback(
     (
-      cwd: string,
+      requestedCwd: string,
       filePath: string,
       staged: boolean
     ): DiffLineAnnotation<ReviewComment>[] => {
-      const key = makeBatchKey(cwd, filePath, staged)
+      const key = makeBatchKey(requestedCwd, filePath, staged)
 
       return batch.get(key) ?? EMPTY
     },
@@ -197,103 +239,246 @@ export const useFeedbackBatch = (): UseFeedbackBatchReturn => {
 
   const addAnnotation = useCallback(
     (
-      cwd: string,
+      requestedCwd: string,
       filePath: string,
       staged: boolean,
       annotation: DiffLineAnnotation<ReviewComment>
     ): 'ok' | 'cap-reached' => {
-      const key = makeBatchKey(cwd, filePath, staged)
+      const key = makeBatchKey(requestedCwd, filePath, staged)
 
-      if (countAnnotationsInBatch(optimisticBatchRef.current) >= SOFT_CAP) {
+      const optimisticBatch =
+        optimisticBatchesRef.current.get(ownerKey) ?? EMPTY_BATCH
+
+      if (countAnnotationsInBatch(optimisticBatch) >= SOFT_CAP) {
         addAnnotationResultRef.current = 'cap-reached'
 
         return addAnnotationResultRef.current
       }
 
-      optimisticBatchRef.current = addAnnotationToBatch(
-        optimisticBatchRef.current,
+      const optimisticNextBatch = addAnnotationToBatch(
+        optimisticBatch,
         key,
         annotation
       )
+      optimisticBatchesRef.current = new Map(optimisticBatchesRef.current).set(
+        ownerKey,
+        optimisticNextBatch
+      )
       addAnnotationResultRef.current = 'ok'
-      setBatch((prev) => {
-        if (countAnnotationsInBatch(prev) >= SOFT_CAP) {
+      setBatchesByOwner((prev) => {
+        const currentBatch = prev.get(ownerKey) ?? EMPTY_BATCH
+        if (countAnnotationsInBatch(currentBatch) >= SOFT_CAP) {
           addAnnotationResultRef.current = 'cap-reached'
-          optimisticBatchRef.current = prev
+          optimisticBatchesRef.current = prev
 
           return prev
         }
 
+        const nextBatch = addAnnotationToBatch(currentBatch, key, annotation)
+        const next = new Map(prev).set(ownerKey, nextBatch)
+        optimisticBatchesRef.current = next
         addAnnotationResultRef.current = 'ok'
-        const next = addAnnotationToBatch(prev, key, annotation)
-        optimisticBatchRef.current = next
 
         return next
       })
 
       return addAnnotationResultRef.current
     },
-    []
+    [ownerKey]
   )
 
   const updateAnnotation = useCallback(
     (
-      cwd: string,
+      requestedCwd: string,
       filePath: string,
       staged: boolean,
       id: string,
       patch: Partial<ReviewComment>
     ): void => {
-      const key = makeBatchKey(cwd, filePath, staged)
-      optimisticBatchRef.current = updateAnnotationInBatch(
-        optimisticBatchRef.current,
+      const key = makeBatchKey(requestedCwd, filePath, staged)
+
+      const optimisticBatch =
+        optimisticBatchesRef.current.get(ownerKey) ?? EMPTY_BATCH
+
+      const optimisticNextBatch = updateAnnotationInBatch(
+        optimisticBatch,
         key,
         id,
         patch
       )
+      optimisticBatchesRef.current = new Map(optimisticBatchesRef.current).set(
+        ownerKey,
+        optimisticNextBatch
+      )
 
-      setBatch((prev) => {
-        const next = updateAnnotationInBatch(prev, key, id, patch)
-        optimisticBatchRef.current = next
+      setBatchesByOwner((prev) => {
+        const currentBatch = prev.get(ownerKey) ?? EMPTY_BATCH
+        const nextBatch = updateAnnotationInBatch(currentBatch, key, id, patch)
+        const next = new Map(prev).set(ownerKey, nextBatch)
+        optimisticBatchesRef.current = next
 
         return next
       })
     },
-    []
+    [ownerKey]
   )
 
   const removeAnnotation = useCallback(
-    (cwd: string, filePath: string, staged: boolean, id: string): void => {
-      const key = makeBatchKey(cwd, filePath, staged)
-      optimisticBatchRef.current = removeAnnotationFromBatch(
-        optimisticBatchRef.current,
+    (
+      requestedCwd: string,
+      filePath: string,
+      staged: boolean,
+      id: string
+    ): void => {
+      const key = makeBatchKey(requestedCwd, filePath, staged)
+
+      const optimisticBatch =
+        optimisticBatchesRef.current.get(ownerKey) ?? EMPTY_BATCH
+
+      const optimisticNextBatch = removeAnnotationFromBatch(
+        optimisticBatch,
         key,
         id
       )
+      const optimisticNext = new Map(optimisticBatchesRef.current)
+      if (optimisticNextBatch.size === 0) {
+        optimisticNext.delete(ownerKey)
+      } else {
+        optimisticNext.set(ownerKey, optimisticNextBatch)
+      }
+      optimisticBatchesRef.current = optimisticNext
 
-      setBatch((prev) => {
-        const next = removeAnnotationFromBatch(prev, key, id)
-        optimisticBatchRef.current = next
+      setBatchesByOwner((prev) => {
+        const currentBatch = prev.get(ownerKey) ?? EMPTY_BATCH
+        const nextBatch = removeAnnotationFromBatch(currentBatch, key, id)
+        const next = new Map(prev)
+        if (nextBatch.size === 0) {
+          next.delete(ownerKey)
+        } else {
+          next.set(ownerKey, nextBatch)
+        }
+        optimisticBatchesRef.current = next
 
         return next
       })
     },
-    []
+    [ownerKey]
   )
 
   const clearBatch = useCallback((): void => {
-    const next: FeedbackBatch = new Map()
-    optimisticBatchRef.current = next
-    setBatch(() => next)
-  }, [])
+    setBatchesByOwner((prev) => {
+      if (!prev.has(ownerKey)) {
+        return prev
+      }
+
+      const next = new Map(prev)
+      next.delete(ownerKey)
+      optimisticBatchesRef.current = next
+
+      return next
+    })
+  }, [ownerKey])
+
+  const feedbackBatch = useMemo<UseFeedbackBatchReturn>(
+    () => ({
+      batch,
+      annotationsForFile,
+      addAnnotation,
+      updateAnnotation,
+      removeAnnotation,
+      clearBatch,
+      totalAnnotations,
+    }),
+    [
+      batch,
+      annotationsForFile,
+      addAnnotation,
+      updateAnnotation,
+      removeAnnotation,
+      clearBatch,
+      totalAnnotations,
+    ]
+  )
+
+  const feedbackRepoRootRef = useMemo<FeedbackRepoRootStoreRef>(
+    () => ({
+      get current(): string {
+        return repoRootsRef.current.get(makeRepoRootKey(ownerKey, cwd)) ?? ''
+      },
+      set current(nextRoot: string) {
+        const rootKey = makeRepoRootKey(ownerKey, cwd)
+        if (repoRootsRef.current.get(rootKey) === nextRoot) {
+          return
+        }
+
+        const next = new Map(repoRootsRef.current)
+        if (nextRoot.length === 0) {
+          next.delete(rootKey)
+        } else {
+          next.set(rootKey, nextRoot)
+        }
+        repoRootsRef.current = next
+      },
+      repoRootForCwd(requestedCwd: string): string {
+        return (
+          repoRootsRef.current.get(makeRepoRootKey(ownerKey, requestedCwd)) ??
+          ''
+        )
+      },
+    }),
+    [cwd, ownerKey]
+  )
+
+  const summaries = useMemo<FeedbackBatchSummary[]>(
+    () =>
+      [...batchesByOwner.entries()]
+        .map(([entryOwnerKey, entryBatch]) => ({
+          ownerKey: entryOwnerKey,
+          fileCount: entryBatch.size,
+          commentCount: countAnnotationsInBatch(entryBatch),
+        }))
+        .filter((summary) => summary.commentCount > 0),
+    [batchesByOwner]
+  )
+
+  const pruneOwners = useCallback(
+    (liveOwnerKeys: ReadonlySet<string>): void => {
+      setBatchesByOwner((prev) => {
+        const next = new Map(
+          [...prev.entries()].filter(([entryOwnerKey]) =>
+            liveOwnerKeys.has(entryOwnerKey)
+          )
+        )
+
+        if (next.size === prev.size) {
+          return prev
+        }
+
+        optimisticBatchesRef.current = next
+
+        return next
+      })
+
+      const nextRepoRoots = new Map(
+        [...repoRootsRef.current.entries()].filter(([rootKey]) =>
+          liveOwnerKeys.has(ownerKeyFromRepoRootKey(rootKey))
+        )
+      )
+
+      if (nextRepoRoots.size !== repoRootsRef.current.size) {
+        repoRootsRef.current = nextRepoRoots
+      }
+    },
+    []
+  )
 
   return {
-    batch,
-    annotationsForFile,
-    addAnnotation,
-    updateAnnotation,
-    removeAnnotation,
-    clearBatch,
-    totalAnnotations,
+    feedbackBatch,
+    feedbackRepoRootRef,
+    summaries,
+    pruneOwners,
   }
 }
+
+export const useFeedbackBatch = (): UseFeedbackBatchReturn =>
+  useFeedbackBatchStore(LOCAL_FEEDBACK_OWNER_KEY, '').feedbackBatch

--- a/src/features/workspace/WorkspaceView.subscription.test.tsx
+++ b/src/features/workspace/WorkspaceView.subscription.test.tsx
@@ -439,7 +439,7 @@ describe('WorkspaceView lifted-subscription contract', () => {
     expect(capturedPanelProps.gitStatus).toBe(capturedDockPanelProps.gitStatus)
   })
 
-  test('DockPanel receives a workspace feedback batch that clears on cwd change', async () => {
+  test('DockPanel receives a terminal-bound feedback batch that survives cwd change', async () => {
     render(<WorkspaceView />)
 
     await openDockPanelMock()
@@ -469,13 +469,15 @@ describe('WorkspaceView lifted-subscription contract', () => {
       expect(capturedDockPanelProps.feedbackBatch?.totalAnnotations()).toBe(1)
     )
     if (feedbackRepoRootRef) {
-      feedbackRepoRootRef.current = '/repo'
+      act(() => {
+        feedbackRepoRootRef.current = '/repo'
+      })
     }
 
     fireEvent.click(screen.getByTestId('mock-terminal-cwd-change'))
 
     await waitFor(() =>
-      expect(capturedDockPanelProps.feedbackBatch?.totalAnnotations()).toBe(0)
+      expect(capturedDockPanelProps.feedbackBatch?.totalAnnotations()).toBe(1)
     )
     expect(capturedDockPanelProps.feedbackRepoRootRef?.current).toBe('')
   })

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -89,7 +89,7 @@ import { useAgentStatus } from '../agent-status/hooks/useAgentStatus'
 import { useAgentReattach } from '../agent-status/hooks/useAgentReattach'
 import { useAgentStatusHotLoading } from '../agent-status/hooks/useAgentStatusHotLoading'
 import { useGitStatus } from '../diff/hooks/useGitStatus'
-import { useFeedbackBatch } from '../diff/hooks/useFeedbackBatch'
+import { useFeedbackBatchStore } from '../diff/hooks/useFeedbackBatch'
 import type { PaneCandidate } from '../diff/services/activePanePicker'
 import { sumLines } from '../diff/utils/sumLines'
 import { findActivePane } from '../sessions/utils/activeSessionPane'
@@ -148,6 +148,24 @@ const rateLimitPercentage = (
   }
 
   return Math.round(limit.usedPercentage)
+}
+
+const UNBOUND_FEEDBACK_OWNER_KEY = 'workspace:unbound-feedback'
+
+const makeFeedbackOwnerKey = (sessionId: string, paneId: string): string =>
+  `${sessionId}:${paneId}`
+
+interface PendingFeedbackReview {
+  key: string
+  label: string
+  commentCount: number
+  fileCount: number
+}
+
+interface FeedbackOwnerTarget {
+  sessionId: string
+  paneId: string
+  label: string
 }
 
 const formatStatusDuration = (durationMs: number): string | undefined => {
@@ -1752,18 +1770,79 @@ const WorkspaceViewContent = (): ReactElement => {
   const [selectedDiffFile, setSelectedDiffFile] =
     useState<SelectedDiffFile | null>(null)
 
-  const feedbackBatch = useFeedbackBatch()
-  const feedbackRepoRootRef = useRef('')
-  const { clearBatch: clearFeedbackBatch } = feedbackBatch
-  const previousFeedbackCwdRef = useRef(activeCwd)
+  const activeFeedbackOwnerKey =
+    activeSessionId !== null && activePtyBackedPaneId !== undefined
+      ? makeFeedbackOwnerKey(activeSessionId, activePtyBackedPaneId)
+      : UNBOUND_FEEDBACK_OWNER_KEY
 
-  useEffect(() => {
-    if (previousFeedbackCwdRef.current !== activeCwd) {
-      previousFeedbackCwdRef.current = activeCwd
-      feedbackRepoRootRef.current = ''
-      clearFeedbackBatch()
+  const {
+    feedbackBatch,
+    feedbackRepoRootRef,
+    summaries: feedbackSummaries,
+    pruneOwners: pruneFeedbackOwners,
+  } = useFeedbackBatchStore(activeFeedbackOwnerKey, activeCwd)
+
+  useLayoutEffect(() => {
+    pruneFeedbackOwners(livePaneKeys)
+  }, [livePaneKeys, pruneFeedbackOwners])
+
+  const feedbackOwnerTargets = useMemo(() => {
+    const targets = new Map<string, FeedbackOwnerTarget>()
+
+    for (const session of sessions) {
+      for (const pane of session.panes) {
+        const label =
+          pane.userLabel ??
+          pane.agentTitle ??
+          (session.panes.length > 1
+            ? `${session.name} · ${pane.id}`
+            : session.name)
+
+        targets.set(makeFeedbackOwnerKey(session.id, pane.id), {
+          sessionId: session.id,
+          paneId: pane.id,
+          label,
+        })
+      }
     }
-  }, [activeCwd, clearFeedbackBatch])
+
+    return targets
+  }, [sessions])
+
+  const pendingFeedbackReviews = useMemo<PendingFeedbackReview[]>(
+    () =>
+      feedbackSummaries.flatMap((summary) => {
+        const target = feedbackOwnerTargets.get(summary.ownerKey)
+
+        return target
+          ? [
+              {
+                key: summary.ownerKey,
+                label: target.label,
+                commentCount: summary.commentCount,
+                fileCount: summary.fileCount,
+              },
+            ]
+          : []
+      }),
+    [feedbackOwnerTargets, feedbackSummaries]
+  )
+
+  // Called by the diff dock's unfinished-review selector when the user picks a
+  // pending review owned by another terminal pane.
+  const handlePendingFeedbackReviewSelect = useCallback(
+    (key: string): void => {
+      const target = feedbackOwnerTargets.get(key)
+      if (!target) {
+        return
+      }
+
+      setActiveSessionId(target.sessionId)
+      setSessionActivePane(target.sessionId, target.paneId)
+      openDock('diff')
+    },
+    [feedbackOwnerTargets, openDock, setActiveSessionId, setSessionActivePane]
+  )
 
   const editorGitStatusCwd = parentPathForGitStatus(editorBuffer.filePath)
   const editorFileLookupCwd = parentPathForFileLookup(editorBuffer.filePath)
@@ -2448,6 +2527,9 @@ const WorkspaceViewContent = (): ReactElement => {
       feedbackBatch={feedbackBatch}
       feedbackRepoRootRef={feedbackRepoRootRef}
       feedbackDispatch={feedbackDispatch}
+      pendingFeedbackReviews={pendingFeedbackReviews}
+      activeFeedbackReviewKey={activeFeedbackOwnerKey}
+      onPendingFeedbackReviewSelect={handlePendingFeedbackReviewSelect}
     />
   ) : // Closed dock renders nothing — the bottom action bar's dock toggle is
   // the single reopen affordance (the old "show panel" peek bar is gone).

--- a/src/features/workspace/components/DockPanel.test.tsx
+++ b/src/features/workspace/components/DockPanel.test.tsx
@@ -1006,6 +1006,129 @@ describe('DockPanel', () => {
     ).not.toBeInTheDocument()
   })
 
+  test('diff header switches between multiple unfinished terminal-bound reviews', async () => {
+    const user = userEvent.setup()
+    const onPendingFeedbackReviewSelect = vi.fn()
+
+    renderDockPanel({
+      tab: 'diff',
+      pendingFeedbackReviews: [
+        {
+          key: 'session-a:p0',
+          label: 'Agent A',
+          commentCount: 2,
+          fileCount: 1,
+        },
+        {
+          key: 'session-b:p0',
+          label: 'Agent B',
+          commentCount: 1,
+          fileCount: 1,
+        },
+      ],
+      activeFeedbackReviewKey: 'session-b:p0',
+      onPendingFeedbackReviewSelect,
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Reviews 2' }))
+
+    const reviewItems = screen.getAllByRole('menuitem')
+    expect(reviewItems).toHaveLength(2)
+    expect(within(reviewItems[0]).getByText('Agent A')).toBeInTheDocument()
+    expect(within(reviewItems[0]).getByText('p0')).toBeInTheDocument()
+    expect(within(reviewItems[0]).queryByText('Active')).not.toBeInTheDocument()
+    expect(reviewItems[0]).not.toHaveClass('bg-primary-container/15')
+    expect(
+      within(reviewItems[0]).getByText('2 comments · 1 file')
+    ).toBeInTheDocument()
+    expect(within(reviewItems[1]).getByText('Agent B')).toBeInTheDocument()
+    expect(within(reviewItems[1]).queryByText('Active')).not.toBeInTheDocument()
+    expect(reviewItems[1]).toHaveAttribute('aria-current', 'true')
+    expect(reviewItems[1]).toHaveClass('bg-primary-container/15')
+    expect(
+      within(reviewItems[1]).getByText('1 comment · 1 file')
+    ).toBeInTheDocument()
+
+    await user.click(within(reviewItems[1]).getByText('Agent B'))
+
+    expect(onPendingFeedbackReviewSelect).toHaveBeenCalledWith('session-b:p0')
+  })
+
+  test('diff header renders one unfinished terminal-bound review as a pane chip', async () => {
+    const user = userEvent.setup()
+    const onPendingFeedbackReviewSelect = vi.fn()
+
+    renderDockPanel({
+      tab: 'diff',
+      pendingFeedbackReviews: [
+        {
+          key: 'session-a:p1',
+          label: 'Agent A',
+          commentCount: 2,
+          fileCount: 1,
+        },
+      ],
+      activeFeedbackReviewKey: 'session-a:p1',
+      onPendingFeedbackReviewSelect,
+    })
+
+    expect(
+      screen.queryByRole('button', { name: 'Reviews 1' })
+    ).not.toBeInTheDocument()
+
+    const reviewChip = screen.getByRole('button', { name: 'p1' })
+    expect(reviewChip).toHaveAttribute('aria-pressed', 'true')
+
+    await user.click(reviewChip)
+
+    expect(onPendingFeedbackReviewSelect).toHaveBeenCalledWith('session-a:p1')
+  })
+
+  test('narrow diff dock lists unfinished reviews in compact actions menu', async () => {
+    const user = userEvent.setup()
+    const onPendingFeedbackReviewSelect = vi.fn()
+
+    renderDockPanel({
+      tab: 'diff',
+      position: 'left',
+      horizontalSize: 360,
+      pendingFeedbackReviews: [
+        {
+          key: 'session-a:p0',
+          label: 'Agent A',
+          commentCount: 2,
+          fileCount: 1,
+        },
+        {
+          key: 'session-b:p0',
+          label: 'Agent B',
+          commentCount: 1,
+          fileCount: 1,
+        },
+      ],
+      activeFeedbackReviewKey: 'session-b:p0',
+      onPendingFeedbackReviewSelect,
+    })
+
+    await user.click(screen.getByRole('button', { name: /more dock actions/i }))
+
+    const menu = screen.getByTestId('dock-actions-menu')
+    expect(within(menu).getByText('Unfinished reviews · 2')).toBeInTheDocument()
+    expect(within(menu).getByText('Agent A')).toBeInTheDocument()
+    expect(within(menu).getByText('1 comment · 1 file')).toBeInTheDocument()
+
+    const reviewButtons = within(menu).getAllByRole('button')
+    expect(reviewButtons[1]).toHaveAttribute('aria-current', 'true')
+    expect(reviewButtons[1]).toHaveClass('bg-primary-container/15')
+    expect(
+      within(reviewButtons[1]).queryByText('Active')
+    ).not.toBeInTheDocument()
+
+    await user.click(within(menu).getByText('Agent A'))
+
+    expect(onPendingFeedbackReviewSelect).toHaveBeenCalledWith('session-a:p0')
+  })
+
   test('renders controlled active tab', () => {
     renderDockPanel({ tab: 'diff' })
 

--- a/src/features/workspace/components/DockPanel.tsx
+++ b/src/features/workspace/components/DockPanel.tsx
@@ -27,6 +27,9 @@ import {
 import { DockSwitcher, type DockPosition } from './DockSwitcher'
 import { DockTab } from './DockTab'
 import { ViewModeToggle, type ViewMode } from './ViewModeToggle'
+import { Menu } from '@/components/Menu'
+import { ToolbarButton } from '@/components/ToolbarButton'
+import { Tooltip } from '@/components/Tooltip'
 import type { SelectedDiffFile } from '../../diff/types'
 import type { UseGitStatusReturn } from '../../diff/hooks/useGitStatus'
 import type { UseFeedbackBatchReturn } from '../../diff/hooks/useFeedbackBatch'
@@ -43,6 +46,163 @@ import { ResizeHandle } from '@/components/ResizeHandle'
 type TabType = 'editor' | 'diff'
 
 const MARKDOWN_FILE_PATTERN = /\.(md|markdown)$/i
+const REVIEW_REPORT_ICON = 'grading'
+
+export interface PendingFeedbackReview {
+  key: string
+  label: string
+  commentCount: number
+  fileCount: number
+}
+
+interface FeedbackReviewControlsProps {
+  reviews: readonly PendingFeedbackReview[]
+  activeReviewKey?: string
+  onSelect: (key: string) => void
+}
+
+const reviewPaneId = (key: string): string => {
+  const separatorIndex = key.lastIndexOf(':')
+
+  return separatorIndex === -1 ? key : key.slice(separatorIndex + 1)
+}
+
+const plural = (count: number, singular: string): string =>
+  `${count} ${singular}${count === 1 ? '' : 's'}`
+
+const reviewContextText = (review: PendingFeedbackReview): string =>
+  `${plural(review.commentCount, 'comment')} · ${plural(
+    review.fileCount,
+    'file'
+  )}`
+
+const ReviewRowContent = ({
+  review,
+}: {
+  review: PendingFeedbackReview
+}): ReactElement => (
+  <span className="flex min-w-0 flex-col gap-0.5">
+    <span className="flex min-w-0 items-center gap-2">
+      <span className="truncate">{review.label}</span>
+      <span className="shrink-0 font-mono text-[10px] text-on-surface-variant">
+        {reviewPaneId(review.key)}
+      </span>
+    </span>
+    <span className="text-[0.65rem] leading-tight text-on-surface-variant">
+      {reviewContextText(review)}
+    </span>
+  </span>
+)
+
+const ReviewSwitcher = ({
+  reviews,
+  activeReviewKey = undefined,
+  onSelect,
+}: FeedbackReviewControlsProps): ReactElement | null => {
+  if (reviews.length === 0) {
+    return null
+  }
+
+  if (reviews.length === 1) {
+    const review = reviews[0]
+    const active = review.key === activeReviewKey
+
+    return (
+      <Tooltip
+        content={`${active ? 'Active review' : 'Open unfinished review'} · ${reviewContextText(review)}`}
+      >
+        <ToolbarButton
+          icon={REVIEW_REPORT_ICON}
+          label={reviewPaneId(review.key)}
+          pressed={active}
+          onClick={(): void => onSelect(review.key)}
+          className="h-[26px] min-w-0 rounded-lg px-2 font-mono text-[11px]"
+        />
+      </Tooltip>
+    )
+  }
+
+  const label = `Reviews ${reviews.length}`
+
+  return (
+    <Menu
+      trigger={
+        <ToolbarButton
+          icon="rate_review"
+          label={label}
+          trailingIcon="expand_more"
+          aria-label={label}
+          className="h-[26px] min-w-[7rem] justify-between rounded-lg px-2"
+        />
+      }
+      tooltip={`Switch unfinished review · ${reviews.length} panes`}
+      tooltipPlacement="bottom"
+      placement="bottom-end"
+      width={282}
+      bodyClassName="min-w-52 max-h-[28rem] overflow-auto pt-1 pb-0"
+      aria-label="Unfinished reviews"
+    >
+      <Menu.Section label="Unfinished reviews">
+        {reviews.map((review) => {
+          const active = review.key === activeReviewKey
+
+          return (
+            <Menu.Item
+              key={review.key}
+              icon={REVIEW_REPORT_ICON}
+              active={active}
+              onSelect={(): void => onSelect(review.key)}
+            >
+              <ReviewRowContent review={review} />
+            </Menu.Item>
+          )
+        })}
+      </Menu.Section>
+    </Menu>
+  )
+}
+
+const CompactReviewList = ({
+  reviews,
+  activeReviewKey = undefined,
+  onSelect,
+}: FeedbackReviewControlsProps): ReactElement | null => {
+  if (reviews.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="flex min-w-[220px] flex-col gap-1">
+      <div className="px-1 text-[0.65rem] font-bold uppercase tracking-wider text-on-surface-variant">
+        Unfinished reviews · {reviews.length}
+      </div>
+      {reviews.map((review) => {
+        const active = review.key === activeReviewKey
+
+        return (
+          <button
+            key={review.key}
+            type="button"
+            aria-current={active ? 'true' : undefined}
+            data-active-review={active ? 'true' : undefined}
+            onClick={(): void => onSelect(review.key)}
+            className={`flex w-full min-w-0 items-start gap-2 rounded px-2 py-1.5 text-left text-xs text-on-surface transition-colors hover:bg-on-surface/10 focus:outline-none focus-visible:bg-on-surface/10 ${
+              active ? 'bg-primary-container/15' : ''
+            }`}
+          >
+            <span
+              aria-hidden="true"
+              className="material-symbols-outlined mt-0.5 shrink-0 text-base leading-none text-on-surface-variant"
+            >
+              {REVIEW_REPORT_ICON}
+            </span>
+            <ReviewRowContent review={review} />
+          </button>
+        )
+      })}
+    </div>
+  )
+}
 
 type SelectedDiffControl =
   | { selectedDiffFile?: undefined; onSelectedDiffFileChange?: undefined }
@@ -99,6 +259,10 @@ interface DockPanelBaseProps {
   feedbackRepoRootRef?: FeedbackRepoRootRef
   /** Optional feedback dispatch target for inline review comments. */
   feedbackDispatch?: FeedbackDispatchTarget
+  /** Unfinished terminal-bound reviews available from other panes. */
+  pendingFeedbackReviews?: readonly PendingFeedbackReview[]
+  activeFeedbackReviewKey?: string
+  onPendingFeedbackReviewSelect?: (key: string) => void
   isFocused?: boolean
   onContainerFocus?: () => void
 }
@@ -142,6 +306,9 @@ const DockPanel = forwardRef<DockPanelHandle, DockPanelProps>(
       feedbackBatch = undefined,
       feedbackRepoRootRef = undefined,
       feedbackDispatch = undefined,
+      pendingFeedbackReviews = [],
+      activeFeedbackReviewKey = undefined,
+      onPendingFeedbackReviewSelect = undefined,
       isFocused = false,
       onContainerFocus = undefined,
       editorFileLifecycleStatus = null,
@@ -278,6 +445,11 @@ const DockPanel = forwardRef<DockPanelHandle, DockPanelProps>(
     const compactActions =
       !isVerticalDock && horizontalSize < DOCK_INLINE_ACTIONS_MIN_WIDTH_PX
 
+    const showPendingFeedbackReviews =
+      tab === 'diff' &&
+      pendingFeedbackReviews.length > 0 &&
+      onPendingFeedbackReviewSelect !== undefined
+
     const editorPathCrumbStatus: EditorPathCrumbStatus | null = isDirty
       ? 'UNSAVED'
       : editorFileLifecycleStatus === 'DELETED'
@@ -371,6 +543,16 @@ const DockPanel = forwardRef<DockPanelHandle, DockPanelProps>(
           onClose={onClose}
           compactActions={compactActions}
           menuAlign={position === 'left' ? 'left' : 'right'}
+          hasCompactMenuBadge={showPendingFeedbackReviews}
+          compactMenuLeadingContent={
+            showPendingFeedbackReviews ? (
+              <CompactReviewList
+                reviews={pendingFeedbackReviews}
+                activeReviewKey={activeFeedbackReviewKey}
+                onSelect={onPendingFeedbackReviewSelect}
+              />
+            ) : null
+          }
         >
           <div className="flex items-center gap-1">
             {isMarkdown && tab === 'editor' ? (
@@ -378,6 +560,13 @@ const DockPanel = forwardRef<DockPanelHandle, DockPanelProps>(
             ) : null}
             {isMarkdown && tab === 'editor' && viewMode === 'reading' ? (
               <ReadingStyleMenu />
+            ) : null}
+            {showPendingFeedbackReviews && !compactActions ? (
+              <ReviewSwitcher
+                reviews={pendingFeedbackReviews}
+                activeReviewKey={activeFeedbackReviewKey}
+                onSelect={onPendingFeedbackReviewSelect}
+              />
             ) : null}
             <DockSwitcher position={position} onPick={onPositionChange} />
           </div>

--- a/src/features/workspace/components/DockTab.test.tsx
+++ b/src/features/workspace/components/DockTab.test.tsx
@@ -80,6 +80,22 @@ describe('DockTab', () => {
     ).toBeInTheDocument()
   })
 
+  test('compact pending badge does not intercept pointer events', () => {
+    render(
+      <DockTab
+        tab="editor"
+        onTabChange={vi.fn()}
+        onClose={vi.fn()}
+        compactActions
+        hasCompactMenuBadge
+      />
+    )
+
+    expect(screen.getByTestId('dock-actions-badge')).toHaveClass(
+      'pointer-events-none'
+    )
+  })
+
   test('compact menu closes when clicking outside', async () => {
     const user = userEvent.setup()
     render(

--- a/src/features/workspace/components/DockTab.tsx
+++ b/src/features/workspace/components/DockTab.tsx
@@ -27,6 +27,10 @@ interface DockTabProps {
   menuAlign?: 'left' | 'right'
   /** Slot rendered between the tab strip spacer and the action cluster. */
   children?: ReactNode
+  /** Extra content rendered before the regular controls inside the compact menu. */
+  compactMenuLeadingContent?: ReactNode
+  /** Whether the compact overflow trigger should show an unread-style dot. */
+  hasCompactMenuBadge?: boolean
 }
 
 const DOCK_TAB_OPTIONS = [
@@ -58,6 +62,8 @@ export const DockTab = ({
   compactActions = false,
   menuAlign = 'right',
   children = undefined,
+  compactMenuLeadingContent = undefined,
+  hasCompactMenuBadge = false,
 }: DockTabProps): ReactElement => {
   const actionsMenuId = useId()
   const [actionsOpen, setActionsOpen] = useState(false)
@@ -180,6 +186,13 @@ export const DockTab = ({
               className="h-6 w-6 rounded-[5px] text-[16px] focus:bg-wash-subtle focus:text-primary"
             />
           </Tooltip>
+          {hasCompactMenuBadge ? (
+            <span
+              data-testid="dock-actions-badge"
+              aria-hidden="true"
+              className="pointer-events-none absolute right-0.5 top-0.5 h-1.5 w-1.5 rounded-full bg-primary"
+            />
+          ) : null}
 
           {actionsOpen && (
             <div
@@ -189,6 +202,7 @@ export const DockTab = ({
               className={`absolute ${menuAlignClass} top-[28px] z-50 flex min-w-[190px] flex-col gap-2 rounded-lg border border-outline-variant/35 bg-surface-container-lowest p-2 shadow-xl`}
               onClick={() => setActionsOpen(false)}
             >
+              {compactMenuLeadingContent}
               <div className="flex items-center justify-between gap-2">
                 {children}
                 <Tooltip


### PR DESCRIPTION
## Summary
- keep unfinished diff review batches bound to their owning terminal pane instead of the currently selected cwd
- add a review switcher in the diff dock for returning to pending terminal-bound reviews
- keep finish/discard actions available for pending feedback even when the current diff view is empty
- simplify the review switcher active state to background-only styling with the grading report icon

## Validation
- npm run lint
- npm run test
- pre-push test hook passed during git push
