### PR TITLE
feat(tooltip): add native overlay burner tooltips

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -22,6 +22,7 @@ import { BACKEND_EVENT, BACKEND_INVOKE } from './ipc-channels'
 import {
   setupNativeOverlayIpc,
   type NativeOverlayController,
+  type NativeOverlayKind,
 } from './native-overlay'
 import { spawnSidecar, type Sidecar } from './sidecar'
 import { setupBrowserPaneIpc, type BrowserPaneController } from './browser-pane'
@@ -106,9 +107,12 @@ const resolveSidecarBin = (): string => {
   return path.resolve(__dirname, '..', 'target', 'debug', BINARY_NAME)
 }
 
-const withNativeOverlayMode = (url: string): string => {
+const withNativeOverlayMode = (
+  url: string,
+  mode: NativeOverlayKind
+): string => {
   const parsedUrl = new URL(url)
-  parsedUrl.searchParams.set('nativeOverlay', '1')
+  parsedUrl.searchParams.set('nativeOverlay', mode)
 
   return parsedUrl.toString()
 }
@@ -116,19 +120,20 @@ const withNativeOverlayMode = (url: string): string => {
 // The overlay window loads the same renderer bundle in a host-only mode. That
 // URL boots React; the actual menu rows/actions still arrive later as a
 // serialized NativeOverlayRequest over IPC.
-const resolveNativeOverlayRendererUrl = (): string => {
+const resolveNativeOverlayRendererUrl = (mode: NativeOverlayKind): string => {
   const devUrl = process.env.VITE_DEV_SERVER_URL
 
   if (app.isPackaged) {
-    return withNativeOverlayMode(`${APP_ORIGIN}/index.html`)
+    return withNativeOverlayMode(`${APP_ORIGIN}/index.html`, mode)
   }
 
   if (devUrl !== undefined && devUrl.length > 0) {
-    return withNativeOverlayMode(devUrl)
+    return withNativeOverlayMode(devUrl, mode)
   }
 
   return withNativeOverlayMode(
-    pathToFileURL(path.join(__dirname, '..', 'dist', 'index.html')).toString()
+    pathToFileURL(path.join(__dirname, '..', 'dist', 'index.html')).toString(),
+    mode
   )
 }
 
@@ -447,8 +452,11 @@ const setupApp = async (): Promise<void> => {
   }
   nativeOverlayController?.unregister()
   nativeOverlayController = null
+  // Menus are interactive, but tooltips must stay passive and sit above them;
+  // two overlay renderer layers keep those roles from stealing each other.
   nativeOverlayController = setupNativeOverlayIpc(
-    resolveNativeOverlayRendererUrl()
+    resolveNativeOverlayRendererUrl('menu'),
+    resolveNativeOverlayRendererUrl('tooltip')
   )
   setupDialogIpc(ipcMain)
 

--- a/electron/native-overlay-channels.ts
+++ b/electron/native-overlay-channels.ts
@@ -17,4 +17,6 @@ export const NATIVE_OVERLAY_RENDER = 'native-overlay:render'
 
 export const NATIVE_OVERLAY_CLEAR = 'native-overlay:clear'
 
+export const NATIVE_OVERLAY_KEYDOWN = 'native-overlay:keydown'
+
 export const NATIVE_OVERLAY_READY = 'native-overlay:ready'

--- a/electron/native-overlay.test.ts
+++ b/electron/native-overlay.test.ts
@@ -49,6 +49,7 @@ interface FakeWindow {
   loadURL: ReturnType<typeof vi.fn>
   on: ReturnType<typeof vi.fn>
   removeListener: ReturnType<typeof vi.fn>
+  isFocused: ReturnType<typeof vi.fn>
   isDestroyed: () => boolean
   emit: (event: string) => void
   reset: () => void
@@ -114,6 +115,7 @@ const electronMock = vi.hoisted(() => {
           )
         )
       }),
+      isFocused: vi.fn((): boolean => false),
       isDestroyed: (): boolean => destroyed,
       emit: (event: string): void => {
         const handlersForEvent = handlersByEvent.get(event) ?? []
@@ -137,6 +139,7 @@ const electronMock = vi.hoisted(() => {
         this.loadURL.mockClear()
         this.on.mockClear()
         this.removeListener.mockClear()
+        this.isFocused.mockClear()
       },
     } as FakeWindow
   }
@@ -210,7 +213,20 @@ const request = {
   },
 } as const
 
-const overlayUrl = 'vimeflow://app/index.html?nativeOverlay=1'
+const tooltipRequest = {
+  surfaceId: 'tooltip-1',
+  kind: 'tooltip',
+  anchorRect: { x: 90, y: 100, width: 30, height: 20 },
+  placement: 'top',
+  payload: {
+    kind: 'tooltip',
+    text: 'collapse status',
+    maxWidth: 320,
+  },
+} as const
+
+const menuOverlayUrl = 'vimeflow://app/index.html?nativeOverlay=menu'
+const tooltipOverlayUrl = 'vimeflow://app/index.html?nativeOverlay=tooltip'
 
 const handler = (channel: string): IpcHandler => {
   const registered = electronMock.handlers.get(channel)
@@ -221,8 +237,8 @@ const handler = (channel: string): IpcHandler => {
   return registered
 }
 
-const finishOverlayLoad = (): FakeWindow => {
-  const overlayWindow = electronMock.overlayWindows[0]
+const finishOverlayLoad = (index = 0): FakeWindow => {
+  const overlayWindow = electronMock.overlayWindows[index]
   overlayWindow.webContents.emit('did-finish-load')
 
   return overlayWindow
@@ -244,7 +260,11 @@ describe('NativeOverlayController', () => {
 
   beforeEach(() => {
     electronMock.reset()
-    controller = new NativeOverlayController({ overlayUrl, platform: 'darwin' })
+    controller = new NativeOverlayController({
+      menuOverlayUrl,
+      tooltipOverlayUrl,
+      platform: 'darwin',
+    })
     controller.register()
   })
 
@@ -263,10 +283,7 @@ describe('NativeOverlayController', () => {
 
     await acknowledgeOverlayReady(overlayWindow)
     await expect(openPromise).resolves.toEqual({ accepted: true })
-    expect(electronMock.BrowserWindow).toHaveBeenCalledOnce()
-    expect(electronMock.BrowserWindow).not.toHaveBeenCalledWith(
-      expect.objectContaining({ focusable: false })
-    )
+    expect(electronMock.BrowserWindow).toHaveBeenCalledTimes(2)
 
     expect(electronMock.BrowserWindow).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -274,6 +291,7 @@ describe('NativeOverlayController', () => {
         backgroundColor: '#00000000',
         frame: false,
         hasShadow: false,
+        focusable: false,
         parent: electronMock.owner,
         show: false,
         skipTaskbar: true,
@@ -284,6 +302,15 @@ describe('NativeOverlayController', () => {
           preload: expect.stringContaining('preload.mjs'),
           sandbox: true,
         }),
+      })
+    )
+
+    expect(electronMock.BrowserWindow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        acceptFirstMouse: false,
+        focusable: false,
+        parent: electronMock.owner,
+        transparent: true,
       })
     )
 
@@ -299,7 +326,10 @@ describe('NativeOverlayController', () => {
       overlayWindow.webContents.setWindowOpenHandler
     ).toHaveBeenCalledOnce()
 
-    expect(overlayWindow.loadURL).toHaveBeenCalledWith(overlayUrl)
+    expect(overlayWindow.loadURL).toHaveBeenCalledWith(menuOverlayUrl)
+    expect(electronMock.overlayWindows[1]?.loadURL).toHaveBeenCalledWith(
+      tooltipOverlayUrl
+    )
 
     expect(overlayWindow.setBounds).toHaveBeenCalledWith({
       x: 5,
@@ -308,10 +338,93 @@ describe('NativeOverlayController', () => {
       height: 500,
     })
     expect(overlayWindow.showInactive).toHaveBeenCalledOnce()
-    expect(overlayWindow.webContents.focus).toHaveBeenCalledOnce()
-    expect(overlayWindow.showInactive.mock.invocationCallOrder[0]).toBeLessThan(
-      overlayWindow.webContents.focus.mock.invocationCallOrder[0]
+    expect(overlayWindow.webContents.focus).not.toHaveBeenCalled()
+  })
+
+  test('opens passive tooltip layer without replacing an active menu', async () => {
+    const menuOpenPromise = handler(NATIVE_OVERLAY_OPEN)(
+      { sender: electronMock.owner.webContents },
+      request
     )
+    const menuWindow = finishOverlayLoad()
+    const tooltipWindow = finishOverlayLoad(1)
+    await acknowledgeOverlayReady(menuWindow)
+    await menuOpenPromise
+
+    menuWindow.webContents.send.mockClear()
+    menuWindow.hide.mockClear()
+    menuWindow.setIgnoreMouseEvents.mockClear()
+
+    const tooltipOpenPromise = handler(NATIVE_OVERLAY_OPEN)(
+      { sender: electronMock.owner.webContents },
+      tooltipRequest
+    )
+    await Promise.resolve()
+
+    expect(tooltipWindow.webContents.send).toHaveBeenCalledWith(
+      NATIVE_OVERLAY_RENDER,
+      tooltipRequest
+    )
+
+    await acknowledgeOverlayReady(tooltipWindow, tooltipRequest.surfaceId)
+    await expect(tooltipOpenPromise).resolves.toEqual({ accepted: true })
+
+    expect(menuWindow.webContents.send).not.toHaveBeenCalledWith(
+      NATIVE_OVERLAY_CLEAR
+    )
+    expect(menuWindow.hide).not.toHaveBeenCalled()
+    expect(menuWindow.setIgnoreMouseEvents).not.toHaveBeenCalledWith(true)
+    expect(tooltipWindow.setIgnoreMouseEvents).toHaveBeenLastCalledWith(true)
+    expect(tooltipWindow.webContents.focus).not.toHaveBeenCalled()
+    expect(tooltipWindow.setAlwaysOnTop).toHaveBeenCalledWith(
+      true,
+      'screen-saver'
+    )
+
+    handler(NATIVE_OVERLAY_CLOSE)(
+      { sender: electronMock.owner.webContents },
+      { surfaceId: tooltipRequest.surfaceId, reason: 'renderer' }
+    )
+
+    expect(tooltipWindow.webContents.send).toHaveBeenCalledWith(
+      NATIVE_OVERLAY_CLEAR
+    )
+    expect(tooltipWindow.hide).toHaveBeenCalledOnce()
+    expect(menuWindow.hide).not.toHaveBeenCalled()
+  })
+
+  test('parent close tears down active menu and tooltip layers together', async () => {
+    const menuOpenPromise = handler(NATIVE_OVERLAY_OPEN)(
+      { sender: electronMock.owner.webContents },
+      request
+    )
+    const menuWindow = finishOverlayLoad()
+    const tooltipWindow = finishOverlayLoad(1)
+    await acknowledgeOverlayReady(menuWindow)
+    await menuOpenPromise
+
+    const tooltipOpenPromise = handler(NATIVE_OVERLAY_OPEN)(
+      { sender: electronMock.owner.webContents },
+      tooltipRequest
+    )
+    await acknowledgeOverlayReady(tooltipWindow, tooltipRequest.surfaceId)
+    await tooltipOpenPromise
+
+    electronMock.owner.webContents.focus.mockClear()
+    electronMock.owner.emit('close')
+
+    expect(menuWindow.webContents.send).toHaveBeenCalledWith(
+      NATIVE_OVERLAY_CLEAR
+    )
+
+    expect(tooltipWindow.webContents.send).toHaveBeenCalledWith(
+      NATIVE_OVERLAY_CLEAR
+    )
+    expect(menuWindow.hide).toHaveBeenCalledOnce()
+    expect(tooltipWindow.hide).toHaveBeenCalledOnce()
+    expect(menuWindow.close).toHaveBeenCalledOnce()
+    expect(tooltipWindow.close).toHaveBeenCalledOnce()
+    expect(electronMock.owner.webContents.focus).not.toHaveBeenCalled()
   })
 
   test('accepts sectioned menu payloads with composite rows', async () => {
@@ -463,7 +576,7 @@ describe('NativeOverlayController', () => {
 
     await expect(openPromise).resolves.toEqual({ accepted: true })
     expect(overlayWindow.showInactive).toHaveBeenCalledOnce()
-    expect(overlayWindow.webContents.focus).toHaveBeenCalledOnce()
+    expect(overlayWindow.webContents.focus).not.toHaveBeenCalled()
   })
 
   test('does not hide a newer active overlay when an older render times out', async () => {
@@ -844,7 +957,11 @@ describe('NativeOverlayController', () => {
 
   test('rejects native overlay on non-macOS platforms', async () => {
     controller.unregister()
-    controller = new NativeOverlayController({ overlayUrl, platform: 'linux' })
+    controller = new NativeOverlayController({
+      menuOverlayUrl,
+      tooltipOverlayUrl,
+      platform: 'linux',
+    })
     controller.register()
 
     await expect(

--- a/electron/native-overlay.test.ts
+++ b/electron/native-overlay.test.ts
@@ -5,6 +5,7 @@ import {
   NATIVE_OVERLAY_CLEAR,
   NATIVE_OVERLAY_CLOSE,
   NATIVE_OVERLAY_CLOSED,
+  NATIVE_OVERLAY_KEYDOWN,
   NATIVE_OVERLAY_OPEN,
   NATIVE_OVERLAY_READY,
   NATIVE_OVERLAY_RENDER,
@@ -30,8 +31,11 @@ interface FakeWebContents {
   focus: ReturnType<typeof vi.fn>
   isDestroyed: ReturnType<typeof vi.fn>
   setWindowOpenHandler: ReturnType<typeof vi.fn>
+  on: ReturnType<typeof vi.fn>
+  removeListener: ReturnType<typeof vi.fn>
   once: (event: string, handler: EventHandler) => void
   emit: (event: string, ...args: unknown[]) => void
+  reset: () => void
 }
 
 interface FakeWindow {
@@ -58,6 +62,7 @@ interface FakeWindow {
 const electronMock = vi.hoisted(() => {
   const createWebContents = (id: number): FakeWebContents => {
     const onceHandlers = new Map<string, EventHandler[]>()
+    const handlersByEvent = new Map<string, EventHandler[]>()
 
     return {
       id,
@@ -65,13 +70,33 @@ const electronMock = vi.hoisted(() => {
       focus: vi.fn(),
       isDestroyed: vi.fn(() => false),
       setWindowOpenHandler: vi.fn(),
+      on: vi.fn((event: string, handler: EventHandler): void => {
+        handlersByEvent.set(event, [
+          ...(handlersByEvent.get(event) ?? []),
+          handler,
+        ])
+      }),
+      removeListener: vi.fn((event: string, handler: EventHandler): void => {
+        handlersByEvent.set(
+          event,
+          (handlersByEvent.get(event) ?? []).filter(
+            (candidate) => candidate !== handler
+          )
+        )
+      }),
       once: (event, handler): void => {
         onceHandlers.set(event, [...(onceHandlers.get(event) ?? []), handler])
       },
       emit: (event, ...args): void => {
+        const persistentHandlersForEvent = handlersByEvent.get(event) ?? []
+        persistentHandlersForEvent.forEach((handler) => handler(...args))
         const handlersForEvent = onceHandlers.get(event) ?? []
         onceHandlers.delete(event)
         handlersForEvent.forEach((handler) => handler(...args))
+      },
+      reset: (): void => {
+        handlersByEvent.clear()
+        onceHandlers.clear()
       },
     }
   }
@@ -128,6 +153,9 @@ const electronMock = vi.hoisted(() => {
         webContents.focus.mockClear()
         webContents.isDestroyed.mockClear()
         webContents.setWindowOpenHandler.mockClear()
+        webContents.on.mockClear()
+        webContents.removeListener.mockClear()
+        webContents.reset()
         this.getContentBounds.mockClear()
         this.setBounds.mockClear()
         this.setAlwaysOnTop.mockClear()
@@ -391,6 +419,48 @@ describe('NativeOverlayController', () => {
     )
     expect(tooltipWindow.hide).toHaveBeenCalledOnce()
     expect(menuWindow.hide).not.toHaveBeenCalled()
+  })
+
+  test('relays owner menu keydown events to the non-focusable menu layer', async () => {
+    const openPromise = handler(NATIVE_OVERLAY_OPEN)(
+      { sender: electronMock.owner.webContents },
+      request
+    )
+    const menuWindow = finishOverlayLoad()
+    await acknowledgeOverlayReady(menuWindow)
+    await openPromise
+
+    menuWindow.webContents.send.mockClear()
+    const event = { preventDefault: vi.fn() }
+
+    electronMock.owner.webContents.emit('before-input-event', event, {
+      type: 'keyDown',
+      key: 'ArrowDown',
+      code: 'ArrowDown',
+      isAutoRepeat: true,
+      isComposing: false,
+      shift: true,
+      control: false,
+      alt: false,
+      meta: false,
+      location: 0,
+      modifiers: ['shift', 'isAutoRepeat'],
+    })
+
+    expect(event.preventDefault).toHaveBeenCalledOnce()
+    expect(menuWindow.webContents.send).toHaveBeenCalledWith(
+      NATIVE_OVERLAY_KEYDOWN,
+      {
+        surfaceId: request.surfaceId,
+        key: 'ArrowDown',
+        code: 'ArrowDown',
+        altKey: false,
+        ctrlKey: false,
+        metaKey: false,
+        shiftKey: true,
+        repeat: true,
+      }
+    )
   })
 
   test('parent close tears down active menu and tooltip layers together', async () => {

--- a/electron/native-overlay.ts
+++ b/electron/native-overlay.ts
@@ -1,8 +1,10 @@
 import {
   BrowserWindow,
   ipcMain,
+  type Event as ElectronEvent,
   type IpcMain,
   type IpcMainInvokeEvent,
+  type Input,
   type WebContents,
 } from 'electron'
 import path from 'node:path'
@@ -13,6 +15,7 @@ import {
   NATIVE_OVERLAY_CLEAR,
   NATIVE_OVERLAY_CLOSE,
   NATIVE_OVERLAY_CLOSED,
+  NATIVE_OVERLAY_KEYDOWN,
   NATIVE_OVERLAY_OPEN,
   NATIVE_OVERLAY_READY,
   NATIVE_OVERLAY_RENDER,
@@ -151,6 +154,17 @@ interface NativeOverlayReadyEvent {
   surfaceId: string
 }
 
+interface NativeOverlayKeyboardEvent {
+  surfaceId: string
+  key: string
+  code: string
+  altKey: boolean
+  ctrlKey: boolean
+  metaKey: boolean
+  shiftKey: boolean
+  repeat: boolean
+}
+
 interface NativeOverlayOpenResult {
   accepted: boolean
   reason?: string
@@ -171,6 +185,7 @@ interface NativeOverlayRecord {
   parentMinimized: () => void
   parentClosing: () => void
   parentClosed: () => void
+  ownerBeforeInput: (event: ElectronEvent, input: Input) => void
   activeSurfaceId: string | null
   activeTooltipSurfaceId: string | null
 }
@@ -193,6 +208,27 @@ interface IpcMainLike {
 }
 
 const OVERLAY_RENDER_TIMEOUT_MS = 1000
+
+const MENU_KEY_MAP: Readonly<Partial<Record<string, string>>> = {
+  ' ': ' ',
+  ArrowDown: 'ArrowDown',
+  ArrowLeft: 'ArrowLeft',
+  ArrowRight: 'ArrowRight',
+  ArrowUp: 'ArrowUp',
+  Down: 'ArrowDown',
+  End: 'End',
+  Enter: 'Enter',
+  Escape: 'Escape',
+  Home: 'Home',
+  Left: 'ArrowLeft',
+  PageDown: 'PageDown',
+  PageUp: 'PageUp',
+  Return: 'Enter',
+  Right: 'ArrowRight',
+  Space: ' ',
+  Tab: 'Tab',
+  Up: 'ArrowUp',
+}
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -348,6 +384,31 @@ const isActionResultEvent = (
 
 const isReadyEvent = (value: unknown): value is NativeOverlayReadyEvent =>
   isRecord(value) && isString(value.surfaceId)
+
+const menuKeyboardEventFromInput = (
+  surfaceId: string,
+  input: Input
+): NativeOverlayKeyboardEvent | null => {
+  if (input.type !== 'keyDown') {
+    return null
+  }
+
+  const key = MENU_KEY_MAP[input.key] ?? MENU_KEY_MAP[input.code]
+  if (key === undefined) {
+    return null
+  }
+
+  return {
+    surfaceId,
+    key,
+    code: input.code,
+    altKey: input.alt,
+    ctrlKey: input.control,
+    metaKey: input.meta,
+    shiftKey: input.shift,
+    repeat: input.isAutoRepeat,
+  }
+}
 
 export class NativeOverlayController {
   private readonly menuOverlayUrl: string
@@ -683,19 +744,31 @@ export class NativeOverlayController {
       }
     }
 
-    const parentBlurred = (): void => {
-      const record = this.overlays.get(parent.id)
+    const ownerBeforeInput = (event: ElectronEvent, input: Input): void => {
+      const activeRecord = this.overlays.get(parent.id)
       if (
-        record &&
-        ((!record.menu.window.isDestroyed() &&
-          record.menu.window.isFocused()) ||
-          (!record.tooltip.window.isDestroyed() &&
-            record.tooltip.window.isFocused()))
+        activeRecord?.activeSurfaceId === undefined ||
+        activeRecord.activeSurfaceId === null
       ) {
         return
       }
 
-      closeForOwnerDeactivation()
+      const surfaceId = activeRecord.activeSurfaceId
+      const surface = this.surfaces.get(surfaceId)
+      if (surface?.kind !== 'menu') {
+        return
+      }
+
+      const keyEvent = menuKeyboardEventFromInput(surfaceId, input)
+      if (keyEvent === null) {
+        return
+      }
+
+      event.preventDefault()
+      activeRecord.menu.window.webContents.send(
+        NATIVE_OVERLAY_KEYDOWN,
+        keyEvent
+      )
     }
 
     const parentClosing = (): void => {
@@ -718,22 +791,24 @@ export class NativeOverlayController {
 
     parent.on('resize', syncBounds)
     parent.on('move', syncBounds)
-    parent.on('blur', parentBlurred)
+    parent.on('blur', closeForOwnerDeactivation)
     parent.on('hide', closeForOwnerDeactivation)
     parent.on('minimize', closeForOwnerDeactivation)
     parent.on('close', parentClosing)
     parent.on('closed', parentClosed)
+    parent.webContents.on('before-input-event', ownerBeforeInput)
 
     const record: NativeOverlayRecord = {
       parent,
       menu,
       tooltip,
       syncBounds,
-      parentBlurred,
+      parentBlurred: closeForOwnerDeactivation,
       parentHidden: closeForOwnerDeactivation,
       parentMinimized: closeForOwnerDeactivation,
       parentClosing,
       parentClosed,
+      ownerBeforeInput,
       activeSurfaceId: null,
       activeTooltipSurfaceId: null,
     }
@@ -772,6 +847,10 @@ export class NativeOverlayController {
     record.parent.removeListener('minimize', record.parentMinimized)
     record.parent.removeListener('close', record.parentClosing)
     record.parent.removeListener('closed', record.parentClosed)
+    record.parent.webContents.removeListener(
+      'before-input-event',
+      record.ownerBeforeInput
+    )
     this.overlays.delete(record.parent.id)
 
     if (!record.menu.window.isDestroyed()) {

--- a/electron/native-overlay.ts
+++ b/electron/native-overlay.ts
@@ -22,7 +22,9 @@ import {
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
-type NativeOverlayKind = 'menu' | 'tooltip' | 'popover' | 'dialog'
+// TODO: add popover/dialog here when they get serializable native overlay
+// payloads and host renderers.
+export type NativeOverlayKind = 'menu' | 'tooltip'
 
 type NativeOverlayCloseReason =
   | 'outside'
@@ -101,6 +103,16 @@ interface NativeOverlayMenuPayload {
   sections?: NativeOverlayMenuSection[]
 }
 
+interface NativeOverlayTooltipPayload {
+  kind: 'tooltip'
+  text: string
+  maxWidth?: number
+}
+
+type SerializableOverlayPayload =
+  | NativeOverlayMenuPayload
+  | NativeOverlayTooltipPayload
+
 interface NativeOverlayThemeSnapshot {
   id?: string
   colorScheme?: string
@@ -112,7 +124,7 @@ interface NativeOverlayRequest {
   kind: NativeOverlayKind
   anchorRect: NativeOverlayRect
   placement: string
-  payload: NativeOverlayMenuPayload
+  payload: SerializableOverlayPayload
   theme?: NativeOverlayThemeSnapshot
 }
 
@@ -144,10 +156,15 @@ interface NativeOverlayOpenResult {
   reason?: string
 }
 
+interface NativeOverlayLayerRecord {
+  window: BrowserWindow
+  ready: Promise<void>
+}
+
 interface NativeOverlayRecord {
   parent: BrowserWindow
-  overlayWindow: BrowserWindow
-  ready: Promise<void>
+  menu: NativeOverlayLayerRecord
+  tooltip: NativeOverlayLayerRecord
   syncBounds: () => void
   parentBlurred: () => void
   parentHidden: () => void
@@ -155,15 +172,18 @@ interface NativeOverlayRecord {
   parentClosing: () => void
   parentClosed: () => void
   activeSurfaceId: string | null
+  activeTooltipSurfaceId: string | null
 }
 
 interface NativeOverlaySurface {
   owner: WebContents
   parentId: number
+  kind: NativeOverlayKind
 }
 
 interface NativeOverlayControllerOptions {
-  overlayUrl: string
+  menuOverlayUrl: string
+  tooltipOverlayUrl: string
   platform?: NodeJS.Platform
 }
 
@@ -265,21 +285,36 @@ const isMenuPayload = (value: unknown): value is NativeOverlayMenuPayload =>
   (value.surfaceTone === undefined || typeof value.surfaceTone === 'string') &&
   (hasMenuItems(value.items) || hasMenuSections(value.sections))
 
+const isTooltipPayload = (
+  value: unknown
+): value is NativeOverlayTooltipPayload =>
+  isRecord(value) &&
+  value.kind === 'tooltip' &&
+  isString(value.text) &&
+  (value.maxWidth === undefined || isFiniteNumber(value.maxWidth))
+
 const isThemeSnapshot = (value: unknown): value is NativeOverlayThemeSnapshot =>
   isRecord(value) &&
   (value.id === undefined || typeof value.id === 'string') &&
   (value.colorScheme === undefined || typeof value.colorScheme === 'string') &&
   isStringRecord(value.variables)
 
+const isSerializablePayloadForKind = (
+  kind: unknown,
+  payload: unknown
+): payload is SerializableOverlayPayload =>
+  (kind === 'menu' && isMenuPayload(payload)) ||
+  (kind === 'tooltip' && isTooltipPayload(payload))
+
 const isNativeOverlayRequest = (
   value: unknown
 ): value is NativeOverlayRequest =>
   isRecord(value) &&
   isString(value.surfaceId) &&
-  value.kind === 'menu' &&
+  (value.kind === 'menu' || value.kind === 'tooltip') &&
   isRect(value.anchorRect) &&
   isString(value.placement) &&
-  isMenuPayload(value.payload) &&
+  isSerializablePayloadForKind(value.kind, value.payload) &&
   (value.theme === undefined || isThemeSnapshot(value.theme))
 
 const isCloseReason = (value: unknown): value is NativeOverlayCloseReason =>
@@ -315,7 +350,8 @@ const isReadyEvent = (value: unknown): value is NativeOverlayReadyEvent =>
   isRecord(value) && isString(value.surfaceId)
 
 export class NativeOverlayController {
-  private readonly overlayUrl: string
+  private readonly menuOverlayUrl: string
+  private readonly tooltipOverlayUrl: string
   private readonly platform: NodeJS.Platform
   private readonly overlays = new Map<number, NativeOverlayRecord>()
   private readonly surfaces = new Map<string, NativeOverlaySurface>()
@@ -323,7 +359,8 @@ export class NativeOverlayController {
   private registeredIpc: IpcMainLike | null = null
 
   constructor(options: NativeOverlayControllerOptions) {
-    this.overlayUrl = options.overlayUrl
+    this.menuOverlayUrl = options.menuOverlayUrl
+    this.tooltipOverlayUrl = options.tooltipOverlayUrl
     this.platform = options.platform ?? process.platform
   }
 
@@ -381,31 +418,82 @@ export class NativeOverlayController {
     }
 
     const record = this.getOrCreateOverlayRecord(parent)
+
+    if (payload.kind === 'tooltip') {
+      return this.openTooltipSurface(event.sender, parent, record, payload)
+    }
+
+    return this.openMenuSurface(event.sender, parent, record, payload)
+  }
+
+  private async openMenuSurface(
+    owner: WebContents,
+    parent: BrowserWindow,
+    record: NativeOverlayRecord,
+    payload: NativeOverlayRequest
+  ): Promise<NativeOverlayOpenResult> {
     if (record.activeSurfaceId !== null) {
       this.closeSurface(record.activeSurfaceId, 'replaced', true)
     }
 
-    await record.ready
+    await record.menu.ready
     record.syncBounds()
-    record.overlayWindow.setIgnoreMouseEvents(false)
-    record.overlayWindow.showInactive()
-    record.overlayWindow.webContents.focus()
+    record.menu.window.setIgnoreMouseEvents(false)
+    record.menu.window.showInactive()
     // Ghostty is an AppKit NSView, so ordinary Electron window ordering can
     // still land behind it. The screen-saver level reliably places this
     // transparent overlay window above that native surface while it is open.
-    record.overlayWindow.setAlwaysOnTop(true, 'screen-saver')
-    record.overlayWindow.moveTop()
+    record.menu.window.setAlwaysOnTop(true, 'screen-saver')
+    record.menu.window.moveTop()
     record.activeSurfaceId = payload.surfaceId
     this.surfaces.set(payload.surfaceId, {
-      owner: event.sender,
+      owner,
       parentId: parent.id,
+      kind: 'menu',
     })
 
     const readyPromise = this.waitForReady(payload.surfaceId)
-    record.overlayWindow.webContents.send(NATIVE_OVERLAY_RENDER, payload)
+    record.menu.window.webContents.send(NATIVE_OVERLAY_RENDER, payload)
     const ready = await readyPromise
     if (!ready || record.activeSurfaceId !== payload.surfaceId) {
       this.closeSurface(payload.surfaceId, 'renderer', false)
+
+      return { accepted: false, reason: 'render-timeout' }
+    }
+
+    return { accepted: true }
+  }
+
+  private async openTooltipSurface(
+    owner: WebContents,
+    parent: BrowserWindow,
+    record: NativeOverlayRecord,
+    payload: NativeOverlayRequest
+  ): Promise<NativeOverlayOpenResult> {
+    if (record.activeTooltipSurfaceId !== null) {
+      this.closeSurface(record.activeTooltipSurfaceId, 'replaced', true, false)
+    }
+
+    await record.tooltip.ready
+    record.syncBounds()
+    record.tooltip.window.setIgnoreMouseEvents(true)
+    record.tooltip.window.showInactive()
+    // Tooltip overlay is intentionally passive and topmost. It shares the same
+    // z-order fix as menus but never takes focus or pointer events from them.
+    record.tooltip.window.setAlwaysOnTop(true, 'screen-saver')
+    record.tooltip.window.moveTop()
+    record.activeTooltipSurfaceId = payload.surfaceId
+    this.surfaces.set(payload.surfaceId, {
+      owner,
+      parentId: parent.id,
+      kind: 'tooltip',
+    })
+
+    const readyPromise = this.waitForReady(payload.surfaceId)
+    record.tooltip.window.webContents.send(NATIVE_OVERLAY_RENDER, payload)
+    const ready = await readyPromise
+    if (!ready || record.activeTooltipSurfaceId !== payload.surfaceId) {
+      this.closeSurface(payload.surfaceId, 'renderer', false, false)
 
       return { accepted: false, reason: 'render-timeout' }
     }
@@ -464,6 +552,10 @@ export class NativeOverlayController {
       return
     }
 
+    if (surface.kind !== 'menu') {
+      return
+    }
+
     const owner = surface.owner
     if (payload.closeOnSelect !== false) {
       this.closeSurface(payload.surfaceId, 'action', false)
@@ -487,20 +579,24 @@ export class NativeOverlayController {
       return
     }
 
-    const record = this.overlays.get(surface.parentId)
-    if (!record || record.overlayWindow.isDestroyed()) {
+    if (surface.kind !== 'menu') {
       return
     }
 
-    record.overlayWindow.webContents.send(NATIVE_OVERLAY_ACTION_RESULT, payload)
-  }
-
-  private getOrCreateOverlayRecord(parent: BrowserWindow): NativeOverlayRecord {
-    const existing = this.overlays.get(parent.id)
-    if (existing) {
-      return existing
+    const record = this.overlays.get(surface.parentId)
+    if (!record || record.menu.window.isDestroyed()) {
+      return
     }
 
+    record.menu.window.webContents.send(NATIVE_OVERLAY_ACTION_RESULT, payload)
+  }
+
+  private createOverlayLayer(
+    parent: BrowserWindow,
+    url: string,
+    focusable: boolean,
+    acceptFirstMouse: boolean
+  ): NativeOverlayLayerRecord {
     const overlayWindow = new BrowserWindow({
       parent,
       show: false,
@@ -514,8 +610,8 @@ export class NativeOverlayController {
       maximizable: false,
       fullscreenable: false,
       skipTaskbar: true,
-      acceptFirstMouse: true,
-      focusable: true,
+      acceptFirstMouse,
+      focusable,
       webPreferences: {
         contextIsolation: true,
         nodeIntegration: false,
@@ -528,21 +624,78 @@ export class NativeOverlayController {
       overlayWindow.webContents.once('did-finish-load', () => resolve())
     })
 
+    overlayWindow.setIgnoreMouseEvents(true)
+    overlayWindow.webContents.setWindowOpenHandler(() => ({ action: 'deny' }))
+    void overlayWindow.loadURL(url)
+
+    return { window: overlayWindow, ready }
+  }
+
+  private getOrCreateOverlayRecord(parent: BrowserWindow): NativeOverlayRecord {
+    const existing = this.overlays.get(parent.id)
+    if (existing) {
+      return existing
+    }
+
+    // NativeOverlay owns two transparent child windows: an interactive menu
+    // layer and a passive tooltip layer above it. Keeping them separate lets a
+    // hover tooltip appear while a menu is open without replacing that menu.
+    const menu = this.createOverlayLayer(
+      parent,
+      this.menuOverlayUrl,
+      false,
+      true
+    )
+
+    const tooltip = this.createOverlayLayer(
+      parent,
+      this.tooltipOverlayUrl,
+      false,
+      false
+    )
+
     const syncBounds = (): void => {
-      if (overlayWindow.isDestroyed() || parent.isDestroyed()) {
+      if (parent.isDestroyed()) {
         return
       }
 
-      overlayWindow.setBounds(parent.getContentBounds())
+      const bounds = parent.getContentBounds()
+      if (!menu.window.isDestroyed()) {
+        menu.window.setBounds(bounds)
+      }
+      if (!tooltip.window.isDestroyed()) {
+        tooltip.window.setBounds(bounds)
+      }
     }
 
     const closeForOwnerDeactivation = (): void => {
-      const activeSurfaceId = this.overlays.get(parent.id)?.activeSurfaceId
-      if (activeSurfaceId === undefined || activeSurfaceId === null) {
+      const record = this.overlays.get(parent.id)
+      if (!record) {
         return
       }
 
-      this.closeSurface(activeSurfaceId, 'outside', true, false)
+      if (record.activeSurfaceId !== null) {
+        this.closeSurface(record.activeSurfaceId, 'outside', true, false)
+      }
+
+      if (record.activeTooltipSurfaceId !== null) {
+        this.closeSurface(record.activeTooltipSurfaceId, 'outside', true, false)
+      }
+    }
+
+    const parentBlurred = (): void => {
+      const record = this.overlays.get(parent.id)
+      if (
+        record &&
+        ((!record.menu.window.isDestroyed() &&
+          record.menu.window.isFocused()) ||
+          (!record.tooltip.window.isDestroyed() &&
+            record.tooltip.window.isFocused()))
+      ) {
+        return
+      }
+
+      closeForOwnerDeactivation()
     }
 
     const parentClosing = (): void => {
@@ -563,28 +716,26 @@ export class NativeOverlayController {
       this.destroyOverlayRecord(record, 'owner-closed', true)
     }
 
-    overlayWindow.setIgnoreMouseEvents(true)
-    overlayWindow.webContents.setWindowOpenHandler(() => ({ action: 'deny' }))
     parent.on('resize', syncBounds)
     parent.on('move', syncBounds)
-    parent.on('blur', closeForOwnerDeactivation)
+    parent.on('blur', parentBlurred)
     parent.on('hide', closeForOwnerDeactivation)
     parent.on('minimize', closeForOwnerDeactivation)
     parent.on('close', parentClosing)
     parent.on('closed', parentClosed)
-    void overlayWindow.loadURL(this.overlayUrl)
 
     const record: NativeOverlayRecord = {
       parent,
-      overlayWindow,
-      ready,
+      menu,
+      tooltip,
       syncBounds,
-      parentBlurred: closeForOwnerDeactivation,
+      parentBlurred,
       parentHidden: closeForOwnerDeactivation,
       parentMinimized: closeForOwnerDeactivation,
       parentClosing,
       parentClosed,
       activeSurfaceId: null,
+      activeTooltipSurfaceId: null,
     }
 
     this.overlays.set(parent.id, record)
@@ -605,6 +756,15 @@ export class NativeOverlayController {
       this.closeSurface(record.activeSurfaceId, reason, notifyOwner, false)
     }
 
+    if (record.activeTooltipSurfaceId !== null) {
+      this.closeSurface(
+        record.activeTooltipSurfaceId,
+        reason,
+        notifyOwner,
+        false
+      )
+    }
+
     record.parent.removeListener('resize', record.syncBounds)
     record.parent.removeListener('move', record.syncBounds)
     record.parent.removeListener('blur', record.parentBlurred)
@@ -614,8 +774,12 @@ export class NativeOverlayController {
     record.parent.removeListener('closed', record.parentClosed)
     this.overlays.delete(record.parent.id)
 
-    if (!record.overlayWindow.isDestroyed()) {
-      record.overlayWindow.close()
+    if (!record.menu.window.isDestroyed()) {
+      record.menu.window.close()
+    }
+
+    if (!record.tooltip.window.isDestroyed()) {
+      record.tooltip.window.close()
     }
   }
 
@@ -654,22 +818,34 @@ export class NativeOverlayController {
     }
 
     const record = this.overlays.get(surface.parentId)
-    const isActiveSurface = record?.activeSurfaceId === surfaceId
+
+    const isActiveSurface =
+      surface.kind === 'tooltip'
+        ? record?.activeTooltipSurfaceId === surfaceId
+        : record?.activeSurfaceId === surfaceId
+
     this.surfaces.delete(surfaceId)
     this.resolvePendingReady(surfaceId, false)
 
     if (record && isActiveSurface) {
-      record.activeSurfaceId = null
-      if (!record.overlayWindow.isDestroyed()) {
-        record.overlayWindow.webContents.send(NATIVE_OVERLAY_CLEAR)
-        record.overlayWindow.hide()
-        record.overlayWindow.setAlwaysOnTop(false)
-        record.overlayWindow.setIgnoreMouseEvents(true)
+      const overlayWindow =
+        surface.kind === 'tooltip' ? record.tooltip.window : record.menu.window
+      if (surface.kind === 'tooltip') {
+        record.activeTooltipSurfaceId = null
+      } else {
+        record.activeSurfaceId = null
+      }
+
+      if (!overlayWindow.isDestroyed()) {
+        overlayWindow.webContents.send(NATIVE_OVERLAY_CLEAR)
+        overlayWindow.hide()
+        overlayWindow.setAlwaysOnTop(false)
+        overlayWindow.setIgnoreMouseEvents(true)
       }
     }
 
     if (!surface.owner.isDestroyed()) {
-      if (isActiveSurface && restoreOwnerFocus) {
+      if (surface.kind === 'menu' && isActiveSurface && restoreOwnerFocus) {
         surface.owner.focus()
       }
       if (notifyOwner) {
@@ -688,7 +864,11 @@ export class NativeOverlayController {
     }
 
     const record = this.overlays.get(surface.parentId)
-    if (record?.overlayWindow.webContents !== sender) {
+
+    const overlayWindow =
+      surface.kind === 'tooltip' ? record?.tooltip.window : record?.menu.window
+
+    if (overlayWindow?.webContents !== sender) {
       return null
     }
 
@@ -705,12 +885,13 @@ export class NativeOverlayController {
     }
 
     const record = this.overlays.get(surface.parentId)
+
+    const overlayWindow =
+      surface.kind === 'tooltip' ? record?.tooltip.window : record?.menu.window
+
     // Close is intentionally dual-caller: the owner renderer cancels local
     // sessions, while the overlay host closes on outside-press or Escape.
-    if (
-      surface.owner !== sender &&
-      record?.overlayWindow.webContents !== sender
-    ) {
+    if (surface.owner !== sender && overlayWindow?.webContents !== sender) {
       return null
     }
 
@@ -731,9 +912,13 @@ export class NativeOverlayController {
 }
 
 export const setupNativeOverlayIpc = (
-  overlayUrl: string
+  menuOverlayUrl: string,
+  tooltipOverlayUrl: string
 ): NativeOverlayController => {
-  const controller = new NativeOverlayController({ overlayUrl })
+  const controller = new NativeOverlayController({
+    menuOverlayUrl,
+    tooltipOverlayUrl,
+  })
   controller.register(ipcMain)
 
   return controller

--- a/electron/preload.test.ts
+++ b/electron/preload.test.ts
@@ -24,6 +24,7 @@ import {
   NATIVE_OVERLAY_CLEAR,
   NATIVE_OVERLAY_CLOSE,
   NATIVE_OVERLAY_CLOSED,
+  NATIVE_OVERLAY_KEYDOWN,
   NATIVE_OVERLAY_OPEN,
   NATIVE_OVERLAY_READY,
   NATIVE_OVERLAY_RENDER,
@@ -273,6 +274,7 @@ describe('preload nativeOverlay wiring', () => {
     ['onRender', NATIVE_OVERLAY_RENDER],
     ['onClear', NATIVE_OVERLAY_CLEAR],
     ['onActionResult', NATIVE_OVERLAY_ACTION_RESULT],
+    ['onKeyDown', NATIVE_OVERLAY_KEYDOWN],
   ])(
     'host %s registers on the correct channel',
     (method: string, channel: string) => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -12,6 +12,7 @@ import {
   NATIVE_OVERLAY_CLEAR,
   NATIVE_OVERLAY_CLOSE,
   NATIVE_OVERLAY_CLOSED,
+  NATIVE_OVERLAY_KEYDOWN,
   NATIVE_OVERLAY_OPEN,
   NATIVE_OVERLAY_READY,
   NATIVE_OVERLAY_RENDER,
@@ -290,6 +291,17 @@ contextBridge.exposeInMainWorld('vimeflow', {
 
       return (): void => {
         ipcRenderer.off(NATIVE_OVERLAY_ACTION_RESULT, handler)
+      }
+    },
+    onKeyDown: (callback: (payload: unknown) => void): (() => void) => {
+      const handler = (_event: IpcRendererEvent, payload: unknown): void => {
+        callback(payload)
+      }
+
+      ipcRenderer.on(NATIVE_OVERLAY_KEYDOWN, handler)
+
+      return (): void => {
+        ipcRenderer.off(NATIVE_OVERLAY_KEYDOWN, handler)
       }
     },
   },

--- a/src/components/Menu.test.tsx
+++ b/src/components/Menu.test.tsx
@@ -4,9 +4,15 @@ import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import {
   __resetNativeOverlayForTest,
+  type NativeOverlayMenuPayload,
   type NativeOverlayRequest,
 } from '@/components/base/floating/nativeOverlay'
 import { Menu } from './Menu'
+
+type NativeOverlayMenuRequest = NativeOverlayRequest & {
+  kind: 'menu'
+  payload: NativeOverlayMenuPayload
+}
 
 let restorePlatform: (() => void) | null = null
 
@@ -71,6 +77,17 @@ const installNativeOverlayBridge = (): {
       closeListener?.(event)
     },
   }
+}
+
+const nativeMenuRequestAt = (
+  open: ReturnType<typeof vi.fn>,
+  index = 0
+): NativeOverlayMenuRequest => {
+  const request = open.mock.calls[index][0] as NativeOverlayRequest
+  expect(request.kind).toBe('menu')
+  expect(request.payload.kind).toBe('menu')
+
+  return request as NativeOverlayMenuRequest
 }
 
 const deferredNativeOpen = (): {
@@ -992,7 +1009,7 @@ describe('Menu.Context', () => {
 
     await waitFor(() => expect(nativeBridge.open).toHaveBeenCalledOnce())
 
-    const request = nativeBridge.open.mock.calls[0][0] as NativeOverlayRequest
+    const request = nativeMenuRequestAt(nativeBridge.open)
     const firstItem = request.payload.items?.[0]
     expect(screen.queryByRole('menu')).not.toBeInTheDocument()
     expect(request).toMatchObject({
@@ -1066,7 +1083,7 @@ describe('Menu.Context', () => {
 
     await waitFor(() => expect(nativeBridge.open).toHaveBeenCalledOnce())
 
-    const request = nativeBridge.open.mock.calls[0][0] as NativeOverlayRequest
+    const request = nativeMenuRequestAt(nativeBridge.open)
 
     expect(request).toMatchObject({
       anchorRect: { x: 50, y: 60, width: 180, height: 22 },
@@ -1117,7 +1134,7 @@ describe('Menu.Context', () => {
     )
 
     await waitFor(() => expect(nativeBridge.open).toHaveBeenCalledOnce())
-    const request = nativeBridge.open.mock.calls[0][0] as NativeOverlayRequest
+    const request = nativeMenuRequestAt(nativeBridge.open)
 
     act(() => {
       nativeBridge.closed({ surfaceId: request.surfaceId, reason: 'outside' })
@@ -1172,7 +1189,7 @@ describe('Menu.Context', () => {
     await user.click(trigger)
     await waitFor(() => expect(nativeBridge.open).toHaveBeenCalledOnce())
 
-    const request = nativeBridge.open.mock.calls[0][0] as NativeOverlayRequest
+    const request = nativeMenuRequestAt(nativeBridge.open)
     const checkbox = request.payload.sections?.[0]?.items[0]
 
     expect(screen.queryByRole('menu')).not.toBeInTheDocument()
@@ -1249,8 +1266,7 @@ describe('Menu.Context', () => {
     await user.click(trigger)
     await waitFor(() => expect(nativeBridge.open).toHaveBeenCalledOnce())
 
-    const firstRequest = nativeBridge.open.mock
-      .calls[0][0] as NativeOverlayRequest
+    const firstRequest = nativeMenuRequestAt(nativeBridge.open)
     const firstCheckbox = firstRequest.payload.sections?.[0]?.items[0]
 
     act(() => {
@@ -1262,8 +1278,7 @@ describe('Menu.Context', () => {
 
     await waitFor(() => expect(nativeBridge.open).toHaveBeenCalledTimes(2))
 
-    const secondRequest = nativeBridge.open.mock
-      .calls[1][0] as NativeOverlayRequest
+    const secondRequest = nativeMenuRequestAt(nativeBridge.open, 1)
 
     expect(nativeBridge.close).toHaveBeenCalledWith({
       surfaceId: firstRequest.surfaceId,
@@ -1374,7 +1389,7 @@ describe('Menu.Context', () => {
     await user.click(screen.getByRole('button', { name: 'Open layouts' }))
     await waitFor(() => expect(nativeBridge.open).toHaveBeenCalledOnce())
 
-    const request = nativeBridge.open.mock.calls[0][0] as NativeOverlayRequest
+    const request = nativeMenuRequestAt(nativeBridge.open)
     const composite = request.payload.sections?.[0]?.items[0]
 
     expect(screen.queryByRole('menu')).not.toBeInTheDocument()
@@ -1438,7 +1453,7 @@ describe('Menu.Context', () => {
 
     render(<Harness />)
     await waitFor(() => expect(nativeBridge.open).toHaveBeenCalledOnce())
-    const request = nativeBridge.open.mock.calls[0][0] as NativeOverlayRequest
+    const request = nativeMenuRequestAt(nativeBridge.open)
 
     await user.click(screen.getByRole('button', { name: 'Rerender 0' }))
 

--- a/src/components/Menu.test.tsx
+++ b/src/components/Menu.test.tsx
@@ -4,15 +4,10 @@ import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import {
   __resetNativeOverlayForTest,
-  type NativeOverlayMenuPayload,
+  type NativeOverlayMenuRequest,
   type NativeOverlayRequest,
 } from '@/components/base/floating/nativeOverlay'
 import { Menu } from './Menu'
-
-type NativeOverlayMenuRequest = NativeOverlayRequest & {
-  kind: 'menu'
-  payload: NativeOverlayMenuPayload
-}
 
 let restorePlatform: (() => void) | null = null
 

--- a/src/components/NativeOverlayHost.test.tsx
+++ b/src/components/NativeOverlayHost.test.tsx
@@ -160,14 +160,17 @@ const installNativeOverlayHostBridge = (): {
   emitRender: (payload: unknown) => void
   emitClear: () => void
   emitActionResult: (payload: unknown) => void
+  emitKeyDown: (payload: unknown) => void
 } => {
   cleanupHostBridgeEvents?.()
   const renderEvent = 'native-overlay-host-render'
   const clearEvent = 'native-overlay-host-clear'
   const actionResultEvent = 'native-overlay-host-action-result'
+  const keyDownEvent = 'native-overlay-host-keydown'
   let renderListener: ((payload: unknown) => void) | null = null
   let clearListener: (() => void) | null = null
   let actionResultListener: ((payload: unknown) => void) | null = null
+  let keyDownListener: ((payload: unknown) => void) | null = null
   const ready = vi.fn(() => Promise.resolve())
   const action = vi.fn(() => Promise.resolve())
   const close = vi.fn(() => Promise.resolve())
@@ -185,13 +188,19 @@ const installNativeOverlayHostBridge = (): {
     actionResultListener?.((event as CustomEvent<unknown>).detail)
   }
 
+  const handleKeyDownEvent = (event: Event): void => {
+    keyDownListener?.((event as CustomEvent<unknown>).detail)
+  }
+
   window.addEventListener(renderEvent, handleRenderEvent)
   window.addEventListener(clearEvent, handleClearEvent)
   window.addEventListener(actionResultEvent, handleActionResultEvent)
+  window.addEventListener(keyDownEvent, handleKeyDownEvent)
   cleanupHostBridgeEvents = (): void => {
     window.removeEventListener(renderEvent, handleRenderEvent)
     window.removeEventListener(clearEvent, handleClearEvent)
     window.removeEventListener(actionResultEvent, handleActionResultEvent)
+    window.removeEventListener(keyDownEvent, handleKeyDownEvent)
     cleanupHostBridgeEvents = null
   }
 
@@ -214,6 +223,11 @@ const installNativeOverlayHostBridge = (): {
       }),
       onActionResult: vi.fn((callback: (payload: unknown) => void) => {
         actionResultListener = callback
+
+        return vi.fn()
+      }),
+      onKeyDown: vi.fn((callback: (payload: unknown) => void) => {
+        keyDownListener = callback
 
         return vi.fn()
       }),
@@ -240,6 +254,9 @@ const installNativeOverlayHostBridge = (): {
     },
     emitActionResult: (payload): void => {
       fireEvent(window, new CustomEvent(actionResultEvent, { detail: payload }))
+    },
+    emitKeyDown: (payload): void => {
+      fireEvent(window, new CustomEvent(keyDownEvent, { detail: payload }))
     },
   }
 }
@@ -292,6 +309,34 @@ describe('NativeOverlayHost', () => {
     bridge.emitClear()
 
     expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+  })
+
+  test('dispatches forwarded menu keydown events to the active menu', async () => {
+    const bridge = installNativeOverlayHostBridge()
+    render(<NativeOverlayHost />)
+
+    bridge.emitRender(request)
+    expect(
+      await screen.findByRole('menu', { name: 'Terminal actions' })
+    ).toBeInTheDocument()
+
+    bridge.emitKeyDown({
+      surfaceId: request.surfaceId,
+      key: 'Escape',
+      code: 'Escape',
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      repeat: false,
+    })
+
+    await waitFor(() => {
+      expect(bridge.close).toHaveBeenCalledWith({
+        surfaceId: request.surfaceId,
+        reason: 'outside',
+      })
+    })
   })
 
   test('dispatches the selected action and hides the menu', async () => {

--- a/src/components/NativeOverlayHost.test.tsx
+++ b/src/components/NativeOverlayHost.test.tsx
@@ -138,6 +138,18 @@ const detailRequest: NativeOverlayRequest = {
   },
 }
 
+const tooltipRequest: NativeOverlayRequest = {
+  surfaceId: 'tooltip-1',
+  kind: 'tooltip',
+  anchorRect: { x: 100, y: 120, width: 30, height: 20 },
+  placement: 'top',
+  payload: {
+    kind: 'tooltip',
+    text: 'collapse status',
+    maxWidth: 240,
+  },
+}
+
 let cleanupHostBridgeEvents: (() => void) | null = null
 
 const installNativeOverlayHostBridge = (): {
@@ -256,6 +268,30 @@ describe('NativeOverlayHost', () => {
       expect(bridge.ready).toHaveBeenCalledWith({ surfaceId: 'surface-1' })
     })
     expect(bridge.ownerOverlayClose).not.toHaveBeenCalled()
+  })
+
+  test('renders a passive native overlay tooltip request in tooltip mode', async () => {
+    const bridge = installNativeOverlayHostBridge()
+    render(<NativeOverlayHost mode="tooltip" />)
+
+    bridge.emitRender(tooltipRequest)
+
+    const tooltip = await screen.findByRole('tooltip')
+    expect(tooltip).toHaveTextContent('collapse status')
+    expect(tooltip).toHaveClass('whitespace-nowrap')
+    expect(tooltip).toHaveStyle({
+      left: '115px',
+      top: '114px',
+      transform: 'translate(-50%, -100%)',
+    })
+
+    await waitFor(() => {
+      expect(bridge.ready).toHaveBeenCalledWith({ surfaceId: 'tooltip-1' })
+    })
+
+    bridge.emitClear()
+
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
   })
 
   test('dispatches the selected action and hides the menu', async () => {

--- a/src/components/NativeOverlayHost.tsx
+++ b/src/components/NativeOverlayHost.tsx
@@ -30,6 +30,18 @@ interface NativeOverlayHostBridge {
   onRender: (callback: (payload: unknown) => void) => () => void
   onClear: (callback: () => void) => () => void
   onActionResult: (callback: (payload: unknown) => void) => () => void
+  onKeyDown: (callback: (payload: unknown) => void) => () => void
+}
+
+interface NativeOverlayKeyboardEvent {
+  surfaceId: string
+  key: string
+  code: string
+  altKey: boolean
+  ctrlKey: boolean
+  metaKey: boolean
+  shiftKey: boolean
+  repeat: boolean
 }
 
 const COPY_FEEDBACK_MS = 1300
@@ -70,6 +82,21 @@ const isCopyActionResult = (
   typeof (value as { actionId?: unknown }).actionId === 'string' &&
   (value as { feedback?: unknown }).feedback === 'copy' &&
   typeof (value as { ok?: unknown }).ok === 'boolean'
+
+const isNativeOverlayKeyboardEvent = (
+  value: unknown
+): value is NativeOverlayKeyboardEvent =>
+  typeof value === 'object' &&
+  value !== null &&
+  !Array.isArray(value) &&
+  typeof (value as { surfaceId?: unknown }).surfaceId === 'string' &&
+  typeof (value as { key?: unknown }).key === 'string' &&
+  typeof (value as { code?: unknown }).code === 'string' &&
+  typeof (value as { altKey?: unknown }).altKey === 'boolean' &&
+  typeof (value as { ctrlKey?: unknown }).ctrlKey === 'boolean' &&
+  typeof (value as { metaKey?: unknown }).metaKey === 'boolean' &&
+  typeof (value as { shiftKey?: unknown }).shiftKey === 'boolean' &&
+  typeof (value as { repeat?: unknown }).repeat === 'boolean'
 
 const OVERLAY_MENU_ROW_CLASSES =
   'group flex min-h-8 w-full items-center justify-between gap-6 rounded px-2.5 py-1.5 ' +
@@ -195,6 +222,30 @@ const applyThemeSnapshot = (
   if (theme.colorScheme !== undefined) {
     root.style.colorScheme = theme.colorScheme
   }
+}
+
+const dispatchNativeOverlayKeyDown = (
+  event: NativeOverlayKeyboardEvent
+): void => {
+  const target =
+    document.activeElement instanceof HTMLElement &&
+    document.activeElement !== document.body
+      ? document.activeElement
+      : (document.querySelector<HTMLElement>('[role="menu"]') ?? document.body)
+
+  target.dispatchEvent(
+    new KeyboardEvent('keydown', {
+      key: event.key,
+      code: event.code,
+      altKey: event.altKey,
+      ctrlKey: event.ctrlKey,
+      metaKey: event.metaKey,
+      shiftKey: event.shiftKey,
+      repeat: event.repeat,
+      bubbles: true,
+      cancelable: true,
+    })
+  )
 }
 
 const tooltipStyleForRequest = (
@@ -333,10 +384,24 @@ export const NativeOverlayHost = ({
       showCopyFeedback(payload.actionId)
     })
 
+    const cleanupKeyDown = bridge.onKeyDown((payload) => {
+      if (mode !== 'menu' || !isNativeOverlayKeyboardEvent(payload)) {
+        return
+      }
+
+      const current = requestRef.current
+      if (current?.surfaceId !== payload.surfaceId) {
+        return
+      }
+
+      dispatchNativeOverlayKeyDown(payload)
+    })
+
     return (): void => {
       cleanupRender()
       cleanupClear()
       cleanupActionResult()
+      cleanupKeyDown()
     }
   }, [clearCopyFeedback, mode, showCopyFeedback])
 

--- a/src/components/NativeOverlayHost.tsx
+++ b/src/components/NativeOverlayHost.tsx
@@ -3,14 +3,17 @@ import {
   useEffect,
   useRef,
   useState,
+  type CSSProperties,
   type ReactElement,
 } from 'react'
 import { IconButton } from '@/components/IconButton'
 import { Menu } from '@/components/Menu'
 import type {
   NativeOverlayMenuItem,
+  NativeOverlayMenuRequest,
   NativeOverlayMenuSection,
   NativeOverlayRequest,
+  NativeOverlayTooltipRequest,
 } from '@/components/base/floating/nativeOverlay'
 import type { Placement } from '@/components/base/floating/glassSurface'
 import { TOOLTIP_SUPPRESSED } from '@/lib/constants'
@@ -34,12 +37,23 @@ const COPY_FEEDBACK_MS = 1300
 const nativeOverlayHostBridge = (): NativeOverlayHostBridge | undefined =>
   window.vimeflow?.nativeOverlayHost
 
-const isMenuRequest = (value: unknown): value is NativeOverlayRequest =>
+const isMenuRequest = (value: unknown): value is NativeOverlayMenuRequest =>
   typeof value === 'object' &&
   value !== null &&
   !Array.isArray(value) &&
   (value as { kind?: unknown }).kind === 'menu' &&
   (value as { payload?: { kind?: unknown } }).payload?.kind === 'menu'
+
+const isTooltipRequest = (
+  value: unknown
+): value is NativeOverlayTooltipRequest =>
+  typeof value === 'object' &&
+  value !== null &&
+  !Array.isArray(value) &&
+  (value as { kind?: unknown }).kind === 'tooltip' &&
+  (value as { payload?: { kind?: unknown; text?: unknown } }).payload?.kind ===
+    'tooltip' &&
+  typeof (value as { payload?: { text?: unknown } }).payload?.text === 'string'
 
 const isCopyActionResult = (
   value: unknown
@@ -95,6 +109,11 @@ const OVERLAY_MENU_COPY_FEEDBACK_SUCCESS_CLASSES =
 const OVERLAY_MENU_COPY_FEEDBACK_LABEL_CLASSES =
   'font-sans text-[10px] font-medium'
 
+const OVERLAY_TOOLTIP_CLASSES =
+  'pointer-events-none rounded-md px-3 py-1.5 text-xs text-on-surface ' +
+  'whitespace-nowrap shadow-lg bg-surface-container-high/90 backdrop-blur-md ' +
+  'backdrop-saturate-150 border border-outline-variant/20'
+
 const OVERLAY_MENU_COMPOSITE_PRIMARY_CLASSES =
   'flex min-w-0 flex-1 items-center gap-2.5 rounded text-left outline-none ' +
   'focus-visible:ring-1 focus-visible:ring-primary disabled:cursor-default ' +
@@ -129,7 +148,7 @@ const overlayMenuItemLabelClass = (item: NativeOverlayMenuItem): string =>
     : OVERLAY_MENU_ITEM_LABEL_CLASSES
 
 const sectionsForRequest = (
-  request: NativeOverlayRequest
+  request: NativeOverlayMenuRequest
 ): NativeOverlayMenuSection[] => {
   if (request.payload.sections !== undefined) {
     return [...request.payload.sections]
@@ -178,7 +197,58 @@ const applyThemeSnapshot = (
   }
 }
 
-export const NativeOverlayHost = (): ReactElement | null => {
+const tooltipStyleForRequest = (
+  request: NativeOverlayTooltipRequest
+): CSSProperties => {
+  const gap = 6
+  const { x, y, width, height } = request.anchorRect
+  const placement = request.placement
+
+  const style: CSSProperties = {
+    position: 'fixed',
+    maxWidth: request.payload.maxWidth ?? 320,
+  }
+
+  if (placement.startsWith('bottom')) {
+    return {
+      ...style,
+      left: x + width / 2,
+      top: y + height + gap,
+      transform: 'translateX(-50%)',
+    }
+  }
+
+  if (placement.startsWith('left')) {
+    return {
+      ...style,
+      left: x - gap,
+      top: y + height / 2,
+      transform: 'translate(-100%, -50%)',
+    }
+  }
+
+  if (placement.startsWith('right')) {
+    return {
+      ...style,
+      left: x + width + gap,
+      top: y + height / 2,
+      transform: 'translateY(-50%)',
+    }
+  }
+
+  return {
+    ...style,
+    left: x + width / 2,
+    top: y - gap,
+    transform: 'translate(-50%, -100%)',
+  }
+}
+
+export const NativeOverlayHost = ({
+  mode = 'menu',
+}: {
+  mode?: 'menu' | 'tooltip'
+}): ReactElement | null => {
   const [request, setRequest] = useState<NativeOverlayRequest | null>(null)
   const [copiedActionId, setCopiedActionId] = useState<string | null>(null)
   const requestRef = useRef<NativeOverlayRequest | null>(null)
@@ -230,7 +300,15 @@ export const NativeOverlayHost = (): ReactElement | null => {
     }
 
     const cleanupRender = bridge.onRender((payload) => {
-      if (isMenuRequest(payload)) {
+      if (mode === 'menu' && isMenuRequest(payload)) {
+        applyThemeSnapshot(payload.theme)
+        clearCopyFeedback()
+        setRequest(payload)
+
+        return
+      }
+
+      if (mode === 'tooltip' && isTooltipRequest(payload)) {
         applyThemeSnapshot(payload.theme)
         clearCopyFeedback()
         setRequest(payload)
@@ -260,7 +338,7 @@ export const NativeOverlayHost = (): ReactElement | null => {
       cleanupClear()
       cleanupActionResult()
     }
-  }, [clearCopyFeedback, showCopyFeedback])
+  }, [clearCopyFeedback, mode, showCopyFeedback])
 
   useEffect(() => {
     if (request === null) {
@@ -285,6 +363,26 @@ export const NativeOverlayHost = (): ReactElement | null => {
   }, [clearCopyFeedback])
 
   if (request === null) {
+    return null
+  }
+
+  if (mode === 'tooltip') {
+    if (!isTooltipRequest(request)) {
+      return null
+    }
+
+    return (
+      <div
+        role="tooltip"
+        className={OVERLAY_TOOLTIP_CLASSES}
+        style={tooltipStyleForRequest(request)}
+      >
+        {request.payload.text}
+      </div>
+    )
+  }
+
+  if (!isMenuRequest(request)) {
     return null
   }
 

--- a/src/components/Tooltip.test.tsx
+++ b/src/components/Tooltip.test.tsx
@@ -380,6 +380,27 @@ describe('Tooltip', () => {
     })
   })
 
+  test('falls back locally when native tooltip overlay is rejected', async () => {
+    vi.stubEnv('VITE_NATIVE_OVERLAY', '1')
+    setNavigatorPlatform('MacIntel')
+    const nativeBridge = installNativeOverlayBridge()
+    nativeBridge.open.mockResolvedValue({ accepted: false })
+    const user = userEvent.setup()
+
+    render(
+      <Tooltip content="collapse status" delayMs={0} nativeOverlay>
+        <button type="button">trigger</button>
+      </Tooltip>
+    )
+
+    await user.hover(screen.getByRole('button', { name: 'trigger' }))
+
+    await waitFor(() => expect(nativeBridge.open).toHaveBeenCalledOnce())
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      'collapse status'
+    )
+  })
+
   test('supports interactive floating content when requested', async () => {
     const user = userEvent.setup()
     const handleCopy = vi.fn()

--- a/src/components/Tooltip.test.tsx
+++ b/src/components/Tooltip.test.tsx
@@ -1,8 +1,53 @@
 import { createRef } from 'react'
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, test, vi } from 'vitest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { __resetNativeOverlayForTest } from '@/components/base/floating/nativeOverlay'
 import { Tooltip, type TooltipProps } from './Tooltip'
+
+let restorePlatform: (() => void) | null = null
+
+const setNavigatorPlatform = (platform: string): void => {
+  restorePlatform?.()
+  const original = Object.getOwnPropertyDescriptor(window.navigator, 'platform')
+
+  Object.defineProperty(window.navigator, 'platform', {
+    configurable: true,
+    value: platform,
+  })
+
+  restorePlatform = (): void => {
+    if (original === undefined) {
+      delete (window.navigator as unknown as { platform?: string }).platform
+
+      return
+    }
+
+    Object.defineProperty(window.navigator, 'platform', original)
+  }
+}
+
+const installNativeOverlayBridge = (): {
+  open: ReturnType<typeof vi.fn>
+  close: ReturnType<typeof vi.fn>
+} => {
+  const open = vi.fn().mockResolvedValue({ accepted: true })
+  const close = vi.fn().mockResolvedValue(undefined)
+
+  window.vimeflow = {
+    invoke: <T,>(): Promise<T> => Promise.resolve(null as T),
+    listen: vi.fn(() => Promise.resolve(vi.fn())),
+    nativeOverlay: {
+      open,
+      close,
+      actionResult: vi.fn(() => Promise.resolve()),
+      onAction: vi.fn(() => vi.fn()),
+      onClose: vi.fn(() => vi.fn()),
+    },
+  }
+
+  return { open, close }
+}
 
 const rect = ({
   x,
@@ -26,6 +71,14 @@ const rect = ({
     bottom: y + height,
     toJSON: () => ({}),
   }) as DOMRect
+
+afterEach(() => {
+  restorePlatform?.()
+  restorePlatform = null
+  vi.unstubAllEnvs()
+  __resetNativeOverlayForTest()
+  delete window.vimeflow
+})
 
 describe('Tooltip', () => {
   test('returns children unchanged when disabled', () => {
@@ -274,6 +327,57 @@ describe('Tooltip', () => {
     await user.hover(screen.getByRole('button', { name: 'trigger' }))
     await screen.findByRole('tooltip')
     expect(screen.queryByTestId('tooltip-shortcut')).not.toBeInTheDocument()
+  })
+
+  test('sends plain text tooltip requests through native overlay when opted in', async () => {
+    vi.stubEnv('VITE_NATIVE_OVERLAY', '1')
+    setNavigatorPlatform('MacIntel')
+    const nativeBridge = installNativeOverlayBridge()
+    const user = userEvent.setup()
+
+    render(
+      <Tooltip
+        content="collapse status"
+        delayMs={0}
+        placement="bottom"
+        maxWidth={180}
+        nativeOverlay
+      >
+        <button type="button">trigger</button>
+      </Tooltip>
+    )
+
+    const trigger = screen.getByRole('button', { name: 'trigger' })
+    vi.spyOn(trigger, 'getBoundingClientRect').mockReturnValue(
+      rect({ x: 20, y: 30, width: 40, height: 12 })
+    )
+
+    await user.hover(trigger)
+
+    await waitFor(() => expect(nativeBridge.open).toHaveBeenCalledOnce())
+    const request = nativeBridge.open.mock.calls[0][0] as { surfaceId: string }
+
+    expect(request).toMatchObject({
+      surfaceId: expect.stringMatching(/^tooltip:/),
+      kind: 'tooltip',
+      anchorRect: { x: 20, y: 30, width: 40, height: 12 },
+      placement: 'bottom',
+      payload: {
+        kind: 'tooltip',
+        text: 'collapse status',
+        maxWidth: 180,
+      },
+    })
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+
+    await user.unhover(trigger)
+
+    await waitFor(() => {
+      expect(nativeBridge.close).toHaveBeenCalledWith({
+        surfaceId: request.surfaceId,
+        reason: 'renderer',
+      })
+    })
   })
 
   test('supports interactive floating content when requested', async () => {

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -2,6 +2,7 @@ import {
   cloneElement,
   isValidElement,
   useEffect,
+  useId,
   useState,
   type ReactElement,
   type ReactNode,
@@ -25,6 +26,10 @@ import {
   type Placement,
 } from '@floating-ui/react'
 import {
+  NATIVE_OVERLAY_KINDS,
+  closeNativeOverlay,
+  nativeOverlayThemeSnapshot,
+  openNativeOverlay,
   selectFloatingTransport,
   warnNativeOverlayFallback,
 } from '@/components/base/floating/nativeOverlay'
@@ -122,18 +127,30 @@ export const Tooltip = ({
   // `0` is still treated as content (it renders as a visible "0" tooltip).
   const hasContent = content != null && content !== false && content !== ''
   const enabled = !disabled && hasContent && isValidElement(children)
+  const nativeSurfaceId = `tooltip:${useId()}`
 
   const [open, setOpen] = useState(false)
 
-  useEffect(() => {
-    if (
-      open &&
-      nativeOverlay &&
-      selectFloatingTransport(nativeOverlay) === 'native-overlay'
-    ) {
-      warnNativeOverlayFallback('tooltip native overlay is not in v0')
-    }
-  }, [nativeOverlay, open])
+  const [nativeStatus, setNativeStatus] = useState<
+    'idle' | 'opening' | 'accepted' | 'failed'
+  >('idle')
+
+  const transport = selectFloatingTransport(nativeOverlay)
+  const nativeTooltipText = typeof content === 'string' ? content : null
+
+  const nativeUnsupportedReason =
+    nativeTooltipText === null
+      ? 'tooltip native overlay only supports plain text'
+      : interactive
+        ? 'interactive tooltip native overlay is not in v0'
+        : bare
+          ? 'bare tooltip native overlay is not in v0'
+          : shortcut !== undefined
+            ? 'shortcut tooltip native overlay is not in v0'
+            : null
+
+  const canUseNativeOverlay =
+    open && transport === 'native-overlay' && nativeUnsupportedReason === null
 
   // Reset stale open state when the tooltip becomes ineligible mid-flight
   // (consumer toggles disabled, or content drops to null/undefined). Without
@@ -162,11 +179,99 @@ export const Tooltip = ({
     useHover(context, {
       enabled,
       delay: { open: delayMs, close: interactive ? 150 : 0 },
-      handleClose: safePolygon(),
+      handleClose: interactive ? safePolygon() : undefined,
     }),
     useFocus(context, { enabled }),
     useDismiss(context, { enabled, escapeKey: true }),
     useRole(context, { enabled, role: interactive ? 'dialog' : 'tooltip' }),
+  ])
+
+  useEffect(() => {
+    if (
+      open &&
+      transport === 'native-overlay' &&
+      nativeUnsupportedReason !== null
+    ) {
+      warnNativeOverlayFallback(nativeUnsupportedReason)
+    }
+  }, [nativeUnsupportedReason, open, transport])
+
+  useEffect(() => {
+    if (!canUseNativeOverlay || nativeTooltipText === null) {
+      if (!open) {
+        setNativeStatus('idle')
+      }
+
+      return
+    }
+
+    const reference = refs.reference.current
+    if (!(reference instanceof Element)) {
+      warnNativeOverlayFallback('tooltip native overlay is missing an anchor')
+      setNativeStatus('failed')
+
+      return
+    }
+
+    const state = { canceled: false }
+    const rect = reference.getBoundingClientRect()
+    setNativeStatus('opening')
+
+    void (async (): Promise<void> => {
+      const accepted = await openNativeOverlay(
+        {
+          surfaceId: nativeSurfaceId,
+          kind: NATIVE_OVERLAY_KINDS.tooltip,
+          anchorRect: {
+            x: rect.x,
+            y: rect.y,
+            width: rect.width,
+            height: rect.height,
+          },
+          placement,
+          payload: {
+            kind: 'tooltip',
+            text: nativeTooltipText,
+            maxWidth,
+          },
+          theme: nativeOverlayThemeSnapshot(),
+        },
+        {
+          actions: new Map(),
+          onClose: () => setOpen(false),
+        }
+      )
+
+      if (state.canceled) {
+        if (accepted) {
+          closeNativeOverlay(nativeSurfaceId)
+        }
+
+        return
+      }
+
+      if (!accepted) {
+        warnNativeOverlayFallback('tooltip native overlay was rejected')
+        setNativeStatus('failed')
+
+        return
+      }
+
+      setNativeStatus('accepted')
+    })()
+
+    return (): void => {
+      state.canceled = true
+      closeNativeOverlay(nativeSurfaceId)
+    }
+  }, [
+    canUseNativeOverlay,
+    maxWidth,
+    nativeSurfaceId,
+    nativeTooltipText,
+    open,
+    placement,
+    refs.reference,
   ])
 
   const childRef = isValidElement(children)
@@ -186,6 +291,9 @@ export const Tooltip = ({
     ? `${interactionClass} z-50`
     : `${interactionClass} ${TOOLTIP_BASE_CLASSES}`
   const classes = className ? `${tooltipClasses} ${className}` : tooltipClasses
+
+  const showLocalTooltip =
+    open && (!canUseNativeOverlay || nativeStatus === 'failed')
 
   const floatingSurface = (
     <div
@@ -216,7 +324,7 @@ export const Tooltip = ({
         ...getReferenceProps(children.props as Record<string, unknown>),
         ref: mergedRef,
       })}
-      {open && (
+      {showLocalTooltip && (
         <FloatingPortal>
           {interactive ? (
             <FloatingFocusManager

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -131,9 +131,7 @@ export const Tooltip = ({
 
   const [open, setOpen] = useState(false)
 
-  const [nativeStatus, setNativeStatus] = useState<
-    'idle' | 'opening' | 'accepted' | 'failed'
-  >('idle')
+  const [nativeFailed, setNativeFailed] = useState(false)
 
   const transport = selectFloatingTransport(nativeOverlay)
   const nativeTooltipText = typeof content === 'string' ? content : null
@@ -199,7 +197,7 @@ export const Tooltip = ({
   useEffect(() => {
     if (!canUseNativeOverlay || nativeTooltipText === null) {
       if (!open) {
-        setNativeStatus('idle')
+        setNativeFailed(false)
       }
 
       return
@@ -208,14 +206,14 @@ export const Tooltip = ({
     const reference = refs.reference.current
     if (!(reference instanceof Element)) {
       warnNativeOverlayFallback('tooltip native overlay is missing an anchor')
-      setNativeStatus('failed')
+      setNativeFailed(true)
 
       return
     }
 
     const state = { canceled: false }
     const rect = reference.getBoundingClientRect()
-    setNativeStatus('opening')
+    setNativeFailed(false)
 
     void (async (): Promise<void> => {
       const accepted = await openNativeOverlay(
@@ -252,12 +250,10 @@ export const Tooltip = ({
 
       if (!accepted) {
         warnNativeOverlayFallback('tooltip native overlay was rejected')
-        setNativeStatus('failed')
+        setNativeFailed(true)
 
         return
       }
-
-      setNativeStatus('accepted')
     })()
 
     return (): void => {
@@ -292,8 +288,7 @@ export const Tooltip = ({
     : `${interactionClass} ${TOOLTIP_BASE_CLASSES}`
   const classes = className ? `${tooltipClasses} ${className}` : tooltipClasses
 
-  const showLocalTooltip =
-    open && (!canUseNativeOverlay || nativeStatus === 'failed')
+  const showLocalTooltip = open && (!canUseNativeOverlay || nativeFailed)
 
   const floatingSurface = (
     <div

--- a/src/components/base/floating/nativeOverlay.ts
+++ b/src/components/base/floating/nativeOverlay.ts
@@ -13,6 +13,10 @@ export const NATIVE_OVERLAY_KINDS = {
 export type NativeOverlayKind =
   (typeof NATIVE_OVERLAY_KINDS)[keyof typeof NATIVE_OVERLAY_KINDS]
 
+export type NativeOverlayLayerKind =
+  | typeof NATIVE_OVERLAY_KINDS.menu
+  | typeof NATIVE_OVERLAY_KINDS.tooltip
+
 export interface NativeOverlayRect {
   x: number
   y: number
@@ -91,10 +95,18 @@ export interface NativeOverlayMenuPayload {
   sections?: NativeOverlayMenuSection[]
 }
 
-// Menus are the only native overlay payload today. Keep this named boundary so
-// it can become a discriminated union when tooltip, popover, and dialog get
-// their own plain-data payload models instead of arbitrary React children.
-export type SerializableOverlayPayload = NativeOverlayMenuPayload
+export interface NativeOverlayTooltipPayload {
+  kind: 'tooltip'
+  text: string
+  maxWidth?: number
+}
+
+// Native overlay payloads are plain data only. Menu and tooltip are supported
+// today; popover/dialog should join this union only after they get their own
+// serializable models instead of arbitrary React children.
+export type SerializableOverlayPayload =
+  | NativeOverlayMenuPayload
+  | NativeOverlayTooltipPayload
 
 export interface NativeOverlayRequest {
   surfaceId: string
@@ -103,6 +115,16 @@ export interface NativeOverlayRequest {
   placement: string
   payload: SerializableOverlayPayload
   theme?: NativeOverlayThemeSnapshot
+}
+
+export type NativeOverlayMenuRequest = NativeOverlayRequest & {
+  kind: typeof NATIVE_OVERLAY_KINDS.menu
+  payload: NativeOverlayMenuPayload
+}
+
+export type NativeOverlayTooltipRequest = NativeOverlayRequest & {
+  kind: typeof NATIVE_OVERLAY_KINDS.tooltip
+  payload: NativeOverlayTooltipPayload
 }
 
 export interface NativeOverlayActionEvent {

--- a/src/components/base/floating/nativeOverlay.ts
+++ b/src/components/base/floating/nativeOverlay.ts
@@ -13,10 +13,6 @@ export const NATIVE_OVERLAY_KINDS = {
 export type NativeOverlayKind =
   (typeof NATIVE_OVERLAY_KINDS)[keyof typeof NATIVE_OVERLAY_KINDS]
 
-export type NativeOverlayLayerKind =
-  | typeof NATIVE_OVERLAY_KINDS.menu
-  | typeof NATIVE_OVERLAY_KINDS.tooltip
-
 export interface NativeOverlayRect {
   x: number
   y: number

--- a/src/features/terminal/components/BurnerTerminalPopup/index.tsx
+++ b/src/features/terminal/components/BurnerTerminalPopup/index.tsx
@@ -321,6 +321,7 @@ export const BurnerTerminalPopup = ({
                 // Lift above the z-[100] popup — the shared tooltip portals to
                 // body at z-50 and would otherwise paint behind the overlay.
                 className="!z-[110]"
+                nativeOverlay
               >
                 <IconButton
                   icon="sync"
@@ -338,14 +339,21 @@ export const BurnerTerminalPopup = ({
               </Tooltip>
             )}
 
-            <IconButton
-              icon="close"
-              label="Hide burner terminal"
-              showTooltip={TOOLTIP_SUPPRESSED} // popup already provides a z-lifted Tooltip
-              data-testid="burner-hide"
-              onClick={onHide}
-              className="h-[26px] w-[26px] rounded-[7px]"
-            />
+            <Tooltip
+              content="Hide burner terminal"
+              placement="bottom"
+              className="!z-[110]"
+              nativeOverlay
+            >
+              <IconButton
+                icon="close"
+                label="Hide burner terminal"
+                showTooltip={TOOLTIP_SUPPRESSED} // popup already provides a z-lifted Tooltip
+                data-testid="burner-hide"
+                onClick={onHide}
+                className="h-[26px] w-[26px] rounded-[7px]"
+              />
+            </Tooltip>
           </div>
         </header>
 

--- a/src/features/terminal/components/TerminalPane/HeaderActions.tsx
+++ b/src/features/terminal/components/TerminalPane/HeaderActions.tsx
@@ -1,5 +1,7 @@
 import type { ReactElement } from 'react'
 import { IconButton } from '@/components/IconButton'
+import { Tooltip } from '@/components/Tooltip'
+import { TOOLTIP_SUPPRESSED } from '@/lib/constants'
 
 const burnerButtonLabel = (active: boolean, shellExists: boolean): string => {
   if (active) {
@@ -42,48 +44,62 @@ export const HeaderActions = ({
   onBurner = undefined,
   burnerActive = false,
   burnerShellExists = false,
-}: HeaderActionsProps): ReactElement => (
-  <>
-    {onBurner && (
-      <IconButton
-        icon="terminal"
-        label={burnerButtonLabel(burnerActive, burnerShellExists)}
-        size="sm"
-        onClick={(event) => {
-          event.stopPropagation()
-          onBurner()
-        }}
-        // Running is a status tint, not a toggle — no `pressed` (it would override the accent).
-        className={
-          burnerActive
-            ? 'bg-agent-shell-accent/15 text-agent-shell-accent'
-            : undefined
-        }
-      />
-    )}
+}: HeaderActionsProps): ReactElement => {
+  const burnerLabel = burnerButtonLabel(burnerActive, burnerShellExists)
+  const collapseLabel = isCollapsed ? 'expand status' : 'collapse status'
 
-    {!hideCollapseToggle && (
-      <IconButton
-        icon={isCollapsed ? 'unfold_more' : 'unfold_less'}
-        label={isCollapsed ? 'expand status' : 'collapse status'}
-        size="sm"
-        onClick={(event) => {
-          event.stopPropagation()
-          onToggleCollapse()
-        }}
-      />
-    )}
+  return (
+    <>
+      {onBurner && (
+        <Tooltip content={burnerLabel} placement="bottom" nativeOverlay>
+          <IconButton
+            icon="terminal"
+            label={burnerLabel}
+            showTooltip={TOOLTIP_SUPPRESSED}
+            size="sm"
+            onClick={(event) => {
+              event.stopPropagation()
+              onBurner()
+            }}
+            // Running is a status tint, not a toggle — no `pressed` (it would override the accent).
+            className={
+              burnerActive
+                ? 'bg-agent-shell-accent/15 text-agent-shell-accent'
+                : undefined
+            }
+          />
+        </Tooltip>
+      )}
 
-    {onClose && (
-      <IconButton
-        icon="close"
-        label="close pane"
-        size="sm"
-        onClick={(event) => {
-          event.stopPropagation()
-          onClose()
-        }}
-      />
-    )}
-  </>
-)
+      {!hideCollapseToggle && (
+        <Tooltip content={collapseLabel} placement="bottom" nativeOverlay>
+          <IconButton
+            icon={isCollapsed ? 'unfold_more' : 'unfold_less'}
+            label={collapseLabel}
+            showTooltip={TOOLTIP_SUPPRESSED}
+            size="sm"
+            onClick={(event) => {
+              event.stopPropagation()
+              onToggleCollapse()
+            }}
+          />
+        </Tooltip>
+      )}
+
+      {onClose && (
+        <Tooltip content="close pane" placement="bottom" nativeOverlay>
+          <IconButton
+            icon="close"
+            label="close pane"
+            showTooltip={TOOLTIP_SUPPRESSED}
+            size="sm"
+            onClick={(event) => {
+              event.stopPropagation()
+              onClose()
+            }}
+          />
+        </Tooltip>
+      )}
+    </>
+  )
+}

--- a/src/lib/backend.ts
+++ b/src/lib/backend.ts
@@ -49,6 +49,7 @@ export interface BackendApi {
     onRender: (callback: (event: unknown) => void) => UnlistenFn
     onClear: (callback: () => void) => UnlistenFn
     onActionResult: (callback: (event: unknown) => void) => UnlistenFn
+    onKeyDown: (callback: (event: unknown) => void) => UnlistenFn
   }
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -19,11 +19,24 @@ if (!rootElement) {
   throw new Error('Root element not found')
 }
 
+const nativeOverlayMode = new URLSearchParams(window.location.search).get(
+  'nativeOverlay'
+)
+
 const isNativeOverlayWindow =
-  new URLSearchParams(window.location.search).get('nativeOverlay') === '1'
+  nativeOverlayMode === '1' ||
+  nativeOverlayMode === 'menu' ||
+  nativeOverlayMode === 'tooltip'
+
+const nativeOverlayHostMode =
+  nativeOverlayMode === 'tooltip' ? 'tooltip' : 'menu'
 
 createRoot(rootElement).render(
   <StrictMode>
-    {isNativeOverlayWindow ? <NativeOverlayHost /> : <App />}
+    {isNativeOverlayWindow ? (
+      <NativeOverlayHost mode={nativeOverlayHostMode} />
+    ) : (
+      <App />
+    )}
   </StrictMode>
 )


### PR DESCRIPTION
## Summary
- add a separate native overlay tooltip layer above the menu layer
- wire burner/tooltips through the native overlay host
- relay owner-window keyboard navigation to non-focusable native overlay menus
- simplify native overlay fallback state and add tooltip rejection coverage

## Validation
- npx vitest run electron/native-overlay.test.ts electron/preload.test.ts src/components/NativeOverlayHost.test.tsx src/components/Tooltip.test.tsx src/components/Menu.test.tsx
- npm run type-check
- npm run lint
- npm run format:check
- npm test via pre-push hook: 365 files passed, 4465 tests passed, 3 skipped

Claude final review: APPROVE, no findings.


Refs VIM-264