### PR TITLE
[codex] wire git ref chip native overlay

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -61,7 +61,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 94       | 91   | 2026-06-28   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 83       | 82   | 2026-06-30   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
-| [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 78       | 75   | 2026-06-30   |
+| [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 79       | 76   | 2026-06-30   |
 | [Canonical Path Dedupe](patterns/canonical-path-dedupe.md)                                           | correctness        | 2        | 0    | 2026-06-14   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)                                       | backend            | 4        | 2    | 2026-06-14   |
 | [Command Injection](patterns/command-injection.md)                                                   | security           | 8        | 3    | 2026-06-16   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -59,7 +59,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 84       | 38   | 2026-06-25   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 9        | 4    | 2026-06-28   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 94       | 91   | 2026-06-28   |
-| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 82       | 81   | 2026-06-30   |
+| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 83       | 82   | 2026-06-30   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 78       | 75   | 2026-06-30   |
 | [Canonical Path Dedupe](patterns/canonical-path-dedupe.md)                                           | correctness        | 2        | 0    | 2026-06-14   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -96,7 +96,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [CloudFormation Stale References](patterns/cloudformation-stale-references.md)                       | infrastructure     | 2        | 1    | 2026-06-12   |
 | [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 7        | 7    | 2026-06-22   |
 | [Unsafe Block Safety Comments](patterns/unsafe-block-safety-comments.md)                             | security           | 1        | 0    | 2026-06-14   |
-| [Type Contract Safety](patterns/type-contract-safety.md)                                             | code-quality       | 13       | 7    | 2026-06-28   |
+| [Type Contract Safety](patterns/type-contract-safety.md)                                             | code-quality       | 14       | 8    | 2026-06-30   |
 | [String Construction Hygiene](patterns/string-construction-hygiene.md)                               | code-quality       | 2        | 1    | 2026-06-19   |
 | [Agent-State Guards](patterns/agent-state-guards.md)                                                 | correctness        | 14       | 9    | 2026-06-28   |
 | [React Prop Contracts](patterns/react-prop-contracts.md)                                             | react-patterns     | 8        | 6    | 2026-06-22   |
@@ -110,6 +110,6 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Vite HMR Static Dependencies](patterns/vite-hmr-static-deps.md)                                     | code-quality       | 3        | 2    | 2026-06-18   |
 | [Custom Pane Layout Preservation](patterns/custom-pane-layout-preservation.md)                       | correctness        | 13       | 5    | 2026-06-22   |
 | [Pane Slot Identity](patterns/pane-slot-identity.md)                                                 | correctness        | 3        | 1    | 2026-06-22   |
-| [Transient UI Side Effects](patterns/transient-ui-side-effects.md)                                   | react-patterns     | 8        | 3    | 2026-06-26   |
+| [Transient UI Side Effects](patterns/transient-ui-side-effects.md)                                   | react-patterns     | 9        | 4    | 2026-06-30   |
 | [Async Global State Mutation](patterns/async-global-state-mutation.md)                               | backend            | 1        | 0    | 2026-06-19   |
 | [Boolean Sentinel Consistency](patterns/boolean-sentinel-consistency.md)                             | code-quality       | 5        | 2    | 2026-06-30   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -59,7 +59,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 84       | 38   | 2026-06-25   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 9        | 4    | 2026-06-28   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 94       | 91   | 2026-06-28   |
-| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 83       | 82   | 2026-06-30   |
+| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 84       | 83   | 2026-06-30   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 79       | 76   | 2026-06-30   |
 | [Canonical Path Dedupe](patterns/canonical-path-dedupe.md)                                           | correctness        | 2        | 0    | 2026-06-14   |

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -3,7 +3,7 @@ id: accessibility
 category: a11y
 created: 2026-04-09
 last_updated: 2026-06-30
-ref_count: 82
+ref_count: 83
 ---
 
 # Accessibility
@@ -771,4 +771,13 @@ handlers must not trap focus without implementing the promised behavior.
 - **File:** `electron/native-overlay.ts`
 - **Finding:** The native overlay `BrowserWindow` was created with `focusable: false`, so keyboard-opened menus could render above the owner window but could not receive Arrow or Enter events for row navigation and activation.
 - **Fix:** Removed the non-focusable window option and focused the overlay `webContents` immediately after `showInactive()`, preserving owner-focus restoration on close. Electron controller tests now assert the overlay is not created with `focusable: false` and receives focus after being shown.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 76. Focus auto-open was disabled in local native-overlay fallback mode
+
+- **Source:** github-claude | PR #638 round 2 | 2026-06-30
+- **Severity:** HIGH
+- **File:** `src/features/terminal/components/TerminalPane/GitRefChip.tsx` L313-316
+- **Finding:** `GitRefChip` suppressed focus-triggered menu opening whenever the `nativeOverlay` prop was true, but the caller now passes that prop unconditionally while the actual native overlay transport remains feature-flagged and macOS-gated. Default local fallback builds therefore lost the prior Tab-to-chip keyboard auto-open behavior.
+- **Fix:** Reused the floating transport selector for the focus guard so focus auto-open is suppressed only when the native overlay transport is actually active. Added a regression test covering `nativeOverlay={true}` with the default local fallback.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -3,7 +3,7 @@ id: accessibility
 category: a11y
 created: 2026-04-09
 last_updated: 2026-06-30
-ref_count: 81
+ref_count: 82
 ---
 
 # Accessibility
@@ -762,4 +762,13 @@ handlers must not trap focus without implementing the promised behavior.
 - **File:** `electron/native-overlay.ts`
 - **Finding:** The native overlay window was shown with `showInactive()` but neither the window nor its `webContents` received focus. Keyboard-opened menus rendered above the owner window while Escape, Arrow, and Enter stayed routed to the owner or terminal.
 - **Fix:** Focused the overlay `webContents` immediately after showing the overlay window, preserving the existing owner-focus restoration in `closeSurface`. Electron controller tests now assert the overlay receives focus on open.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 75. Native overlay menu window was non-focusable
+
+- **Source:** github-codex-connector | PR #638 round 1 | 2026-06-30
+- **Severity:** P2 / MEDIUM
+- **File:** `electron/native-overlay.ts`
+- **Finding:** The native overlay `BrowserWindow` was created with `focusable: false`, so keyboard-opened menus could render above the owner window but could not receive Arrow or Enter events for row navigation and activation.
+- **Fix:** Removed the non-focusable window option and focused the overlay `webContents` immediately after `showInactive()`, preserving owner-focus restoration on close. Electron controller tests now assert the overlay is not created with `focusable: false` and receives focus after being shown.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/async-race-conditions.md
+++ b/docs/reviews/patterns/async-race-conditions.md
@@ -3,7 +3,7 @@ id: async-race-conditions
 category: react-patterns
 created: 2026-04-09
 last_updated: 2026-06-30
-ref_count: 75
+ref_count: 76
 ---
 
 # Async Race Conditions
@@ -812,4 +812,18 @@ prevent showing previous data.
   `record.activeSurfaceId === surfaceId`. Stale closes still delete their
   surface record and settle pending ready promises, but they no longer disturb
   a newer active surface.
+- **Commit:** same commit as this entry
+
+### 78. Native overlay restored focus reopened the dismissed menu
+
+- **Source:** github-claude | PR #638 round 2 | 2026-06-30
+- **Severity:** LOW
+- **File:** `src/features/terminal/components/TerminalPane/GitRefChip.tsx`
+- **Finding:** The Git ref chip opened its native overlay from `focus`, but
+  native overlay dismissal restores focus to the owner window asynchronously.
+  If that focus event arrived before the close IPC updated the local guard, the
+  just-dismissed overlay could reopen without user intent.
+- **Fix:** Disabled focus-triggered opens for the native overlay path and kept
+  explicit click, Enter, Space, and ArrowDown activation. Added regression
+  coverage that restored focus alone does not call the native overlay bridge.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/transient-ui-side-effects.md
+++ b/docs/reviews/patterns/transient-ui-side-effects.md
@@ -2,8 +2,8 @@
 id: transient-ui-side-effects
 category: react-patterns
 created: 2026-06-20
-last_updated: 2026-06-26
-ref_count: 3
+last_updated: 2026-06-30
+ref_count: 4
 ---
 
 # Transient UI Side Effects
@@ -123,4 +123,18 @@ to persistent state through a separate, explicit path.
   suppresses the status bar and threaded it through `Header` to `HeaderActions`.
   Added regression coverage for the awaiting-restart pane and header forwarding
   behavior.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 9. Native overlay host retained stale theme variables
+
+- **Source:** github-claude | PR #638 round 1 | 2026-06-30
+- **Severity:** MEDIUM
+- **File:** `src/components/NativeOverlayHost.tsx`
+- **Finding:** `applyThemeSnapshot` returned immediately when a native overlay
+  render request omitted `theme`, leaving any prior CSS variables, `data-theme`,
+  and `colorScheme` on the persistent overlay document.
+- **Fix:** Reset theme-owned `--color-*` and `--shadow-*` inline properties plus
+  theme metadata before each render, then apply the new snapshot only when one
+  is present. Added regression coverage for a themed request followed by an
+  unthemed request in the same host window.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/type-contract-safety.md
+++ b/docs/reviews/patterns/type-contract-safety.md
@@ -2,8 +2,8 @@
 id: type-contract-safety
 category: code-quality
 created: 2026-06-15
-last_updated: 2026-06-28
-ref_count: 7
+last_updated: 2026-06-30
+ref_count: 8
 ---
 
 # Type Contract Safety
@@ -157,3 +157,17 @@ expands.
   `VITE_GHOSTTY_NATIVE_MACOS` or `VITE_GHOSTTY_NATIVE_MACOS_PARENT` is enabled,
   matching the main-process registration guard.
 - **Commit:** same commit as this entry
+
+### 14. Native overlay menu payload omitted `surfaceTone`
+
+- **Source:** github-claude | PR #638 round 1 | 2026-06-30
+- **Severity:** LOW
+- **File:** `electron/native-overlay.ts`
+- **Finding:** The renderer-side native overlay payload included
+  `surfaceTone`, but the main-process `NativeOverlayMenuPayload` type and guard
+  only knew about `matchAnchorWidth`, leaving the protocol shape split across
+  process boundaries.
+- **Fix:** Added `surfaceTone?: string` to the Electron-side menu payload and
+  accepted string values in the runtime validator. Extended the themed overlay
+  controller test to pass the field through to the renderer.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/electron/native-overlay-channels.ts
+++ b/electron/native-overlay-channels.ts
@@ -2,9 +2,12 @@ export const NATIVE_OVERLAY_OPEN = 'native-overlay:open'
 
 export const NATIVE_OVERLAY_CLOSE = 'native-overlay:close'
 
+export const NATIVE_OVERLAY_ACTION_RESULT = 'native-overlay:action-result'
+
 export type NativeOverlayInvokeChannel =
   | typeof NATIVE_OVERLAY_OPEN
   | typeof NATIVE_OVERLAY_CLOSE
+  | typeof NATIVE_OVERLAY_ACTION_RESULT
 
 export const NATIVE_OVERLAY_ACTION = 'native-overlay:action'
 

--- a/electron/native-overlay.test.ts
+++ b/electron/native-overlay.test.ts
@@ -230,7 +230,7 @@ const finishOverlayLoad = (): FakeWindow => {
 
 const acknowledgeOverlayReady = async (
   overlayWindow: FakeWindow,
-  surfaceId = request.surfaceId
+  surfaceId: string = request.surfaceId
 ): Promise<void> => {
   await Promise.resolve()
   handler(NATIVE_OVERLAY_READY)(
@@ -264,11 +264,13 @@ describe('NativeOverlayController', () => {
     await acknowledgeOverlayReady(overlayWindow)
     await expect(openPromise).resolves.toEqual({ accepted: true })
     expect(electronMock.BrowserWindow).toHaveBeenCalledOnce()
+    expect(electronMock.BrowserWindow).not.toHaveBeenCalledWith(
+      expect.objectContaining({ focusable: false })
+    )
     expect(electronMock.BrowserWindow).toHaveBeenCalledWith(
       expect.objectContaining({
         acceptFirstMouse: true,
         backgroundColor: '#00000000',
-        focusable: false,
         frame: false,
         hasShadow: false,
         parent: electronMock.owner,
@@ -305,7 +307,10 @@ describe('NativeOverlayController', () => {
       height: 500,
     })
     expect(overlayWindow.showInactive).toHaveBeenCalledOnce()
-    expect(overlayWindow.webContents.focus).not.toHaveBeenCalled()
+    expect(overlayWindow.webContents.focus).toHaveBeenCalledOnce()
+    expect(overlayWindow.showInactive.mock.invocationCallOrder[0]).toBeLessThan(
+      overlayWindow.webContents.focus.mock.invocationCallOrder[0]
+    )
   })
 
   test('accepts sectioned menu payloads with composite rows', async () => {
@@ -453,7 +458,7 @@ describe('NativeOverlayController', () => {
 
     await expect(openPromise).resolves.toEqual({ accepted: true })
     expect(overlayWindow.showInactive).toHaveBeenCalledOnce()
-    expect(overlayWindow.webContents.focus).not.toHaveBeenCalled()
+    expect(overlayWindow.webContents.focus).toHaveBeenCalledOnce()
   })
 
   test('does not hide a newer active overlay when an older render times out', async () => {

--- a/electron/native-overlay.test.ts
+++ b/electron/native-overlay.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import {
   NATIVE_OVERLAY_ACTION,
+  NATIVE_OVERLAY_ACTION_RESULT,
   NATIVE_OVERLAY_CLEAR,
   NATIVE_OVERLAY_CLOSE,
   NATIVE_OVERLAY_CLOSED,
@@ -773,6 +774,7 @@ describe('NativeOverlayController', () => {
         surfaceId: request.surfaceId,
         actionId: 'copy',
         closeOnSelect: false,
+        feedback: 'copy',
       }
     )
 
@@ -782,6 +784,7 @@ describe('NativeOverlayController', () => {
         surfaceId: request.surfaceId,
         actionId: 'copy',
         closeOnSelect: false,
+        feedback: 'copy',
       }
     )
 
@@ -797,7 +800,35 @@ describe('NativeOverlayController', () => {
         surfaceId: request.surfaceId,
         actionId: 'copy',
         closeOnSelect: false,
+        feedback: 'copy',
       }
+    )
+
+    const result = {
+      surfaceId: request.surfaceId,
+      actionId: 'copy',
+      feedback: 'copy',
+      ok: true,
+    } as const
+
+    handler(NATIVE_OVERLAY_ACTION_RESULT)(
+      { sender: overlayWindow.webContents },
+      result
+    )
+
+    expect(overlayWindow.webContents.send).not.toHaveBeenCalledWith(
+      NATIVE_OVERLAY_ACTION_RESULT,
+      result
+    )
+
+    handler(NATIVE_OVERLAY_ACTION_RESULT)(
+      { sender: electronMock.owner.webContents },
+      result
+    )
+
+    expect(overlayWindow.webContents.send).toHaveBeenCalledWith(
+      NATIVE_OVERLAY_ACTION_RESULT,
+      result
     )
   })
 

--- a/electron/native-overlay.test.ts
+++ b/electron/native-overlay.test.ts
@@ -228,12 +228,13 @@ const finishOverlayLoad = (): FakeWindow => {
 }
 
 const acknowledgeOverlayReady = async (
-  overlayWindow: FakeWindow
+  overlayWindow: FakeWindow,
+  surfaceId = request.surfaceId
 ): Promise<void> => {
   await Promise.resolve()
   handler(NATIVE_OVERLAY_READY)(
     { sender: overlayWindow.webContents },
-    { surfaceId: request.surfaceId }
+    { surfaceId }
   )
 }
 
@@ -266,9 +267,10 @@ describe('NativeOverlayController', () => {
       expect.objectContaining({
         acceptFirstMouse: true,
         backgroundColor: '#00000000',
-        focusable: true,
+        focusable: false,
         frame: false,
         hasShadow: false,
+        parent: electronMock.owner,
         show: false,
         skipTaskbar: true,
         transparent: true,
@@ -302,7 +304,7 @@ describe('NativeOverlayController', () => {
       height: 500,
     })
     expect(overlayWindow.showInactive).toHaveBeenCalledOnce()
-    expect(overlayWindow.webContents.focus).toHaveBeenCalledOnce()
+    expect(overlayWindow.webContents.focus).not.toHaveBeenCalled()
   })
 
   test('accepts sectioned menu payloads with composite rows', async () => {
@@ -371,6 +373,36 @@ describe('NativeOverlayController', () => {
     await expect(openPromise).resolves.toEqual({ accepted: true })
   })
 
+  test('accepts themed menu payloads for the overlay renderer', async () => {
+    const themedRequest = {
+      ...request,
+      surfaceId: 'surface-themed',
+      theme: {
+        id: 'flexoki',
+        colorScheme: 'light',
+        variables: {
+          '--color-surface-container-high': 'var(--color-test-surface-high)',
+          '--shadow-menu': 'var(--shadow-test-menu)',
+        },
+      },
+    } as const
+
+    const openPromise = handler(NATIVE_OVERLAY_OPEN)(
+      { sender: electronMock.owner.webContents },
+      themedRequest
+    )
+    const overlayWindow = finishOverlayLoad()
+
+    await Promise.resolve()
+    expect(overlayWindow.webContents.send).toHaveBeenCalledWith(
+      NATIVE_OVERLAY_RENDER,
+      themedRequest
+    )
+
+    await acknowledgeOverlayReady(overlayWindow, themedRequest.surfaceId)
+    await expect(openPromise).resolves.toEqual({ accepted: true })
+  })
+
   test('falls back locally and hides the overlay window when render is never acknowledged', async () => {
     vi.useFakeTimers()
     try {
@@ -420,7 +452,7 @@ describe('NativeOverlayController', () => {
 
     await expect(openPromise).resolves.toEqual({ accepted: true })
     expect(overlayWindow.showInactive).toHaveBeenCalledOnce()
-    expect(overlayWindow.webContents.focus).toHaveBeenCalledOnce()
+    expect(overlayWindow.webContents.focus).not.toHaveBeenCalled()
   })
 
   test('does not hide a newer active overlay when an older render times out', async () => {
@@ -574,6 +606,65 @@ describe('NativeOverlayController', () => {
     )
   })
 
+  test.each(['blur', 'hide', 'minimize'])(
+    'parent window %s dismisses the overlay without refocusing the owner',
+    async (eventName) => {
+      const openPromise = handler(NATIVE_OVERLAY_OPEN)(
+        { sender: electronMock.owner.webContents },
+        request
+      )
+      const overlayWindow = finishOverlayLoad()
+      await acknowledgeOverlayReady(overlayWindow)
+      await openPromise
+
+      electronMock.owner.webContents.focus.mockClear()
+      electronMock.owner.emit(eventName)
+
+      expect(overlayWindow.webContents.send).toHaveBeenCalledWith(
+        NATIVE_OVERLAY_CLEAR
+      )
+      expect(overlayWindow.hide).toHaveBeenCalledOnce()
+      expect(overlayWindow.setAlwaysOnTop).toHaveBeenLastCalledWith(false)
+      expect(overlayWindow.setIgnoreMouseEvents).toHaveBeenLastCalledWith(true)
+      expect(electronMock.owner.webContents.focus).not.toHaveBeenCalled()
+      expect(electronMock.owner.webContents.send).toHaveBeenCalledWith(
+        NATIVE_OVERLAY_CLOSED,
+        { surfaceId: request.surfaceId, reason: 'outside' }
+      )
+    }
+  )
+
+  test('parent window close tears down the overlay before it can stand alone', async () => {
+    const openPromise = handler(NATIVE_OVERLAY_OPEN)(
+      { sender: electronMock.owner.webContents },
+      request
+    )
+    const overlayWindow = finishOverlayLoad()
+    await acknowledgeOverlayReady(overlayWindow)
+    await openPromise
+
+    electronMock.owner.webContents.focus.mockClear()
+    electronMock.owner.emit('close')
+
+    expect(overlayWindow.webContents.send).toHaveBeenCalledWith(
+      NATIVE_OVERLAY_CLEAR
+    )
+    expect(overlayWindow.hide).toHaveBeenCalledOnce()
+    expect(overlayWindow.setAlwaysOnTop).toHaveBeenLastCalledWith(false)
+    expect(overlayWindow.setIgnoreMouseEvents).toHaveBeenLastCalledWith(true)
+    expect(overlayWindow.close).toHaveBeenCalledOnce()
+    expect(electronMock.owner.webContents.focus).not.toHaveBeenCalled()
+    expect(electronMock.owner.removeListener).toHaveBeenCalledWith(
+      'close',
+      expect.any(Function)
+    )
+
+    expect(electronMock.owner.webContents.send).toHaveBeenCalledWith(
+      NATIVE_OVERLAY_CLOSED,
+      { surfaceId: request.surfaceId, reason: 'owner-closed' }
+    )
+  })
+
   test('close after overlay window destruction updates owner without calling destroyed window methods', async () => {
     const openPromise = handler(NATIVE_OVERLAY_OPEN)(
       { sender: electronMock.owner.webContents },
@@ -664,6 +755,49 @@ describe('NativeOverlayController', () => {
     expect(electronMock.owner.webContents.send).toHaveBeenCalledWith(
       NATIVE_OVERLAY_ACTION,
       { surfaceId: request.surfaceId, actionId: 'copy' }
+    )
+  })
+
+  test('action can keep the overlay open for copy feedback', async () => {
+    const openPromise = handler(NATIVE_OVERLAY_OPEN)(
+      { sender: electronMock.owner.webContents },
+      request
+    )
+    const overlayWindow = finishOverlayLoad()
+    await acknowledgeOverlayReady(overlayWindow)
+    await openPromise
+
+    handler(NATIVE_OVERLAY_ACTION)(
+      { sender: overlayWindow.webContents },
+      {
+        surfaceId: request.surfaceId,
+        actionId: 'copy',
+        closeOnSelect: false,
+      }
+    )
+
+    handler(NATIVE_OVERLAY_ACTION)(
+      { sender: overlayWindow.webContents },
+      {
+        surfaceId: request.surfaceId,
+        actionId: 'copy',
+        closeOnSelect: false,
+      }
+    )
+
+    expect(overlayWindow.hide).not.toHaveBeenCalled()
+    expect(overlayWindow.webContents.send).not.toHaveBeenCalledWith(
+      NATIVE_OVERLAY_CLEAR
+    )
+
+    expect(electronMock.owner.webContents.send).toHaveBeenCalledTimes(2)
+    expect(electronMock.owner.webContents.send).toHaveBeenCalledWith(
+      NATIVE_OVERLAY_ACTION,
+      {
+        surfaceId: request.surfaceId,
+        actionId: 'copy',
+        closeOnSelect: false,
+      }
     )
   })
 

--- a/electron/native-overlay.test.ts
+++ b/electron/native-overlay.test.ts
@@ -267,6 +267,7 @@ describe('NativeOverlayController', () => {
     expect(electronMock.BrowserWindow).not.toHaveBeenCalledWith(
       expect.objectContaining({ focusable: false })
     )
+
     expect(electronMock.BrowserWindow).toHaveBeenCalledWith(
       expect.objectContaining({
         acceptFirstMouse: true,
@@ -383,6 +384,10 @@ describe('NativeOverlayController', () => {
     const themedRequest = {
       ...request,
       surfaceId: 'surface-themed',
+      payload: {
+        ...request.payload,
+        surfaceTone: 'primary-container-soft',
+      },
       theme: {
         id: 'flexoki',
         colorScheme: 'light',

--- a/electron/native-overlay.ts
+++ b/electron/native-overlay.ts
@@ -96,6 +96,7 @@ interface NativeOverlayMenuPayload {
   kind: 'menu'
   ariaLabel?: string
   matchAnchorWidth?: boolean
+  surfaceTone?: string
   items?: NativeOverlayMenuItem[]
   sections?: NativeOverlayMenuSection[]
 }
@@ -261,6 +262,7 @@ const isMenuPayload = (value: unknown): value is NativeOverlayMenuPayload =>
   (value.ariaLabel === undefined || typeof value.ariaLabel === 'string') &&
   (value.matchAnchorWidth === undefined ||
     typeof value.matchAnchorWidth === 'boolean') &&
+  (value.surfaceTone === undefined || typeof value.surfaceTone === 'string') &&
   (hasMenuItems(value.items) || hasMenuSections(value.sections))
 
 const isThemeSnapshot = (value: unknown): value is NativeOverlayThemeSnapshot =>

--- a/electron/native-overlay.ts
+++ b/electron/native-overlay.ts
@@ -9,6 +9,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import {
   NATIVE_OVERLAY_ACTION,
+  NATIVE_OVERLAY_ACTION_RESULT,
   NATIVE_OVERLAY_CLEAR,
   NATIVE_OVERLAY_CLOSE,
   NATIVE_OVERLAY_CLOSED,
@@ -123,6 +124,14 @@ interface NativeOverlayActionEvent {
   surfaceId: string
   actionId: string
   closeOnSelect?: boolean
+  feedback?: 'copy'
+}
+
+interface NativeOverlayActionResultEvent {
+  surfaceId: string
+  actionId: string
+  feedback: 'copy'
+  ok: boolean
 }
 
 interface NativeOverlayReadyEvent {
@@ -288,7 +297,17 @@ const isActionEvent = (value: unknown): value is NativeOverlayActionEvent =>
   isString(value.surfaceId) &&
   isString(value.actionId) &&
   (value.closeOnSelect === undefined ||
-    typeof value.closeOnSelect === 'boolean')
+    typeof value.closeOnSelect === 'boolean') &&
+  (value.feedback === undefined || value.feedback === 'copy')
+
+const isActionResultEvent = (
+  value: unknown
+): value is NativeOverlayActionResultEvent =>
+  isRecord(value) &&
+  isString(value.surfaceId) &&
+  isString(value.actionId) &&
+  value.feedback === 'copy' &&
+  typeof value.ok === 'boolean'
 
 const isReadyEvent = (value: unknown): value is NativeOverlayReadyEvent =>
   isRecord(value) && isString(value.surfaceId)
@@ -315,6 +334,7 @@ export class NativeOverlayController {
     ipc.handle(NATIVE_OVERLAY_CLOSE, this.handleClose)
     ipc.handle(NATIVE_OVERLAY_READY, this.handleReady)
     ipc.handle(NATIVE_OVERLAY_ACTION, this.handleAction)
+    ipc.handle(NATIVE_OVERLAY_ACTION_RESULT, this.handleActionResult)
     this.registeredIpc = ipc
   }
 
@@ -324,6 +344,7 @@ export class NativeOverlayController {
       this.registeredIpc.removeHandler(NATIVE_OVERLAY_CLOSE)
       this.registeredIpc.removeHandler(NATIVE_OVERLAY_READY)
       this.registeredIpc.removeHandler(NATIVE_OVERLAY_ACTION)
+      this.registeredIpc.removeHandler(NATIVE_OVERLAY_ACTION_RESULT)
       this.registeredIpc = null
     }
 
@@ -448,6 +469,27 @@ export class NativeOverlayController {
     if (!owner.isDestroyed()) {
       owner.send(NATIVE_OVERLAY_ACTION, payload)
     }
+  }
+
+  private readonly handleActionResult = (
+    event: IpcMainInvokeEvent,
+    payload: unknown
+  ): void => {
+    if (!isActionResultEvent(payload)) {
+      return
+    }
+
+    const surface = this.surfaceFromOwnerSender(payload.surfaceId, event.sender)
+    if (!surface) {
+      return
+    }
+
+    const record = this.overlays.get(surface.parentId)
+    if (!record || record.overlayWindow.isDestroyed()) {
+      return
+    }
+
+    record.overlayWindow.webContents.send(NATIVE_OVERLAY_ACTION_RESULT, payload)
   }
 
   private getOrCreateOverlayRecord(parent: BrowserWindow): NativeOverlayRecord {
@@ -666,6 +708,18 @@ export class NativeOverlayController {
       surface.owner !== sender &&
       record?.overlayWindow.webContents !== sender
     ) {
+      return null
+    }
+
+    return surface
+  }
+
+  private surfaceFromOwnerSender(
+    surfaceId: string,
+    sender: WebContents
+  ): NativeOverlaySurface | null {
+    const surface = this.surfaces.get(surfaceId)
+    if (surface?.owner !== sender) {
       return null
     }
 

--- a/electron/native-overlay.ts
+++ b/electron/native-overlay.ts
@@ -387,6 +387,7 @@ export class NativeOverlayController {
     record.syncBounds()
     record.overlayWindow.setIgnoreMouseEvents(false)
     record.overlayWindow.showInactive()
+    record.overlayWindow.webContents.focus()
     // Ghostty is an AppKit NSView, so ordinary Electron window ordering can
     // still land behind it. The screen-saver level reliably places this
     // transparent overlay window above that native surface while it is open.
@@ -512,7 +513,6 @@ export class NativeOverlayController {
       fullscreenable: false,
       skipTaskbar: true,
       acceptFirstMouse: true,
-      focusable: false,
       webPreferences: {
         contextIsolation: true,
         nodeIntegration: false,

--- a/electron/native-overlay.ts
+++ b/electron/native-overlay.ts
@@ -41,7 +41,10 @@ interface NativeOverlayMenuActionItem {
   type?: 'item'
   id: string
   label: string
+  detail?: string
   icon?: string
+  feedback?: 'copy'
+  closeOnSelect?: boolean
   shortcut?: string
   disabled?: boolean
 }
@@ -91,8 +94,15 @@ interface NativeOverlayMenuSection {
 interface NativeOverlayMenuPayload {
   kind: 'menu'
   ariaLabel?: string
+  matchAnchorWidth?: boolean
   items?: NativeOverlayMenuItem[]
   sections?: NativeOverlayMenuSection[]
+}
+
+interface NativeOverlayThemeSnapshot {
+  id?: string
+  colorScheme?: string
+  variables: Record<string, string>
 }
 
 interface NativeOverlayRequest {
@@ -101,6 +111,7 @@ interface NativeOverlayRequest {
   anchorRect: NativeOverlayRect
   placement: string
   payload: NativeOverlayMenuPayload
+  theme?: NativeOverlayThemeSnapshot
 }
 
 interface NativeOverlayCloseRequest {
@@ -111,6 +122,7 @@ interface NativeOverlayCloseRequest {
 interface NativeOverlayActionEvent {
   surfaceId: string
   actionId: string
+  closeOnSelect?: boolean
 }
 
 interface NativeOverlayReadyEvent {
@@ -127,6 +139,10 @@ interface NativeOverlayRecord {
   overlayWindow: BrowserWindow
   ready: Promise<void>
   syncBounds: () => void
+  parentBlurred: () => void
+  parentHidden: () => void
+  parentMinimized: () => void
+  parentClosing: () => void
   parentClosed: () => void
   activeSurfaceId: string | null
 }
@@ -203,7 +219,11 @@ const isMenuItem = (value: unknown): value is NativeOverlayMenuItem => {
     (isActionType || isCheckboxType) &&
     isString(value.id) &&
     isString(value.label) &&
+    (value.detail === undefined || typeof value.detail === 'string') &&
     (value.icon === undefined || typeof value.icon === 'string') &&
+    (value.feedback === undefined || value.feedback === 'copy') &&
+    (value.closeOnSelect === undefined ||
+      typeof value.closeOnSelect === 'boolean') &&
     (value.shortcut === undefined || typeof value.shortcut === 'string') &&
     (value.disabled === undefined || typeof value.disabled === 'boolean')
   )
@@ -222,11 +242,23 @@ const hasMenuSections = (sections: unknown): boolean =>
   sections.length > 0 &&
   sections.every(isMenuSection)
 
+const isStringRecord = (value: unknown): value is Record<string, string> =>
+  isRecord(value) &&
+  Object.values(value).every((entry) => typeof entry === 'string')
+
 const isMenuPayload = (value: unknown): value is NativeOverlayMenuPayload =>
   isRecord(value) &&
   value.kind === 'menu' &&
   (value.ariaLabel === undefined || typeof value.ariaLabel === 'string') &&
+  (value.matchAnchorWidth === undefined ||
+    typeof value.matchAnchorWidth === 'boolean') &&
   (hasMenuItems(value.items) || hasMenuSections(value.sections))
+
+const isThemeSnapshot = (value: unknown): value is NativeOverlayThemeSnapshot =>
+  isRecord(value) &&
+  (value.id === undefined || typeof value.id === 'string') &&
+  (value.colorScheme === undefined || typeof value.colorScheme === 'string') &&
+  isStringRecord(value.variables)
 
 const isNativeOverlayRequest = (
   value: unknown
@@ -236,7 +268,8 @@ const isNativeOverlayRequest = (
   value.kind === 'menu' &&
   isRect(value.anchorRect) &&
   isString(value.placement) &&
-  isMenuPayload(value.payload)
+  isMenuPayload(value.payload) &&
+  (value.theme === undefined || isThemeSnapshot(value.theme))
 
 const isCloseReason = (value: unknown): value is NativeOverlayCloseReason =>
   value === 'outside' ||
@@ -251,7 +284,11 @@ const isCloseRequest = (value: unknown): value is NativeOverlayCloseRequest =>
   (value.reason === undefined || isCloseReason(value.reason))
 
 const isActionEvent = (value: unknown): value is NativeOverlayActionEvent =>
-  isRecord(value) && isString(value.surfaceId) && isString(value.actionId)
+  isRecord(value) &&
+  isString(value.surfaceId) &&
+  isString(value.actionId) &&
+  (value.closeOnSelect === undefined ||
+    typeof value.closeOnSelect === 'boolean')
 
 const isReadyEvent = (value: unknown): value is NativeOverlayReadyEvent =>
   isRecord(value) && isString(value.surfaceId)
@@ -295,13 +332,8 @@ export class NativeOverlayController {
     }
     this.pendingReady.clear()
 
-    for (const record of this.overlays.values()) {
-      record.parent.removeListener('resize', record.syncBounds)
-      record.parent.removeListener('move', record.syncBounds)
-      record.parent.removeListener('closed', record.parentClosed)
-      if (!record.overlayWindow.isDestroyed()) {
-        record.overlayWindow.close()
-      }
+    for (const record of [...this.overlays.values()]) {
+      this.destroyOverlayRecord(record, 'owner-closed', false)
     }
 
     this.overlays.clear()
@@ -334,7 +366,6 @@ export class NativeOverlayController {
     record.syncBounds()
     record.overlayWindow.setIgnoreMouseEvents(false)
     record.overlayWindow.showInactive()
-    record.overlayWindow.webContents.focus()
     // Ghostty is an AppKit NSView, so ordinary Electron window ordering can
     // still land behind it. The screen-saver level reliably places this
     // transparent overlay window above that native surface while it is open.
@@ -410,7 +441,9 @@ export class NativeOverlayController {
     }
 
     const owner = surface.owner
-    this.closeSurface(payload.surfaceId, 'action', false)
+    if (payload.closeOnSelect !== false) {
+      this.closeSurface(payload.surfaceId, 'action', false)
+    }
 
     if (!owner.isDestroyed()) {
       owner.send(NATIVE_OVERLAY_ACTION, payload)
@@ -424,6 +457,7 @@ export class NativeOverlayController {
     }
 
     const overlayWindow = new BrowserWindow({
+      parent,
       show: false,
       frame: false,
       transparent: true,
@@ -436,7 +470,7 @@ export class NativeOverlayController {
       fullscreenable: false,
       skipTaskbar: true,
       acceptFirstMouse: true,
-      focusable: true,
+      focusable: false,
       webPreferences: {
         contextIsolation: true,
         nodeIntegration: false,
@@ -457,26 +491,41 @@ export class NativeOverlayController {
       overlayWindow.setBounds(parent.getContentBounds())
     }
 
+    const closeForOwnerDeactivation = (): void => {
+      const activeSurfaceId = this.overlays.get(parent.id)?.activeSurfaceId
+      if (activeSurfaceId === undefined || activeSurfaceId === null) {
+        return
+      }
+
+      this.closeSurface(activeSurfaceId, 'outside', true, false)
+    }
+
+    const parentClosing = (): void => {
+      const record = this.overlays.get(parent.id)
+      if (!record) {
+        return
+      }
+
+      this.destroyOverlayRecord(record, 'owner-closed', true)
+    }
+
     const parentClosed = (): void => {
       const record = this.overlays.get(parent.id)
       if (!record) {
         return
       }
 
-      if (record.activeSurfaceId !== null) {
-        this.closeSurface(record.activeSurfaceId, 'owner-closed', true)
-      }
-
-      this.overlays.delete(parent.id)
-      if (!overlayWindow.isDestroyed()) {
-        overlayWindow.close()
-      }
+      this.destroyOverlayRecord(record, 'owner-closed', true)
     }
 
     overlayWindow.setIgnoreMouseEvents(true)
     overlayWindow.webContents.setWindowOpenHandler(() => ({ action: 'deny' }))
     parent.on('resize', syncBounds)
     parent.on('move', syncBounds)
+    parent.on('blur', closeForOwnerDeactivation)
+    parent.on('hide', closeForOwnerDeactivation)
+    parent.on('minimize', closeForOwnerDeactivation)
+    parent.on('close', parentClosing)
     parent.on('closed', parentClosed)
     void overlayWindow.loadURL(this.overlayUrl)
 
@@ -485,6 +534,10 @@ export class NativeOverlayController {
       overlayWindow,
       ready,
       syncBounds,
+      parentBlurred: closeForOwnerDeactivation,
+      parentHidden: closeForOwnerDeactivation,
+      parentMinimized: closeForOwnerDeactivation,
+      parentClosing,
       parentClosed,
       activeSurfaceId: null,
     }
@@ -492,6 +545,33 @@ export class NativeOverlayController {
     this.overlays.set(parent.id, record)
 
     return record
+  }
+
+  private destroyOverlayRecord(
+    record: NativeOverlayRecord,
+    reason: NativeOverlayCloseReason,
+    notifyOwner: boolean
+  ): void {
+    if (!this.overlays.has(record.parent.id)) {
+      return
+    }
+
+    if (record.activeSurfaceId !== null) {
+      this.closeSurface(record.activeSurfaceId, reason, notifyOwner, false)
+    }
+
+    record.parent.removeListener('resize', record.syncBounds)
+    record.parent.removeListener('move', record.syncBounds)
+    record.parent.removeListener('blur', record.parentBlurred)
+    record.parent.removeListener('hide', record.parentHidden)
+    record.parent.removeListener('minimize', record.parentMinimized)
+    record.parent.removeListener('close', record.parentClosing)
+    record.parent.removeListener('closed', record.parentClosed)
+    this.overlays.delete(record.parent.id)
+
+    if (!record.overlayWindow.isDestroyed()) {
+      record.overlayWindow.close()
+    }
   }
 
   private waitForReady(surfaceId: string): Promise<boolean> {
@@ -520,7 +600,8 @@ export class NativeOverlayController {
   private closeSurface(
     surfaceId: string,
     reason: NativeOverlayCloseReason,
-    notifyOwner: boolean
+    notifyOwner: boolean,
+    restoreOwnerFocus = true
   ): void {
     const surface = this.surfaces.get(surfaceId)
     if (!surface) {
@@ -543,7 +624,7 @@ export class NativeOverlayController {
     }
 
     if (!surface.owner.isDestroyed()) {
-      if (isActiveSurface) {
+      if (isActiveSurface && restoreOwnerFocus) {
         surface.owner.focus()
       }
       if (notifyOwner) {

--- a/electron/native-overlay.ts
+++ b/electron/native-overlay.ts
@@ -515,6 +515,7 @@ export class NativeOverlayController {
       fullscreenable: false,
       skipTaskbar: true,
       acceptFirstMouse: true,
+      focusable: true,
       webPreferences: {
         contextIsolation: true,
         nodeIntegration: false,

--- a/electron/preload.test.ts
+++ b/electron/preload.test.ts
@@ -20,6 +20,7 @@ import {
 } from './browser-pane-channels'
 import {
   NATIVE_OVERLAY_ACTION,
+  NATIVE_OVERLAY_ACTION_RESULT,
   NATIVE_OVERLAY_CLEAR,
   NATIVE_OVERLAY_CLOSE,
   NATIVE_OVERLAY_CLOSED,
@@ -93,6 +94,7 @@ const nativeOverlayInvokeCases: readonly [
 ][] = [
   ['open', NATIVE_OVERLAY_OPEN, { surfaceId: 'surface-1' }],
   ['close', NATIVE_OVERLAY_CLOSE, { surfaceId: 'surface-1' }],
+  ['actionResult', NATIVE_OVERLAY_ACTION_RESULT, { surfaceId: 'surface-1' }],
 ]
 
 describe('preload browserPane wiring', () => {
@@ -270,6 +272,7 @@ describe('preload nativeOverlay wiring', () => {
   test.each([
     ['onRender', NATIVE_OVERLAY_RENDER],
     ['onClear', NATIVE_OVERLAY_CLEAR],
+    ['onActionResult', NATIVE_OVERLAY_ACTION_RESULT],
   ])(
     'host %s registers on the correct channel',
     (method: string, channel: string) => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -8,6 +8,7 @@ import {
 } from './ipc-channels'
 import {
   NATIVE_OVERLAY_ACTION,
+  NATIVE_OVERLAY_ACTION_RESULT,
   NATIVE_OVERLAY_CLEAR,
   NATIVE_OVERLAY_CLOSE,
   NATIVE_OVERLAY_CLOSED,
@@ -226,6 +227,8 @@ contextBridge.exposeInMainWorld('vimeflow', {
       ipcRenderer.invoke(NATIVE_OVERLAY_OPEN, request),
     close: (request: unknown): Promise<unknown> =>
       ipcRenderer.invoke(NATIVE_OVERLAY_CLOSE, request),
+    actionResult: (request: unknown): Promise<unknown> =>
+      ipcRenderer.invoke(NATIVE_OVERLAY_ACTION_RESULT, request),
     onAction: (callback: (payload: unknown) => void): (() => void) => {
       const handler = (_event: IpcRendererEvent, payload: unknown): void => {
         callback(payload)
@@ -276,6 +279,17 @@ contextBridge.exposeInMainWorld('vimeflow', {
 
       return (): void => {
         ipcRenderer.off(NATIVE_OVERLAY_CLEAR, handler)
+      }
+    },
+    onActionResult: (callback: (payload: unknown) => void): (() => void) => {
+      const handler = (_event: IpcRendererEvent, payload: unknown): void => {
+        callback(payload)
+      }
+
+      ipcRenderer.on(NATIVE_OVERLAY_ACTION_RESULT, handler)
+
+      return (): void => {
+        ipcRenderer.off(NATIVE_OVERLAY_ACTION_RESULT, handler)
       }
     },
   },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "electron:build:linux:x64": "node scripts/package-electron.mjs linux-x64",
     "electron:build:mac:arm64": "node scripts/package-electron.mjs mac-arm64",
     "electron:dev": "npm run generate:bindings && npm run backend:build && vite --mode electron",
+    "electron:dev:ghostty": "npm run ghostty:native-parent:build && cross-env VITE_GHOSTTY_NATIVE_MACOS_PARENT=1 VITE_NATIVE_OVERLAY=1 npm run electron:dev -- --port 5174",
     "ghostty:native-parent:build": "node scripts/build-ghostty-native-parent.js",
     "ghostty:native-parent:smoke": "node scripts/smoke-ghostty-native-parent.js",
     "prepare": "husky",

--- a/src/components/Menu.test.tsx
+++ b/src/components/Menu.test.tsx
@@ -96,6 +96,8 @@ afterEach(() => {
   vi.clearAllMocks()
   restorePlatform?.()
   restorePlatform = null
+  document.documentElement.removeAttribute('style')
+  document.documentElement.removeAttribute('data-theme')
   delete window.vimeflow
 })
 
@@ -1023,6 +1025,76 @@ describe('Menu.Context', () => {
     })
 
     expect(onSelect).toHaveBeenCalledOnce()
+  })
+
+  test('serializes context menu detail rows with anchor-width matching', async () => {
+    vi.stubEnv('VITE_NATIVE_OVERLAY', '1')
+    setNavigatorPlatform('MacIntel')
+    const nativeBridge = installNativeOverlayBridge()
+    const closeOnSelect = false
+    const root = document.documentElement
+    root.dataset.theme = 'flexoki'
+    root.style.colorScheme = 'light'
+    root.style.setProperty(
+      '--color-surface-container-high',
+      'var(--color-test-surface-high)'
+    )
+    root.style.setProperty('--shadow-menu', 'var(--shadow-test-menu)')
+
+    render(
+      <Menu.Context
+        position={{ x: 50, y: 60, width: 180, height: 22 }}
+        open
+        nativeOverlay
+        matchAnchorWidth
+        onOpenChange={vi.fn()}
+        aria-label="Git ref details"
+      >
+        <Menu.Row
+          label="Copy path"
+          nativeOverlayIcon="folder_open"
+          nativeOverlayDetail="/Users/will/projects/vimeflow"
+          nativeOverlayFeedback="copy"
+          nativeOverlayCloseOnSelect={closeOnSelect}
+          onSelect={vi.fn()}
+        >
+          <span aria-hidden="true">folder_open</span>
+          <span>path</span>
+          <span>/Users/will/projects/vimeflow</span>
+        </Menu.Row>
+      </Menu.Context>
+    )
+
+    await waitFor(() => expect(nativeBridge.open).toHaveBeenCalledOnce())
+
+    const request = nativeBridge.open.mock.calls[0][0] as NativeOverlayRequest
+
+    expect(request).toMatchObject({
+      anchorRect: { x: 50, y: 60, width: 180, height: 22 },
+      theme: {
+        id: 'flexoki',
+        colorScheme: 'light',
+        variables: {
+          '--color-surface-container-high': 'var(--color-test-surface-high)',
+          '--shadow-menu': 'var(--shadow-test-menu)',
+        },
+      },
+      payload: {
+        kind: 'menu',
+        ariaLabel: 'Git ref details',
+        matchAnchorWidth: true,
+        items: [
+          {
+            id: expect.any(String),
+            label: 'Copy path',
+            detail: '/Users/will/projects/vimeflow',
+            icon: 'folder_open',
+            feedback: 'copy',
+            closeOnSelect: false,
+          },
+        ],
+      },
+    })
   })
 
   test('native overlay outside close flows back through onOpenChange', async () => {

--- a/src/components/Menu.test.tsx
+++ b/src/components/Menu.test.tsx
@@ -47,6 +47,7 @@ const installNativeOverlayBridge = (): {
     nativeOverlay: {
       open,
       close,
+      actionResult: vi.fn(() => Promise.resolve()),
       onAction: vi.fn((callback: (event: unknown) => void) => {
         actionListener = callback
 
@@ -1031,7 +1032,6 @@ describe('Menu.Context', () => {
     vi.stubEnv('VITE_NATIVE_OVERLAY', '1')
     setNavigatorPlatform('MacIntel')
     const nativeBridge = installNativeOverlayBridge()
-    const closeOnSelect = false
     const root = document.documentElement
     root.dataset.theme = 'flexoki'
     root.style.colorScheme = 'light'
@@ -1055,7 +1055,6 @@ describe('Menu.Context', () => {
           nativeOverlayIcon="folder_open"
           nativeOverlayDetail="/Users/will/projects/vimeflow"
           nativeOverlayFeedback="copy"
-          nativeOverlayCloseOnSelect={closeOnSelect}
           onSelect={vi.fn()}
         >
           <span aria-hidden="true">folder_open</span>

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -36,11 +36,13 @@ import {
   openNativeOverlay,
   selectFloatingTransport,
   warnNativeOverlayFallback,
+  type NativeOverlayActionHandler,
+  type NativeOverlayActionResult,
   type NativeOverlayMenuItem,
   type NativeOverlayMenuSection,
+  type NativeOverlayMenuSurfaceTone,
   type NativeOverlayMenuSubAction,
   type NativeOverlayRequest,
-  type NativeOverlayActionHandler,
 } from '@/components/base/floating/nativeOverlay'
 import { OptionList, type DropdownOption } from '@/components/base/OptionList'
 import { type Placement } from '@/components/base/floating/glassSurface'
@@ -84,8 +86,19 @@ const useMenuContext = (): MenuContextValue => {
 
 const MENU_BODY_CLASSES = 'py-1 min-w-52 max-h-[28rem] overflow-auto'
 
-const CONTEXT_MENU_SURFACE_CLASSES =
-  'z-[110] overflow-hidden rounded-md border border-outline-variant/30 bg-surface-container-high shadow-lg outline-none focus:outline-none focus-visible:outline-none'
+const CONTEXT_MENU_SURFACE_BASE_CLASSES =
+  'z-[110] overflow-hidden rounded-md border shadow-lg outline-none focus:outline-none focus-visible:outline-none'
+
+const CONTEXT_MENU_SURFACE_CLASSES = `${CONTEXT_MENU_SURFACE_BASE_CLASSES} border-outline-variant/30 bg-surface-container-high text-on-surface`
+
+const CONTEXT_MENU_PRIMARY_CONTAINER_SOFT_SURFACE_CLASSES = `${CONTEXT_MENU_SURFACE_BASE_CLASSES} border-primary-container/20 vf-native-overlay-primary-container-soft text-on-surface`
+
+const contextMenuSurfaceClasses = (
+  surfaceTone: NativeOverlayMenuSurfaceTone | undefined
+): string =>
+  surfaceTone === 'primary-container-soft'
+    ? CONTEXT_MENU_PRIMARY_CONTAINER_SOFT_SURFACE_CLASSES
+    : CONTEXT_MENU_SURFACE_CLASSES
 
 const CONTEXT_MENU_BODY_CLASSES = 'min-w-0 max-h-[28rem] overflow-auto'
 
@@ -649,13 +662,13 @@ interface MenuRowNativeOverlayAction {
   icon?: string
   pressed?: boolean
   disabled?: boolean
-  onSelect: () => void
+  onSelect: () => NativeOverlayActionResult
 }
 
 interface MenuRowProps {
   label: string
   disabled?: boolean
-  onSelect?: () => void
+  onSelect?: () => NativeOverlayActionResult
   className?: string
   nativeOverlayIcon?: string
   nativeOverlayActive?: boolean
@@ -682,7 +695,7 @@ const MenuRow = ({
       return
     }
 
-    onSelect?.()
+    void onSelect?.()
   }
 
   const handleKeyDown: KeyboardEventHandler<HTMLDivElement> = (event) => {
@@ -1119,6 +1132,7 @@ interface MenuContextMenuProps {
   onOpenChange: (open: boolean) => void
   'aria-label': string
   nativeOverlay?: boolean
+  surfaceTone?: NativeOverlayMenuSurfaceTone
   children: ReactNode
 }
 
@@ -1146,15 +1160,13 @@ interface NativeMenuActionSpec {
 const invokeNativeMenuAction = (
   spec: NativeMenuActionSpec,
   actionId: string
-): void => {
+): NativeOverlayActionResult => {
   const action = spec.actions.get(actionId)
   if (typeof action === 'function') {
-    action()
-
-    return
+    return action()
   }
 
-  action?.run()
+  return action?.run()
 }
 
 const nativeMenuLiveAction = (
@@ -1164,12 +1176,14 @@ const nativeMenuLiveAction = (
   const action = specRef.current.actions.get(actionId)
 
   if (typeof action === 'function') {
-    return (): void => invokeNativeMenuAction(specRef.current, actionId)
+    return (): NativeOverlayActionResult =>
+      invokeNativeMenuAction(specRef.current, actionId)
   }
 
   return {
     retainSession: true,
-    run: (): void => invokeNativeMenuAction(specRef.current, actionId),
+    run: (): NativeOverlayActionResult =>
+      invokeNativeMenuAction(specRef.current, actionId),
   }
 }
 
@@ -1191,17 +1205,19 @@ const nativeMenuCompositeActionsFromRowActions = (
   id: string,
   close: () => void
 ): NativeMenuCompositeActions => {
-  const extraActions = new Map<string, () => void>()
+  const extraActions = new Map<string, () => NativeOverlayActionResult>()
 
   const actions = nativeOverlayActions.map((nativeAction, actionIndex) => {
     const actionId = `${id}:action:${String(actionIndex)}`
-    extraActions.set(actionId, (): void => {
+    extraActions.set(actionId, (): NativeOverlayActionResult => {
       if (nativeAction.disabled === true) {
         return
       }
 
-      nativeAction.onSelect()
+      const result = nativeAction.onSelect()
       close()
+
+      return result
     })
 
     return nativeMenuSubActionFromRowAction(nativeAction, actionId)
@@ -1297,27 +1313,33 @@ const nativeMenuRowFromElement = (
         ...(disabled ? { disabled: true } : {}),
         actions,
       },
-      action: (): void => {
+      action: (): NativeOverlayActionResult => {
         if (disabled) {
           return
         }
 
-        element.props.onSelect?.()
+        const result = element.props.onSelect?.()
         close()
+
+        return result
       },
       extraActions,
     }
   }
 
   if (element.props.nativeOverlayDetail !== undefined) {
-    const closeOnSelect = element.props.nativeOverlayCloseOnSelect !== false
+    const closeOnSelect =
+      element.props.nativeOverlayCloseOnSelect !== false &&
+      element.props.nativeOverlayFeedback !== 'copy'
 
-    const run = (): void => {
+    const run = (): NativeOverlayActionResult => {
       if (!disabled) {
-        element.props.onSelect?.()
+        const result = element.props.onSelect?.()
         if (closeOnSelect) {
           close()
         }
+
+        return result
       }
     }
 
@@ -1358,10 +1380,12 @@ const nativeMenuRowFromElement = (
       ...(shortcut === undefined ? {} : { shortcut }),
       ...(disabled ? { disabled: true } : {}),
     },
-    action: (): void => {
+    action: (): NativeOverlayActionResult => {
       if (!disabled) {
-        element.props.onSelect?.()
+        const result = element.props.onSelect?.()
         close()
+
+        return result
       }
     },
   }
@@ -1393,13 +1417,15 @@ const nativeMenuItemFromElement = (
         : { shortcut: formatShortcut(element.props.shortcut) }),
       ...(disabled ? { disabled: true } : {}),
     },
-    action: (): void => {
+    action: (): NativeOverlayActionResult => {
       if (disabled) {
         return
       }
 
-      element.props.onSelect()
+      const result = element.props.onSelect()
       close()
+
+      return result
     },
   }
 }
@@ -1571,6 +1597,7 @@ const nativeMenuContextSpec = (
   surfaceId: string,
   ariaLabel: string,
   matchAnchorWidth: boolean,
+  surfaceTone: NativeOverlayMenuSurfaceTone | undefined,
   children: ReactNode,
   close: () => void
 ): NativeMenuContextSpec => {
@@ -1584,6 +1611,7 @@ const nativeMenuContextSpec = (
           kind: NATIVE_OVERLAY_KINDS.menu,
           ariaLabel,
           ...(matchAnchorWidth ? { matchAnchorWidth: true } : {}),
+          ...(surfaceTone === undefined ? {} : { surfaceTone }),
           items: [],
         },
         actions,
@@ -1619,6 +1647,7 @@ const nativeMenuContextSpec = (
           kind: NATIVE_OVERLAY_KINDS.menu,
           ariaLabel,
           ...(matchAnchorWidth ? { matchAnchorWidth: true } : {}),
+          ...(surfaceTone === undefined ? {} : { surfaceTone }),
           items: [],
         },
         actions,
@@ -1638,6 +1667,7 @@ const nativeMenuContextSpec = (
       kind: NATIVE_OVERLAY_KINDS.menu,
       ariaLabel,
       ...(matchAnchorWidth ? { matchAnchorWidth: true } : {}),
+      ...(surfaceTone === undefined ? {} : { surfaceTone }),
       items,
     },
     actions,
@@ -1657,6 +1687,7 @@ const MenuContextMenu = ({
   onOpenChange,
   'aria-label': ariaLabel,
   nativeOverlay = false,
+  surfaceTone = undefined,
   children,
 }: MenuContextMenuProps): ReactElement | null => {
   const surfaceId = useId()
@@ -1667,12 +1698,23 @@ const MenuContextMenu = ({
   >('idle')
   const listRef = useRef<(HTMLElement | null)[]>([])
   const labelsRef = useRef<(string | null)[]>([])
+  const closingRef = useRef(false)
 
   const { disabledIndices, itemCount, setRowDisabled, clearRow } =
     useMenuDisabledIndices()
 
   const handleOpenChange = useCallback(
     (nextOpen: boolean): void => {
+      if (!nextOpen) {
+        if (closingRef.current) {
+          return
+        }
+
+        closingRef.current = true
+      } else {
+        closingRef.current = false
+      }
+
       if (!nextOpen) {
         setActiveIndex(null)
       }
@@ -1690,6 +1732,7 @@ const MenuContextMenu = ({
     surfaceId,
     ariaLabel,
     matchAnchorWidth,
+    surfaceTone,
     children,
     () => handleOpenChangeRef.current(false)
   )
@@ -1722,9 +1765,12 @@ const MenuContextMenu = ({
   useEffect(() => {
     if (!open) {
       setNativeAttempt('idle')
+      closingRef.current = false
 
       return
     }
+
+    closingRef.current = false
 
     if (
       nativeOverlay &&
@@ -1734,6 +1780,27 @@ const MenuContextMenu = ({
       warnNativeOverlayFallback(nativeUnsupportedReason)
     }
   }, [nativeOverlay, nativeUnsupportedReason, open, transport])
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+
+    const closeOnEscape = (event: KeyboardEvent): void => {
+      if (event.key !== 'Escape' || event.defaultPrevented) {
+        return
+      }
+
+      event.preventDefault()
+      handleOpenChangeRef.current(false)
+    }
+
+    document.addEventListener('keydown', closeOnEscape, { capture: true })
+
+    return (): void => {
+      document.removeEventListener('keydown', closeOnEscape, { capture: true })
+    }
+  }, [open])
 
   useEffect(() => {
     if (!canAttemptNative) {
@@ -1868,7 +1935,7 @@ const MenuContextMenu = ({
       width={matchAnchorWidth ? position.width : undefined}
       ariaLabel={ariaLabel}
       focus={{ modal: false }}
-      surfaceClassName={CONTEXT_MENU_SURFACE_CLASSES}
+      surfaceClassName={contextMenuSurfaceClasses(surfaceTone)}
       bodyClassName={CONTEXT_MENU_BODY_CLASSES}
       contextValue={contextValue}
     >

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -32,6 +32,7 @@ import {
 import {
   NATIVE_OVERLAY_KINDS,
   closeNativeOverlay,
+  nativeOverlayThemeSnapshot,
   openNativeOverlay,
   selectFloatingTransport,
   warnNativeOverlayFallback,
@@ -444,6 +445,7 @@ const MenuRoot = ({
           },
           placement,
           payload: nativeSpecRef.current.payload,
+          theme: nativeOverlayThemeSnapshot(),
         },
         {
           actions: nativeActions,
@@ -657,6 +659,9 @@ interface MenuRowProps {
   className?: string
   nativeOverlayIcon?: string
   nativeOverlayActive?: boolean
+  nativeOverlayDetail?: string
+  nativeOverlayFeedback?: 'copy'
+  nativeOverlayCloseOnSelect?: boolean
   nativeOverlayActions?: readonly MenuRowNativeOverlayAction[]
   children: ReactNode
 }
@@ -1109,6 +1114,7 @@ const MenuSubmenu = <T extends string | number>({
 interface MenuContextMenuProps {
   position: { x: number; y: number; width?: number; height?: number }
   placement?: Placement
+  matchAnchorWidth?: boolean
   open: boolean
   onOpenChange: (open: boolean) => void
   'aria-label': string
@@ -1303,6 +1309,36 @@ const nativeMenuRowFromElement = (
     }
   }
 
+  if (element.props.nativeOverlayDetail !== undefined) {
+    const closeOnSelect = element.props.nativeOverlayCloseOnSelect !== false
+
+    const run = (): void => {
+      if (!disabled) {
+        element.props.onSelect?.()
+        if (closeOnSelect) {
+          close()
+        }
+      }
+    }
+
+    return {
+      item: {
+        id,
+        label: element.props.label,
+        detail: element.props.nativeOverlayDetail,
+        ...(element.props.nativeOverlayIcon === undefined
+          ? {}
+          : { icon: element.props.nativeOverlayIcon }),
+        ...(element.props.nativeOverlayFeedback === undefined
+          ? {}
+          : { feedback: element.props.nativeOverlayFeedback }),
+        ...(closeOnSelect ? {} : { closeOnSelect: false }),
+        ...(disabled ? { disabled: true } : {}),
+      },
+      action: closeOnSelect ? run : { retainSession: true, run },
+    }
+  }
+
   const texts = childTexts(element.props.children)
   if (texts === null) {
     return null
@@ -1316,6 +1352,9 @@ const nativeMenuRowFromElement = (
     item: {
       id,
       label: element.props.label,
+      ...(element.props.nativeOverlayIcon === undefined
+        ? {}
+        : { icon: element.props.nativeOverlayIcon }),
       ...(shortcut === undefined ? {} : { shortcut }),
       ...(disabled ? { disabled: true } : {}),
     },
@@ -1531,6 +1570,7 @@ const nativeAnchoredMenuSpec = (
 const nativeMenuContextSpec = (
   surfaceId: string,
   ariaLabel: string,
+  matchAnchorWidth: boolean,
   children: ReactNode,
   close: () => void
 ): NativeMenuContextSpec => {
@@ -1540,7 +1580,12 @@ const nativeMenuContextSpec = (
   for (const [index, child] of Children.toArray(children).entries()) {
     if (!isValidElement(child)) {
       return {
-        payload: { kind: NATIVE_OVERLAY_KINDS.menu, ariaLabel, items: [] },
+        payload: {
+          kind: NATIVE_OVERLAY_KINDS.menu,
+          ariaLabel,
+          ...(matchAnchorWidth ? { matchAnchorWidth: true } : {}),
+          items: [],
+        },
         actions,
         unsupportedReason: 'non-element menu child',
       }
@@ -1570,7 +1615,12 @@ const nativeMenuContextSpec = (
 
     if (nativeRow === null) {
       return {
-        payload: { kind: NATIVE_OVERLAY_KINDS.menu, ariaLabel, items: [] },
+        payload: {
+          kind: NATIVE_OVERLAY_KINDS.menu,
+          ariaLabel,
+          ...(matchAnchorWidth ? { matchAnchorWidth: true } : {}),
+          items: [],
+        },
         actions,
         unsupportedReason: 'unsupported menu content',
       }
@@ -1584,7 +1634,12 @@ const nativeMenuContextSpec = (
   }
 
   return {
-    payload: { kind: NATIVE_OVERLAY_KINDS.menu, ariaLabel, items },
+    payload: {
+      kind: NATIVE_OVERLAY_KINDS.menu,
+      ariaLabel,
+      ...(matchAnchorWidth ? { matchAnchorWidth: true } : {}),
+      items,
+    },
     actions,
     unsupportedReason: items.length === 0 ? 'empty menu' : null,
   }
@@ -1597,6 +1652,7 @@ const nativeMenuContextSpec = (
 const MenuContextMenu = ({
   position,
   placement = 'bottom-start',
+  matchAnchorWidth = false,
   open,
   onOpenChange,
   'aria-label': ariaLabel,
@@ -1630,8 +1686,12 @@ const MenuContextMenu = ({
 
   const transport = selectFloatingTransport(nativeOverlay)
 
-  const nativeSpec = nativeMenuContextSpec(surfaceId, ariaLabel, children, () =>
-    handleOpenChangeRef.current(false)
+  const nativeSpec = nativeMenuContextSpec(
+    surfaceId,
+    ariaLabel,
+    matchAnchorWidth,
+    children,
+    () => handleOpenChangeRef.current(false)
   )
   const nativeSpecRef = useRef(nativeSpec)
   nativeSpecRef.current = nativeSpec
@@ -1696,6 +1756,7 @@ const MenuContextMenu = ({
           },
           placement,
           payload: nativeSpecRef.current.payload,
+          theme: nativeOverlayThemeSnapshot(),
         },
         {
           actions: nativeActions,
@@ -1804,6 +1865,7 @@ const MenuContextMenu = ({
       floatingProps={getFloatingProps()}
       listRef={listRef}
       labelsRef={labelsRef}
+      width={matchAnchorWidth ? position.width : undefined}
       ariaLabel={ariaLabel}
       focus={{ modal: false }}
       surfaceClassName={CONTEXT_MENU_SURFACE_CLASSES}

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -86,6 +86,10 @@ const useMenuContext = (): MenuContextValue => {
 
 const MENU_BODY_CLASSES = 'py-1 min-w-52 max-h-[28rem] overflow-auto'
 
+export const isNativeOverlayMenuTransportActive = (
+  nativeOverlay: boolean
+): boolean => selectFloatingTransport(nativeOverlay) === 'native-overlay'
+
 const CONTEXT_MENU_SURFACE_BASE_CLASSES =
   'z-[110] overflow-hidden rounded-md border shadow-lg outline-none focus:outline-none focus-visible:outline-none'
 

--- a/src/components/NativeOverlayHost.test.tsx
+++ b/src/components/NativeOverlayHost.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import type { NativeOverlayRequest } from '@/components/base/floating/nativeOverlay'
@@ -99,6 +105,38 @@ const compositeRequest: NativeOverlayRequest = {
   },
 }
 
+const detailRequest: NativeOverlayRequest = {
+  surfaceId: 'surface-4',
+  kind: 'menu',
+  anchorRect: { x: 40, y: 48, width: 196, height: 22 },
+  placement: 'bottom',
+  theme: {
+    id: 'flexoki',
+    colorScheme: 'light',
+    variables: {
+      '--color-surface-container-high': 'var(--color-test-surface-high)',
+      '--color-on-surface': 'var(--color-test-on-surface)',
+      '--shadow-menu': 'var(--shadow-test-menu)',
+    },
+  },
+  payload: {
+    kind: 'menu',
+    ariaLabel: 'Git ref details',
+    matchAnchorWidth: true,
+    items: [
+      {
+        id: 'copy-path',
+        label: 'Copy path',
+        detail:
+          '/Users/will/projects/vimeflow/worktrees/native-overlay-git-ref',
+        icon: 'folder_open',
+        feedback: 'copy',
+        closeOnSelect: false,
+      },
+    ],
+  },
+}
+
 let cleanupHostBridgeEvents: (() => void) | null = null
 
 const installNativeOverlayHostBridge = (): {
@@ -178,6 +216,8 @@ const installNativeOverlayHostBridge = (): {
 afterEach(() => {
   cleanupHostBridgeEvents?.()
   document.body.removeAttribute('data-native-overlay-host')
+  document.documentElement.removeAttribute('style')
+  document.documentElement.removeAttribute('data-theme')
   delete window.vimeflow
 })
 
@@ -265,6 +305,46 @@ describe('NativeOverlayHost', () => {
       actionId: 'duplicate-custom',
     })
     expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  test('renders copy detail rows with anchor width and copied feedback', async () => {
+    const user = userEvent.setup()
+    const bridge = installNativeOverlayHostBridge()
+    render(<NativeOverlayHost />)
+
+    bridge.emitRender(detailRequest)
+
+    const menu = await screen.findByRole('menu', { name: 'Git ref details' })
+    const row = screen.getByRole('menuitem', { name: 'Copy path' })
+
+    expect(menu).toHaveStyle({ width: '196px' })
+    expect(document.documentElement.dataset.theme).toBe('flexoki')
+    expect(document.documentElement.style.colorScheme).toBe('light')
+    expect(
+      document.documentElement.style.getPropertyValue(
+        '--color-surface-container-high'
+      )
+    ).toBe('var(--color-test-surface-high)')
+
+    expect(row).toHaveTextContent(
+      '/Users/will/projects/vimeflow/worktrees/native-overlay-git-ref'
+    )
+    expect(within(row).getByText('content_copy')).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(bridge.ready).toHaveBeenCalledWith({ surfaceId: 'surface-4' })
+    })
+
+    await user.click(row)
+
+    expect(bridge.action).toHaveBeenCalledWith({
+      surfaceId: 'surface-4',
+      actionId: 'copy-path',
+      closeOnSelect: false,
+    })
+    expect(screen.getByRole('menu', { name: 'Git ref details' })).toBe(menu)
+    expect(within(row).getByText('check')).toBeInTheDocument()
+    expect(within(row).getByText('Copied')).toHaveClass('text-[10px]')
   })
 
   test('closes on Escape and clears on host clear', async () => {

--- a/src/components/NativeOverlayHost.test.tsx
+++ b/src/components/NativeOverlayHost.test.tsx
@@ -430,9 +430,9 @@ describe('NativeOverlayHost', () => {
       )
     ).toBe('')
 
-    expect(document.documentElement.style.getPropertyValue('--shadow-menu')).toBe(
-      ''
-    )
+    expect(
+      document.documentElement.style.getPropertyValue('--shadow-menu')
+    ).toBe('')
   })
 
   test('closes on Escape and clears on host clear', async () => {

--- a/src/components/NativeOverlayHost.test.tsx
+++ b/src/components/NativeOverlayHost.test.tsx
@@ -123,6 +123,7 @@ const detailRequest: NativeOverlayRequest = {
     kind: 'menu',
     ariaLabel: 'Git ref details',
     matchAnchorWidth: true,
+    surfaceTone: 'primary-container-soft',
     items: [
       {
         id: 'copy-path',
@@ -146,12 +147,15 @@ const installNativeOverlayHostBridge = (): {
   ownerOverlayClose: ReturnType<typeof vi.fn>
   emitRender: (payload: unknown) => void
   emitClear: () => void
+  emitActionResult: (payload: unknown) => void
 } => {
   cleanupHostBridgeEvents?.()
   const renderEvent = 'native-overlay-host-render'
   const clearEvent = 'native-overlay-host-clear'
+  const actionResultEvent = 'native-overlay-host-action-result'
   let renderListener: ((payload: unknown) => void) | null = null
   let clearListener: (() => void) | null = null
+  let actionResultListener: ((payload: unknown) => void) | null = null
   const ready = vi.fn(() => Promise.resolve())
   const action = vi.fn(() => Promise.resolve())
   const close = vi.fn(() => Promise.resolve())
@@ -165,11 +169,17 @@ const installNativeOverlayHostBridge = (): {
     clearListener?.()
   }
 
+  const handleActionResultEvent = (event: Event): void => {
+    actionResultListener?.((event as CustomEvent<unknown>).detail)
+  }
+
   window.addEventListener(renderEvent, handleRenderEvent)
   window.addEventListener(clearEvent, handleClearEvent)
+  window.addEventListener(actionResultEvent, handleActionResultEvent)
   cleanupHostBridgeEvents = (): void => {
     window.removeEventListener(renderEvent, handleRenderEvent)
     window.removeEventListener(clearEvent, handleClearEvent)
+    window.removeEventListener(actionResultEvent, handleActionResultEvent)
     cleanupHostBridgeEvents = null
   }
 
@@ -190,10 +200,16 @@ const installNativeOverlayHostBridge = (): {
 
         return vi.fn()
       }),
+      onActionResult: vi.fn((callback: (payload: unknown) => void) => {
+        actionResultListener = callback
+
+        return vi.fn()
+      }),
     },
     nativeOverlay: {
       open: vi.fn(() => Promise.resolve({ accepted: true })),
       close: ownerOverlayClose,
+      actionResult: vi.fn(() => Promise.resolve()),
       onAction: vi.fn(() => vi.fn()),
       onClose: vi.fn(() => vi.fn()),
     },
@@ -209,6 +225,9 @@ const installNativeOverlayHostBridge = (): {
     },
     emitClear: (): void => {
       fireEvent(window, new CustomEvent(clearEvent))
+    },
+    emitActionResult: (payload): void => {
+      fireEvent(window, new CustomEvent(actionResultEvent, { detail: payload }))
     },
   }
 }
@@ -318,6 +337,7 @@ describe('NativeOverlayHost', () => {
     const row = screen.getByRole('menuitem', { name: 'Copy path' })
 
     expect(menu).toHaveStyle({ width: '196px' })
+    expect(menu).toHaveClass('vf-native-overlay-primary-container-soft')
     expect(document.documentElement.dataset.theme).toBe('flexoki')
     expect(document.documentElement.style.colorScheme).toBe('light')
     expect(
@@ -329,6 +349,17 @@ describe('NativeOverlayHost', () => {
     expect(row).toHaveTextContent(
       '/Users/will/projects/vimeflow/worktrees/native-overlay-git-ref'
     )
+    expect(row).toHaveClass('rounded-chip')
+    expect(within(row).getByText('Copy path')).toHaveClass(
+      'text-on-surface-muted'
+    )
+
+    expect(
+      within(row).getByText(
+        '/Users/will/projects/vimeflow/worktrees/native-overlay-git-ref'
+      )
+    ).toHaveClass('text-on-surface')
+
     expect(within(row).getByText('content_copy')).toBeInTheDocument()
 
     await waitFor(() => {
@@ -341,8 +372,27 @@ describe('NativeOverlayHost', () => {
       surfaceId: 'surface-4',
       actionId: 'copy-path',
       closeOnSelect: false,
+      feedback: 'copy',
     })
     expect(screen.getByRole('menu', { name: 'Git ref details' })).toBe(menu)
+    expect(within(row).queryByText('check')).not.toBeInTheDocument()
+
+    bridge.emitActionResult({
+      surfaceId: 'surface-4',
+      actionId: 'copy-path',
+      feedback: 'copy',
+      ok: false,
+    })
+
+    expect(within(row).queryByText('check')).not.toBeInTheDocument()
+
+    bridge.emitActionResult({
+      surfaceId: 'surface-4',
+      actionId: 'copy-path',
+      feedback: 'copy',
+      ok: true,
+    })
+
     expect(within(row).getByText('check')).toBeInTheDocument()
     expect(within(row).getByText('Copied')).toHaveClass('text-[10px]')
   })

--- a/src/components/NativeOverlayHost.test.tsx
+++ b/src/components/NativeOverlayHost.test.tsx
@@ -397,6 +397,44 @@ describe('NativeOverlayHost', () => {
     expect(within(row).getByText('Copied')).toHaveClass('text-[10px]')
   })
 
+  test('clears prior theme tokens when a later request has no theme', async () => {
+    const bridge = installNativeOverlayHostBridge()
+    render(<NativeOverlayHost />)
+
+    bridge.emitRender(detailRequest)
+    expect(
+      await screen.findByRole('menu', { name: 'Git ref details' })
+    ).toBeInTheDocument()
+    expect(document.documentElement.dataset.theme).toBe('flexoki')
+    expect(document.documentElement.style.colorScheme).toBe('light')
+    expect(
+      document.documentElement.style.getPropertyValue(
+        '--color-surface-container-high'
+      )
+    ).toBe('var(--color-test-surface-high)')
+
+    expect(
+      document.documentElement.style.getPropertyValue('--shadow-menu')
+    ).toBe('var(--shadow-test-menu)')
+
+    bridge.emitRender(request)
+
+    expect(
+      await screen.findByRole('menu', { name: 'Terminal actions' })
+    ).toBeInTheDocument()
+    expect(document.documentElement.dataset.theme).toBeUndefined()
+    expect(document.documentElement.style.colorScheme).toBe('')
+    expect(
+      document.documentElement.style.getPropertyValue(
+        '--color-surface-container-high'
+      )
+    ).toBe('')
+
+    expect(document.documentElement.style.getPropertyValue('--shadow-menu')).toBe(
+      ''
+    )
+  })
+
   test('closes on Escape and clears on host clear', async () => {
     const user = userEvent.setup()
     const bridge = installNativeOverlayHostBridge()

--- a/src/components/NativeOverlayHost.tsx
+++ b/src/components/NativeOverlayHost.tsx
@@ -17,11 +17,17 @@ import { TOOLTIP_SUPPRESSED } from '@/lib/constants'
 
 interface NativeOverlayHostBridge {
   ready: (request: { surfaceId: string }) => Promise<unknown>
-  action: (request: { surfaceId: string; actionId: string }) => Promise<unknown>
+  action: (request: {
+    surfaceId: string
+    actionId: string
+    closeOnSelect?: boolean
+  }) => Promise<unknown>
   close: (request: { surfaceId: string; reason: 'outside' }) => Promise<unknown>
   onRender: (callback: (payload: unknown) => void) => () => void
   onClear: (callback: () => void) => () => void
 }
+
+const COPY_FEEDBACK_MS = 1300
 
 const nativeOverlayHostBridge = (): NativeOverlayHostBridge | undefined =>
   window.vimeflow?.nativeOverlayHost
@@ -34,7 +40,7 @@ const isMenuRequest = (value: unknown): value is NativeOverlayRequest =>
   (value as { payload?: { kind?: unknown } }).payload?.kind === 'menu'
 
 const OVERLAY_MENU_ROW_CLASSES =
-  'flex min-h-8 w-full items-center justify-between gap-6 rounded px-2.5 py-1.5 ' +
+  'group flex min-h-8 w-full items-center justify-between gap-6 rounded px-2.5 py-1.5 ' +
   'text-left text-xs text-on-surface outline-none ring-0 transition-colors ' +
   'hover:bg-on-surface/10 focus:outline-none focus-visible:bg-on-surface/10 ' +
   'aria-disabled:cursor-default aria-disabled:text-on-surface-variant/45 ' +
@@ -43,6 +49,23 @@ const OVERLAY_MENU_ROW_CLASSES =
 const OVERLAY_MENU_SHORTCUT_CLASSES =
   'shrink-0 rounded bg-on-surface/10 px-1.5 py-0.5 font-mono text-[10px] ' +
   'text-on-surface-variant'
+
+const OVERLAY_MENU_ITEM_TEXT_CLASSES = 'flex min-w-0 flex-1 flex-col gap-px'
+
+const OVERLAY_MENU_ITEM_LABEL_CLASSES = 'truncate'
+
+const OVERLAY_MENU_ITEM_DETAIL_CLASSES =
+  'truncate font-mono text-[10px] text-on-surface-muted'
+
+const OVERLAY_MENU_COPY_FEEDBACK_CLASSES =
+  'inline-flex shrink-0 items-center gap-1 text-on-surface-muted transition-colors ' +
+  'group-hover:text-on-surface-variant'
+
+const OVERLAY_MENU_COPY_FEEDBACK_SUCCESS_CLASSES =
+  'inline-flex shrink-0 items-center gap-1 text-success'
+
+const OVERLAY_MENU_COPY_FEEDBACK_LABEL_CLASSES =
+  'font-sans text-[10px] font-medium'
 
 const OVERLAY_MENU_COMPOSITE_PRIMARY_CLASSES =
   'flex min-w-0 flex-1 items-center gap-2.5 rounded text-left outline-none ' +
@@ -81,10 +104,65 @@ const isCompositeItem = (
 ): item is Extract<NativeOverlayMenuItem, { type: 'composite' }> =>
   item.type === 'composite'
 
+const applyThemeSnapshot = (
+  theme: NativeOverlayRequest['theme'] | undefined
+): void => {
+  if (theme === undefined) {
+    return
+  }
+
+  const root = document.documentElement
+  for (const [name, value] of Object.entries(theme.variables)) {
+    root.style.setProperty(name, value)
+  }
+
+  if (theme.id === undefined) {
+    delete root.dataset.theme
+  } else {
+    root.dataset.theme = theme.id
+  }
+
+  if (theme.colorScheme !== undefined) {
+    root.style.colorScheme = theme.colorScheme
+  }
+}
+
 export const NativeOverlayHost = (): ReactElement | null => {
   const [request, setRequest] = useState<NativeOverlayRequest | null>(null)
+  const [copiedActionId, setCopiedActionId] = useState<string | null>(null)
   const requestRef = useRef<NativeOverlayRequest | null>(null)
+  const copyFeedbackTimerRef = useRef<number | null>(null)
   requestRef.current = request
+
+  const clearCopyFeedback = useCallback((): void => {
+    if (copyFeedbackTimerRef.current !== null) {
+      window.clearTimeout(copyFeedbackTimerRef.current)
+      copyFeedbackTimerRef.current = null
+    }
+
+    setCopiedActionId(null)
+  }, [])
+
+  const showCopyFeedback = useCallback((actionId: string): void => {
+    if (copyFeedbackTimerRef.current !== null) {
+      window.clearTimeout(copyFeedbackTimerRef.current)
+    }
+
+    setCopiedActionId(actionId)
+    copyFeedbackTimerRef.current = window.setTimeout(() => {
+      copyFeedbackTimerRef.current = null
+      setCopiedActionId(null)
+    }, COPY_FEEDBACK_MS)
+  }, [])
+
+  useEffect(
+    () => (): void => {
+      if (copyFeedbackTimerRef.current !== null) {
+        window.clearTimeout(copyFeedbackTimerRef.current)
+      }
+    },
+    []
+  )
 
   useEffect(() => {
     document.body.dataset.nativeOverlayHost = 'true'
@@ -102,11 +180,14 @@ export const NativeOverlayHost = (): ReactElement | null => {
 
     const cleanupRender = bridge.onRender((payload) => {
       if (isMenuRequest(payload)) {
+        applyThemeSnapshot(payload.theme)
+        clearCopyFeedback()
         setRequest(payload)
       }
     })
 
     const cleanupClear = bridge.onClear(() => {
+      clearCopyFeedback()
       setRequest(null)
     })
 
@@ -114,7 +195,7 @@ export const NativeOverlayHost = (): ReactElement | null => {
       cleanupRender()
       cleanupClear()
     }
-  }, [])
+  }, [clearCopyFeedback])
 
   useEffect(() => {
     if (request === null) {
@@ -130,22 +211,40 @@ export const NativeOverlayHost = (): ReactElement | null => {
       return
     }
 
+    clearCopyFeedback()
     setRequest(null)
     void nativeOverlayHostBridge()?.close({
       surfaceId: current.surfaceId,
       reason: 'outside',
     })
-  }, [])
+  }, [clearCopyFeedback])
 
   if (request === null) {
     return null
   }
 
-  const dispatchAction = (actionId: string): void => {
-    setRequest(null)
+  const dispatchAction = (
+    actionId: string,
+    options: {
+      closeOnSelect?: boolean
+      feedback?: 'copy'
+    } = {}
+  ): void => {
+    const closeOnSelect = options.closeOnSelect !== false
+
+    if (options.feedback === 'copy') {
+      showCopyFeedback(actionId)
+    }
+
+    if (closeOnSelect) {
+      clearCopyFeedback()
+      setRequest(null)
+    }
+
     void nativeOverlayHostBridge()?.action({
       surfaceId: request.surfaceId,
       actionId,
+      ...(closeOnSelect ? {} : { closeOnSelect: false }),
     })
   }
 
@@ -153,6 +252,7 @@ export const NativeOverlayHost = (): ReactElement | null => {
     <Menu.Context
       position={request.anchorRect}
       placement={request.placement as Placement}
+      matchAnchorWidth={request.payload.matchAnchorWidth === true}
       open
       onOpenChange={(open): void => {
         if (!open) {
@@ -265,6 +365,30 @@ export const NativeOverlayHost = (): ReactElement | null => {
               )
             }
 
+            const copyFeedback =
+              item.feedback === 'copy' ? (
+                <span
+                  className={
+                    copiedActionId === item.id
+                      ? OVERLAY_MENU_COPY_FEEDBACK_SUCCESS_CLASSES
+                      : OVERLAY_MENU_COPY_FEEDBACK_CLASSES
+                  }
+                  aria-live="polite"
+                >
+                  <span
+                    aria-hidden="true"
+                    className="material-symbols-outlined text-[15px] leading-none"
+                  >
+                    {copiedActionId === item.id ? 'check' : 'content_copy'}
+                  </span>
+                  {copiedActionId === item.id ? (
+                    <span className={OVERLAY_MENU_COPY_FEEDBACK_LABEL_CLASSES}>
+                      Copied
+                    </span>
+                  ) : null}
+                </span>
+              ) : null
+
             return (
               <Menu.Row
                 key={item.id}
@@ -273,29 +397,42 @@ export const NativeOverlayHost = (): ReactElement | null => {
                 className={OVERLAY_MENU_ROW_CLASSES}
                 onSelect={(): void => {
                   if (item.disabled !== true) {
-                    dispatchAction(item.id)
+                    dispatchAction(item.id, {
+                      closeOnSelect: item.closeOnSelect,
+                      feedback: item.feedback,
+                    })
                   }
                 }}
               >
-                <span className="flex items-center gap-2.5">
+                <span className="flex min-w-0 flex-1 items-center gap-2.5">
                   {item.icon === undefined ? null : (
                     <span
                       aria-hidden="true"
-                      className="material-symbols-outlined text-base leading-none opacity-70"
+                      className="material-symbols-outlined shrink-0 text-base leading-none opacity-70"
                     >
                       {item.icon}
                     </span>
                   )}
-                  <span>{item.label}</span>
+                  <span className={OVERLAY_MENU_ITEM_TEXT_CLASSES}>
+                    <span className={OVERLAY_MENU_ITEM_LABEL_CLASSES}>
+                      {item.label}
+                    </span>
+                    {item.detail === undefined ? null : (
+                      <span className={OVERLAY_MENU_ITEM_DETAIL_CLASSES}>
+                        {item.detail}
+                      </span>
+                    )}
+                  </span>
                 </span>
-                {item.shortcut === undefined ? null : (
-                  <kbd
-                    className={OVERLAY_MENU_SHORTCUT_CLASSES}
-                    aria-hidden="true"
-                  >
-                    {item.shortcut}
-                  </kbd>
-                )}
+                {copyFeedback ??
+                  (item.shortcut === undefined ? null : (
+                    <kbd
+                      className={OVERLAY_MENU_SHORTCUT_CLASSES}
+                      aria-hidden="true"
+                    >
+                      {item.shortcut}
+                    </kbd>
+                  ))}
               </Menu.Row>
             )
           })}

--- a/src/components/NativeOverlayHost.tsx
+++ b/src/components/NativeOverlayHost.tsx
@@ -21,10 +21,12 @@ interface NativeOverlayHostBridge {
     surfaceId: string
     actionId: string
     closeOnSelect?: boolean
+    feedback?: 'copy'
   }) => Promise<unknown>
   close: (request: { surfaceId: string; reason: 'outside' }) => Promise<unknown>
   onRender: (callback: (payload: unknown) => void) => () => void
   onClear: (callback: () => void) => () => void
+  onActionResult: (callback: (payload: unknown) => void) => () => void
 }
 
 const COPY_FEEDBACK_MS = 1300
@@ -39,10 +41,33 @@ const isMenuRequest = (value: unknown): value is NativeOverlayRequest =>
   (value as { kind?: unknown }).kind === 'menu' &&
   (value as { payload?: { kind?: unknown } }).payload?.kind === 'menu'
 
+const isCopyActionResult = (
+  value: unknown
+): value is {
+  surfaceId: string
+  actionId: string
+  feedback: 'copy'
+  ok: boolean
+} =>
+  typeof value === 'object' &&
+  value !== null &&
+  !Array.isArray(value) &&
+  typeof (value as { surfaceId?: unknown }).surfaceId === 'string' &&
+  typeof (value as { actionId?: unknown }).actionId === 'string' &&
+  (value as { feedback?: unknown }).feedback === 'copy' &&
+  typeof (value as { ok?: unknown }).ok === 'boolean'
+
 const OVERLAY_MENU_ROW_CLASSES =
   'group flex min-h-8 w-full items-center justify-between gap-6 rounded px-2.5 py-1.5 ' +
   'text-left text-xs text-on-surface outline-none ring-0 transition-colors ' +
   'hover:bg-on-surface/10 focus:outline-none focus-visible:bg-on-surface/10 ' +
+  'aria-disabled:cursor-default aria-disabled:text-on-surface-variant/45 ' +
+  'aria-disabled:hover:bg-transparent aria-disabled:focus:bg-transparent'
+
+const OVERLAY_MENU_DETAIL_ROW_CLASSES =
+  'group flex min-h-8 w-full items-center gap-2 rounded-chip px-[7px] py-1.5 ' +
+  'text-left text-xs text-on-surface outline-none transition-colors ' +
+  'hover:bg-primary-container/[0.12] focus:outline-none focus-visible:bg-primary-container/[0.12] ' +
   'aria-disabled:cursor-default aria-disabled:text-on-surface-variant/45 ' +
   'aria-disabled:hover:bg-transparent aria-disabled:focus:bg-transparent'
 
@@ -54,8 +79,11 @@ const OVERLAY_MENU_ITEM_TEXT_CLASSES = 'flex min-w-0 flex-1 flex-col gap-px'
 
 const OVERLAY_MENU_ITEM_LABEL_CLASSES = 'truncate'
 
+const OVERLAY_MENU_ITEM_DETAIL_LABEL_CLASSES =
+  'font-sans text-[8.5px] uppercase tracking-[0.09em] text-on-surface-muted'
+
 const OVERLAY_MENU_ITEM_DETAIL_CLASSES =
-  'truncate font-mono text-[10px] text-on-surface-muted'
+  'truncate font-mono text-[11px] text-on-surface'
 
 const OVERLAY_MENU_COPY_FEEDBACK_CLASSES =
   'inline-flex shrink-0 items-center gap-1 text-on-surface-muted transition-colors ' +
@@ -78,6 +106,16 @@ const overlayMenuActionButtonClass = (pressed: boolean): string =>
       ? 'bg-primary text-on-primary'
       : 'text-on-surface-muted hover:bg-on-surface/10 hover:text-primary'
   }`
+
+const overlayMenuRowClass = (item: NativeOverlayMenuItem): string =>
+  'detail' in item && item.detail !== undefined
+    ? OVERLAY_MENU_DETAIL_ROW_CLASSES
+    : OVERLAY_MENU_ROW_CLASSES
+
+const overlayMenuItemLabelClass = (item: NativeOverlayMenuItem): string =>
+  'detail' in item && item.detail !== undefined
+    ? OVERLAY_MENU_ITEM_DETAIL_LABEL_CLASSES
+    : OVERLAY_MENU_ITEM_LABEL_CLASSES
 
 const sectionsForRequest = (
   request: NativeOverlayRequest
@@ -191,11 +229,25 @@ export const NativeOverlayHost = (): ReactElement | null => {
       setRequest(null)
     })
 
+    const cleanupActionResult = bridge.onActionResult((payload) => {
+      if (!isCopyActionResult(payload) || !payload.ok) {
+        return
+      }
+
+      const current = requestRef.current
+      if (current?.surfaceId !== payload.surfaceId) {
+        return
+      }
+
+      showCopyFeedback(payload.actionId)
+    })
+
     return (): void => {
       cleanupRender()
       cleanupClear()
+      cleanupActionResult()
     }
-  }, [clearCopyFeedback])
+  }, [clearCopyFeedback, showCopyFeedback])
 
   useEffect(() => {
     if (request === null) {
@@ -232,10 +284,6 @@ export const NativeOverlayHost = (): ReactElement | null => {
   ): void => {
     const closeOnSelect = options.closeOnSelect !== false
 
-    if (options.feedback === 'copy') {
-      showCopyFeedback(actionId)
-    }
-
     if (closeOnSelect) {
       clearCopyFeedback()
       setRequest(null)
@@ -245,6 +293,7 @@ export const NativeOverlayHost = (): ReactElement | null => {
       surfaceId: request.surfaceId,
       actionId,
       ...(closeOnSelect ? {} : { closeOnSelect: false }),
+      ...(options.feedback === undefined ? {} : { feedback: options.feedback }),
     })
   }
 
@@ -253,6 +302,7 @@ export const NativeOverlayHost = (): ReactElement | null => {
       position={request.anchorRect}
       placement={request.placement as Placement}
       matchAnchorWidth={request.payload.matchAnchorWidth === true}
+      surfaceTone={request.payload.surfaceTone}
       open
       onOpenChange={(open): void => {
         if (!open) {
@@ -394,7 +444,7 @@ export const NativeOverlayHost = (): ReactElement | null => {
                 key={item.id}
                 label={item.label}
                 disabled={item.disabled}
-                className={OVERLAY_MENU_ROW_CLASSES}
+                className={overlayMenuRowClass(item)}
                 onSelect={(): void => {
                   if (item.disabled !== true) {
                     dispatchAction(item.id, {
@@ -414,7 +464,7 @@ export const NativeOverlayHost = (): ReactElement | null => {
                     </span>
                   )}
                   <span className={OVERLAY_MENU_ITEM_TEXT_CLASSES}>
-                    <span className={OVERLAY_MENU_ITEM_LABEL_CLASSES}>
+                    <span className={overlayMenuItemLabelClass(item)}>
                       {item.label}
                     </span>
                     {item.detail === undefined ? null : (

--- a/src/components/NativeOverlayHost.tsx
+++ b/src/components/NativeOverlayHost.tsx
@@ -107,6 +107,17 @@ const overlayMenuActionButtonClass = (pressed: boolean): string =>
       : 'text-on-surface-muted hover:bg-on-surface/10 hover:text-primary'
   }`
 
+const resetThemeSnapshot = (root: HTMLElement): void => {
+  for (const name of Array.from(root.style)) {
+    if (name.startsWith('--color-') || name.startsWith('--shadow-')) {
+      root.style.removeProperty(name)
+    }
+  }
+
+  delete root.dataset.theme
+  root.style.colorScheme = ''
+}
+
 const overlayMenuRowClass = (item: NativeOverlayMenuItem): string =>
   'detail' in item && item.detail !== undefined
     ? OVERLAY_MENU_DETAIL_ROW_CLASSES
@@ -145,11 +156,13 @@ const isCompositeItem = (
 const applyThemeSnapshot = (
   theme: NativeOverlayRequest['theme'] | undefined
 ): void => {
+  const root = document.documentElement
+  resetThemeSnapshot(root)
+
   if (theme === undefined) {
     return
   }
 
-  const root = document.documentElement
   for (const [name, value] of Object.entries(theme.variables)) {
     root.style.setProperty(name, value)
   }

--- a/src/components/base/floating/nativeOverlay.test.ts
+++ b/src/components/base/floating/nativeOverlay.test.ts
@@ -51,8 +51,10 @@ const installBridge = (
   openResults: Promise<{ accepted: boolean }>[]
 ): {
   action: (event: NativeOverlayActionEvent) => void
+  actionResult: ReturnType<typeof vi.fn>
 } => {
   let actionListener: ((event: unknown) => void) | null = null
+  const actionResult = vi.fn(() => Promise.resolve())
 
   window.vimeflow = {
     invoke: <T>(): Promise<T> => Promise.resolve(null as T),
@@ -68,6 +70,7 @@ const installBridge = (
         return result
       }),
       close: vi.fn(() => Promise.resolve()),
+      actionResult,
       onAction: vi.fn((callback: (event: unknown) => void) => {
         actionListener = callback
 
@@ -78,6 +81,7 @@ const installBridge = (
   }
 
   return {
+    actionResult,
     action: (event): void => {
       actionListener?.(event)
     },
@@ -171,5 +175,82 @@ describe('openNativeOverlay', () => {
       '[vimeflow:native-overlay] open failed',
       expect.any(Error)
     )
+  })
+
+  test('reports copy feedback success only after the retained action succeeds', async () => {
+    const open = deferredOpen()
+    const bridge = installBridge([open.promise])
+    const copy = vi.fn(() => Promise.resolve(true))
+
+    const result = openNativeOverlay(requestForSurface('surface-1'), {
+      actions: new Map([
+        [
+          'copy',
+          {
+            retainSession: true,
+            run: copy,
+          },
+        ],
+      ]),
+      onClose: vi.fn(),
+    })
+
+    open.resolve({ accepted: true })
+    await expect(result).resolves.toBe(true)
+
+    bridge.action({
+      surfaceId: 'surface-1',
+      actionId: 'copy',
+      feedback: 'copy',
+      closeOnSelect: false,
+    })
+
+    expect(bridge.actionResult).not.toHaveBeenCalled()
+    await Promise.resolve()
+
+    expect(copy).toHaveBeenCalledOnce()
+    expect(bridge.actionResult).toHaveBeenCalledWith({
+      surfaceId: 'surface-1',
+      actionId: 'copy',
+      feedback: 'copy',
+      ok: true,
+    })
+  })
+
+  test('reports copy feedback failure when the retained action fails', async () => {
+    const open = deferredOpen()
+    const bridge = installBridge([open.promise])
+
+    const result = openNativeOverlay(requestForSurface('surface-1'), {
+      actions: new Map([
+        [
+          'copy',
+          {
+            retainSession: true,
+            run: (): boolean => false,
+          },
+        ],
+      ]),
+      onClose: vi.fn(),
+    })
+
+    open.resolve({ accepted: true })
+    await expect(result).resolves.toBe(true)
+
+    bridge.action({
+      surfaceId: 'surface-1',
+      actionId: 'copy',
+      feedback: 'copy',
+      closeOnSelect: false,
+    })
+
+    await Promise.resolve()
+
+    expect(bridge.actionResult).toHaveBeenCalledWith({
+      surfaceId: 'surface-1',
+      actionId: 'copy',
+      feedback: 'copy',
+      ok: false,
+    })
   })
 })

--- a/src/components/base/floating/nativeOverlay.test.ts
+++ b/src/components/base/floating/nativeOverlay.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import {
   __resetNativeOverlayForTest,
+  nativeOverlayThemeSnapshot,
   openNativeOverlay,
   type NativeOverlayActionEvent,
   type NativeOverlayRequest,
@@ -85,7 +86,29 @@ const installBridge = (
 
 afterEach(() => {
   __resetNativeOverlayForTest()
+  document.documentElement.removeAttribute('style')
+  document.documentElement.removeAttribute('data-theme')
   delete window.vimeflow
+})
+
+describe('nativeOverlayThemeSnapshot', () => {
+  test('captures the active theme tokens for the overlay renderer', () => {
+    const root = document.documentElement
+    root.dataset.theme = 'flexoki'
+    root.style.colorScheme = 'light'
+    root.style.setProperty('--color-surface', 'var(--color-test-surface)')
+    root.style.setProperty('--shadow-modal', 'var(--shadow-test-modal)')
+    root.style.setProperty('--layout-gap', '8px')
+
+    expect(nativeOverlayThemeSnapshot()).toEqual({
+      id: 'flexoki',
+      colorScheme: 'light',
+      variables: {
+        '--color-surface': 'var(--color-test-surface)',
+        '--shadow-modal': 'var(--shadow-test-modal)',
+      },
+    })
+  })
 })
 
 describe('openNativeOverlay', () => {

--- a/src/components/base/floating/nativeOverlay.ts
+++ b/src/components/base/floating/nativeOverlay.ts
@@ -20,11 +20,20 @@ export interface NativeOverlayRect {
   height: number
 }
 
+export interface NativeOverlayThemeSnapshot {
+  id?: string
+  colorScheme?: string
+  variables: Record<string, string>
+}
+
 export interface NativeOverlayMenuActionItem {
   type?: 'item'
   id: string
   label: string
+  detail?: string
   icon?: string
+  feedback?: 'copy'
+  closeOnSelect?: boolean
   shortcut?: string
   disabled?: boolean
 }
@@ -74,6 +83,7 @@ export interface NativeOverlayMenuSection {
 export interface NativeOverlayMenuPayload {
   kind: 'menu'
   ariaLabel?: string
+  matchAnchorWidth?: boolean
   items?: NativeOverlayMenuItem[]
   sections?: NativeOverlayMenuSection[]
 }
@@ -89,11 +99,13 @@ export interface NativeOverlayRequest {
   anchorRect: NativeOverlayRect
   placement: string
   payload: SerializableOverlayPayload
+  theme?: NativeOverlayThemeSnapshot
 }
 
 export interface NativeOverlayActionEvent {
   surfaceId: string
   actionId: string
+  closeOnSelect?: boolean
 }
 
 export interface NativeOverlayCloseEvent {
@@ -104,6 +116,37 @@ export interface NativeOverlayCloseEvent {
 export interface NativeOverlayOpenResult {
   accepted: boolean
   reason?: string
+}
+
+const THEME_VARIABLE_PREFIXES = ['--color-', '--shadow-'] as const
+
+// Native overlays render in a separate transparent BrowserWindow, so they do
+// not automatically inherit the main renderer's live CSS variables. Capture the
+// active token values when the surface opens and let the overlay host apply
+// them before rendering the shared React menu.
+export const nativeOverlayThemeSnapshot = (): NativeOverlayThemeSnapshot => {
+  const root = document.documentElement
+  const variables: Record<string, string> = {}
+
+  for (let index = 0; index < root.style.length; index += 1) {
+    const name = root.style.item(index)
+    if (!THEME_VARIABLE_PREFIXES.some((prefix) => name.startsWith(prefix))) {
+      continue
+    }
+
+    const value = root.style.getPropertyValue(name)
+    if (value.length > 0) {
+      variables[name] = value
+    }
+  }
+
+  return {
+    ...(root.dataset.theme === undefined ? {} : { id: root.dataset.theme }),
+    ...(root.style.colorScheme.length === 0
+      ? {}
+      : { colorScheme: root.style.colorScheme }),
+    variables,
+  }
 }
 
 // Renderer-side handle for the optional Electron preload bridge. Floating

--- a/src/components/base/floating/nativeOverlay.ts
+++ b/src/components/base/floating/nativeOverlay.ts
@@ -38,6 +38,8 @@ export interface NativeOverlayMenuActionItem {
   disabled?: boolean
 }
 
+export type NativeOverlayMenuSurfaceTone = 'primary-container-soft'
+
 export interface NativeOverlayMenuCheckboxItem {
   type: 'checkbox'
   id: string
@@ -84,6 +86,7 @@ export interface NativeOverlayMenuPayload {
   kind: 'menu'
   ariaLabel?: string
   matchAnchorWidth?: boolean
+  surfaceTone?: NativeOverlayMenuSurfaceTone
   items?: NativeOverlayMenuItem[]
   sections?: NativeOverlayMenuSection[]
 }
@@ -106,6 +109,14 @@ export interface NativeOverlayActionEvent {
   surfaceId: string
   actionId: string
   closeOnSelect?: boolean
+  feedback?: 'copy'
+}
+
+export interface NativeOverlayActionResultEvent {
+  surfaceId: string
+  actionId: string
+  feedback: 'copy'
+  ok: boolean
 }
 
 export interface NativeOverlayCloseEvent {
@@ -157,15 +168,18 @@ export const nativeOverlayThemeSnapshot = (): NativeOverlayThemeSnapshot => {
 interface NativeOverlayBridge {
   open: (request: NativeOverlayRequest) => Promise<NativeOverlayOpenResult>
   close: (request: { surfaceId: string; reason: 'renderer' }) => Promise<void>
+  actionResult: (request: NativeOverlayActionResultEvent) => Promise<void>
   onAction: (callback: (event: unknown) => void) => () => void
   onClose: (callback: (event: unknown) => void) => () => void
 }
 
+export type NativeOverlayActionResult = boolean | void | Promise<boolean | void>
+
 export type NativeOverlayActionHandler =
-  | (() => void)
+  | (() => NativeOverlayActionResult)
   | {
       retainSession: true
-      run: () => void
+      run: () => NativeOverlayActionResult
     }
 
 interface NativeOverlaySession {
@@ -184,7 +198,10 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 const isActionEvent = (value: unknown): value is NativeOverlayActionEvent =>
   isRecord(value) &&
   typeof value.surfaceId === 'string' &&
-  typeof value.actionId === 'string'
+  typeof value.actionId === 'string' &&
+  (value.closeOnSelect === undefined ||
+    typeof value.closeOnSelect === 'boolean') &&
+  (value.feedback === undefined || value.feedback === 'copy')
 
 const isCloseEvent = (value: unknown): value is NativeOverlayCloseEvent =>
   isRecord(value) &&
@@ -193,6 +210,37 @@ const isCloseEvent = (value: unknown): value is NativeOverlayCloseEvent =>
 
 const bridge = (): NativeOverlayBridge | undefined =>
   typeof window === 'undefined' ? undefined : window.vimeflow?.nativeOverlay
+
+const reportActionResult = (
+  event: NativeOverlayActionEvent,
+  ok: boolean
+): void => {
+  if (event.feedback === undefined) {
+    return
+  }
+
+  void bridge()?.actionResult({
+    surfaceId: event.surfaceId,
+    actionId: event.actionId,
+    feedback: event.feedback,
+    ok,
+  })
+}
+
+const runActionAndReport = (
+  event: NativeOverlayActionEvent,
+  run: () => NativeOverlayActionResult
+): void => {
+  void (async (): Promise<void> => {
+    try {
+      const result = await run()
+      reportActionResult(event, result === true)
+    } catch (error) {
+      reportActionResult(event, false)
+      log.warn('action failed', error)
+    }
+  })()
+}
 
 export const isNativeOverlayFeatureEnabled = (): boolean =>
   import.meta.env.VITE_NATIVE_OVERLAY === '1'
@@ -228,12 +276,12 @@ const handleAction = (event: unknown): void => {
     // makes each surface/action id at-most-once. We intentionally do not retry
     // callbacks because copy/paste/rename-style actions may have side effects.
     sessions.delete(event.surfaceId)
-    action()
+    runActionAndReport(event, action)
 
     return
   }
 
-  action.run()
+  runActionAndReport(event, action.run)
 }
 
 const handleClose = (event: unknown): void => {

--- a/src/features/terminal/components/LayoutSwitcher/LayoutDisplayCustomLayouts.test.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutDisplayCustomLayouts.test.tsx
@@ -80,6 +80,7 @@ const installNativeOverlayBridge = (): {
     nativeOverlay: {
       open,
       close: vi.fn().mockResolvedValue(undefined),
+      actionResult: vi.fn().mockResolvedValue(undefined),
       onAction: vi.fn((callback: (event: unknown) => void) => {
         actionListener = callback
 

--- a/src/features/terminal/components/TerminalPane/GitRefChip.test.tsx
+++ b/src/features/terminal/components/TerminalPane/GitRefChip.test.tsx
@@ -1,16 +1,9 @@
 // cspell:ignore worktree testids worktrees
 import userEvent from '@testing-library/user-event'
-import {
-  act,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-  within,
-} from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, expect, test, vi } from 'vitest'
 import { writeClipboardText } from '@/lib/clipboard'
-import { GitRefChip, GitRefCopyRows, composeCopyRows } from './GitRefChip'
+import { GitRefChip, composeCopyRows } from './GitRefChip'
 
 vi.mock('@/lib/clipboard', () => ({
   writeClipboardText: vi.fn().mockResolvedValue(true),
@@ -49,6 +42,7 @@ const installNativeOverlayBridge = (): {
     nativeOverlay: {
       open,
       close: vi.fn().mockResolvedValue(undefined),
+      actionResult: vi.fn().mockResolvedValue(undefined),
       onAction: vi.fn(() => vi.fn()),
       onClose: vi.fn(() => vi.fn()),
     },
@@ -167,6 +161,7 @@ test('detached=true applies two-tone coral (text-tertiary branch, text-error wor
   const chip = screen.getByTestId('git-ref-chip')
   expect(chip.className).toMatch(/bg-tertiary\/\[0\.06\]/)
   expect(chip.className).toMatch(/border-tertiary/)
+  expect(chip.className).toMatch(/focus-visible:outline-none/)
   expect(screen.getByTestId('git-ref-chip-br-label').className).toMatch(
     /text-tertiary/
   )
@@ -347,6 +342,61 @@ test('GitRefChip opens the copy menu from keyboard focus', async () => {
   ).toBeInTheDocument()
 })
 
+test('GitRefChip closes on Escape without reopening from restored focus', async () => {
+  const user = userEvent.setup()
+  render(
+    <GitRefChip
+      worktreeName="feat-jose"
+      branch="feat/jose-auth"
+      cwd="/Users/will/projects/vimeflow/.claude/worktrees/feat-jose"
+    />
+  )
+
+  await user.tab()
+  expect(
+    screen.getByRole('menu', { name: 'Git ref details' })
+  ).toBeInTheDocument()
+
+  await user.keyboard('{Escape}')
+
+  await waitFor(() => {
+    expect(screen.queryByRole('menu', { name: 'Git ref details' })).toBeNull()
+  })
+
+  expect(screen.getByTestId('git-ref-chip')).toHaveAttribute(
+    'aria-expanded',
+    'false'
+  )
+})
+
+test('GitRefChip copies the selected row through the menu', async () => {
+  vi.mocked(writeClipboardText).mockClear()
+  render(
+    <GitRefChip
+      worktreeName="feat-jose"
+      branch="feat/jose-auth"
+      cwd="/Users/will/projects/vimeflow/.claude/worktrees/feat-jose"
+    />
+  )
+
+  fireEvent.click(screen.getByTestId('git-ref-chip'))
+  fireEvent.click(screen.getByRole('menuitem', { name: 'Copy path' }))
+
+  await waitFor(() =>
+    expect(writeClipboardText).toHaveBeenCalledWith(
+      '/Users/will/projects/vimeflow/.claude/worktrees/feat-jose'
+    )
+  )
+
+  expect(
+    screen.getByRole('menu', { name: 'Git ref details' })
+  ).toBeInTheDocument()
+
+  expect(screen.getByRole('menuitem', { name: 'Copy path' })).toHaveTextContent(
+    'check'
+  )
+})
+
 test('GitRefChip sends native overlay rows with chip-width matching', async () => {
   vi.stubEnv('VITE_NATIVE_OVERLAY', '1')
   setNavigatorPlatform('MacIntel')
@@ -382,6 +432,7 @@ test('GitRefChip sends native overlay rows with chip-width matching', async () =
     anchorRect: { x: number; y: number; width: number; height: number }
     payload: {
       matchAnchorWidth?: boolean
+      surfaceTone?: string
       items?: readonly {
         label?: string
         detail?: string
@@ -397,6 +448,7 @@ test('GitRefChip sends native overlay rows with chip-width matching', async () =
     anchorRect: { x: 7, y: 11, width: 238, height: 22 },
     payload: {
       matchAnchorWidth: true,
+      surfaceTone: 'primary-container-soft',
       items: expect.arrayContaining([
         expect.objectContaining({
           label: 'Copy path',
@@ -409,133 +461,4 @@ test('GitRefChip sends native overlay rows with chip-width matching', async () =
       ]),
     },
   })
-})
-
-test('GitRefCopyRows renders one copy button per row carrying its value', () => {
-  render(
-    <GitRefCopyRows
-      worktreeName="feat-jose"
-      branch="feat/jose-auth"
-      cwd="/Users/will/projects/vimeflow/.claude/worktrees/feat-jose"
-    />
-  )
-
-  expect(
-    screen.getByRole('button', { name: 'Copy worktree' })
-  ).toHaveTextContent('feat-jose')
-
-  expect(screen.getByRole('button', { name: 'Copy path' })).toHaveTextContent(
-    '/Users/will/projects/vimeflow/.claude/worktrees/feat-jose'
-  )
-
-  expect(screen.getByRole('button', { name: 'Copy branch' })).toHaveTextContent(
-    'feat/jose-auth'
-  )
-})
-
-test('GitRefCopyRows omits the worktree row when there is no worktree', () => {
-  render(
-    <GitRefCopyRows
-      worktreeName={null}
-      branch="ci/release-v0.9"
-      cwd="/Users/will/projects/vimeflow"
-    />
-  )
-  expect(screen.queryByRole('button', { name: 'Copy worktree' })).toBeNull()
-  expect(screen.getByRole('button', { name: 'Copy path' })).toBeInTheDocument()
-  expect(
-    screen.getByRole('button', { name: 'Copy branch' })
-  ).toBeInTheDocument()
-})
-
-test('GitRefCopyRows omits the path row when there is no cwd', () => {
-  render(<GitRefCopyRows worktreeName="feat-jose" branch="main" cwd={null} />)
-  expect(screen.queryByRole('button', { name: 'Copy path' })).toBeNull()
-  expect(
-    screen.getByRole('button', { name: 'Copy worktree' })
-  ).toBeInTheDocument()
-
-  expect(
-    screen.getByRole('button', { name: 'Copy branch' })
-  ).toBeInTheDocument()
-})
-
-test('GitRefCopyRows labels the branch row "Copy detached head" when detached', () => {
-  render(
-    <GitRefCopyRows worktreeName={null} branch="a7f23c0" cwd={null} detached />
-  )
-
-  expect(
-    screen.getByRole('button', { name: 'Copy detached head' })
-  ).toHaveTextContent('a7f23c0')
-})
-
-test('clicking a row copies its value and flips that row glyph to a check', async () => {
-  vi.mocked(writeClipboardText).mockClear()
-  render(
-    <GitRefCopyRows
-      worktreeName="feat-jose"
-      branch="feat/jose-auth"
-      cwd="/Users/will/projects/vimeflow/.claude/worktrees/feat-jose"
-    />
-  )
-  const pathButton = screen.getByRole('button', { name: 'Copy path' })
-  expect(within(pathButton).getByText('content_copy')).toBeInTheDocument()
-
-  fireEvent.click(pathButton)
-
-  await waitFor(() =>
-    expect(writeClipboardText).toHaveBeenCalledWith(
-      '/Users/will/projects/vimeflow/.claude/worktrees/feat-jose'
-    )
-  )
-  expect(await within(pathButton).findByText('check')).toBeInTheDocument()
-  // Other rows are unaffected — only the clicked row shows the check.
-  expect(
-    within(screen.getByRole('button', { name: 'Copy branch' })).getByText(
-      'content_copy'
-    )
-  ).toBeInTheDocument()
-})
-
-test('copy failure keeps the row glyph on content_copy', async () => {
-  vi.mocked(writeClipboardText).mockResolvedValueOnce(false)
-  render(<GitRefCopyRows worktreeName={null} branch="main" cwd={null} />)
-  const branchButton = screen.getByRole('button', { name: 'Copy branch' })
-
-  fireEvent.click(branchButton)
-
-  await waitFor(() => expect(writeClipboardText).toHaveBeenCalledWith('main'))
-  expect(within(branchButton).queryByText('check')).toBeNull()
-  expect(within(branchButton).getByText('content_copy')).toBeInTheDocument()
-})
-
-test('the copied check reverts to content_copy after the feedback window', async () => {
-  vi.useFakeTimers()
-  try {
-    vi.mocked(writeClipboardText).mockClear()
-    render(
-      <GitRefCopyRows
-        worktreeName={null}
-        branch="main"
-        cwd="/Users/will/projects/vimeflow"
-      />
-    )
-    const pathButton = screen.getByRole('button', { name: 'Copy path' })
-
-    fireEvent.click(pathButton)
-    await act(async () => {
-      await Promise.resolve()
-    })
-    expect(writeClipboardText).toHaveBeenCalled()
-    expect(within(pathButton).getByText('check')).toBeInTheDocument()
-
-    act(() => {
-      vi.advanceTimersByTime(1300)
-    })
-
-    expect(within(pathButton).getByText('content_copy')).toBeInTheDocument()
-  } finally {
-    vi.useRealTimers()
-  }
 })

--- a/src/features/terminal/components/TerminalPane/GitRefChip.test.tsx
+++ b/src/features/terminal/components/TerminalPane/GitRefChip.test.tsx
@@ -424,7 +424,7 @@ test('GitRefChip sends native overlay rows with chip-width matching', async () =
     toJSON: () => ({}),
   } as DOMRect)
 
-  fireEvent.focus(chip)
+  fireEvent.keyDown(chip, { key: 'ArrowDown' })
 
   await waitFor(() => expect(nativeBridge.open).toHaveBeenCalledOnce())
 
@@ -461,4 +461,22 @@ test('GitRefChip sends native overlay rows with chip-width matching', async () =
       ]),
     },
   })
+})
+
+test('GitRefChip does not open the native overlay from focus restoration', () => {
+  vi.stubEnv('VITE_NATIVE_OVERLAY', '1')
+  setNavigatorPlatform('MacIntel')
+  const nativeBridge = installNativeOverlayBridge()
+
+  render(
+    <GitRefChip
+      worktreeName="native-overlay-git-ref"
+      branch="codex/native-overlay-git-ref"
+      nativeOverlay
+    />
+  )
+
+  fireEvent.focus(screen.getByTestId('git-ref-chip'))
+
+  expect(nativeBridge.open).not.toHaveBeenCalled()
 })

--- a/src/features/terminal/components/TerminalPane/GitRefChip.test.tsx
+++ b/src/features/terminal/components/TerminalPane/GitRefChip.test.tsx
@@ -8,13 +8,62 @@ import {
   waitFor,
   within,
 } from '@testing-library/react'
-import { expect, test, vi } from 'vitest'
+import { afterEach, expect, test, vi } from 'vitest'
 import { writeClipboardText } from '@/lib/clipboard'
 import { GitRefChip, GitRefCopyRows, composeCopyRows } from './GitRefChip'
 
 vi.mock('@/lib/clipboard', () => ({
   writeClipboardText: vi.fn().mockResolvedValue(true),
 }))
+
+let restorePlatform: (() => void) | null = null
+
+const setNavigatorPlatform = (platform: string): void => {
+  restorePlatform?.()
+  const original = Object.getOwnPropertyDescriptor(window.navigator, 'platform')
+
+  Object.defineProperty(window.navigator, 'platform', {
+    configurable: true,
+    value: platform,
+  })
+
+  restorePlatform = (): void => {
+    if (original === undefined) {
+      delete (window.navigator as unknown as { platform?: string }).platform
+
+      return
+    }
+
+    Object.defineProperty(window.navigator, 'platform', original)
+  }
+}
+
+const installNativeOverlayBridge = (): {
+  open: ReturnType<typeof vi.fn>
+} => {
+  const open = vi.fn().mockResolvedValue({ accepted: true })
+
+  window.vimeflow = {
+    invoke: <T,>(): Promise<T> => Promise.resolve(null as T),
+    listen: vi.fn(() => Promise.resolve(vi.fn())),
+    nativeOverlay: {
+      open,
+      close: vi.fn().mockResolvedValue(undefined),
+      onAction: vi.fn(() => vi.fn()),
+      onClose: vi.fn(() => vi.fn()),
+    },
+  }
+
+  return { open }
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.clearAllMocks()
+  restorePlatform?.()
+  restorePlatform = null
+  delete window.vimeflow
+})
 
 test('renders nothing when branch is null', () => {
   render(<GitRefChip worktreeName="feat-jose" branch={null} />)
@@ -276,7 +325,7 @@ test('icons carry material-symbols-outlined class + aria-hidden', () => {
   expect(brIcon.getAttribute('aria-hidden')).toBe('true')
 })
 
-test('GitRefChip opens the copy popover from keyboard focus', async () => {
+test('GitRefChip opens the copy menu from keyboard focus', async () => {
   const user = userEvent.setup()
   render(
     <GitRefChip
@@ -288,12 +337,78 @@ test('GitRefChip opens the copy popover from keyboard focus', async () => {
 
   await user.tab()
 
-  expect(screen.getByTestId('git-ref-chip')).toHaveFocus()
   expect(screen.getByTestId('git-ref-chip')).toHaveAttribute('tabindex', '0')
   expect(
-    screen.getByRole('dialog', { name: 'Git ref details' })
+    screen.getByRole('menu', { name: 'Git ref details' })
   ).toBeInTheDocument()
-  expect(screen.getByRole('button', { name: 'Copy path' })).toBeInTheDocument()
+  expect(screen.getByRole('menuitem', { name: 'Copy worktree' })).toHaveFocus()
+  expect(
+    screen.getByRole('menuitem', { name: 'Copy path' })
+  ).toBeInTheDocument()
+})
+
+test('GitRefChip sends native overlay rows with chip-width matching', async () => {
+  vi.stubEnv('VITE_NATIVE_OVERLAY', '1')
+  setNavigatorPlatform('MacIntel')
+  const nativeBridge = installNativeOverlayBridge()
+
+  render(
+    <GitRefChip
+      worktreeName="native-overlay-git-ref"
+      branch="codex/native-overlay-git-ref"
+      cwd="/Users/will/projects/vimeflow/worktrees/native-overlay-git-ref"
+      nativeOverlay
+    />
+  )
+
+  const chip = screen.getByTestId('git-ref-chip')
+  vi.spyOn(chip, 'getBoundingClientRect').mockReturnValue({
+    x: 7,
+    y: 11,
+    width: 238,
+    height: 22,
+    top: 11,
+    left: 7,
+    right: 245,
+    bottom: 33,
+    toJSON: () => ({}),
+  } as DOMRect)
+
+  fireEvent.focus(chip)
+
+  await waitFor(() => expect(nativeBridge.open).toHaveBeenCalledOnce())
+
+  const request = nativeBridge.open.mock.calls[0][0] as {
+    anchorRect: { x: number; y: number; width: number; height: number }
+    payload: {
+      matchAnchorWidth?: boolean
+      items?: readonly {
+        label?: string
+        detail?: string
+        icon?: string
+        feedback?: string
+        closeOnSelect?: boolean
+      }[]
+    }
+  }
+
+  expect(screen.queryByRole('menu', { name: 'Git ref details' })).toBeNull()
+  expect(request).toMatchObject({
+    anchorRect: { x: 7, y: 11, width: 238, height: 22 },
+    payload: {
+      matchAnchorWidth: true,
+      items: expect.arrayContaining([
+        expect.objectContaining({
+          label: 'Copy path',
+          detail:
+            '/Users/will/projects/vimeflow/worktrees/native-overlay-git-ref',
+          icon: 'folder_open',
+          feedback: 'copy',
+          closeOnSelect: false,
+        }),
+      ]),
+    },
+  })
 })
 
 test('GitRefCopyRows renders one copy button per row carrying its value', () => {

--- a/src/features/terminal/components/TerminalPane/GitRefChip.test.tsx
+++ b/src/features/terminal/components/TerminalPane/GitRefChip.test.tsx
@@ -342,6 +342,25 @@ test('GitRefChip opens the copy menu from keyboard focus', async () => {
   ).toBeInTheDocument()
 })
 
+test('GitRefChip keeps focus auto-open when nativeOverlay falls back locally', async () => {
+  const user = userEvent.setup()
+  render(
+    <GitRefChip
+      worktreeName="feat-jose"
+      branch="feat/jose-auth"
+      cwd="/Users/will/projects/vimeflow/.claude/worktrees/feat-jose"
+      nativeOverlay
+    />
+  )
+
+  await user.tab()
+
+  expect(
+    screen.getByRole('menu', { name: 'Git ref details' })
+  ).toBeInTheDocument()
+  expect(screen.getByRole('menuitem', { name: 'Copy worktree' })).toHaveFocus()
+})
+
 test('GitRefChip closes on Escape without reopening from restored focus', async () => {
   const user = userEvent.setup()
   render(

--- a/src/features/terminal/components/TerminalPane/GitRefChip.tsx
+++ b/src/features/terminal/components/TerminalPane/GitRefChip.tsx
@@ -7,7 +7,7 @@ import {
   type ReactElement,
 } from 'react'
 import { Chip } from '@/components/Chip'
-import { Menu } from '@/components/Menu'
+import { Menu, isNativeOverlayMenuTransportActive } from '@/components/Menu'
 import { writeClipboardText } from '@/lib/clipboard'
 
 export interface GitRefChipProps {
@@ -240,6 +240,9 @@ export const GitRefChip = ({
   const tooltipCwd = cwd !== undefined && cwd.length > 0 ? cwd : null
   const copyRows = composeCopyRows(worktreeName, branch, tooltipCwd, detached)
 
+  const usesNativeOverlayTransport =
+    isNativeOverlayMenuTransportActive(nativeOverlay)
+
   // `max-w-full` + `min-w-0` cap the chip at its container's width so the
   // branch label truncates with an ellipsis instead of the chip overflowing
   // and being hard-clipped (the Chip primitive is `shrink-0`).
@@ -311,7 +314,7 @@ export const GitRefChip = ({
   }
 
   const handleFocus = (): void => {
-    if (nativeOverlay) {
+    if (usesNativeOverlayTransport) {
       return
     }
 

--- a/src/features/terminal/components/TerminalPane/GitRefChip.tsx
+++ b/src/features/terminal/components/TerminalPane/GitRefChip.tsx
@@ -1,7 +1,13 @@
 // cspell:ignore worktree
-import { useEffect, useRef, useState, type ReactElement } from 'react'
+import {
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactElement,
+} from 'react'
 import { Chip } from '@/components/Chip'
-import { Tooltip } from '@/components/Tooltip'
+import { Menu } from '@/components/Menu'
 import { writeClipboardText } from '@/lib/clipboard'
 
 export interface GitRefChipProps {
@@ -19,6 +25,7 @@ export interface GitRefChipProps {
    * chip renders the full ref by default.
    */
   collapsibleWorktree?: boolean
+  nativeOverlay?: boolean
 }
 
 export type GitRefCopyRowKey = 'worktree' | 'path' | 'branch'
@@ -90,78 +97,10 @@ export const composeCopyRows = (
 /** How long a copied row shows its green check before reverting. */
 const COPY_FEEDBACK_MS = 1300
 
-interface GitRefCopyRowProps {
-  row: GitRefCopyRowData
-  copied: boolean
-  onCopy: (key: GitRefCopyRowKey, value: string) => Promise<void>
-}
-
-// One click-to-copy row: leading icon · stacked micro label + mono value
-// (truncates when long) · trailing copy glyph that flips to a check while
-// copied. The whole row is the button — clicking anywhere copies the value.
-const GitRefCopyRow = ({
-  row,
-  copied,
-  onCopy,
-}: GitRefCopyRowProps): ReactElement => (
-  <button
-    type="button"
-    aria-label={`Copy ${row.label}`}
-    onClick={(event) => {
-      // The popover renders in a portal, so React still bubbles this click to
-      // the pane's focus handler — stop it so copying never refocuses the pane.
-      event.stopPropagation()
-      void onCopy(row.key, row.value)
-    }}
-    className="group flex w-full items-center gap-2 rounded-chip px-[7px] py-1.5 text-left hover:bg-primary-container/[0.12]"
-  >
-    <span
-      aria-hidden="true"
-      className={`material-symbols-outlined shrink-0 text-[13px] ${row.iconClassName}`}
-    >
-      {row.icon}
-    </span>
-    <span className="flex min-w-0 flex-1 flex-col gap-px">
-      <span className="font-sans text-[8.5px] uppercase tracking-[0.09em] text-on-surface-muted">
-        {row.label}
-      </span>
-      <span className="truncate font-mono text-[11px] text-on-surface">
-        {row.value}
-      </span>
-    </span>
-    <span
-      aria-hidden="true"
-      className={`material-symbols-outlined shrink-0 text-[13px] ${
-        copied
-          ? 'text-success'
-          : 'text-on-surface-muted group-hover:text-on-surface-variant'
-      }`}
-    >
-      {copied ? 'check' : 'content_copy'}
-    </span>
-  </button>
-)
-
-export interface GitRefCopyRowsProps {
-  worktreeName: string | null
-  branch: string
-  cwd: string | null
-  detached?: boolean
-}
-
-/**
- * Interactive content of the chip's copy popover — one click-to-copy row per
- * ref fact, with a transient green check on the row just copied. Rendered as
- * the chip's `bare interactive` Tooltip surface; exported so the row + copy
- * behavior is unit-testable without driving the floating surface's hover state
- * (the Tooltip only mounts this on hover, through a portal).
- */
-export const GitRefCopyRows = ({
-  worktreeName,
-  branch,
-  cwd,
-  detached = false,
-}: GitRefCopyRowsProps): ReactElement => {
+const useGitRefCopyFeedback = (): {
+  copiedKey: GitRefCopyRowKey | null
+  handleCopy: (key: GitRefCopyRowKey, value: string) => Promise<void>
+} => {
   const [copiedKey, setCopiedKey] = useState<GitRefCopyRowKey | null>(null)
   const timerRef = useRef<number | null>(null)
 
@@ -193,6 +132,97 @@ export const GitRefCopyRows = ({
     }, COPY_FEEDBACK_MS)
   }
 
+  return { copiedKey, handleCopy }
+}
+
+interface GitRefCopyRowProps {
+  row: GitRefCopyRowData
+  copied: boolean
+  onCopy: (key: GitRefCopyRowKey, value: string) => Promise<void>
+}
+
+interface GitRefCopyRowContentProps {
+  row: GitRefCopyRowData
+  copied: boolean
+}
+
+const GitRefCopyRowContent = ({
+  row,
+  copied,
+}: GitRefCopyRowContentProps): ReactElement => (
+  <>
+    <span
+      aria-hidden="true"
+      className={`material-symbols-outlined shrink-0 text-[13px] ${row.iconClassName}`}
+    >
+      {row.icon}
+    </span>
+    <span className="flex min-w-0 flex-1 flex-col gap-px">
+      <span className="font-sans text-[8.5px] uppercase tracking-[0.09em] text-on-surface-muted">
+        {row.label}
+      </span>
+      <span className="truncate font-mono text-[11px] text-on-surface">
+        {row.value}
+      </span>
+    </span>
+    <span
+      aria-hidden="true"
+      className={`material-symbols-outlined shrink-0 text-[13px] ${
+        copied
+          ? 'text-success'
+          : 'text-on-surface-muted group-hover:text-on-surface-variant'
+      }`}
+    >
+      {copied ? 'check' : 'content_copy'}
+    </span>
+  </>
+)
+
+// One click-to-copy row: leading icon · stacked micro label + mono value
+// (truncates when long) · trailing copy glyph that flips to a check while
+// copied. The whole row is the button — clicking anywhere copies the value.
+const GitRefCopyRow = ({
+  row,
+  copied,
+  onCopy,
+}: GitRefCopyRowProps): ReactElement => (
+  <button
+    type="button"
+    aria-label={`Copy ${row.label}`}
+    onClick={(event) => {
+      // The popover renders in a portal, so React still bubbles this click to
+      // the pane's focus handler — stop it so copying never refocuses the pane.
+      event.stopPropagation()
+      void onCopy(row.key, row.value)
+    }}
+    className="group flex w-full items-center gap-2 rounded-chip px-[7px] py-1.5 text-left hover:bg-primary-container/[0.12]"
+  >
+    <GitRefCopyRowContent row={row} copied={copied} />
+  </button>
+)
+
+export interface GitRefCopyRowsProps {
+  worktreeName: string | null
+  branch: string
+  cwd: string | null
+  detached?: boolean
+}
+
+/**
+ * Interactive content of the chip's copy popover — one click-to-copy row per
+ * ref fact, with a transient green check on the row just copied. Rendered as
+ * the chip's `bare interactive` Tooltip surface; exported so the row + copy
+ * behavior is unit-testable without driving the floating surface's hover state
+ * (the Tooltip only mounts this on hover, through a portal).
+ */
+export const GitRefCopyRows = ({
+  worktreeName,
+  branch,
+  cwd,
+  detached = false,
+}: GitRefCopyRowsProps): ReactElement => {
+  const { copiedKey, handleCopy } = useGitRefCopyFeedback()
+
   return (
     <div className="flex flex-col">
       {composeCopyRows(worktreeName, branch, cwd, detached).map((row) => (
@@ -207,12 +237,38 @@ export const GitRefCopyRows = ({
   )
 }
 
-// The copy popover reuses the "Tweaks panel" floating chrome (same family as
-// the activity-details card): a 244px glass card with an accent-bright hairline
-// border, soft modal shadow, and a subtle slide-in. All semantic tokens, so it
-// recolors across every theme.
-const GIT_REF_TIP_SURFACE =
-  'w-[244px] rounded-pane border border-primary/20 bg-surface-container/[0.92] p-1 shadow-modal backdrop-blur-[20px] backdrop-saturate-150 animate-vf-tip-in'
+const GIT_REF_MENU_ROW_CLASSES =
+  'group flex min-h-8 w-full items-center gap-2 rounded-chip px-[7px] py-1.5 text-left text-xs text-on-surface outline-none transition-colors hover:bg-primary-container/[0.12] focus-visible:bg-primary-container/[0.12]'
+
+const KEEP_GIT_REF_MENU_OPEN_ON_COPY = false
+
+interface GitRefCopyMenuRowElementsOptions {
+  rows: readonly GitRefCopyRowData[]
+  copiedKey: GitRefCopyRowKey | null
+  onCopy: (key: GitRefCopyRowKey, value: string) => Promise<void>
+}
+
+const gitRefCopyMenuRowElements = ({
+  rows,
+  copiedKey,
+  onCopy,
+}: GitRefCopyMenuRowElementsOptions): ReactElement[] =>
+  rows.map((row) => (
+    <Menu.Row
+      key={row.key}
+      label={`Copy ${row.label}`}
+      className={GIT_REF_MENU_ROW_CLASSES}
+      nativeOverlayIcon={row.icon}
+      nativeOverlayDetail={row.value}
+      nativeOverlayFeedback="copy"
+      nativeOverlayCloseOnSelect={KEEP_GIT_REF_MENU_OPEN_ON_COPY}
+      onSelect={() => {
+        void onCopy(row.key, row.value)
+      }}
+    >
+      <GitRefCopyRowContent row={row} copied={copiedKey === row.key} />
+    </Menu.Row>
+  ))
 
 export const GitRefChip = ({
   worktreeName,
@@ -220,13 +276,26 @@ export const GitRefChip = ({
   cwd = undefined,
   detached = false,
   collapsibleWorktree = false,
+  nativeOverlay = false,
 }: GitRefChipProps): ReactElement | null => {
+  const chipRef = useRef<HTMLSpanElement | null>(null)
+  const [open, setOpen] = useState(false)
+
+  const [anchorRect, setAnchorRect] = useState({
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
+  })
+  const { copiedKey, handleCopy } = useGitRefCopyFeedback()
+
   if (branch === null || branch.length === 0) {
     return null
   }
 
   const hasWorktree = worktreeName !== null && worktreeName.length > 0
   const tooltipCwd = cwd !== undefined && cwd.length > 0 ? cwd : null
+  const copyRows = composeCopyRows(worktreeName, branch, tooltipCwd, detached)
 
   // `max-w-full` + `min-w-0` cap the chip at its container's width so the
   // branch label truncates with an ellipsis instead of the chip overflowing
@@ -261,30 +330,64 @@ export const GitRefChip = ({
     detached ? 'text-tertiary' : 'text-on-surface'
   }`
 
+  const updateAnchorRect = (): boolean => {
+    const rect = chipRef.current?.getBoundingClientRect()
+    if (rect === undefined) {
+      return false
+    }
+
+    setAnchorRect({
+      x: rect.x,
+      y: rect.y,
+      width: rect.width,
+      height: rect.height,
+    })
+
+    return true
+  }
+
+  const openCopyMenu = (): void => {
+    if (updateAnchorRect()) {
+      setOpen(true)
+    }
+  }
+
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLSpanElement>): void => {
+    if (
+      event.key !== 'Enter' &&
+      event.key !== ' ' &&
+      event.key !== 'ArrowDown'
+    ) {
+      return
+    }
+
+    event.preventDefault()
+    openCopyMenu()
+  }
+
   return (
-    <Tooltip
-      bare
-      interactive
-      ariaLabel="Git ref details"
-      placement="bottom"
-      className={GIT_REF_TIP_SURFACE}
-      content={
-        <GitRefCopyRows
-          worktreeName={worktreeName}
-          branch={branch}
-          cwd={tooltipCwd}
-          detached={detached}
-        />
-      }
-    >
+    <>
       <Chip
+        ref={chipRef}
         data-testid="git-ref-chip"
+        role="button"
         aria-label="Git ref details"
+        aria-haspopup="menu"
+        aria-expanded={open}
         tabIndex={0}
         tone="custom"
         size="custom"
         radius="chip"
         className={frameClasses}
+        onClick={(event): void => {
+          event.stopPropagation()
+          openCopyMenu()
+        }}
+        onMouseDown={(event): void => {
+          event.stopPropagation()
+        }}
+        onFocus={openCopyMenu}
+        onKeyDown={handleKeyDown}
       >
         {hasWorktree && (
           <>
@@ -320,6 +423,21 @@ export const GitRefChip = ({
           {branch}
         </span>
       </Chip>
-    </Tooltip>
+      <Menu.Context
+        position={anchorRect}
+        placement="bottom"
+        matchAnchorWidth
+        open={open}
+        onOpenChange={setOpen}
+        aria-label="Git ref details"
+        nativeOverlay={nativeOverlay}
+      >
+        {gitRefCopyMenuRowElements({
+          rows: copyRows,
+          copiedKey,
+          onCopy: handleCopy,
+        })}
+      </Menu.Context>
+    </>
   )
 }

--- a/src/features/terminal/components/TerminalPane/GitRefChip.tsx
+++ b/src/features/terminal/components/TerminalPane/GitRefChip.tsx
@@ -99,7 +99,7 @@ const COPY_FEEDBACK_MS = 1300
 
 const useGitRefCopyFeedback = (): {
   copiedKey: GitRefCopyRowKey | null
-  handleCopy: (key: GitRefCopyRowKey, value: string) => Promise<void>
+  handleCopy: (key: GitRefCopyRowKey, value: string) => Promise<boolean>
 } => {
   const [copiedKey, setCopiedKey] = useState<GitRefCopyRowKey | null>(null)
   const timerRef = useRef<number | null>(null)
@@ -117,10 +117,10 @@ const useGitRefCopyFeedback = (): {
   const handleCopy = async (
     key: GitRefCopyRowKey,
     value: string
-  ): Promise<void> => {
+  ): Promise<boolean> => {
     const copied = await writeClipboardText(value)
     if (!copied) {
-      return
+      return false
     }
 
     setCopiedKey(key)
@@ -130,15 +130,11 @@ const useGitRefCopyFeedback = (): {
     timerRef.current = window.setTimeout(() => {
       setCopiedKey(null)
     }, COPY_FEEDBACK_MS)
+
+    return true
   }
 
   return { copiedKey, handleCopy }
-}
-
-interface GitRefCopyRowProps {
-  row: GitRefCopyRowData
-  copied: boolean
-  onCopy: (key: GitRefCopyRowKey, value: string) => Promise<void>
 }
 
 interface GitRefCopyRowContentProps {
@@ -178,74 +174,13 @@ const GitRefCopyRowContent = ({
   </>
 )
 
-// One click-to-copy row: leading icon · stacked micro label + mono value
-// (truncates when long) · trailing copy glyph that flips to a check while
-// copied. The whole row is the button — clicking anywhere copies the value.
-const GitRefCopyRow = ({
-  row,
-  copied,
-  onCopy,
-}: GitRefCopyRowProps): ReactElement => (
-  <button
-    type="button"
-    aria-label={`Copy ${row.label}`}
-    onClick={(event) => {
-      // The popover renders in a portal, so React still bubbles this click to
-      // the pane's focus handler — stop it so copying never refocuses the pane.
-      event.stopPropagation()
-      void onCopy(row.key, row.value)
-    }}
-    className="group flex w-full items-center gap-2 rounded-chip px-[7px] py-1.5 text-left hover:bg-primary-container/[0.12]"
-  >
-    <GitRefCopyRowContent row={row} copied={copied} />
-  </button>
-)
-
-export interface GitRefCopyRowsProps {
-  worktreeName: string | null
-  branch: string
-  cwd: string | null
-  detached?: boolean
-}
-
-/**
- * Interactive content of the chip's copy popover — one click-to-copy row per
- * ref fact, with a transient green check on the row just copied. Rendered as
- * the chip's `bare interactive` Tooltip surface; exported so the row + copy
- * behavior is unit-testable without driving the floating surface's hover state
- * (the Tooltip only mounts this on hover, through a portal).
- */
-export const GitRefCopyRows = ({
-  worktreeName,
-  branch,
-  cwd,
-  detached = false,
-}: GitRefCopyRowsProps): ReactElement => {
-  const { copiedKey, handleCopy } = useGitRefCopyFeedback()
-
-  return (
-    <div className="flex flex-col">
-      {composeCopyRows(worktreeName, branch, cwd, detached).map((row) => (
-        <GitRefCopyRow
-          key={row.key}
-          row={row}
-          copied={copiedKey === row.key}
-          onCopy={handleCopy}
-        />
-      ))}
-    </div>
-  )
-}
-
 const GIT_REF_MENU_ROW_CLASSES =
   'group flex min-h-8 w-full items-center gap-2 rounded-chip px-[7px] py-1.5 text-left text-xs text-on-surface outline-none transition-colors hover:bg-primary-container/[0.12] focus-visible:bg-primary-container/[0.12]'
-
-const KEEP_GIT_REF_MENU_OPEN_ON_COPY = false
 
 interface GitRefCopyMenuRowElementsOptions {
   rows: readonly GitRefCopyRowData[]
   copiedKey: GitRefCopyRowKey | null
-  onCopy: (key: GitRefCopyRowKey, value: string) => Promise<void>
+  onCopy: (key: GitRefCopyRowKey, value: string) => Promise<boolean>
 }
 
 const gitRefCopyMenuRowElements = ({
@@ -261,10 +196,7 @@ const gitRefCopyMenuRowElements = ({
       nativeOverlayIcon={row.icon}
       nativeOverlayDetail={row.value}
       nativeOverlayFeedback="copy"
-      nativeOverlayCloseOnSelect={KEEP_GIT_REF_MENU_OPEN_ON_COPY}
-      onSelect={() => {
-        void onCopy(row.key, row.value)
-      }}
+      onSelect={() => onCopy(row.key, row.value)}
     >
       <GitRefCopyRowContent row={row} copied={copiedKey === row.key} />
     </Menu.Row>
@@ -279,6 +211,8 @@ export const GitRefChip = ({
   nativeOverlay = false,
 }: GitRefChipProps): ReactElement | null => {
   const chipRef = useRef<HTMLSpanElement | null>(null)
+  const skipRestoredFocusRef = useRef(false)
+  const skipRestoredFocusTimerRef = useRef<number | null>(null)
   const [open, setOpen] = useState(false)
 
   const [anchorRect, setAnchorRect] = useState({
@@ -288,6 +222,15 @@ export const GitRefChip = ({
     height: 0,
   })
   const { copiedKey, handleCopy } = useGitRefCopyFeedback()
+
+  useEffect(
+    () => (): void => {
+      if (skipRestoredFocusTimerRef.current !== null) {
+        window.clearTimeout(skipRestoredFocusTimerRef.current)
+      }
+    },
+    []
+  )
 
   if (branch === null || branch.length === 0) {
     return null
@@ -301,7 +244,7 @@ export const GitRefChip = ({
   // branch label truncates with an ellipsis instead of the chip overflowing
   // and being hard-clipped (the Chip primitive is `shrink-0`).
   const frameBase =
-    'inline-flex items-center gap-1.5 h-[22px] pl-1.5 pr-2 rounded-chip border min-w-0 max-w-full overflow-hidden'
+    'inline-flex items-center gap-1.5 h-[22px] pl-1.5 pr-2 rounded-chip border min-w-0 max-w-full overflow-hidden outline-none focus:outline-none focus-visible:outline-none'
 
   // Two-tone coral when detached, per docs/design/git-chip/GitRefChip.html:
   // worktree uses `text-error` (lighter coral), branch uses
@@ -352,6 +295,35 @@ export const GitRefChip = ({
     }
   }
 
+  const handleOpenChange = (nextOpen: boolean): void => {
+    if (!nextOpen) {
+      skipRestoredFocusRef.current = true
+      if (skipRestoredFocusTimerRef.current !== null) {
+        window.clearTimeout(skipRestoredFocusTimerRef.current)
+      }
+      skipRestoredFocusTimerRef.current = window.setTimeout(() => {
+        skipRestoredFocusRef.current = false
+        skipRestoredFocusTimerRef.current = null
+      }, 0)
+    }
+
+    setOpen(nextOpen)
+  }
+
+  const handleFocus = (): void => {
+    if (skipRestoredFocusRef.current) {
+      skipRestoredFocusRef.current = false
+      if (skipRestoredFocusTimerRef.current !== null) {
+        window.clearTimeout(skipRestoredFocusTimerRef.current)
+        skipRestoredFocusTimerRef.current = null
+      }
+
+      return
+    }
+
+    openCopyMenu()
+  }
+
   const handleKeyDown = (event: ReactKeyboardEvent<HTMLSpanElement>): void => {
     if (
       event.key !== 'Enter' &&
@@ -386,7 +358,7 @@ export const GitRefChip = ({
         onMouseDown={(event): void => {
           event.stopPropagation()
         }}
-        onFocus={openCopyMenu}
+        onFocus={handleFocus}
         onKeyDown={handleKeyDown}
       >
         {hasWorktree && (
@@ -427,8 +399,9 @@ export const GitRefChip = ({
         position={anchorRect}
         placement="bottom"
         matchAnchorWidth
+        surfaceTone="primary-container-soft"
         open={open}
-        onOpenChange={setOpen}
+        onOpenChange={handleOpenChange}
         aria-label="Git ref details"
         nativeOverlay={nativeOverlay}
       >

--- a/src/features/terminal/components/TerminalPane/GitRefChip.tsx
+++ b/src/features/terminal/components/TerminalPane/GitRefChip.tsx
@@ -311,6 +311,10 @@ export const GitRefChip = ({
   }
 
   const handleFocus = (): void => {
+    if (nativeOverlay) {
+      return
+    }
+
     if (skipRestoredFocusRef.current) {
       skipRestoredFocusRef.current = false
       if (skipRestoredFocusTimerRef.current !== null) {

--- a/src/features/terminal/components/TerminalPane/PaneStatusBar.tsx
+++ b/src/features/terminal/components/TerminalPane/PaneStatusBar.tsx
@@ -7,6 +7,7 @@ export interface PaneStatusBarProps {
   worktreeName: string | null
   branch: string | null
   cwd?: string
+  nativeOverlay?: boolean
   added: number
   removed: number
   lastActivityAt: string
@@ -30,6 +31,7 @@ export const PaneStatusBar = ({
   worktreeName,
   branch,
   cwd = undefined,
+  nativeOverlay = false,
   added,
   removed,
   lastActivityAt,
@@ -52,6 +54,7 @@ export const PaneStatusBar = ({
           branch={branch}
           cwd={cwd}
           collapsibleWorktree
+          nativeOverlay={nativeOverlay}
         />
       </div>
 

--- a/src/features/terminal/components/TerminalPane/index.tsx
+++ b/src/features/terminal/components/TerminalPane/index.tsx
@@ -308,6 +308,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
             worktreeName={worktreeName}
             branch={branch}
             cwd={pane.cwd}
+            nativeOverlay
             added={added}
             removed={removed}
             lastActivityAt={session.lastActivityAt}

--- a/src/index.css
+++ b/src/index.css
@@ -111,6 +111,14 @@
     background: transparent;
   }
 
+  .vf-native-overlay-primary-container-soft {
+    background-color: color-mix(
+      in srgb,
+      var(--color-surface-container-high) 94%,
+      var(--color-primary-container)
+    );
+  }
+
   .vf-app-drag-region {
     -webkit-app-region: drag;
     user-select: none;

--- a/src/lib/backend.ts
+++ b/src/lib/backend.ts
@@ -37,6 +37,7 @@ export interface BackendApi {
   nativeOverlay?: {
     open: (request: unknown) => Promise<{ accepted: boolean; reason?: string }>
     close: (request: unknown) => Promise<void>
+    actionResult: (request: unknown) => Promise<void>
     onAction: (callback: (event: unknown) => void) => UnlistenFn
     onClose: (callback: (event: unknown) => void) => UnlistenFn
   }
@@ -47,6 +48,7 @@ export interface BackendApi {
     close: (request: unknown) => Promise<unknown>
     onRender: (callback: (event: unknown) => void) => UnlistenFn
     onClear: (callback: () => void) => UnlistenFn
+    onActionResult: (callback: (event: unknown) => void) => UnlistenFn
   }
 }
 

--- a/tests/e2e/core/specs/browser-pane-overlay.spec.ts
+++ b/tests/e2e/core/specs/browser-pane-overlay.spec.ts
@@ -1,4 +1,4 @@
-import { clickBySelector } from '../../shared/actions.js'
+import { clickLayoutButton } from '../../shared/actions.js'
 import type { LayoutId, PaneKind } from '@/features/sessions/types'
 import {
   LAYOUTS,
@@ -208,7 +208,7 @@ const waitForPaneKinds = async (
 
 const switchToLayout = async (layout: LayoutShape): Promise<void> => {
   await waitForActiveSplitView()
-  await clickBySelector(`button[aria-label="${layout.name}"]`)
+  await clickLayoutButton(layout.name)
 
   await browser.waitUntil(
     async () =>

--- a/tests/e2e/core/specs/files-to-editor.spec.ts
+++ b/tests/e2e/core/specs/files-to-editor.spec.ts
@@ -24,7 +24,7 @@ describe('File explorer → editor flow', () => {
     // FilesView's root toggles from the Tailwind `hidden` utility class to
     // `flex` (HTML `hidden` attribute is NOT used — see SessionsView /
     // FilesView source for the Tailwind v4 cascade-layer rationale).
-    const filesTab = await $('button=FILES')
+    const filesTab = await $('button[aria-label="FILES"]')
     await filesTab.waitForDisplayed({ timeout: 15_000 })
     await filesTab.click()
 

--- a/tests/e2e/core/specs/ipc-roundtrip.spec.ts
+++ b/tests/e2e/core/specs/ipc-roundtrip.spec.ts
@@ -5,7 +5,7 @@ describe('IPC round-trip', () => {
     // FilesView's root toggles from the Tailwind `hidden` utility class to
     // `flex` (HTML `hidden` attribute is NOT used — see SessionsView /
     // FilesView source for the Tailwind v4 cascade-layer rationale).
-    const filesTab = await $('button=FILES')
+    const filesTab = await $('button[aria-label="FILES"]')
     await filesTab.waitForDisplayed({ timeout: 15_000 })
     await filesTab.click()
 

--- a/tests/e2e/core/specs/navigation.spec.ts
+++ b/tests/e2e/core/specs/navigation.spec.ts
@@ -1,14 +1,30 @@
 import { clickBySelector } from '../../shared/actions.js'
 
 describe('BottomDrawer navigation', () => {
-  it('defaults to editor panel and switches to diff panel on click', async () => {
+  it('defaults to diff panel and switches to editor panel on click', async () => {
+    const initialDiffPanel = await $('[data-testid="diff-panel"]')
+    await initialDiffPanel.waitForDisplayed({ timeout: 15_000 })
+
+    await clickBySelector('button[aria-label="Editor"]')
+
     const editorPanel = await $('[data-testid="editor-panel"]')
-    await editorPanel.waitForDisplayed({ timeout: 15_000 })
+    await editorPanel.waitForDisplayed({ timeout: 10_000 })
+
+    await browser.waitUntil(
+      async () => !(await (await $('[data-testid="diff-panel"]')).isExisting()),
+      {
+        timeout: 5_000,
+        timeoutMsg: 'diff-panel still in DOM after switching to editor',
+      }
+    )
 
     await clickBySelector('button[aria-label="Diff Viewer"]')
 
-    const diffPanel = await $('[data-testid="diff-panel"]')
-    await diffPanel.waitForDisplayed({ timeout: 10_000 })
+    await (
+      await $('[data-testid="diff-panel"]')
+    ).waitForDisplayed({
+      timeout: 10_000,
+    })
 
     await browser.waitUntil(
       async () =>
@@ -18,12 +34,5 @@ describe('BottomDrawer navigation', () => {
         timeoutMsg: 'editor-panel still in DOM after switching to diff',
       }
     )
-
-    await clickBySelector('button[aria-label="Editor"]')
-    await (
-      await $('[data-testid="editor-panel"]')
-    ).waitForDisplayed({
-      timeout: 10_000,
-    })
   })
 })

--- a/tests/e2e/shared/actions.ts
+++ b/tests/e2e/shared/actions.ts
@@ -16,6 +16,47 @@ export const clickBySelector = async (selector: string): Promise<void> => {
   if (!ok) throw new Error(`clickBySelector: no element for ${selector}`)
 }
 
+const hasElement = async (selector: string): Promise<boolean> =>
+  await browser.execute(
+    (s: string) => document.querySelector<HTMLElement>(s) !== null,
+    selector
+  )
+
+export const clickLayoutButton = async (layoutName: string): Promise<void> => {
+  const layoutButtonSelector = `button[aria-label="${layoutName}"]`
+
+  if (!(await hasElement(layoutButtonSelector))) {
+    await clickBySelector('button[aria-label="Configure displayed layouts"]')
+
+    await browser.waitUntil(
+      async () =>
+        await hasElement(
+          `button[role="menuitemcheckbox"][aria-label="${layoutName}"]`
+        ),
+      {
+        timeout: 5_000,
+        interval: 100,
+        timeoutMsg: `layout display menu did not show ${layoutName}`,
+      }
+    )
+
+    await clickBySelector(
+      `button[role="menuitemcheckbox"][aria-label="${layoutName}"]`
+    )
+
+    await browser.waitUntil(
+      async () => await hasElement(layoutButtonSelector),
+      {
+        timeout: 5_000,
+        interval: 100,
+        timeoutMsg: `${layoutName} layout button did not appear`,
+      }
+    )
+  }
+
+  await clickBySelector(layoutButtonSelector)
+}
+
 export const focusBySelector = async (selector: string): Promise<void> => {
   const ok = await browser.execute((s: string) => {
     const el = document.querySelector<HTMLElement>(s)

--- a/tests/e2e/terminal/specs/pane-lifecycle.spec.ts
+++ b/tests/e2e/terminal/specs/pane-lifecycle.spec.ts
@@ -1,4 +1,4 @@
-import { clickBySelector } from '../../shared/actions.js'
+import { clickBySelector, clickLayoutButton } from '../../shared/actions.js'
 
 const waitForPaneCount = async (expected: number): Promise<void> => {
   await browser.waitUntil(
@@ -68,7 +68,7 @@ describe('Pane lifecycle split focus', () => {
       timeout: 20_000,
     })
 
-    await clickBySelector('button[aria-label="Vertical split"]')
+    await clickLayoutButton('Vertical split')
 
     await browser.waitUntil(
       async () =>
@@ -93,7 +93,7 @@ describe('Pane lifecycle split focus', () => {
     await clickBySelector('[data-testid="split-view-slot"][data-pane-id="p1"]')
     await assertWorkspaceVisible(2, 'focusing p1')
 
-    await clickBySelector('button[aria-label="Single"]')
+    await clickLayoutButton('Single')
     await waitForPaneCount(1)
     await assertWorkspaceVisible(1, 'switching to single layout')
     await assertVisiblePaneIds(['p1'])


### PR DESCRIPTION
## Summary
- wire the terminal Git ref chip through the native overlay menu transport
- keep copy feedback pending until the owner renderer confirms clipboard success
- make the Git ref overlay theme-aware, opaque, and keep the Git chip borderless in all states
- centralize Escape dismissal without double-closing controlled context menus

## Validation
- pre-push suite: 365 test files passed, 4454 tests passed, 3 skipped
- lint-staged on commit/amend: eslint, prettier, tsc
- focused native overlay/GitRefChip/Menu checks during development


Refs VIM-263