### PR TITLE
fix(diff): stabilize manual refresh

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -45,14 +45,14 @@ When appending findings to a pattern file, label the source so future readers ca
 | ---------------------------------------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md)                                                     | security           | 28       | 7    | 2026-06-22   |
 | [Native Surface Occlusion](patterns/native-surface-occlusion.md)                                     | correctness        | 3        | 0    | 2026-06-15   |
-| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 59       | 63   | 2026-06-27   |
+| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 59       | 64   | 2026-06-27   |
 | [Imperative Animation Ownership](patterns/imperative-animation-ownership.md)                         | react-patterns     | 7        | 3    | 2026-06-17   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Fixed-Position Portals](patterns/fixed-position-portals.md)                                         | react-patterns     | 2        | 1    | 2026-06-22   |
 | [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 19       | 19   | 2026-06-21   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)                                             | cross-platform     | 12       | 12   | 2026-06-22   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                                                       | code-quality       | 7        | 0    | 2026-06-11   |
-| [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 17       | 13   | 2026-06-30   |
+| [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 17       | 14   | 2026-06-30   |
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 8        | 2    | 2026-06-19   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 4        | 0    | 2026-06-21   |
@@ -99,7 +99,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [String Construction Hygiene](patterns/string-construction-hygiene.md)                               | code-quality       | 2        | 1    | 2026-06-19   |
 | [Agent-State Guards](patterns/agent-state-guards.md)                                                 | correctness        | 10       | 7    | 2026-06-22   |
 | [React Prop Contracts](patterns/react-prop-contracts.md)                                             | react-patterns     | 8        | 6    | 2026-06-22   |
-| [Stale Retained Interactions](patterns/stale-retained-interactions.md)                               | react-patterns     | 2        | 2    | 2026-06-15   |
+| [Stale Retained Interactions](patterns/stale-retained-interactions.md)                               | react-patterns     | 3        | 3    | 2026-07-01   |
 | [Retained State Identity](patterns/retained-state-identity.md)                                       | react-patterns     | 2        | 2    | 2026-06-28   |
 | [Authoritative Completion Guard](patterns/authoritative-completion-guard.md)                         | correctness        | 6        | 3    | 2026-06-27   |
 | [Equality Guard Completeness](patterns/equality-guard-completeness.md)                               | correctness        | 2        | 0    | 2026-06-17   |

--- a/docs/reviews/patterns/derived-state-consistency.md
+++ b/docs/reviews/patterns/derived-state-consistency.md
@@ -3,7 +3,7 @@ id: derived-state-consistency
 category: code-quality
 created: 2026-06-07
 last_updated: 2026-06-30
-ref_count: 13
+ref_count: 14
 ---
 
 # Derived State Consistency

--- a/docs/reviews/patterns/react-lifecycle.md
+++ b/docs/reviews/patterns/react-lifecycle.md
@@ -3,7 +3,7 @@ id: react-lifecycle
 category: react-patterns
 created: 2026-04-09
 last_updated: 2026-06-27
-ref_count: 63
+ref_count: 64
 ---
 
 # React Lifecycle

--- a/docs/reviews/patterns/stale-retained-interactions.md
+++ b/docs/reviews/patterns/stale-retained-interactions.md
@@ -2,8 +2,8 @@
 id: stale-retained-interactions
 category: react-patterns
 created: 2026-06-15
-last_updated: 2026-06-15
-ref_count: 2
+last_updated: 2026-07-01
+ref_count: 3
 ---
 
 # Stale Retained Interactions
@@ -30,4 +30,13 @@ When a React component renders retained or stale content while fresh data for a 
 - **File:** `src/features/agent-status/components/AgentStatusPanel/index.test.tsx`
 - **Finding:** The test named `makes retained body non-interactive while fetching a cold target pane` clicked `src/retained.ts`, but that text was rendered by `ActivityFeed`, while `onOpenDiff` is only wired through `FilesChanged`. Because the retained snapshot used an empty `gitStatus`, there was no `FilesChanged` row to click, so `expect(onOpenDiff).not.toHaveBeenCalled()` stayed true even if `inert` were removed from the actionable body.
 - **Fix:** Populated the retained snapshot with a `gitStatus.files` entry and changed the click target to the rendered `FilesChanged` row button. Added an inert click-blocking polyfill to the jsdom test setup because jsdom exposes the `inert` attribute but does not suppress activation of inert subtrees, so synthetic clicks on the row would otherwise still dispatch `onOpenDiff` and make the meaningful assertion fail.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 3. Inactive review target still seeded bracket hunk navigation
+
+- **Source:** github-codex-connector | PR #639 round 1 | 2026-07-01
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/diff/Panel.tsx`
+- **Finding:** Toolbar hunk navigation deactivated the visible review cursor but left the retained `currentTarget` pointing at the previous row. Bracket-key hunk navigation then preferred that retained target over the visible `focusedHunkIndex`, so mixing toolbar and keyboard navigation could jump from a stale hunk instead of the focused hunk.
+- **Fix:** Used the hook's `activeTarget` as the hunk-navigation origin and fell back to `clampedHunkIndex` when the review cursor is inactive. Added a regression test for toolbar `next hunk` followed by `]`.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/src/features/diff/Panel.test.tsx
+++ b/src/features/diff/Panel.test.tsx
@@ -85,8 +85,8 @@ vi.mock('@pierre/diffs/react', () => ({
     renderGutterUtility = undefined,
     renderAnnotation = undefined,
   }: {
-    oldFile: { name: string; contents: string }
-    newFile: { name: string; contents: string }
+    oldFile: { name: string; contents: string; cacheKey?: string }
+    newFile: { name: string; contents: string; cacheKey?: string }
     options: {
       diffStyle?: string
       theme?: string
@@ -126,8 +126,10 @@ vi.mock('@pierre/diffs/react', () => ({
       data-testid="multi-file-diff"
       data-old-name={oldFile.name}
       data-old-contents={oldFile.contents}
+      data-old-cache-key={oldFile.cacheKey}
       data-new-name={newFile.name}
       data-new-contents={newFile.contents}
+      data-new-cache-key={newFile.cacheKey}
       data-diff-style={options.diffStyle}
       data-theme={options.theme}
       data-line-diff-type={options.lineDiffType}
@@ -168,6 +170,8 @@ const fileDiffMock = ({
   diff,
   loading,
   error,
+  latestDiffStatus = null,
+  acceptLatestDiff = vi.fn(),
   oldText = '',
   newText = '',
   rawDiff = '',
@@ -176,6 +180,8 @@ const fileDiffMock = ({
   diff: FileDiff | null
   loading: boolean
   error: Error | null
+  latestDiffStatus?: UseFileDiffReturn['latestDiffStatus']
+  acceptLatestDiff?: () => void
   oldText?: string
   newText?: string
   rawDiff?: string
@@ -195,7 +201,9 @@ const fileDiffMock = ({
   diff,
   loading,
   error,
+  latestDiffStatus,
   refetch: vi.fn(),
+  acceptLatestDiff,
 })
 
 // Trigger every active ResizeObserver instance with the given width.
@@ -1707,7 +1715,9 @@ describe('Panel', () => {
         diff: hunkFileDiff,
         loading: false,
         error: null,
+        latestDiffStatus: null,
         refetch: refetchSpy,
+        acceptLatestDiff: vi.fn(),
       })
 
       render(
@@ -1746,7 +1756,9 @@ describe('Panel', () => {
         diff: hunkFileDiff,
         loading: false,
         error: null,
+        latestDiffStatus: null,
         refetch: vi.fn(),
+        acceptLatestDiff: vi.fn(),
       })
 
       render(
@@ -1793,7 +1805,9 @@ describe('Panel', () => {
         diff: hunkFileDiff,
         loading: false,
         error: null,
+        latestDiffStatus: null,
         refetch: vi.fn(),
+        acceptLatestDiff: vi.fn(),
       })
 
       render(
@@ -1832,7 +1846,9 @@ describe('Panel', () => {
         diff: hunkFileDiff,
         loading: false,
         error: null,
+        latestDiffStatus: null,
         refetch: vi.fn(),
+        acceptLatestDiff: vi.fn(),
       })
 
       render(
@@ -1871,7 +1887,9 @@ describe('Panel', () => {
         diff: hunkFileDiff,
         loading: false,
         error: null,
+        latestDiffStatus: null,
         refetch: vi.fn(),
+        acceptLatestDiff: vi.fn(),
       })
 
       render(
@@ -1928,7 +1946,9 @@ describe('Panel', () => {
         diff: hunkFileDiff,
         loading: false,
         error: null,
+        latestDiffStatus: null,
         refetch: vi.fn(),
+        acceptLatestDiff: vi.fn(),
       })
 
       render(
@@ -1967,7 +1987,9 @@ describe('Panel', () => {
         diff: hunkFileDiff,
         loading: false,
         error: null,
+        latestDiffStatus: null,
         refetch: vi.fn(),
+        acceptLatestDiff: vi.fn(),
       })
 
       render(
@@ -2005,7 +2027,9 @@ describe('Panel', () => {
         diff: hunkFileDiff,
         loading: false,
         error: null,
+        latestDiffStatus: null,
         refetch: vi.fn(),
+        acceptLatestDiff: vi.fn(),
       })
 
       render(
@@ -2058,7 +2082,9 @@ describe('Panel', () => {
         diff: hunkFileDiff,
         loading: false,
         error: null,
+        latestDiffStatus: null,
         refetch: vi.fn(),
+        acceptLatestDiff: vi.fn(),
       })
 
       render(
@@ -2447,6 +2473,36 @@ describe('Panel', () => {
       expect(
         screen.getByRole('dialog', { name: /Comment on line R20/ })
       ).toBeInTheDocument()
+    })
+
+    test('mouse-selected hunk is the start point for [] navigation', (): void => {
+      render(
+        <Panel
+          cwd="/repo"
+          selectedFile={{ path: 'src/multi.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+        />
+      )
+
+      const scrollBody = screen.getByTestId('diff-scroll-body')
+      const hoveredLine = document.createElement('div')
+      hoveredLine.setAttribute('data-line-type', 'change-addition')
+      hoveredLine.setAttribute('data-line', '20')
+      scrollBody.append(hoveredLine)
+
+      fireEvent.pointerMove(hoveredLine)
+
+      const diff = screen.getByTestId('multi-file-diff')
+      expect(diff).toHaveAttribute('data-selected-lines-start', '20')
+      expect(diff).toHaveAttribute('data-selected-lines-side', 'additions')
+
+      fireEvent.keyDown(diff, { key: ']' })
+
+      expect(
+        screen.getByRole('group', { name: /hunk 3\/3/i })
+      ).toBeInTheDocument()
+      expect(diff).toHaveAttribute('data-selected-lines-start', '50')
+      expect(diff).toHaveAttribute('data-selected-lines-side', 'deletions')
     })
 
     test('clicking next-hunk three times wraps from last hunk back to first', async (): Promise<void> => {
@@ -3194,7 +3250,7 @@ describe('Panel', () => {
       })
     })
 
-    test('Ctrl+D and Ctrl+U page the diff scroll body', (): void => {
+    test('Ctrl+D and Ctrl+U page the diff scroll body and cursor together', (): void => {
       render(
         <Panel
           cwd="/repo"
@@ -3206,19 +3262,52 @@ describe('Panel', () => {
       const scrollBody = screen.getByTestId('diff-scroll-body')
       Object.defineProperty(scrollBody, 'clientHeight', {
         configurable: true,
-        value: 400,
+        value: 100,
       })
-      scrollBody.scrollTop = 100
+
+      const rect = (top: number, bottom: number): DOMRect => ({
+        bottom,
+        height: bottom - top,
+        left: 0,
+        right: 0,
+        top,
+        width: 100,
+        x: 0,
+        y: top,
+        toJSON: () => ({}),
+      })
+
+      Object.defineProperty(scrollBody, 'getBoundingClientRect', {
+        configurable: true,
+        value: () => rect(0, 100),
+      })
+
+      for (const line of [1, 2, 3]) {
+        const element = document.createElement('div')
+        const top = (line - 1) * 90
+
+        element.setAttribute('data-line-type', 'context')
+        element.setAttribute('data-line', String(line))
+        Object.defineProperty(element, 'getBoundingClientRect', {
+          configurable: true,
+          value: () =>
+            rect(top - scrollBody.scrollTop, top - scrollBody.scrollTop + 20),
+        })
+        scrollBody.append(element)
+      }
 
       fireEvent.keyDown(screen.getByTestId('multi-file-diff'), {
         key: 'd',
         ctrlKey: true,
       })
-      expect(scrollBody.scrollTop).toBe(300)
+      const diff = screen.getByTestId('multi-file-diff')
+      expect(scrollBody.scrollTop).toBe(160)
+      expect(diff).toHaveAttribute('data-selected-lines-start', '3')
       expect(screen.getByTestId('diff-populated-state')).toHaveFocus()
 
       fireEvent.keyDown(document, { key: 'u', ctrlKey: true })
-      expect(scrollBody.scrollTop).toBe(100)
+      expect(scrollBody.scrollTop).toBe(0)
+      expect(diff).toHaveAttribute('data-selected-lines-start', '1')
     })
 
     test('t toggles split and unified view', (): void => {
@@ -3514,7 +3603,9 @@ describe('Panel', () => {
       )
     })
 
-    test('keeps the current same-file diff visible while a refreshed diff loads', (): void => {
+    test('shows manual refresh only when the visible active-file diff is out of sync', async (): Promise<void> => {
+      const user = userEvent.setup()
+      const acceptLatestDiff = vi.fn()
       let fileDiffState = fileDiffMock({
         diff: inlineFileDiff,
         loading: false,
@@ -3559,6 +3650,7 @@ describe('Panel', () => {
         diff: inlineFileDiff,
         loading: true,
         error: null,
+        latestDiffStatus: 'updating',
         oldText: 'old',
         newText: 'new v1',
         rawDiff: '',
@@ -3572,12 +3664,19 @@ describe('Panel', () => {
         'new v1'
       )
 
+      expect(
+        screen.queryByRole('button', { name: 'refresh diff' })
+      ).not.toBeInTheDocument()
+      expect(screen.queryByText('Updating diff...')).not.toBeInTheDocument()
+
       fileDiffState = fileDiffMock({
         diff: inlineFileDiff,
         loading: false,
         error: null,
+        latestDiffStatus: 'ready',
+        acceptLatestDiff,
         oldText: 'old',
-        newText: 'new v2',
+        newText: 'new v1',
         rawDiff: '',
       })
 
@@ -3585,8 +3684,10 @@ describe('Panel', () => {
 
       expect(screen.getByTestId('multi-file-diff')).toHaveAttribute(
         'data-new-contents',
-        'new v2'
+        'new v1'
       )
+      await user.click(screen.getByRole('button', { name: 'refresh diff' }))
+      expect(acceptLatestDiff).toHaveBeenCalledOnce()
 
       expect(useFileDiffSpy).toHaveBeenLastCalledWith(
         'src/foo.ts',
@@ -3595,6 +3696,57 @@ describe('Panel', () => {
         false,
         '/repo:2:src/foo.ts:unstaged'
       )
+    })
+
+    test('keeps submitted comments when manual refresh swaps the diff response', async (): Promise<void> => {
+      const user = userEvent.setup()
+      let newText = 'new v1'
+
+      vi.spyOn(useFileDiffModule, 'useFileDiff').mockImplementation(() =>
+        fileDiffMock({
+          diff: inlineFileDiff,
+          loading: false,
+          error: null,
+          oldText: 'old',
+          newText,
+          rawDiff: '',
+        })
+      )
+
+      const props = {
+        cwd: '/repo',
+        selectedFile: { path: 'src/foo.ts', staged: false, cwd: '/repo' },
+        onSelectedFileChange: vi.fn(),
+      } as const
+
+      const { rerender } = render(<Panel {...props} />)
+
+      setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
+
+      await user.click(
+        within(screen.getByTestId('gutter-utility-slot')).getByRole('button', {
+          name: 'Add comment on this line',
+        })
+      )
+
+      await user.type(
+        within(
+          screen.getByRole('dialog', { name: /Comment on line/ })
+        ).getByPlaceholderText('Request change'),
+        'Comment survives refresh'
+      )
+      await user.keyboard('{Enter}')
+
+      expect(screen.getByText('Comment survives refresh')).toBeInTheDocument()
+
+      newText = 'new v2'
+      rerender(<Panel {...props} />)
+
+      expect(screen.getByTestId('multi-file-diff')).toHaveAttribute(
+        'data-new-contents',
+        'new v2'
+      )
+      expect(screen.getByText('Comment survives refresh')).toBeInTheDocument()
     })
 
     test('keeps a recoverable draft notice when refresh removes the target line', async (): Promise<void> => {

--- a/src/features/diff/Panel.test.tsx
+++ b/src/features/diff/Panel.test.tsx
@@ -2505,6 +2505,33 @@ describe('Panel', () => {
       expect(diff).toHaveAttribute('data-selected-lines-side', 'deletions')
     })
 
+    test('toolbar-selected hunk is the start point for [] navigation', async (): Promise<void> => {
+      const user = userEvent.setup()
+
+      render(
+        <Panel
+          cwd="/repo"
+          selectedFile={{ path: 'src/multi.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+        />
+      )
+
+      await user.click(screen.getByRole('button', { name: /next hunk/i }))
+
+      const diff = screen.getByTestId('multi-file-diff')
+      expect(
+        screen.getByRole('group', { name: /hunk 2\/3/i })
+      ).toBeInTheDocument()
+
+      fireEvent.keyDown(diff, { key: ']' })
+
+      expect(
+        screen.getByRole('group', { name: /hunk 3\/3/i })
+      ).toBeInTheDocument()
+      expect(diff).toHaveAttribute('data-selected-lines-start', '50')
+      expect(diff).toHaveAttribute('data-selected-lines-side', 'deletions')
+    })
+
     test('clicking next-hunk three times wraps from last hunk back to first', async (): Promise<void> => {
       const user = userEvent.setup()
 

--- a/src/features/diff/Panel.tsx
+++ b/src/features/diff/Panel.tsx
@@ -813,6 +813,7 @@ export const Panel = ({
   const {
     targets: reviewTargets,
     currentTarget: reviewTarget,
+    activeTarget: activeReviewTarget,
     currentTargetComment: reviewTargetComment,
     activeTargetIndex: reviewTargetIndex,
     activateTarget: activateReviewTarget,
@@ -980,7 +981,7 @@ export const Panel = ({
         return
       }
 
-      const currentHunkIndex = reviewTarget?.hunkIndex ?? clampedHunkIndex
+      const currentHunkIndex = activeReviewTarget?.hunkIndex ?? clampedHunkIndex
 
       const next =
         (((currentHunkIndex + delta) % hunks.length) + hunks.length) %
@@ -1007,11 +1008,11 @@ export const Panel = ({
     [
       activateReviewTarget,
       activeResponse,
+      activeReviewTarget,
       clampedHunkIndex,
       deactivateReviewTarget,
       flashHunkSelection,
       focusDiffRoot,
-      reviewTarget,
       reviewTargets,
       scrollHunkIntoView,
       scrollTargetIntoView,

--- a/src/features/diff/Panel.tsx
+++ b/src/features/diff/Panel.tsx
@@ -20,7 +20,7 @@ import { toPierreInputs, findRawDiffHunkIndex } from './services/pierreAdapter'
 import { extractHunkPatch } from './services/gitPatch'
 import { createGitService } from './services/gitService'
 import { useNotifyInfo } from '../workspace/hooks/useNotifyInfo'
-import type { ChangedFile, FileDiff, SelectedDiffFile } from './types'
+import type { ChangedFile, SelectedDiffFile } from './types'
 import {
   useFeedbackBatch,
   parseBatchKey,
@@ -44,14 +44,12 @@ import {
   type AnnotationTarget,
 } from './hooks/useReviewCommentDraft'
 import { useToolbarState } from './hooks/useToolbarState'
+import { useReviewTargetNavigation } from './hooks/useReviewTargetNavigation'
 import { Notifier } from './components/Notifier'
 import { PanelBody } from './components/PanelBody'
 
 const DIFF_NATIVE_FOCUS_SELECTOR =
   'button, input, textarea, select, [contenteditable], [role="textbox"]'
-
-const PIERRE_DIFF_CONTAINER_SELECTOR = 'diffs-container'
-const STICKY_HEADER_SCROLL_GAP_PX = 4
 
 /**
  * Controlled/uncontrolled selection pair as a discriminated union. Forces
@@ -99,335 +97,7 @@ let feedbackCommentSeq = 0
 const nextFeedbackCommentId = (): string =>
   `feedback-comment-${(feedbackCommentSeq += 1)}`
 
-interface KeyboardLineTarget {
-  lineNumber: number
-  side: AnnotationSide
-  hunkIndex: number
-  splitRowIndex: number
-  changed: boolean
-}
-
 type KeyboardConfirmAction = 'stage-hunk' | 'discard-hunk' | 'discard-file'
-
-const keyboardLineTargetsForDiff = (
-  fileDiff: FileDiff
-): KeyboardLineTarget[] => {
-  const targets: KeyboardLineTarget[] = []
-
-  fileDiff.hunks.forEach((hunk, hunkIndex) => {
-    let oldLine = hunk.oldStart
-    let newLine = hunk.newStart
-    let splitRowIndex = 0
-    let pendingDeletions: KeyboardLineTarget[] = []
-    let pendingAdditions: KeyboardLineTarget[] = []
-
-    const flushChangedRows = (): void => {
-      const rowCount = Math.max(
-        pendingDeletions.length,
-        pendingAdditions.length
-      )
-
-      for (let rowOffset = 0; rowOffset < rowCount; rowOffset += 1) {
-        const rowIndex = splitRowIndex + rowOffset
-        if (rowOffset < pendingDeletions.length) {
-          const deletion = pendingDeletions[rowOffset]
-          targets.push({ ...deletion, splitRowIndex: rowIndex })
-        }
-
-        if (rowOffset < pendingAdditions.length) {
-          const addition = pendingAdditions[rowOffset]
-          targets.push({ ...addition, splitRowIndex: rowIndex })
-        }
-      }
-
-      splitRowIndex += rowCount
-      pendingDeletions = []
-      pendingAdditions = []
-    }
-
-    if (hunk.lines.length === 0) {
-      targets.push({
-        lineNumber: hunk.newLines === 0 ? hunk.oldStart : hunk.newStart,
-        side: hunk.newLines === 0 ? 'deletions' : 'additions',
-        hunkIndex,
-        splitRowIndex,
-        changed: true,
-      })
-
-      return
-    }
-
-    for (const line of hunk.lines) {
-      const oldLineNumber =
-        line.oldLineNumber ?? (line.type === 'added' ? undefined : oldLine)
-
-      const newLineNumber =
-        line.newLineNumber ?? (line.type === 'removed' ? undefined : newLine)
-
-      if (line.type === 'removed') {
-        if (oldLineNumber !== undefined) {
-          pendingDeletions.push({
-            lineNumber: oldLineNumber,
-            side: 'deletions',
-            hunkIndex,
-            splitRowIndex,
-            changed: true,
-          })
-        }
-      } else if (line.type === 'added') {
-        if (newLineNumber !== undefined) {
-          pendingAdditions.push({
-            lineNumber: newLineNumber,
-            side: 'additions',
-            hunkIndex,
-            splitRowIndex,
-            changed: true,
-          })
-        }
-      } else {
-        flushChangedRows()
-
-        if (newLineNumber !== undefined) {
-          targets.push({
-            lineNumber: newLineNumber,
-            side: 'additions',
-            hunkIndex,
-            splitRowIndex,
-            changed: false,
-          })
-        }
-
-        splitRowIndex += 1
-      }
-
-      if (line.type !== 'added') {
-        oldLine += 1
-      }
-
-      if (line.type !== 'removed') {
-        newLine += 1
-      }
-    }
-
-    flushChangedRows()
-  })
-
-  return targets
-}
-
-const sameKeyboardRow = (
-  left: KeyboardLineTarget,
-  right: KeyboardLineTarget
-): boolean =>
-  left.hunkIndex === right.hunkIndex &&
-  left.splitRowIndex === right.splitRowIndex
-
-const keyboardRowIndexForTarget = (
-  targets: KeyboardLineTarget[],
-  targetIndex: number
-): number => {
-  let rowIndex = 0
-
-  for (let index = 1; index <= targetIndex; index += 1) {
-    if (!sameKeyboardRow(targets[index - 1], targets[index])) {
-      rowIndex += 1
-    }
-  }
-
-  return rowIndex
-}
-
-const keyboardRowCountForTargets = (targets: KeyboardLineTarget[]): number =>
-  targets.length === 0
-    ? 0
-    : keyboardRowIndexForTarget(targets, targets.length - 1) + 1
-
-// Matches Pierre's rendered rows/gutters for the current keyboard target.
-const lineSelectorForKeyboardTarget = (target: KeyboardLineTarget): string => {
-  const lineNumber = target.lineNumber
-
-  if (target.side === 'deletions') {
-    return (
-      `[data-line-type="change-deletion"][data-line="${lineNumber}"], ` +
-      `[data-line-type="change-deletion"][data-column-number="${lineNumber}"], ` +
-      `[data-line-type="removed"][data-line="${lineNumber}"], ` +
-      `[data-line-type="removed"][data-column-number="${lineNumber}"]`
-    )
-  }
-
-  return (
-    `[data-line-type="change-addition"][data-line="${lineNumber}"], ` +
-    `[data-line-type="change-addition"][data-column-number="${lineNumber}"], ` +
-    `[data-line-type="context"][data-line="${lineNumber}"], ` +
-    `[data-line-type="context"][data-column-number="${lineNumber}"], ` +
-    `[data-line-type="added"][data-line="${lineNumber}"], ` +
-    `[data-line-type="added"][data-column-number="${lineNumber}"]`
-  )
-}
-
-const fallbackLineSelectorForKeyboardTarget = (
-  target: KeyboardLineTarget
-): string => {
-  const lineNumber = target.lineNumber
-
-  return `[data-line="${lineNumber}"], [data-column-number="${lineNumber}"]`
-}
-
-const scopedDiffRootForKeyboardTarget = (
-  shadowRoot: ShadowRoot,
-  target: KeyboardLineTarget
-): ParentNode => {
-  const sideRoot = shadowRoot.querySelector<HTMLElement>(
-    target.side === 'deletions' ? '[data-deletions]' : '[data-additions]'
-  )
-
-  return (
-    sideRoot ??
-    shadowRoot.querySelector<HTMLElement>('[data-unified]') ??
-    shadowRoot
-  )
-}
-
-const findKeyboardTargetLineElement = (
-  root: HTMLElement,
-  target: KeyboardLineTarget
-): HTMLElement | null => {
-  const selector = lineSelectorForKeyboardTarget(target)
-  const fallbackSelector = fallbackLineSelectorForKeyboardTarget(target)
-
-  const localLine =
-    root.querySelector<HTMLElement>(selector) ??
-    root.querySelector<HTMLElement>(fallbackSelector)
-
-  if (localLine !== null) {
-    return localLine
-  }
-
-  for (const container of root.querySelectorAll<HTMLElement>(
-    PIERRE_DIFF_CONTAINER_SELECTOR
-  )) {
-    const shadowRoot = container.shadowRoot
-    if (shadowRoot === null) {
-      continue
-    }
-
-    const scopedRoot = scopedDiffRootForKeyboardTarget(shadowRoot, target)
-
-    const line =
-      scopedRoot.querySelector<HTMLElement>(selector) ??
-      scopedRoot.querySelector<HTMLElement>(fallbackSelector)
-
-    if (line !== null) {
-      return line
-    }
-  }
-
-  return null
-}
-
-const lineRangeFitsContainer = (
-  container: HTMLElement,
-  firstLine: HTMLElement,
-  lastLine: HTMLElement
-): boolean => {
-  if (container.clientHeight <= 0) {
-    return true
-  }
-
-  const firstRect = firstLine.getBoundingClientRect()
-  const lastRect = lastLine.getBoundingClientRect()
-  const top = Math.min(firstRect.top, lastRect.top)
-  const bottom = Math.max(firstRect.bottom, lastRect.bottom)
-
-  return bottom - top <= container.clientHeight
-}
-
-const stickyHeaderOffsetForDiffRoot = (root: HTMLElement): number => {
-  const headers = [
-    ...root.querySelectorAll<HTMLElement>('[data-diffs-header][data-sticky]'),
-  ]
-
-  for (const container of root.querySelectorAll<HTMLElement>(
-    PIERRE_DIFF_CONTAINER_SELECTOR
-  )) {
-    if (container.shadowRoot !== null) {
-      headers.push(
-        ...container.shadowRoot.querySelectorAll<HTMLElement>(
-          '[data-diffs-header][data-sticky]'
-        )
-      )
-    }
-  }
-
-  const height = Math.max(
-    0,
-    ...headers.map((header) => header.getBoundingClientRect().height)
-  )
-
-  return height === 0 ? 0 : height + STICKY_HEADER_SCROLL_GAP_PX
-}
-
-const revealLineBelowStickyHeader = (
-  container: HTMLElement,
-  line: HTMLElement,
-  reservePreviousRow: boolean
-): void => {
-  const stickyOffset = stickyHeaderOffsetForDiffRoot(container)
-  if (stickyOffset === 0) {
-    return
-  }
-
-  const containerTop = container.getBoundingClientRect().top
-  const lineRect = line.getBoundingClientRect()
-  const rowOffset = reservePreviousRow ? lineRect.height : 0
-  const overlap = containerTop + stickyOffset + rowOffset - lineRect.top
-
-  if (overlap > 0) {
-    container.scrollTop = Math.max(0, container.scrollTop - Math.ceil(overlap))
-  }
-}
-
-const scrollLineElementIntoView = (
-  container: HTMLElement,
-  line: HTMLElement,
-  targetIndex: number,
-  targetCount: number,
-  delta: number
-): void => {
-  if (delta === 0) {
-    line.scrollIntoView({ block: 'nearest', inline: 'nearest' })
-    revealLineBelowStickyHeader(container, line, false)
-
-    return
-  }
-
-  if (targetCount === 1) {
-    line.scrollIntoView({
-      block: delta > 0 ? 'end' : 'start',
-      inline: 'nearest',
-    })
-    revealLineBelowStickyHeader(container, line, delta < 0)
-
-    return
-  }
-
-  if (targetIndex === 0) {
-    line.scrollIntoView({ block: 'start', inline: 'nearest' })
-    revealLineBelowStickyHeader(container, line, delta < 0)
-
-    return
-  }
-
-  if (targetIndex === targetCount - 1) {
-    line.scrollIntoView({ block: 'end', inline: 'nearest' })
-    revealLineBelowStickyHeader(container, line, false)
-
-    return
-  }
-
-  line.scrollIntoView({ block: 'nearest', inline: 'nearest' })
-  revealLineBelowStickyHeader(container, line, delta < 0)
-}
 
 const keyboardConfirmCopy = (
   action: KeyboardConfirmAction,
@@ -622,7 +292,9 @@ export const Panel = ({
     response,
     loading: diffLoading,
     error: diffError,
+    latestDiffStatus,
     refetch: refetchDiff,
+    acceptLatestDiff,
   } = useFileDiff(
     selectedFilePath,
     selectedFileStaged,
@@ -986,100 +658,6 @@ export const Panel = ({
     setNavSelection(null)
   }, [selectedFilePath, selectedFileStaged, clearNavSelectionTimer])
 
-  const keyboardLineTargets = useMemo(
-    (): KeyboardLineTarget[] =>
-      activeResponse === null
-        ? []
-        : keyboardLineTargetsForDiff(activeResponse.fileDiff),
-    [activeResponse]
-  )
-
-  const [keyboardLineIndex, setKeyboardLineIndex] = useState(0)
-  const [keyboardLineActive, setKeyboardLineActive] = useState(false)
-
-  useEffect(() => {
-    setKeyboardLineIndex(0)
-    setKeyboardLineActive(false)
-  }, [selectedFilePath, selectedFileStaged])
-
-  useEffect(() => {
-    if (keyboardLineTargets.length === 0) {
-      setKeyboardLineIndex(0)
-      setKeyboardLineActive(false)
-
-      return
-    }
-
-    setKeyboardLineIndex((prev) =>
-      Math.min(prev, keyboardLineTargets.length - 1)
-    )
-  }, [keyboardLineTargets.length])
-
-  const keyboardLineTarget: KeyboardLineTarget | null =
-    keyboardLineTargets.length > 0
-      ? keyboardLineTargets[
-          Math.min(keyboardLineIndex, keyboardLineTargets.length - 1)
-        ]
-      : null
-
-  const keyboardSelectedLines: SelectedLineRange | null =
-    keyboardLineActive && keyboardLineTarget !== null
-      ? {
-          start: keyboardLineTarget.lineNumber,
-          end: keyboardLineTarget.lineNumber,
-          side: keyboardLineTarget.side,
-        }
-      : null
-
-  const keyboardLineComment = useMemo(():
-    | DiffLineAnnotation<ReviewComment>
-    | undefined => {
-    if (keyboardLineTarget === null) {
-      return undefined
-    }
-
-    return realAnnotations.find(
-      (annotation) =>
-        annotation.lineNumber === keyboardLineTarget.lineNumber &&
-        annotation.side === keyboardLineTarget.side
-    )
-  }, [keyboardLineTarget, realAnnotations])
-
-  const onPrevHunk = useCallback((): void => {
-    if (!activeResponse) {
-      return
-    }
-
-    const hunks = activeResponse.fileDiff.hunks
-    if (hunks.length === 0) {
-      return
-    }
-
-    const next = (clampedHunkIndex + hunks.length - 1) % hunks.length
-    setKeyboardLineActive(false)
-    setFocusedHunkIndex(next)
-    flashHunkSelection(hunks[next])
-  }, [activeResponse, clampedHunkIndex, flashHunkSelection])
-
-  const onNextHunk = useCallback((): void => {
-    if (!activeResponse) {
-      return
-    }
-
-    const hunks = activeResponse.fileDiff.hunks
-    if (hunks.length === 0) {
-      return
-    }
-
-    const next = (clampedHunkIndex + 1) % hunks.length
-    setKeyboardLineActive(false)
-    setFocusedHunkIndex(next)
-    flashHunkSelection(hunks[next])
-  }, [activeResponse, clampedHunkIndex, flashHunkSelection])
-
-  const selectedLines: SelectedLineRange | null =
-    keyboardSelectedLines ?? navSelection
-
   // Shared helper for all three hunk-based staging operations. Extracts the
   // focused hunk patch, calls the provided service operation, then refreshes
   // the diff and git status. Surfaces any IPC failure via notifyInfo so the
@@ -1222,6 +800,86 @@ export const Panel = ({
     toggleDiffStyle,
   } = useToolbarState()
 
+  const clearTransientSelection = useCallback((): void => {
+    clearNavSelectionTimer()
+    setNavSelection(null)
+  }, [clearNavSelectionTimer])
+
+  const reviewTargetFileKey =
+    selectedFilePath === null
+      ? ''
+      : `${selectedFilePath}:${selectedFileStaged ? 'staged' : 'unstaged'}`
+
+  const {
+    targets: reviewTargets,
+    currentTarget: reviewTarget,
+    currentTargetComment: reviewTargetComment,
+    activeTargetIndex: reviewTargetIndex,
+    activateTarget: activateReviewTarget,
+    activateTargetNearViewportCenter,
+    deactivateTarget: deactivateReviewTarget,
+    handlePointerMove: handleBodyPointerMove,
+    moveTargetLine,
+    moveTargetSide,
+    scrollHunkIntoView,
+    scrollTargetIntoView,
+    selectedLines: reviewSelectedLines,
+    targetIndexForHunk,
+  } = useReviewTargetNavigation({
+    annotations: realAnnotations,
+    clearTransientSelection,
+    diffStyle: effectiveDiffStyle,
+    fileDiff: activeResponse?.fileDiff ?? null,
+    fileKey: reviewTargetFileKey,
+    onHunkIndexChange: setFocusedHunkIndex,
+    scrollBodyRef: diffScrollBodyRef,
+  })
+
+  const onPrevHunk = useCallback((): void => {
+    if (!activeResponse) {
+      return
+    }
+
+    const hunks = activeResponse.fileDiff.hunks
+    if (hunks.length === 0) {
+      return
+    }
+
+    const next = (clampedHunkIndex + hunks.length - 1) % hunks.length
+    deactivateReviewTarget()
+    setFocusedHunkIndex(next)
+    flashHunkSelection(hunks[next])
+  }, [
+    activeResponse,
+    clampedHunkIndex,
+    deactivateReviewTarget,
+    flashHunkSelection,
+  ])
+
+  const onNextHunk = useCallback((): void => {
+    if (!activeResponse) {
+      return
+    }
+
+    const hunks = activeResponse.fileDiff.hunks
+    if (hunks.length === 0) {
+      return
+    }
+
+    const next = (clampedHunkIndex + 1) % hunks.length
+    deactivateReviewTarget()
+    setFocusedHunkIndex(next)
+    flashHunkSelection(hunks[next])
+  }, [
+    activeResponse,
+    clampedHunkIndex,
+    deactivateReviewTarget,
+    flashHunkSelection,
+  ])
+
+  const selectedLines: SelectedLineRange | null =
+    reviewSelectedLines ?? navSelection
+
   // Memoize the Pierre input pair on response identity. Without this,
   // `toPierreInputs(response)` would mint fresh { oldFile, newFile } object
   // references on every parent render, invalidating Pierre's internal
@@ -1233,6 +891,9 @@ export const Panel = ({
     () => (activeResponse ? toPierreInputs(activeResponse) : null),
     [activeResponse]
   )
+
+  const panelRenderKey =
+    pierreInputs === null ? renderKey : `${renderKey}:${pierreInputs.identity}`
 
   // File navigation — index of the selected file within effectiveFiles, or
   // -1 when nothing is selected. The (path, staged) pair is the identity used
@@ -1294,180 +955,40 @@ export const Panel = ({
 
       const distance = Math.max(Math.floor(node.clientHeight / 2), 160)
       node.scrollTop = Math.max(0, node.scrollTop + direction * distance)
+      activateTargetNearViewportCenter()
       focusDiffRoot()
     },
-    [focusDiffRoot]
+    [activateTargetNearViewportCenter, focusDiffRoot]
   )
 
-  // Keeps j/k line navigation visible without changing the selected target.
-  const scrollKeyboardTargetIntoView = useCallback(
-    (target: KeyboardLineTarget, targetIndex: number, delta: number): void => {
-      const node = diffScrollBodyRef.current
-      if (node === null) {
-        return
-      }
-
-      const line = findKeyboardTargetLineElement(node, target)
-      if (line === null) {
-        return
-      }
-
-      scrollLineElementIntoView(
-        node,
-        line,
-        effectiveDiffStyle === 'split'
-          ? keyboardRowIndexForTarget(keyboardLineTargets, targetIndex)
-          : targetIndex,
-        effectiveDiffStyle === 'split'
-          ? keyboardRowCountForTargets(keyboardLineTargets)
-          : keyboardLineTargets.length,
-        delta
-      )
-    },
-    [effectiveDiffStyle, keyboardLineTargets]
-  )
-
-  // Hunk jumps reveal the hunk top, then include the end only when it fits.
-  const scrollHunkIntoView = useCallback(
-    (hunkIndex: number): boolean => {
-      const node = diffScrollBodyRef.current
-      if (node === null) {
-        return false
-      }
-
-      const hunkTargets = keyboardLineTargets.filter(
-        (target) => target.hunkIndex === hunkIndex
-      )
-      if (hunkTargets.length === 0) {
-        return false
-      }
-
-      const firstTarget = hunkTargets[0]
-      const lastTarget = hunkTargets[hunkTargets.length - 1]
-      const firstLine = findKeyboardTargetLineElement(node, firstTarget)
-      const lastLine = findKeyboardTargetLineElement(node, lastTarget)
-      if (firstLine === null || lastLine === null) {
-        return false
-      }
-
-      firstLine.scrollIntoView({ block: 'start', inline: 'nearest' })
-
-      if (
-        firstLine === lastLine ||
-        !lineRangeFitsContainer(node, firstLine, lastLine)
-      ) {
-        return true
-      }
-
-      lastLine.scrollIntoView({ block: 'nearest', inline: 'nearest' })
-
-      return true
-    },
-    [keyboardLineTargets]
-  )
-
-  // Moves the keyboard comment target one rendered diff line at a time.
-  const moveKeyboardLine = useCallback(
+  const moveReviewTargetLine = useCallback(
     (delta: number): void => {
-      if (keyboardLineTargets.length === 0) {
-        return
-      }
-
-      clearNavSelectionTimer()
-      setNavSelection(null)
-      setKeyboardLineActive(true)
-      setKeyboardLineIndex((prev) => {
-        const currentIndex = Math.min(prev, keyboardLineTargets.length - 1)
-        const currentTarget = keyboardLineTargets[currentIndex]
-        let rowTargetIndex = currentIndex + delta
-
-        if (
-          rowTargetIndex < 0 ||
-          rowTargetIndex >= keyboardLineTargets.length
-        ) {
-          return currentIndex
-        }
-
-        if (effectiveDiffStyle === 'split') {
-          rowTargetIndex = currentIndex
-
-          while (
-            rowTargetIndex + delta >= 0 &&
-            rowTargetIndex + delta < keyboardLineTargets.length
-          ) {
-            rowTargetIndex += delta
-
-            const rowTarget = keyboardLineTargets[rowTargetIndex]
-            if (
-              rowTarget.hunkIndex !== currentTarget.hunkIndex ||
-              rowTarget.splitRowIndex !== currentTarget.splitRowIndex
-            ) {
-              break
-            }
-          }
-        }
-
-        const rowTarget = keyboardLineTargets[rowTargetIndex]
-
-        const sameSideIndex = keyboardLineTargets.findIndex(
-          (target) =>
-            target.hunkIndex === rowTarget.hunkIndex &&
-            target.splitRowIndex === rowTarget.splitRowIndex &&
-            target.side === currentTarget.side
-        )
-
-        const next =
-          effectiveDiffStyle === 'split' && sameSideIndex !== -1
-            ? sameSideIndex
-            : rowTargetIndex
-        if (next === currentIndex) {
-          return currentIndex
-        }
-
-        const nextTarget = keyboardLineTargets[next]
-        setFocusedHunkIndex(nextTarget.hunkIndex)
-        scrollKeyboardTargetIntoView(nextTarget, next, delta)
-
-        return next
-      })
+      moveTargetLine(delta)
       focusDiffRoot()
     },
-    [
-      clearNavSelectionTimer,
-      effectiveDiffStyle,
-      focusDiffRoot,
-      keyboardLineTargets,
-      scrollKeyboardTargetIntoView,
-    ]
+    [focusDiffRoot, moveTargetLine]
   )
 
-  // Moves the keyboard comment target to the first changed line in another hunk.
-  const moveKeyboardHunk = useCallback(
+  const moveReviewTargetHunk = useCallback(
     (delta: number): void => {
       if (!activeResponse) {
         return
       }
 
       const hunks = activeResponse.fileDiff.hunks
-      if (hunks.length === 0 || keyboardLineTargets.length === 0) {
+      if (hunks.length === 0 || reviewTargets.length === 0) {
         return
       }
 
+      const currentHunkIndex = reviewTarget?.hunkIndex ?? clampedHunkIndex
+
       const next =
-        (((clampedHunkIndex + delta) % hunks.length) + hunks.length) %
+        (((currentHunkIndex + delta) % hunks.length) + hunks.length) %
         hunks.length
-
-      const changedTargetIndex = keyboardLineTargets.findIndex(
-        (target) => target.hunkIndex === next && target.changed
-      )
-
-      const targetIndex =
-        changedTargetIndex === -1
-          ? keyboardLineTargets.findIndex((target) => target.hunkIndex === next)
-          : changedTargetIndex
+      const targetIndex = targetIndexForHunk(next)
 
       if (targetIndex === -1) {
-        setKeyboardLineActive(false)
+        deactivateReviewTarget()
         setFocusedHunkIndex(next)
         flashHunkSelection(hunks[next])
         focusDiffRoot()
@@ -1475,49 +996,44 @@ export const Panel = ({
         return
       }
 
-      const target = keyboardLineTargets[targetIndex]
+      const target = reviewTargets[targetIndex]
 
-      clearNavSelectionTimer()
-      setNavSelection(null)
-      setKeyboardLineActive(true)
-      setKeyboardLineIndex(targetIndex)
-      setFocusedHunkIndex(next)
+      activateReviewTarget(targetIndex)
       if (!scrollHunkIntoView(next)) {
-        scrollKeyboardTargetIntoView(target, targetIndex, delta)
+        scrollTargetIntoView(target, targetIndex, delta)
       }
       focusDiffRoot()
     },
     [
+      activateReviewTarget,
       activeResponse,
       clampedHunkIndex,
-      clearNavSelectionTimer,
+      deactivateReviewTarget,
       flashHunkSelection,
       focusDiffRoot,
-      keyboardLineTargets,
+      reviewTarget,
+      reviewTargets,
       scrollHunkIntoView,
-      scrollKeyboardTargetIntoView,
+      scrollTargetIntoView,
+      targetIndexForHunk,
     ]
   )
 
-  // Starts a new inline annotation from the current keyboard-selected line.
-  const openKeyboardComment = useCallback((): void => {
-    if (selectedFilePath === null || keyboardLineTarget === null) {
+  const openSelectedComment = useCallback((): void => {
+    if (selectedFilePath === null || reviewTarget === null) {
       notifyInfo('No diff line selected for comment.')
 
       return
     }
 
     const nextTarget: AnnotationTarget = {
-      lineNumber: keyboardLineTarget.lineNumber,
-      side: keyboardLineTarget.side,
+      lineNumber: reviewTarget.lineNumber,
+      side: reviewTarget.side,
       filePath: selectedFilePath,
       staged: selectedFileStaged,
     }
 
-    clearNavSelectionTimer()
-    setNavSelection(null)
-    setKeyboardLineActive(true)
-    setFocusedHunkIndex(keyboardLineTarget.hunkIndex)
+    activateReviewTarget(reviewTargetIndex)
     setCommentDraftText((current) => {
       if (annotationTarget === null) {
         return ''
@@ -1527,51 +1043,23 @@ export const Panel = ({
     }, false)
     setAnnotationTarget(nextTarget)
   }, [
-    clearNavSelectionTimer,
+    activateReviewTarget,
     annotationTarget,
-    keyboardLineTarget,
     notifyInfo,
+    reviewTarget,
+    reviewTargetIndex,
     selectedFilePath,
     selectedFileStaged,
-    setCommentDraftText,
     setAnnotationTarget,
+    setCommentDraftText,
   ])
 
-  const moveKeyboardLineSide = useCallback(
+  const moveReviewTargetSide = useCallback(
     (side: AnnotationSide): void => {
-      if (effectiveDiffStyle !== 'split' || keyboardLineTarget === null) {
-        return
-      }
-
-      const nextIndex = keyboardLineTargets.findIndex(
-        (target) =>
-          target.hunkIndex === keyboardLineTarget.hunkIndex &&
-          target.splitRowIndex === keyboardLineTarget.splitRowIndex &&
-          target.side === side
-      )
-
-      if (nextIndex === -1 || nextIndex === keyboardLineIndex) {
-        return
-      }
-
-      const nextTarget = keyboardLineTargets[nextIndex]
-      clearNavSelectionTimer()
-      setNavSelection(null)
-      setKeyboardLineActive(true)
-      setKeyboardLineIndex(nextIndex)
-      setFocusedHunkIndex(nextTarget.hunkIndex)
-      scrollKeyboardTargetIntoView(nextTarget, nextIndex, 0)
+      moveTargetSide(side)
       focusDiffRoot()
     },
-    [
-      clearNavSelectionTimer,
-      effectiveDiffStyle,
-      focusDiffRoot,
-      keyboardLineIndex,
-      keyboardLineTarget,
-      keyboardLineTargets,
-      scrollKeyboardTargetIntoView,
-    ]
+    [focusDiffRoot, moveTargetSide]
   )
 
   // Opens the y/n guard for destructive or staging keyboard actions.
@@ -1636,63 +1124,59 @@ export const Panel = ({
   )
 
   // Reopens the selected annotation in edit mode.
-  const updateKeyboardComment = useCallback((): void => {
+  const updateSelectedComment = useCallback((): void => {
     if (
       selectedFilePath === null ||
-      keyboardLineTarget === null ||
-      keyboardLineComment === undefined
+      reviewTarget === null ||
+      reviewTargetComment === undefined
     ) {
       notifyInfo('No comment selected.')
 
       return
     }
 
-    clearNavSelectionTimer()
-    setNavSelection(null)
-    setKeyboardLineActive(true)
-    setFocusedHunkIndex(keyboardLineTarget.hunkIndex)
+    activateReviewTarget(reviewTargetIndex)
     setAnnotationTarget({
-      lineNumber: keyboardLineComment.lineNumber,
-      side: keyboardLineComment.side,
+      lineNumber: reviewTargetComment.lineNumber,
+      side: reviewTargetComment.side,
       filePath: selectedFilePath,
       staged: selectedFileStaged,
-      editId: keyboardLineComment.metadata.id,
+      editId: reviewTargetComment.metadata.id,
     })
-    setCommentDraftText(keyboardLineComment.metadata.text, false)
+    setCommentDraftText(reviewTargetComment.metadata.text, false)
   }, [
-    clearNavSelectionTimer,
-    keyboardLineComment,
-    keyboardLineTarget,
+    activateReviewTarget,
     notifyInfo,
+    reviewTarget,
+    reviewTargetComment,
+    reviewTargetIndex,
     selectedFilePath,
     selectedFileStaged,
-    setCommentDraftText,
     setAnnotationTarget,
+    setCommentDraftText,
   ])
 
-  // Deletes the annotation on the current keyboard-selected line.
-  const deleteKeyboardComment = useCallback((): void => {
+  // Deletes the annotation on the selected review target.
+  const deleteSelectedComment = useCallback((): void => {
     if (
       selectedFilePath === null ||
-      keyboardLineTarget === null ||
-      keyboardLineComment === undefined
+      reviewTarget === null ||
+      reviewTargetComment === undefined
     ) {
       notifyInfo('No comment selected.')
 
       return
     }
 
-    clearNavSelectionTimer()
-    setNavSelection(null)
-    setKeyboardLineActive(true)
-    setFocusedHunkIndex(keyboardLineTarget.hunkIndex)
-    removeFeedbackAnnotation(keyboardLineComment.metadata.id)
+    activateReviewTarget(reviewTargetIndex)
+    removeFeedbackAnnotation(reviewTargetComment.metadata.id)
   }, [
-    clearNavSelectionTimer,
-    keyboardLineComment,
-    keyboardLineTarget,
+    activateReviewTarget,
     notifyInfo,
     removeFeedbackAnnotation,
+    reviewTarget,
+    reviewTargetComment,
+    reviewTargetIndex,
     selectedFilePath,
   ])
 
@@ -1700,15 +1184,15 @@ export const Panel = ({
     enabled: true,
     rootRef: diffRootRef,
     confirming: keyboardConfirmAction !== null,
-    onMoveLine: moveKeyboardLine,
+    onMoveLine: moveReviewTargetLine,
     onScrollPage: scrollDiffPage,
     onPreviousFile: (): void => goToFile(-1),
     onNextFile: (): void => goToFile(1),
-    onPreviousHunk: (): void => moveKeyboardHunk(-1),
-    onNextHunk: (): void => moveKeyboardHunk(1),
-    onComment: openKeyboardComment,
-    onUpdateComment: updateKeyboardComment,
-    onDeleteComment: deleteKeyboardComment,
+    onPreviousHunk: (): void => moveReviewTargetHunk(-1),
+    onNextHunk: (): void => moveReviewTargetHunk(1),
+    onComment: openSelectedComment,
+    onUpdateComment: updateSelectedComment,
+    onDeleteComment: deleteSelectedComment,
     onFinishReview: (): void => {
       if (feedback.totalAnnotations() > 0) {
         setFinishOpen(true)
@@ -1718,7 +1202,7 @@ export const Panel = ({
     onDiscardHunk: (): void => openKeyboardConfirm('discard-hunk'),
     onDiscardFile: (): void => openKeyboardConfirm('discard-file'),
     onToggleView: toggleDiffStyle,
-    onMoveLineSide: moveKeyboardLineSide,
+    onMoveLineSide: moveReviewTargetSide,
     onConfirm: confirmKeyboardAction,
     onCancelConfirm: cancelKeyboardConfirm,
   })
@@ -1732,19 +1216,13 @@ export const Panel = ({
         )
       : null
 
-  const clearKeyboardLineActiveOnPointerMove = useCallback((): void => {
-    if (keyboardLineActive) {
-      setKeyboardLineActive(false)
-    }
-  }, [keyboardLineActive])
-
   const handleBodyAddComment = useCallback(
     (lineNumber: number, side: AnnotationSide): void => {
       if (selectedFilePath === null) {
         return
       }
 
-      setKeyboardLineActive(false)
+      deactivateReviewTarget()
 
       const nextTarget: AnnotationTarget = {
         lineNumber,
@@ -1766,6 +1244,7 @@ export const Panel = ({
     },
     [
       annotationTarget,
+      deactivateReviewTarget,
       selectedFilePath,
       selectedFileStaged,
       setCommentDraftText,
@@ -1954,6 +1433,8 @@ export const Panel = ({
             feedbackCount: pendingFeedbackCount,
             onDiscardFeedback: feedback.clearBatch,
             onFinishFeedback,
+            onRefreshActiveFile:
+              latestDiffStatus === 'ready' ? acceptLatestDiff : undefined,
           }}
           finishFeedback={finishFeedback}
           keyboardConfirm={keyboardConfirm}
@@ -1976,13 +1457,13 @@ export const Panel = ({
           diffLoading={diffLoading}
           pierreInputs={pierreInputs}
           tooNarrow={tooNarrow}
-          renderKey={renderKey}
+          renderKey={panelRenderKey}
           options={multiFileDiffOptions}
           selectedLines={selectedLines}
           lineAnnotations={lineAnnotations}
           annotationTarget={annotationTarget}
           commentDraftText={commentDraftText}
-          onPointerMove={clearKeyboardLineActiveOnPointerMove}
+          onPointerMove={handleBodyPointerMove}
           onAddComment={handleBodyAddComment}
           onEditComment={handleBodyEditComment}
           onDeleteComment={removeFeedbackAnnotation}

--- a/src/features/diff/components/PanelBody.test.tsx
+++ b/src/features/diff/components/PanelBody.test.tsx
@@ -1,7 +1,7 @@
 import { createRef, type ReactNode } from 'react'
-import { render, screen } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import type { FileDiffOptions } from '@pierre/diffs'
-import { describe, expect, test, vi } from 'vitest'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { PanelBody } from './PanelBody'
 import type { ReviewComment } from '../hooks/useFeedbackBatch'
 import type { PierreFileInputs } from '../services/pierreAdapter'
@@ -13,21 +13,37 @@ interface MultiFileDiffMockProps {
   options: { diffStyle?: string }
 }
 
+interface WorkerPoolMock {
+  inspectCaches: () => { diffCache: Set<string> }
+  subscribeToStatChanges: (callback: () => void) => () => void
+}
+
+const pierreReactMock = vi.hoisted(() => ({
+  renderCount: 0,
+  workerPool: undefined as WorkerPoolMock | undefined,
+}))
+
 vi.mock('@pierre/diffs/react', () => ({
+  useWorkerPool: (): WorkerPoolMock | undefined => pierreReactMock.workerPool,
   MultiFileDiff: ({
     oldFile,
     newFile,
     lineAnnotations,
     options,
-  }: MultiFileDiffMockProps): ReactNode => (
-    <div
-      data-testid="multi-file-diff"
-      data-old-file={oldFile.name}
-      data-new-file={newFile.name}
-      data-annotations={lineAnnotations.length}
-      data-diff-style={options.diffStyle}
-    />
-  ),
+  }: MultiFileDiffMockProps): ReactNode => {
+    pierreReactMock.renderCount += 1
+
+    return (
+      <div
+        data-testid="multi-file-diff"
+        data-old-file={oldFile.name}
+        data-new-file={newFile.name}
+        data-annotations={lineAnnotations.length}
+        data-diff-style={options.diffStyle}
+        data-render-count={pierreReactMock.renderCount}
+      />
+    )
+  },
 }))
 
 vi.mock('./DiffNarrowPlaceholder', () => ({
@@ -39,6 +55,8 @@ vi.mock('./DiffNarrowPlaceholder', () => ({
 const pierreInputs: PierreFileInputs = {
   oldFile: { name: 'src/foo.ts', contents: 'old' },
   newFile: { name: 'src/foo.ts', contents: 'new' },
+  identity: 'diff-identity',
+  diffCacheKey: 'diff-cache-key',
 }
 
 const options: FileDiffOptions<ReviewComment> = {
@@ -76,6 +94,11 @@ const renderBody = (
   render(<PanelBody {...createBodyProps(overrides)} />)
 
 describe('PanelBody', () => {
+  beforeEach(() => {
+    pierreReactMock.renderCount = 0
+    pierreReactMock.workerPool = undefined
+  })
+
   test('renders loading and error states before the Pierre renderer', () => {
     const { rerender } = renderBody({
       pierreInputs: null,
@@ -112,5 +135,40 @@ describe('PanelBody', () => {
     expect(renderer).toHaveAttribute('data-old-file', 'src/foo.ts')
     expect(renderer).toHaveAttribute('data-new-file', 'src/foo.ts')
     expect(renderer).toHaveAttribute('data-diff-style', 'split')
+  })
+
+  test('rerenders Pierre when the active diff highlight cache becomes available', async () => {
+    const diffCache = new Set<string>()
+    const subscribers = new Set<() => void>()
+
+    pierreReactMock.workerPool = {
+      inspectCaches: (): { diffCache: Set<string> } => ({ diffCache }),
+      subscribeToStatChanges: (callback): (() => void) => {
+        subscribers.add(callback)
+
+        return (): void => {
+          subscribers.delete(callback)
+        }
+      },
+    }
+
+    renderBody()
+
+    expect(screen.getByTestId('multi-file-diff')).toHaveAttribute(
+      'data-render-count',
+      '1'
+    )
+
+    act(() => {
+      diffCache.add(pierreInputs.diffCacheKey)
+      subscribers.forEach((callback) => callback())
+    })
+
+    await waitFor(() =>
+      expect(screen.getByTestId('multi-file-diff')).toHaveAttribute(
+        'data-render-count',
+        '2'
+      )
+    )
   })
 })

--- a/src/features/diff/components/PanelBody.tsx
+++ b/src/features/diff/components/PanelBody.tsx
@@ -1,5 +1,12 @@
-import { type ReactElement, type RefObject } from 'react'
-import { MultiFileDiff } from '@pierre/diffs/react'
+import {
+  type PointerEvent as ReactPointerEvent,
+  type ReactElement,
+  type RefObject,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
+import { MultiFileDiff, useWorkerPool } from '@pierre/diffs/react'
 import type {
   AnnotationSide,
   DiffLineAnnotation,
@@ -39,6 +46,75 @@ const LoadingCard = (): ReactElement => (
   </div>
 )
 
+interface DiffCacheLike {
+  has: (cacheKey: string) => boolean
+}
+
+interface HighlightCacheWorkerPool {
+  inspectCaches: () => { diffCache: DiffCacheLike }
+  subscribeToStatChanges: (callback: () => void) => () => void
+}
+
+const isHighlightCacheWorkerPool = (
+  value: unknown
+): value is HighlightCacheWorkerPool =>
+  typeof value === 'object' &&
+  value !== null &&
+  'inspectCaches' in value &&
+  'subscribeToStatChanges' in value &&
+  typeof value.inspectCaches === 'function' &&
+  typeof value.subscribeToStatChanges === 'function'
+
+const useHighlightCacheRevision = (diffCacheKey: string | null): number => {
+  const workerPool = useWorkerPool()
+
+  const cacheWorkerPool = isHighlightCacheWorkerPool(workerPool)
+    ? workerPool
+    : null
+
+  const [revision, setRevision] = useState(0)
+  const seenCacheKeyRef = useRef<string | null>(null)
+
+  const cacheReadyDuringRender =
+    diffCacheKey !== null &&
+    (cacheWorkerPool?.inspectCaches().diffCache.has(diffCacheKey) ?? false)
+
+  useEffect(() => {
+    if (cacheWorkerPool === null || diffCacheKey === null) {
+      seenCacheKeyRef.current = null
+
+      return
+    }
+
+    const markReady = (): void => {
+      if (seenCacheKeyRef.current === diffCacheKey) {
+        return
+      }
+
+      seenCacheKeyRef.current = diffCacheKey
+      setRevision((current) => current + 1)
+    }
+
+    if (cacheWorkerPool.inspectCaches().diffCache.has(diffCacheKey)) {
+      if (!cacheReadyDuringRender) {
+        markReady()
+      } else {
+        seenCacheKeyRef.current = diffCacheKey
+      }
+
+      return
+    }
+
+    return cacheWorkerPool.subscribeToStatChanges(() => {
+      if (cacheWorkerPool.inspectCaches().diffCache.has(diffCacheKey)) {
+        markReady()
+      }
+    })
+  }, [cacheReadyDuringRender, cacheWorkerPool, diffCacheKey])
+
+  return revision
+}
+
 interface PanelBodyProps {
   scrollBodyRef: RefObject<HTMLDivElement | null>
   diffError: Error | null
@@ -51,7 +127,7 @@ interface PanelBodyProps {
   lineAnnotations: DiffLineAnnotation<ReviewComment>[]
   annotationTarget: AnnotationTarget | null
   commentDraftText: string
-  onPointerMove: () => void
+  onPointerMove: (event: ReactPointerEvent<HTMLDivElement>) => void
   onAddComment: (lineNumber: number, side: AnnotationSide) => void
   onEditComment: (annotation: DiffLineAnnotation<ReviewComment>) => void
   onDeleteComment: (id: string) => void
@@ -79,79 +155,86 @@ export const PanelBody = ({
   onCommentTextChange,
   onConfirmComment,
   onCancelComment,
-}: PanelBodyProps): ReactElement => (
-  <div
-    ref={scrollBodyRef}
-    data-testid="diff-scroll-body"
-    className="min-h-0 flex-1 overflow-auto"
-    onPointerMove={onPointerMove}
-  >
-    {diffError ? (
-      <ErrorCard message={diffError.message} />
-    ) : pierreInputs ? (
-      tooNarrow ? (
-        <DiffNarrowPlaceholder min={DIFF_MIN_WIDTH_PX} />
-      ) : (
-        <MultiFileDiff<ReviewComment>
-          key={renderKey}
-          oldFile={pierreInputs.oldFile}
-          newFile={pierreInputs.newFile}
-          selectedLines={selectedLines}
-          lineAnnotations={lineAnnotations}
-          options={options}
-          renderGutterUtility={(getHoveredLine): ReactElement => (
-            <IconButton
-              icon="add"
-              label="Add comment on this line"
-              size="sm"
-              shortcut="i"
-              className="h-5 w-5 translate-x-3/4 rounded-full bg-primary text-on-primary shadow-md hover:bg-primary/90"
-              onClick={(): void => {
-                const hovered = getHoveredLine()
-                if (hovered) {
-                  onAddComment(hovered.lineNumber, hovered.side)
-                }
-              }}
-            />
-          )}
-          renderAnnotation={(
-            annotation: DiffLineAnnotation<ReviewComment>
-          ): ReactElement => {
-            const isDraft = annotation.metadata.id === DRAFT_ID
+}: PanelBodyProps): ReactElement => {
+  const highlightCacheRevision = useHighlightCacheRevision(
+    pierreInputs?.diffCacheKey ?? null
+  )
+  const effectiveRenderKey = `${renderKey}:${highlightCacheRevision}`
 
-            const isEditing =
-              annotationTarget?.editId !== undefined &&
-              annotationTarget.editId === annotation.metadata.id
+  return (
+    <div
+      ref={scrollBodyRef}
+      data-testid="diff-scroll-body"
+      className="min-h-0 flex-1 overflow-auto"
+      onPointerMove={onPointerMove}
+    >
+      {diffError ? (
+        <ErrorCard message={diffError.message} />
+      ) : pierreInputs ? (
+        tooNarrow ? (
+          <DiffNarrowPlaceholder min={DIFF_MIN_WIDTH_PX} />
+        ) : (
+          <MultiFileDiff<ReviewComment>
+            key={effectiveRenderKey}
+            oldFile={pierreInputs.oldFile}
+            newFile={pierreInputs.newFile}
+            selectedLines={selectedLines}
+            lineAnnotations={lineAnnotations}
+            options={options}
+            renderGutterUtility={(getHoveredLine): ReactElement => (
+              <IconButton
+                icon="add"
+                label="Add comment on this line"
+                size="sm"
+                shortcut="i"
+                className="h-5 w-5 translate-x-3/4 rounded-full bg-primary text-on-primary shadow-md hover:bg-primary/90"
+                onClick={(): void => {
+                  const hovered = getHoveredLine()
+                  if (hovered) {
+                    onAddComment(hovered.lineNumber, hovered.side)
+                  }
+                }}
+              />
+            )}
+            renderAnnotation={(
+              annotation: DiffLineAnnotation<ReviewComment>
+            ): ReactElement => {
+              const isDraft = annotation.metadata.id === DRAFT_ID
 
-            if (isDraft || isEditing) {
+              const isEditing =
+                annotationTarget?.editId !== undefined &&
+                annotationTarget.editId === annotation.metadata.id
+
+              if (isDraft || isEditing) {
+                return (
+                  <ReviewCommentEditor
+                    key={`${annotation.lineNumber}:${annotation.side}:${
+                      isEditing ? annotation.metadata.id : 'draft'
+                    }`}
+                    lineNumber={annotation.lineNumber}
+                    side={annotation.side}
+                    value={commentDraftText}
+                    onTextChange={onCommentTextChange}
+                    onConfirm={onConfirmComment}
+                    onCancel={onCancelComment}
+                  />
+                )
+              }
+
               return (
-                <ReviewCommentEditor
-                  key={`${annotation.lineNumber}:${annotation.side}:${
-                    isEditing ? annotation.metadata.id : 'draft'
-                  }`}
-                  lineNumber={annotation.lineNumber}
-                  side={annotation.side}
-                  value={commentDraftText}
-                  onTextChange={onCommentTextChange}
-                  onConfirm={onConfirmComment}
-                  onCancel={onCancelComment}
+                <ReviewCommentRow
+                  comment={annotation.metadata}
+                  onEdit={(): void => onEditComment(annotation)}
+                  onDelete={(): void => onDeleteComment(annotation.metadata.id)}
                 />
               )
-            }
-
-            return (
-              <ReviewCommentRow
-                comment={annotation.metadata}
-                onEdit={(): void => onEditComment(annotation)}
-                onDelete={(): void => onDeleteComment(annotation.metadata.id)}
-              />
-            )
-          }}
-          style={{ display: 'block', width: '100%' }}
-        />
-      )
-    ) : diffLoading ? (
-      <LoadingCard />
-    ) : null}
-  </div>
-)
+            }}
+            style={{ display: 'block', width: '100%' }}
+          />
+        )
+      ) : diffLoading ? (
+        <LoadingCard />
+      ) : null}
+    </div>
+  )
+}

--- a/src/features/diff/components/toolbar/DiffChipToolbar.test.tsx
+++ b/src/features/diff/components/toolbar/DiffChipToolbar.test.tsx
@@ -759,6 +759,21 @@ describe('DiffChipToolbar', () => {
     expect(onDiscardFeedback).toHaveBeenCalledTimes(1)
   })
 
+  test('renders active-file refresh as a pinned toolbar action', async () => {
+    const user = userEvent.setup()
+    const onRefresh = vi.fn<() => void>()
+
+    renderToolbar({
+      onRefreshActiveFile: onRefresh,
+    })
+
+    const refresh = screen.getByRole('button', { name: 'refresh diff' })
+    expect(refresh).toHaveTextContent('Refresh diff')
+
+    await user.click(refresh)
+    expect(onRefresh).toHaveBeenCalledTimes(1)
+  })
+
   test('the pinned feedback actions render outside PriorityPlus (never overflow)', () => {
     renderToolbar({ feedbackCount: 2 })
 

--- a/src/features/diff/components/toolbar/DiffChipToolbar.tsx
+++ b/src/features/diff/components/toolbar/DiffChipToolbar.tsx
@@ -184,6 +184,7 @@ export interface DiffChipToolbarProps {
   feedbackCount?: number
   onFinishFeedback?: () => void
   onDiscardFeedback?: () => void
+  onRefreshActiveFile?: () => void
 }
 
 // Composed chip toolbar. Pure controlled component — all state lives in the
@@ -234,6 +235,7 @@ export const DiffChipToolbar = ({
   feedbackCount = 0,
   onFinishFeedback = undefined,
   onDiscardFeedback = undefined,
+  onRefreshActiveFile = undefined,
 }: DiffChipToolbarProps): ReactElement => {
   // Discard All confirmation popover state. The trigger is the discard-all
   // button inside the tool-well; the confirm card renders on the shared Popover
@@ -462,6 +464,7 @@ export const DiffChipToolbar = ({
   const showActions = feedbackCount > 0
   const canDiscardFeedback = onDiscardFeedback !== undefined
   const canFinishFeedback = onFinishFeedback !== undefined
+  const showPinnedActions = onRefreshActiveFile !== undefined || showActions
 
   return (
     <div
@@ -476,41 +479,62 @@ export const DiffChipToolbar = ({
         >
           {chips}
         </PriorityPlus>
-        {showActions ? (
+        {showPinnedActions ? (
           <div className="ml-auto flex shrink-0 items-center gap-2 pl-3">
-            <button
-              type="button"
-              aria-label="discard all feedback"
-              disabled={!canDiscardFeedback}
-              onClick={onDiscardFeedback}
-              className="inline-flex items-center h-7 px-3.5 rounded-md font-mono text-[0.6875rem] font-medium bg-transparent border border-outline-variant/60 text-on-surface hover:bg-surface-container hover:border-error/50 hover:text-error transition-colors disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:border-outline-variant/60 disabled:hover:text-on-surface"
-            >
-              Discard
-            </button>
-            <button
-              type="button"
-              aria-label={`finish feedback (${feedbackCount})`}
-              aria-keyshortcuts="Y"
-              disabled={!canFinishFeedback}
-              onClick={onFinishFeedback}
-              className="inline-flex items-center gap-[7px] h-7 pl-[11px] pr-2 rounded-md font-mono text-[0.6875rem] font-bold text-on-primary bg-primary hover:bg-primary-container shadow-[0_1px_5px_color-mix(in_srgb,var(--color-primary)_40%,transparent)] transition-colors disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              <span
-                aria-hidden="true"
-                className="material-symbols-outlined text-sm leading-none"
+            {onRefreshActiveFile !== undefined ? (
+              <button
+                type="button"
+                data-testid="diff-active-file-refresh"
+                aria-label="refresh diff"
+                onClick={onRefreshActiveFile}
+                className="inline-flex h-7 items-center gap-1.5 rounded-md border border-outline-variant/60 bg-transparent px-3 font-mono text-[0.6875rem] font-medium text-on-surface transition-colors hover:border-primary/50 hover:bg-surface-container hover:text-primary disabled:cursor-default disabled:opacity-70 disabled:hover:border-outline-variant/60 disabled:hover:bg-transparent disabled:hover:text-on-surface"
               >
-                check
-              </span>
-              Finish (Y)
-              <Chip
-                tone="custom"
-                radius="pill"
-                size="custom"
-                className="rounded-full bg-on-primary/20 px-1.5 py-px font-mono text-[0.625rem] font-semibold text-on-primary"
+                <span
+                  aria-hidden="true"
+                  className="material-symbols-outlined text-sm leading-none"
+                >
+                  refresh
+                </span>
+                Refresh diff
+              </button>
+            ) : null}
+            {showActions ? (
+              <button
+                type="button"
+                aria-label="discard all feedback"
+                disabled={!canDiscardFeedback}
+                onClick={onDiscardFeedback}
+                className="inline-flex items-center h-7 px-3.5 rounded-md font-mono text-[0.6875rem] font-medium bg-transparent border border-outline-variant/60 text-on-surface hover:bg-surface-container hover:border-error/50 hover:text-error transition-colors disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:border-outline-variant/60 disabled:hover:text-on-surface"
               >
-                {feedbackCount}
-              </Chip>
-            </button>
+                Discard
+              </button>
+            ) : null}
+            {showActions ? (
+              <button
+                type="button"
+                aria-label={`finish feedback (${feedbackCount})`}
+                aria-keyshortcuts="Y"
+                disabled={!canFinishFeedback}
+                onClick={onFinishFeedback}
+                className="inline-flex items-center gap-[7px] h-7 pl-[11px] pr-2 rounded-md font-mono text-[0.6875rem] font-bold text-on-primary bg-primary hover:bg-primary-container shadow-[0_1px_5px_color-mix(in_srgb,var(--color-primary)_40%,transparent)] transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <span
+                  aria-hidden="true"
+                  className="material-symbols-outlined text-sm leading-none"
+                >
+                  check
+                </span>
+                Finish (Y)
+                <Chip
+                  tone="custom"
+                  radius="pill"
+                  size="custom"
+                  className="rounded-full bg-on-primary/20 px-1.5 py-px font-mono text-[0.625rem] font-semibold text-on-primary"
+                >
+                  {feedbackCount}
+                </Chip>
+              </button>
+            ) : null}
           </div>
         ) : null}
       </div>

--- a/src/features/diff/hooks/useFileDiff.test.ts
+++ b/src/features/diff/hooks/useFileDiff.test.ts
@@ -69,7 +69,7 @@ const makeResponse = (
   },
   oldText: `old text for ${fileDiff.filePath}`,
   newText,
-  rawDiff: `${fileDiff.hunks[0].header}\n-old\n+new\n`,
+  rawDiff: `${fileDiff.hunks[0].header}\n-old\n+${newText}\n`,
   repoRoot: '/repo',
 })
 
@@ -99,6 +99,7 @@ describe('useFileDiff', () => {
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     vi.restoreAllMocks()
     getDiff.mockReset()
   })
@@ -206,7 +207,7 @@ describe('useFileDiff', () => {
     expect(response?.rawDiff).toContain('@@ -1 +1 @@')
   })
 
-  test('keeps the current same-file response visible while refreshToken re-fetches', async () => {
+  test('keeps same-file background updates pending until accepted', async () => {
     const filePath = navBarDiff.filePath
 
     let resolveSecond!: (response: GetGitDiffResponse) => void
@@ -229,6 +230,7 @@ describe('useFileDiff', () => {
     })
 
     expect(result.current.response?.newText).toBe('new v1')
+    expect(result.current.latestDiffStatus).toBeNull()
 
     rerender({ token: 'revision-2' })
 
@@ -237,6 +239,7 @@ describe('useFileDiff', () => {
     })
 
     expect(result.current.response?.newText).toBe('new v1')
+    expect(result.current.latestDiffStatus).toBe('updating')
 
     await act(async () => {
       resolveSecond(makeResponse(navBarDiff, 'new v2'))
@@ -247,7 +250,87 @@ describe('useFileDiff', () => {
       expect(result.current.loading).toBe(false)
     })
 
+    expect(result.current.response?.newText).toBe('new v1')
+    expect(result.current.latestDiffStatus).toBe('updating')
+
+    await waitFor(() => {
+      expect(result.current.latestDiffStatus).toBe('ready')
+    })
+
+    act(() => {
+      result.current.acceptLatestDiff()
+    })
+
     expect(result.current.response?.newText).toBe('new v2')
+    expect(result.current.latestDiffStatus).toBeNull()
     expect(getDiff).toHaveBeenCalledTimes(2)
+  })
+
+  test('keeps the latest-diff ready state visible during continuous background updates', async () => {
+    const filePath = navBarDiff.filePath
+
+    let resolveSecond!: (response: GetGitDiffResponse) => void
+    let resolveThird!: (response: GetGitDiffResponse) => void
+
+    const secondFetch = new Promise<GetGitDiffResponse>((resolve) => {
+      resolveSecond = resolve
+    })
+
+    const thirdFetch = new Promise<GetGitDiffResponse>((resolve) => {
+      resolveThird = resolve
+    })
+
+    getDiff
+      .mockResolvedValueOnce(makeResponse(navBarDiff, 'new v1'))
+      .mockReturnValueOnce(secondFetch)
+      .mockReturnValueOnce(thirdFetch)
+
+    const { result, rerender } = renderHook(
+      ({ token }) => useFileDiff(filePath, false, '/repo', false, token),
+      { initialProps: { token: 'revision-1' } }
+    )
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    rerender({ token: 'revision-2' })
+
+    await act(async () => {
+      resolveSecond(makeResponse(navBarDiff, 'new v2'))
+      await secondFetch
+    })
+
+    await waitFor(() => {
+      expect(result.current.latestDiffStatus).toBe('ready')
+    })
+
+    rerender({ token: 'revision-3' })
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(true)
+    })
+
+    expect(result.current.response?.newText).toBe('new v1')
+    expect(result.current.latestDiffStatus).toBe('ready')
+
+    await act(async () => {
+      resolveThird(makeResponse(navBarDiff, 'new v3'))
+      await thirdFetch
+    })
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.response?.newText).toBe('new v1')
+    expect(result.current.latestDiffStatus).toBe('ready')
+
+    act(() => {
+      result.current.acceptLatestDiff()
+    })
+
+    expect(result.current.response?.newText).toBe('new v3')
+    expect(result.current.latestDiffStatus).toBeNull()
   })
 })

--- a/src/features/diff/hooks/useFileDiff.ts
+++ b/src/features/diff/hooks/useFileDiff.ts
@@ -10,10 +10,13 @@
  * parent-provided refresh token force same-file revalidation without clearing
  * the visible response.
  */
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { createGitService } from '../services/gitService'
+import { diffIdentityForResponse } from '../services/pierreAdapter'
 import type { FileDiff } from '../types'
 import type { GetGitDiffResponse } from '../../../bindings/GetGitDiffResponse'
+
+export type LatestDiffStatus = 'updating' | 'ready'
 
 export interface UseFileDiffReturn {
   /**
@@ -26,8 +29,11 @@ export interface UseFileDiffReturn {
   diff: FileDiff | null
   loading: boolean
   error: Error | null
+  latestDiffStatus: LatestDiffStatus | null
   /** Trigger a manual re-fetch of the diff (e.g. after a stage/discard action). */
   refetch: () => void
+  /** Swap the visible diff to the newest background response. */
+  acceptLatestDiff: () => void
 }
 
 interface FileDiffRequest {
@@ -45,6 +51,21 @@ interface FileDiffResponseState {
   response: GetGitDiffResponse
 }
 
+const LATEST_DIFF_READY_DELAY_MS = 800
+
+const requestMatchesSelection = (
+  state: FileDiffResponseState | null,
+  filePath: string,
+  staged: boolean,
+  cwd: string,
+  untracked: boolean | undefined
+): state is FileDiffResponseState =>
+  state !== null &&
+  state.request.filePath === filePath &&
+  state.request.staged === staged &&
+  state.request.cwd === cwd &&
+  state.request.untracked === untracked
+
 /**
  * Hook to fetch diff for a specific file
  * @param filePath - Path to the file
@@ -60,19 +81,65 @@ export const useFileDiff = (
   untracked?: boolean,
   refreshToken?: string
 ): UseFileDiffReturn => {
-  const [responseState, setResponseState] =
+  const [displayedState, setDisplayedState] =
     useState<FileDiffResponseState | null>(null)
+
+  const [latestState, setLatestState] = useState<FileDiffResponseState | null>(
+    null
+  )
+
+  const [latestDiffStatus, setLatestDiffStatus] =
+    useState<LatestDiffStatus | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<Error | null>(null)
   const [refetchKey, setRefetchKey] = useState(0)
+  const displayedStateRef = useRef<FileDiffResponseState | null>(displayedState)
+  const latestDiffStatusRef = useRef<LatestDiffStatus | null>(latestDiffStatus)
+  const readyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const setLatestDiffStatusValue = useCallback(
+    (status: LatestDiffStatus | null): void => {
+      latestDiffStatusRef.current = status
+      setLatestDiffStatus(status)
+    },
+    []
+  )
+
+  const clearReadyTimer = useCallback((): void => {
+    if (readyTimerRef.current !== null) {
+      clearTimeout(readyTimerRef.current)
+      readyTimerRef.current = null
+    }
+  }, [])
 
   const refetch = useCallback((): void => {
     setRefetchKey((k) => k + 1)
   }, [])
 
   useEffect(() => {
+    displayedStateRef.current = displayedState
+  }, [displayedState])
+
+  const acceptLatestDiff = useCallback((): void => {
+    if (latestState === null) {
+      return
+    }
+
+    clearReadyTimer()
+    setDisplayedState(latestState)
+    setLatestState(null)
+    setLatestDiffStatusValue(null)
+    setError(null)
+  }, [clearReadyTimer, latestState, setLatestDiffStatusValue])
+
+  useEffect(() => clearReadyTimer, [clearReadyTimer])
+
+  useEffect(() => {
     if (!filePath) {
-      setResponseState(null)
+      clearReadyTimer()
+      setDisplayedState(null)
+      setLatestState(null)
+      setLatestDiffStatusValue(null)
       setLoading(false)
       setError(null)
 
@@ -90,25 +157,78 @@ export const useFileDiff = (
       refetchKey,
     }
 
+    const currentDisplayedState = displayedStateRef.current
+
+    const backgroundDisplayedState =
+      requestMatchesSelection(
+        currentDisplayedState,
+        filePath,
+        staged,
+        cwd,
+        untracked
+      ) &&
+      currentDisplayedState.request.refetchKey === refetchKey &&
+      currentDisplayedState.request.refreshToken !== refreshToken
+        ? currentDisplayedState
+        : null
+
     const fetchDiff = async (): Promise<void> => {
       try {
+        if (backgroundDisplayedState === null) {
+          clearReadyTimer()
+          setLatestState(null)
+          setLatestDiffStatusValue(null)
+        } else {
+          clearReadyTimer()
+          if (latestDiffStatusRef.current !== 'ready') {
+            setLatestDiffStatusValue('updating')
+          }
+        }
+
         setLoading(true)
-        setError(null)
+        if (backgroundDisplayedState === null) {
+          setError(null)
+        }
 
         const service = createGitService(cwd)
         const result = await service.getDiff(filePath, staged, untracked)
 
         if (!cancelled) {
-          setResponseState({ request, response: result })
+          if (backgroundDisplayedState === null) {
+            setDisplayedState({ request, response: result })
+          } else if (
+            diffIdentityForResponse(result) ===
+            diffIdentityForResponse(backgroundDisplayedState.response)
+          ) {
+            setLatestState(null)
+            setLatestDiffStatusValue(null)
+          } else {
+            setLatestState({ request, response: result })
+            if (latestDiffStatusRef.current === 'ready') {
+              setLatestDiffStatusValue('ready')
+            } else {
+              readyTimerRef.current = setTimeout(() => {
+                setLatestDiffStatusValue('ready')
+                readyTimerRef.current = null
+              }, LATEST_DIFF_READY_DELAY_MS)
+            }
+          }
         }
       } catch (err) {
         if (!cancelled) {
-          setError(
-            err instanceof Error
-              ? err
-              : new Error(`Failed to fetch diff for ${filePath}`)
-          )
-          setResponseState(null)
+          if (backgroundDisplayedState !== null) {
+            if (latestDiffStatusRef.current !== 'ready') {
+              setLatestState(null)
+              setLatestDiffStatusValue(null)
+            }
+          } else {
+            setError(
+              err instanceof Error
+                ? err
+                : new Error(`Failed to fetch diff for ${filePath}`)
+            )
+            setDisplayedState(null)
+          }
         }
       } finally {
         if (!cancelled) {
@@ -122,15 +242,21 @@ export const useFileDiff = (
     return (): void => {
       cancelled = true
     }
-  }, [filePath, staged, untracked, cwd, refreshToken, refetchKey])
+  }, [
+    clearReadyTimer,
+    cwd,
+    filePath,
+    refetchKey,
+    refreshToken,
+    setLatestDiffStatusValue,
+    staged,
+    untracked,
+  ])
 
   const response =
     filePath !== null &&
-    responseState?.request.filePath === filePath &&
-    responseState.request.staged === staged &&
-    responseState.request.cwd === cwd &&
-    responseState.request.untracked === untracked
-      ? responseState.response
+    requestMatchesSelection(displayedState, filePath, staged, cwd, untracked)
+      ? displayedState.response
       : null
 
   const fileDiff = response?.fileDiff ?? null
@@ -140,6 +266,8 @@ export const useFileDiff = (
     diff: fileDiff,
     loading,
     error,
+    latestDiffStatus,
     refetch,
+    acceptLatestDiff,
   }
 }

--- a/src/features/diff/hooks/useReviewTargetNavigation.test.ts
+++ b/src/features/diff/hooks/useReviewTargetNavigation.test.ts
@@ -1,0 +1,96 @@
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, test, vi } from 'vitest'
+import type { DiffLineAnnotation } from '@pierre/diffs'
+import { useReviewTargetNavigation } from './useReviewTargetNavigation'
+import type { FileDiff } from '../types'
+import type { ReviewComment } from './useFeedbackBatch'
+
+const fileDiff: FileDiff = {
+  filePath: 'src/foo.ts',
+  oldPath: 'src/foo.ts',
+  newPath: 'src/foo.ts',
+  hunks: [
+    {
+      id: 'hunk-0',
+      header: '@@ -1,2 +1,2 @@',
+      oldStart: 1,
+      oldLines: 2,
+      newStart: 1,
+      newLines: 2,
+      lines: [
+        { type: 'context', oldLineNumber: 1, newLineNumber: 1, content: 'a' },
+        { type: 'added', newLineNumber: 2, content: 'b' },
+      ],
+    },
+  ],
+}
+
+const annotation: DiffLineAnnotation<ReviewComment> = {
+  lineNumber: 2,
+  side: 'additions',
+  metadata: {
+    id: 'comment-1',
+    text: 'Check this',
+    author: 'self',
+    createdAt: 100,
+  },
+}
+
+describe('useReviewTargetNavigation', () => {
+  test('tracks one active review target for selection and comments', () => {
+    const onHunkIndexChange = vi.fn()
+    const clearTransientSelection = vi.fn()
+    const scrollBodyRef = { current: document.createElement('div') }
+
+    const { result, rerender } = renderHook(
+      ({ fileKey }) =>
+        useReviewTargetNavigation({
+          annotations: [annotation],
+          clearTransientSelection,
+          diffStyle: 'split',
+          fileDiff,
+          fileKey,
+          onHunkIndexChange,
+          scrollBodyRef,
+        }),
+      { initialProps: { fileKey: 'src/foo.ts:unstaged' } }
+    )
+
+    expect(result.current.selectedLines).toBeNull()
+    expect(result.current.currentTarget).toEqual({
+      lineNumber: 1,
+      side: 'additions',
+      hunkIndex: 0,
+      splitRowIndex: 0,
+      changed: false,
+    })
+    expect(result.current.activeTarget).toBeNull()
+
+    act(() => {
+      result.current.activateTarget(1)
+    })
+
+    expect(result.current.selectedLines).toEqual({
+      start: 2,
+      end: 2,
+      side: 'additions',
+    })
+
+    expect(result.current.activeTarget).toEqual({
+      lineNumber: 2,
+      side: 'additions',
+      hunkIndex: 0,
+      splitRowIndex: 1,
+      changed: true,
+    })
+    expect(result.current.currentTargetComment).toEqual(annotation)
+
+    expect(onHunkIndexChange).toHaveBeenCalledWith(0)
+    expect(clearTransientSelection).toHaveBeenCalledOnce()
+
+    rerender({ fileKey: 'src/bar.ts:unstaged' })
+
+    expect(result.current.selectedLines).toBeNull()
+    expect(result.current.activeTarget).toBeNull()
+  })
+})

--- a/src/features/diff/hooks/useReviewTargetNavigation.ts
+++ b/src/features/diff/hooks/useReviewTargetNavigation.ts
@@ -1,0 +1,829 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+  type RefObject,
+} from 'react'
+import type {
+  AnnotationSide,
+  DiffLineAnnotation,
+  SelectedLineRange,
+} from '@pierre/diffs'
+import type { FileDiff } from '../types'
+import type { DiffStyle } from './useToolbarState'
+import type { ReviewComment } from './useFeedbackBatch'
+
+const PIERRE_DIFF_CONTAINER_SELECTOR = 'diffs-container'
+const STICKY_HEADER_SCROLL_GAP_PX = 4
+
+// A review target is the stable comment/navigation address behind a rendered
+// Pierre row. Keyboard and pointer input both resolve to this same shape.
+export interface ReviewNavigationTarget {
+  lineNumber: number
+  side: AnnotationSide
+  hunkIndex: number
+  splitRowIndex: number
+  changed: boolean
+}
+
+interface UseReviewTargetNavigationOptions {
+  annotations: DiffLineAnnotation<ReviewComment>[]
+  clearTransientSelection: () => void
+  diffStyle: DiffStyle
+  fileDiff: FileDiff | null
+  fileKey: string
+  onHunkIndexChange: (hunkIndex: number) => void
+  scrollBodyRef: RefObject<HTMLElement | null>
+}
+
+interface UseReviewTargetNavigationReturn {
+  activeTarget: ReviewNavigationTarget | null
+  activeTargetIndex: number
+  activateTarget: (targetIndex: number) => void
+  activateTargetNearViewportCenter: () => void
+  currentTarget: ReviewNavigationTarget | null
+  currentTargetComment: DiffLineAnnotation<ReviewComment> | undefined
+  deactivateTarget: () => void
+  handlePointerMove: (event: ReactPointerEvent<HTMLElement>) => void
+  moveTargetLine: (delta: number) => void
+  moveTargetSide: (side: AnnotationSide) => void
+  scrollHunkIntoView: (hunkIndex: number) => boolean
+  scrollTargetIntoView: (
+    target: ReviewNavigationTarget,
+    targetIndex: number,
+    delta: number
+  ) => void
+  selectedLines: SelectedLineRange | null
+  targetIndexForHunk: (hunkIndex: number) => number
+  targets: ReviewNavigationTarget[]
+}
+
+// Flattens hunks into row-ordered targets so j/k can move by visible row while
+// h/l can switch sides inside the same split replacement row.
+const reviewTargetsForDiff = (fileDiff: FileDiff): ReviewNavigationTarget[] => {
+  const targets: ReviewNavigationTarget[] = []
+
+  fileDiff.hunks.forEach((hunk, hunkIndex) => {
+    let oldLine = hunk.oldStart
+    let newLine = hunk.newStart
+    let splitRowIndex = 0
+    let pendingDeletions: ReviewNavigationTarget[] = []
+    let pendingAdditions: ReviewNavigationTarget[] = []
+
+    const flushChangedRows = (): void => {
+      const rowCount = Math.max(
+        pendingDeletions.length,
+        pendingAdditions.length
+      )
+
+      for (let rowOffset = 0; rowOffset < rowCount; rowOffset += 1) {
+        const rowIndex = splitRowIndex + rowOffset
+        if (rowOffset < pendingDeletions.length) {
+          const deletion = pendingDeletions[rowOffset]
+          targets.push({ ...deletion, splitRowIndex: rowIndex })
+        }
+
+        if (rowOffset < pendingAdditions.length) {
+          const addition = pendingAdditions[rowOffset]
+          targets.push({ ...addition, splitRowIndex: rowIndex })
+        }
+      }
+
+      splitRowIndex += rowCount
+      pendingDeletions = []
+      pendingAdditions = []
+    }
+
+    if (hunk.lines.length === 0) {
+      targets.push({
+        lineNumber: hunk.newLines === 0 ? hunk.oldStart : hunk.newStart,
+        side: hunk.newLines === 0 ? 'deletions' : 'additions',
+        hunkIndex,
+        splitRowIndex,
+        changed: true,
+      })
+
+      return
+    }
+
+    for (const line of hunk.lines) {
+      const oldLineNumber =
+        line.oldLineNumber ?? (line.type === 'added' ? undefined : oldLine)
+
+      const newLineNumber =
+        line.newLineNumber ?? (line.type === 'removed' ? undefined : newLine)
+
+      if (line.type === 'removed') {
+        if (oldLineNumber !== undefined) {
+          pendingDeletions.push({
+            lineNumber: oldLineNumber,
+            side: 'deletions',
+            hunkIndex,
+            splitRowIndex,
+            changed: true,
+          })
+        }
+      } else if (line.type === 'added') {
+        if (newLineNumber !== undefined) {
+          pendingAdditions.push({
+            lineNumber: newLineNumber,
+            side: 'additions',
+            hunkIndex,
+            splitRowIndex,
+            changed: true,
+          })
+        }
+      } else {
+        flushChangedRows()
+
+        if (newLineNumber !== undefined) {
+          targets.push({
+            lineNumber: newLineNumber,
+            side: 'additions',
+            hunkIndex,
+            splitRowIndex,
+            changed: false,
+          })
+        }
+
+        splitRowIndex += 1
+      }
+
+      if (line.type !== 'added') {
+        oldLine += 1
+      }
+
+      if (line.type !== 'removed') {
+        newLine += 1
+      }
+    }
+
+    flushChangedRows()
+  })
+
+  return targets
+}
+
+const sameReviewRow = (
+  left: ReviewNavigationTarget,
+  right: ReviewNavigationTarget
+): boolean =>
+  left.hunkIndex === right.hunkIndex &&
+  left.splitRowIndex === right.splitRowIndex
+
+const reviewRowIndexForTarget = (
+  targets: ReviewNavigationTarget[],
+  targetIndex: number
+): number => {
+  let rowIndex = 0
+
+  for (let index = 1; index <= targetIndex; index += 1) {
+    if (!sameReviewRow(targets[index - 1], targets[index])) {
+      rowIndex += 1
+    }
+  }
+
+  return rowIndex
+}
+
+const reviewRowCountForTargets = (targets: ReviewNavigationTarget[]): number =>
+  targets.length === 0
+    ? 0
+    : reviewRowIndexForTarget(targets, targets.length - 1) + 1
+
+const reviewTargetIndexForLine = (
+  targets: ReviewNavigationTarget[],
+  lineNumber: number,
+  side: AnnotationSide
+): number =>
+  targets.findIndex(
+    (target) => target.lineNumber === lineNumber && target.side === side
+  )
+
+// Pierre exposes side information through different attributes in split and
+// unified layouts, so pointer navigation reads the closest reliable marker.
+const reviewTargetSideForElement = (
+  element: Element
+): AnnotationSide | null => {
+  const lineType = element.getAttribute('data-line-type')
+
+  if (lineType === 'change-deletion' || lineType === 'removed') {
+    return 'deletions'
+  }
+
+  if (
+    lineType === 'change-addition' ||
+    lineType === 'added' ||
+    lineType === 'context'
+  ) {
+    return 'additions'
+  }
+
+  if (element.closest('[data-deletions]') !== null) {
+    return 'deletions'
+  }
+
+  if (element.closest('[data-additions], [data-unified]') !== null) {
+    return 'additions'
+  }
+
+  return null
+}
+
+// Converts a mouse/pointer row into the same target index used by keyboard
+// navigation, keeping hover and shortcut movement in sync.
+const reviewTargetIndexFromPointerEvent = (
+  event: ReactPointerEvent<HTMLElement>,
+  targets: ReviewNavigationTarget[]
+): number | null => {
+  const path = event.nativeEvent.composedPath()
+
+  for (const item of path) {
+    if (!(item instanceof Element)) {
+      continue
+    }
+
+    const line = item.closest<HTMLElement>('[data-line], [data-column-number]')
+    if (line === null) {
+      continue
+    }
+
+    const side = reviewTargetSideForElement(line)
+
+    const lineValue =
+      line.getAttribute('data-line') ?? line.getAttribute('data-column-number')
+    const lineNumber = lineValue === null ? NaN : Number(lineValue)
+
+    if (side === null || !Number.isFinite(lineNumber)) {
+      continue
+    }
+
+    const index = reviewTargetIndexForLine(targets, lineNumber, side)
+
+    return index === -1 ? null : index
+  }
+
+  return null
+}
+
+// Pierre has changed its row attributes across layouts; keep both selectors so
+// scrolling works in runtime shadow DOM and test light DOM.
+const lineSelectorForReviewTarget = (
+  target: ReviewNavigationTarget
+): string => {
+  const lineNumber = target.lineNumber
+
+  if (target.side === 'deletions') {
+    return (
+      `[data-line-type="change-deletion"][data-line="${lineNumber}"], ` +
+      `[data-line-type="change-deletion"][data-column-number="${lineNumber}"], ` +
+      `[data-line-type="removed"][data-line="${lineNumber}"], ` +
+      `[data-line-type="removed"][data-column-number="${lineNumber}"]`
+    )
+  }
+
+  return (
+    `[data-line-type="change-addition"][data-line="${lineNumber}"], ` +
+    `[data-line-type="change-addition"][data-column-number="${lineNumber}"], ` +
+    `[data-line-type="context"][data-line="${lineNumber}"], ` +
+    `[data-line-type="context"][data-column-number="${lineNumber}"], ` +
+    `[data-line-type="added"][data-line="${lineNumber}"], ` +
+    `[data-line-type="added"][data-column-number="${lineNumber}"]`
+  )
+}
+
+// Some Pierre rows only expose the line number, so fall back to a side-agnostic
+// selector after trying the safer side-aware selector.
+const fallbackLineSelectorForReviewTarget = (
+  target: ReviewNavigationTarget
+): string => {
+  const lineNumber = target.lineNumber
+
+  return `[data-line="${lineNumber}"], [data-column-number="${lineNumber}"]`
+}
+
+// Limits shadow-DOM searches to the relevant split side when possible.
+const scopedDiffRootForReviewTarget = (
+  shadowRoot: ShadowRoot,
+  target: ReviewNavigationTarget
+): ParentNode => {
+  const sideRoot = shadowRoot.querySelector<HTMLElement>(
+    target.side === 'deletions' ? '[data-deletions]' : '[data-additions]'
+  )
+
+  return (
+    sideRoot ??
+    shadowRoot.querySelector<HTMLElement>('[data-unified]') ??
+    shadowRoot
+  )
+}
+
+// Finds the rendered row for a target whether Pierre rendered it in light DOM
+// for tests or inside its shadow DOM in the app.
+const findReviewTargetLineElement = (
+  root: HTMLElement,
+  target: ReviewNavigationTarget
+): HTMLElement | null => {
+  const selector = lineSelectorForReviewTarget(target)
+  const fallbackSelector = fallbackLineSelectorForReviewTarget(target)
+
+  const localLine =
+    root.querySelector<HTMLElement>(selector) ??
+    root.querySelector<HTMLElement>(fallbackSelector)
+
+  if (localLine !== null) {
+    return localLine
+  }
+
+  for (const container of root.querySelectorAll<HTMLElement>(
+    PIERRE_DIFF_CONTAINER_SELECTOR
+  )) {
+    const shadowRoot = container.shadowRoot
+    if (shadowRoot === null) {
+      continue
+    }
+
+    const scopedRoot = scopedDiffRootForReviewTarget(shadowRoot, target)
+
+    const line =
+      scopedRoot.querySelector<HTMLElement>(selector) ??
+      scopedRoot.querySelector<HTMLElement>(fallbackSelector)
+
+    if (line !== null) {
+      return line
+    }
+  }
+
+  return null
+}
+
+// Hunk jumps prefer showing the whole hunk when it can fit in the scroll body.
+const lineRangeFitsContainer = (
+  container: HTMLElement,
+  firstLine: HTMLElement,
+  lastLine: HTMLElement
+): boolean => {
+  if (container.clientHeight <= 0) {
+    return true
+  }
+
+  const firstRect = firstLine.getBoundingClientRect()
+  const lastRect = lastLine.getBoundingClientRect()
+  const top = Math.min(firstRect.top, lastRect.top)
+  const bottom = Math.max(firstRect.bottom, lastRect.bottom)
+
+  return bottom - top <= container.clientHeight
+}
+
+// Sticky Pierre headers can cover the first visible row after scrollIntoView,
+// so measure the active header before nudging rows clear of it.
+const stickyHeaderOffsetForDiffRoot = (root: HTMLElement): number => {
+  const headers = [
+    ...root.querySelectorAll<HTMLElement>('[data-diffs-header][data-sticky]'),
+  ]
+
+  for (const container of root.querySelectorAll<HTMLElement>(
+    PIERRE_DIFF_CONTAINER_SELECTOR
+  )) {
+    if (container.shadowRoot !== null) {
+      headers.push(
+        ...container.shadowRoot.querySelectorAll<HTMLElement>(
+          '[data-diffs-header][data-sticky]'
+        )
+      )
+    }
+  }
+
+  const height = Math.max(
+    0,
+    ...headers.map((header) => header.getBoundingClientRect().height)
+  )
+
+  return height === 0 ? 0 : height + STICKY_HEADER_SCROLL_GAP_PX
+}
+
+// Corrects scrollIntoView when the target row lands underneath the sticky
+// header instead of actually being visible.
+const revealLineBelowStickyHeader = (
+  container: HTMLElement,
+  line: HTMLElement,
+  reservePreviousRow: boolean
+): void => {
+  const stickyOffset = stickyHeaderOffsetForDiffRoot(container)
+  if (stickyOffset === 0) {
+    return
+  }
+
+  const containerTop = container.getBoundingClientRect().top
+  const lineRect = line.getBoundingClientRect()
+  const rowOffset = reservePreviousRow ? lineRect.height : 0
+  const overlap = containerTop + stickyOffset + rowOffset - lineRect.top
+
+  if (overlap > 0) {
+    container.scrollTop = Math.max(0, container.scrollTop - Math.ceil(overlap))
+  }
+}
+
+// Applies the small set of scroll rules the diff view needs: nearest for normal
+// moves, top/bottom at the file edges, then sticky-header correction.
+const scrollLineElementIntoView = (
+  container: HTMLElement,
+  line: HTMLElement,
+  targetIndex: number,
+  targetCount: number,
+  delta: number
+): void => {
+  if (delta === 0) {
+    line.scrollIntoView({ block: 'nearest', inline: 'nearest' })
+    revealLineBelowStickyHeader(container, line, false)
+
+    return
+  }
+
+  if (targetCount === 1) {
+    line.scrollIntoView({
+      block: delta > 0 ? 'end' : 'start',
+      inline: 'nearest',
+    })
+    revealLineBelowStickyHeader(container, line, delta < 0)
+
+    return
+  }
+
+  if (targetIndex === 0) {
+    line.scrollIntoView({ block: 'start', inline: 'nearest' })
+    revealLineBelowStickyHeader(container, line, delta < 0)
+
+    return
+  }
+
+  if (targetIndex === targetCount - 1) {
+    line.scrollIntoView({ block: 'end', inline: 'nearest' })
+    revealLineBelowStickyHeader(container, line, false)
+
+    return
+  }
+
+  line.scrollIntoView({ block: 'nearest', inline: 'nearest' })
+  revealLineBelowStickyHeader(container, line, delta < 0)
+}
+
+// After page scrolling, use the row closest to the viewport center as the new
+// current target so the next j/k move continues from what the user sees.
+const reviewTargetIndexClosestToViewportCenter = (
+  container: HTMLElement,
+  targets: ReviewNavigationTarget[]
+): number | null => {
+  const containerRect = container.getBoundingClientRect()
+  const containerHeight = containerRect.height || container.clientHeight
+  const viewportCenter = containerRect.top + containerHeight / 2
+  let bestIndex: number | null = null
+  let bestDistance = Number.POSITIVE_INFINITY
+
+  targets.forEach((target, index) => {
+    const line = findReviewTargetLineElement(container, target)
+    if (line === null) {
+      return
+    }
+
+    const lineRect = line.getBoundingClientRect()
+    const lineCenter = (lineRect.top + lineRect.bottom) / 2
+    const distance = Math.abs(lineCenter - viewportCenter)
+
+    if (distance < bestDistance) {
+      bestDistance = distance
+      bestIndex = index
+    }
+  })
+
+  return bestIndex
+}
+
+/**
+ * Keeps review navigation out of Panel.
+ *
+ * The hook builds one target list from the current file diff, tracks the current
+ * row plus whether it is visually active, and exposes plain callbacks for
+ * keyboard, pointer, hunk, and page-scroll navigation.
+ */
+export const useReviewTargetNavigation = ({
+  annotations,
+  clearTransientSelection,
+  diffStyle,
+  fileDiff,
+  fileKey,
+  onHunkIndexChange,
+  scrollBodyRef,
+}: UseReviewTargetNavigationOptions): UseReviewTargetNavigationReturn => {
+  const targets = useMemo(
+    (): ReviewNavigationTarget[] =>
+      fileDiff === null ? [] : reviewTargetsForDiff(fileDiff),
+    [fileDiff]
+  )
+
+  const [activeTargetIndex, setActiveTargetIndex] = useState(0)
+  const [active, setActive] = useState(false)
+
+  useEffect(() => {
+    setActiveTargetIndex(0)
+    setActive(false)
+  }, [fileKey])
+
+  useEffect(() => {
+    if (targets.length === 0) {
+      setActiveTargetIndex(0)
+      setActive(false)
+
+      return
+    }
+
+    setActiveTargetIndex((prev) => Math.min(prev, targets.length - 1))
+  }, [targets.length])
+
+  const currentTarget =
+    targets.length > 0
+      ? targets[Math.min(activeTargetIndex, targets.length - 1)]
+      : null
+
+  const activeTarget = active ? currentTarget : null
+
+  const selectedLines: SelectedLineRange | null =
+    active && currentTarget !== null
+      ? {
+          start: currentTarget.lineNumber,
+          end: currentTarget.lineNumber,
+          side: currentTarget.side,
+        }
+      : null
+
+  const currentTargetComment = useMemo(():
+    | DiffLineAnnotation<ReviewComment>
+    | undefined => {
+    if (currentTarget === null) {
+      return undefined
+    }
+
+    return annotations.find(
+      (annotation) =>
+        annotation.lineNumber === currentTarget.lineNumber &&
+        annotation.side === currentTarget.side
+    )
+  }, [currentTarget, annotations])
+
+  const activateTarget = useCallback(
+    (targetIndex: number): void => {
+      if (targetIndex < 0 || targetIndex >= targets.length) {
+        return
+      }
+
+      const target = targets[targetIndex]
+
+      clearTransientSelection()
+      setActive(true)
+      setActiveTargetIndex(targetIndex)
+      onHunkIndexChange(target.hunkIndex)
+    },
+    [clearTransientSelection, onHunkIndexChange, targets]
+  )
+
+  // Hides the visual cursor without forgetting the current row for shortcuts.
+  const deactivateTarget = useCallback((): void => {
+    setActive(false)
+  }, [])
+
+  // Scrolls one target row into view after keyboard, hunk, or side movement.
+  const scrollTargetIntoView = useCallback(
+    (
+      target: ReviewNavigationTarget,
+      targetIndex: number,
+      delta: number
+    ): void => {
+      const node = scrollBodyRef.current
+      if (node === null) {
+        return
+      }
+
+      const line = findReviewTargetLineElement(node, target)
+      if (line === null) {
+        return
+      }
+
+      scrollLineElementIntoView(
+        node,
+        line,
+        diffStyle === 'split'
+          ? reviewRowIndexForTarget(targets, targetIndex)
+          : targetIndex,
+        diffStyle === 'split'
+          ? reviewRowCountForTargets(targets)
+          : targets.length,
+        delta
+      )
+    },
+    [diffStyle, scrollBodyRef, targets]
+  )
+
+  // Hunk jumps show the first hunk row, then include the rest when it fits.
+  const scrollHunkIntoView = useCallback(
+    (hunkIndex: number): boolean => {
+      const node = scrollBodyRef.current
+      if (node === null) {
+        return false
+      }
+
+      const hunkTargets = targets.filter(
+        (target) => target.hunkIndex === hunkIndex
+      )
+      if (hunkTargets.length === 0) {
+        return false
+      }
+
+      const firstTarget = hunkTargets[0]
+      const lastTarget = hunkTargets[hunkTargets.length - 1]
+      const firstLine = findReviewTargetLineElement(node, firstTarget)
+      const lastLine = findReviewTargetLineElement(node, lastTarget)
+      if (firstLine === null || lastLine === null) {
+        return false
+      }
+
+      firstLine.scrollIntoView({ block: 'start', inline: 'nearest' })
+
+      if (
+        firstLine === lastLine ||
+        !lineRangeFitsContainer(node, firstLine, lastLine)
+      ) {
+        return true
+      }
+
+      lastLine.scrollIntoView({ block: 'nearest', inline: 'nearest' })
+
+      return true
+    },
+    [scrollBodyRef, targets]
+  )
+
+  // Hunk navigation lands on the first changed row when possible, not on
+  // unchanged context above the actual change.
+  const targetIndexForHunk = useCallback(
+    (hunkIndex: number): number => {
+      const changedTargetIndex = targets.findIndex(
+        (target) => target.hunkIndex === hunkIndex && target.changed
+      )
+
+      return changedTargetIndex === -1
+        ? targets.findIndex((target) => target.hunkIndex === hunkIndex)
+        : changedTargetIndex
+    },
+    [targets]
+  )
+
+  // Ctrl+U/D moves the scroll body first, then snaps the target to the visible
+  // row closest to the viewport center.
+  const activateTargetNearViewportCenter = useCallback((): void => {
+    const node = scrollBodyRef.current
+    if (node === null) {
+      return
+    }
+
+    const targetIndex = reviewTargetIndexClosestToViewportCenter(node, targets)
+
+    if (targetIndex !== null) {
+      activateTarget(targetIndex)
+    }
+  }, [activateTarget, scrollBodyRef, targets])
+
+  // j/k move by rendered row. In split mode, replacement pairs count as one row
+  // so h/l, not j/k, changes between old and new sides.
+  const moveTargetLine = useCallback(
+    (delta: number): void => {
+      if (targets.length === 0) {
+        return
+      }
+
+      clearTransientSelection()
+      setActive(true)
+      setActiveTargetIndex((prev) => {
+        const currentIndex = Math.min(prev, targets.length - 1)
+        const baseTarget = targets[currentIndex]
+        let rowTargetIndex = currentIndex + delta
+
+        if (rowTargetIndex < 0 || rowTargetIndex >= targets.length) {
+          return currentIndex
+        }
+
+        if (diffStyle === 'split') {
+          rowTargetIndex = currentIndex
+
+          while (
+            rowTargetIndex + delta >= 0 &&
+            rowTargetIndex + delta < targets.length
+          ) {
+            rowTargetIndex += delta
+
+            const rowTarget = targets[rowTargetIndex]
+            if (
+              rowTarget.hunkIndex !== baseTarget.hunkIndex ||
+              rowTarget.splitRowIndex !== baseTarget.splitRowIndex
+            ) {
+              break
+            }
+          }
+        }
+
+        const rowTarget = targets[rowTargetIndex]
+
+        const sameSideIndex = targets.findIndex(
+          (target) =>
+            target.hunkIndex === rowTarget.hunkIndex &&
+            target.splitRowIndex === rowTarget.splitRowIndex &&
+            target.side === baseTarget.side
+        )
+
+        const next =
+          diffStyle === 'split' && sameSideIndex !== -1
+            ? sameSideIndex
+            : rowTargetIndex
+        if (next === currentIndex) {
+          return currentIndex
+        }
+
+        const nextTarget = targets[next]
+        onHunkIndexChange(nextTarget.hunkIndex)
+        scrollTargetIntoView(nextTarget, next, delta)
+
+        return next
+      })
+    },
+    [
+      clearTransientSelection,
+      diffStyle,
+      onHunkIndexChange,
+      scrollTargetIntoView,
+      targets,
+    ]
+  )
+
+  // h/l switch sides within the same split row when both sides exist.
+  const moveTargetSide = useCallback(
+    (side: AnnotationSide): void => {
+      if (diffStyle !== 'split' || currentTarget === null) {
+        return
+      }
+
+      const nextIndex = targets.findIndex(
+        (target) =>
+          target.hunkIndex === currentTarget.hunkIndex &&
+          target.splitRowIndex === currentTarget.splitRowIndex &&
+          target.side === side
+      )
+
+      if (nextIndex === -1 || nextIndex === activeTargetIndex) {
+        return
+      }
+
+      const nextTarget = targets[nextIndex]
+      activateTarget(nextIndex)
+      scrollTargetIntoView(nextTarget, nextIndex, 0)
+    },
+    [
+      activeTargetIndex,
+      activateTarget,
+      currentTarget,
+      diffStyle,
+      scrollTargetIntoView,
+      targets,
+    ]
+  )
+
+  // Pointer hover updates the same current target used by shortcuts.
+  const handlePointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLElement>): void => {
+      const targetIndex = reviewTargetIndexFromPointerEvent(event, targets)
+
+      if (targetIndex !== null) {
+        activateTarget(targetIndex)
+      }
+    },
+    [activateTarget, targets]
+  )
+
+  return {
+    activeTarget,
+    activeTargetIndex,
+    activateTarget,
+    activateTargetNearViewportCenter,
+    currentTarget,
+    currentTargetComment,
+    deactivateTarget,
+    handlePointerMove,
+    moveTargetLine,
+    moveTargetSide,
+    scrollHunkIntoView,
+    scrollTargetIntoView,
+    selectedLines,
+    targetIndexForHunk,
+    targets,
+  }
+}

--- a/src/features/diff/services/pierreAdapter.test.ts
+++ b/src/features/diff/services/pierreAdapter.test.ts
@@ -1,7 +1,11 @@
 import { describe, test, expect } from 'vitest'
 import type { GetGitDiffResponse } from '../../../bindings/GetGitDiffResponse'
 import type { DiffHunk } from '../types'
-import { toPierreInputs, findRawDiffHunkIndex } from './pierreAdapter'
+import {
+  diffIdentityForResponse,
+  toPierreInputs,
+  findRawDiffHunkIndex,
+} from './pierreAdapter'
 
 const baseFileDiff = {
   filePath: 'src/foo.ts',
@@ -33,6 +37,11 @@ describe('toPierreInputs', (): void => {
     expect(result.oldFile.contents).toBe('before contents')
     expect(result.newFile.name).toBe('src/foo.ts')
     expect(result.newFile.contents).toBe('after contents')
+    expect(result.oldFile.cacheKey).toContain(result.identity)
+    expect(result.newFile.cacheKey).toContain(result.identity)
+    expect(result.diffCacheKey).toBe(
+      `${result.oldFile.cacheKey}:${result.newFile.cacheKey}`
+    )
   })
 
   test('renamed file uses each side actual path', (): void => {
@@ -63,6 +72,15 @@ describe('toPierreInputs', (): void => {
     expect(result.oldFile.contents).toBe('')
     expect(result.newFile.name).toBe('src/untracked.ts')
     expect(result.newFile.contents).toBe('new content')
+  })
+
+  test('identity changes when raw diff changes', (): void => {
+    const first = makeResponse({ rawDiff: '@@ -1 +1 @@\n-old\n+new\n' })
+    const second = makeResponse({ rawDiff: '@@ -1 +1 @@\n-old\n+newer\n' })
+
+    expect(diffIdentityForResponse(first)).not.toBe(
+      diffIdentityForResponse(second)
+    )
   })
 })
 

--- a/src/features/diff/services/pierreAdapter.ts
+++ b/src/features/diff/services/pierreAdapter.ts
@@ -4,6 +4,8 @@ import type { GetGitDiffResponse } from '../../../bindings/GetGitDiffResponse'
 export interface PierreFileInputs {
   oldFile: FileContents
   newFile: FileContents
+  identity: string
+  diffCacheKey: string
 }
 
 /**
@@ -14,6 +16,34 @@ export interface PierreFileInputs {
 export interface PierreHunkRange {
   newStart: number
   newLines: number
+}
+
+const hashString = (value: string): string => {
+  let hash = 2166136261
+
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i)
+    hash = Math.imul(hash, 16777619)
+  }
+
+  return (hash >>> 0).toString(36)
+}
+
+export const diffIdentityForResponse = (
+  response: GetGitDiffResponse
+): string => {
+  const { fileDiff, oldText, newText, rawDiff } = response
+
+  const source =
+    rawDiff.length > 0
+      ? rawDiff
+      : `${fileDiff.filePath}\0${oldText}\0${newText}`
+
+  return hashString(
+    `${fileDiff.filePath}\0${fileDiff.oldPath ?? ''}\0${
+      fileDiff.newPath ?? ''
+    }\0${source}`
+  )
 }
 
 /**
@@ -27,10 +57,23 @@ export const toPierreInputs = (
   const { fileDiff, oldText, newText } = response
   const newName = fileDiff.newPath ?? fileDiff.filePath
   const oldName = fileDiff.oldPath ?? newName
+  const identity = diffIdentityForResponse(response)
+  const oldCacheKey = `${identity}:old:${oldName}`
+  const newCacheKey = `${identity}:new:${newName}`
 
   return {
-    oldFile: { name: oldName, contents: oldText },
-    newFile: { name: newName, contents: newText },
+    oldFile: {
+      name: oldName,
+      contents: oldText,
+      cacheKey: oldCacheKey,
+    },
+    newFile: {
+      name: newName,
+      contents: newText,
+      cacheKey: newCacheKey,
+    },
+    identity,
+    diffCacheKey: `${oldCacheKey}:${newCacheKey}`,
   }
 }
 

--- a/src/features/workspace/components/DockPanel.test.tsx
+++ b/src/features/workspace/components/DockPanel.test.tsx
@@ -381,7 +381,9 @@ describe('DockPanel', () => {
       diff: null,
       loading: false,
       error: null,
+      latestDiffStatus: null,
       refetch: vi.fn(),
+      acceptLatestDiff: vi.fn(),
     })
   })
 
@@ -1420,7 +1422,9 @@ describe('DockPanel', () => {
       diff: inlineDiffResponse.fileDiff,
       loading: false,
       error: null,
+      latestDiffStatus: null,
       refetch: vi.fn(),
+      acceptLatestDiff: vi.fn(),
     })
 
     const { rerender } = render(<SharedFeedbackDockHarness tab="diff" open />)
@@ -1446,7 +1450,9 @@ describe('DockPanel', () => {
       diff: inlineDiffResponse.fileDiff,
       loading: false,
       error: null,
+      latestDiffStatus: null,
       refetch: vi.fn(),
+      acceptLatestDiff: vi.fn(),
     })
 
     const { rerender } = render(<SharedFeedbackDockHarness tab="diff" open />)
@@ -1471,7 +1477,9 @@ describe('DockPanel', () => {
       diff: inlineDiffResponse.fileDiff,
       loading: false,
       error: null,
+      latestDiffStatus: null,
       refetch: vi.fn(),
+      acceptLatestDiff: vi.fn(),
     })
 
     const { rerender } = render(<SharedFeedbackDockHarness tab="diff" open />)
@@ -1498,7 +1506,9 @@ describe('DockPanel', () => {
       diff: inlineDiffResponse.fileDiff,
       loading: false,
       error: null,
+      latestDiffStatus: null,
       refetch: vi.fn(),
+      acceptLatestDiff: vi.fn(),
     })
 
     const { rerender } = render(<SharedFeedbackDockHarness tab="diff" open />)
@@ -1526,7 +1536,9 @@ describe('DockPanel', () => {
       diff: diffLoaded ? inlineDiffResponse.fileDiff : null,
       loading: !diffLoaded,
       error: null,
+      latestDiffStatus: null,
       refetch: vi.fn(),
+      acceptLatestDiff: vi.fn(),
     }))
 
     const writePty = vi.fn().mockResolvedValue(undefined)


### PR DESCRIPTION
## Summary
- Stabilize active-file diff refresh so the visible diff stays put while background changes arrive.
- Show a single toolbar Refresh diff action only when newer file content is ready.
- Extract review-target navigation from Panel into useReviewTargetNavigation.
- Preserve comments/drafts and syntax-highlight cache behavior across manual refreshes.

## Test plan
- [x] User verified manual refresh behavior in the app.
- [x] Subagent code review using agents/code-reviewer.md: APPROVE, no findings.
- [x] Ponytail review: Lean already. Ship.
- [x] npx vitest run src/features/diff/hooks/useFileDiff.test.ts src/features/diff/Panel.test.tsx src/features/diff/components/toolbar/DiffChipToolbar.test.tsx
- [x] npx eslint src/features/diff/hooks/useFileDiff.ts src/features/diff/hooks/useFileDiff.test.ts src/features/diff/Panel.tsx src/features/diff/Panel.test.tsx src/features/diff/components/toolbar/DiffChipToolbar.tsx src/features/diff/components/toolbar/DiffChipToolbar.test.tsx
- [x] npm run type-check:generated
- [x] git diff --check
- [x] Pre-push npm test: 357 files passed, 4402 tests passed, 3 skipped