### PR TITLE
feat(diff): add file-level review comments

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -82,7 +82,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Module Boundaries](patterns/module-boundaries.md)                                                   | code-quality       | 17       | 3    | 2026-06-25   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 13       | 3    | 2026-06-15   |
 | [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 28       | 6    | 2026-06-29   |
-| [Verify Render Target](patterns/verify-render-target.md)                                             | code-quality       | 2        | 0    | 2026-05-24   |
+| [Verify Render Target](patterns/verify-render-target.md)                                             | code-quality       | 3        | 1    | 2026-07-01   |
 | [UI Visual Regression](patterns/ui-visual-regression.md)                                             | code-quality       | 15       | 9    | 2026-06-20   |
 | [Status Indicator Display](patterns/status-indicator-display.md)                                     | code-quality       | 3        | 0    | 2026-05-26   |
 | [Parser Resilience](patterns/parser-resilience.md)                                                   | code-quality       | 14       | 8    | 2026-06-22   |
@@ -103,7 +103,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Retained State Identity](patterns/retained-state-identity.md)                                       | react-patterns     | 2        | 2    | 2026-06-28   |
 | [Authoritative Completion Guard](patterns/authoritative-completion-guard.md)                         | correctness        | 6        | 3    | 2026-06-27   |
 | [Equality Guard Completeness](patterns/equality-guard-completeness.md)                               | correctness        | 2        | 0    | 2026-06-17   |
-| [Resizable Layout Bounds](patterns/resizable-layout-bounds.md)                                       | correctness        | 3        | 1    | 2026-06-18   |
+| [Resizable Layout Bounds](patterns/resizable-layout-bounds.md)                                       | correctness        | 3        | 2    | 2026-06-18   |
 | [Schema Version Decoupling](patterns/schema-version-decoupling.md)                                   | correctness        | 1        | 0    | 2026-06-19   |
 | [Shared Controller Segmentation](patterns/shared-controller-segmentation.md)                         | react-patterns     | 2        | 0    | 2026-06-18   |
 | [Vite HMR Static Dependencies](patterns/vite-hmr-static-deps.md)                                     | code-quality       | 3        | 2    | 2026-06-18   |

--- a/docs/reviews/patterns/resizable-layout-bounds.md
+++ b/docs/reviews/patterns/resizable-layout-bounds.md
@@ -3,7 +3,7 @@ id: resizable-layout-bounds
 category: correctness
 created: 2026-06-18
 last_updated: 2026-06-18
-ref_count: 1
+ref_count: 2
 ---
 
 # Resizable Layout Bounds

--- a/docs/reviews/patterns/verify-render-target.md
+++ b/docs/reviews/patterns/verify-render-target.md
@@ -2,8 +2,8 @@
 id: verify-render-target
 category: code-quality
 created: 2026-05-24
-last_updated: 2026-05-24
-ref_count: 0
+last_updated: 2026-07-01
+ref_count: 1
 ---
 
 # Verify Render Target
@@ -39,3 +39,19 @@ is load-bearing.
 - **Finding:** PR #264 added `thin-scrollbar` to FilesPanel's container, but `grep -rn "FilesPanel\b" --include="*.tsx" --include="*.ts" src/` finds zero call sites outside the file itself — FilesPanel uses `mockFileTree` and appears to be a stub pending the sidebar-tabs rework. The PR's test plan even said "open the sidebar Files panel", but the surface a user actually sees there is `FileExplorer` (which was correctly patched in the same PR at line 103), not FilesPanel. The class on the unmounted component had zero runtime payoff and obscured the fact that the sidebar file-tree scroll surface was already covered by the FileExplorer change.
 - **Fix:** Reverted the FilesPanel className edit. Updated the changelog to say "sidebar file explorer" (singular, naming the live surface) instead of "sidebar file panels" (plural, implying both unimported and imported components were patched). Code-review heuristic: before touching a component to fix the "X kind of UI surface", confirm the component is actually rendered — `grep -n "<\?ComponentName\b" src/` for usages, and if all hits live in the component's own file or sibling tests, the component is dead code. A styling edit on dead code is not the same fix as a styling edit on the live surface.
 - **Commit:** same commit as this entry
+
+### 3. Constrain file-level comment panel height
+
+- **Source:** github-codex-connector | PR #641 round 1 | 2026-07-01
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/diff/Panel.tsx`
+- **Finding:** The file-level comments panel was `shrink-0` with no maximum
+  height or internal scroll surface while its parent pane was
+  `overflow-hidden`. With many file-level comments, the panel could consume
+  the right column and squeeze or clip the diff body instead of keeping the
+  diff usable.
+- **Fix:** Added a bounded outer panel height and moved the rendered comment
+  rows into a `min-h-0 overflow-y-auto` list. Extended the existing panel test
+  to assert the bounded container and scrollable list classes.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this
+  line)

--- a/src/features/diff/Panel.test.tsx
+++ b/src/features/diff/Panel.test.tsx
@@ -2978,6 +2978,10 @@ describe('Panel', () => {
         'file-level-comments-panel'
       )
 
+      const commentList = within(fileCommentsPanel).getByTestId(
+        'file-level-comments-list'
+      )
+
       expect(
         within(fileCommentsPanel).getByText('Commented on file')
       ).toBeInTheDocument()
@@ -2991,6 +2995,9 @@ describe('Panel', () => {
           'Review the whole file'
         )
       ).not.toBeInTheDocument()
+
+      expect(fileCommentsPanel).toHaveClass('max-h-56')
+      expect(commentList).toHaveClass('overflow-y-auto')
     })
 
     test('keyboard Shift+U edits the selected file-level comment', async (): Promise<void> => {

--- a/src/features/diff/Panel.test.tsx
+++ b/src/features/diff/Panel.test.tsx
@@ -2867,6 +2867,240 @@ describe('Panel', () => {
       ).toBeInTheDocument()
     })
 
+    test('shows a changed-file cue for adding a file-level comment', async (): Promise<void> => {
+      const user = userEvent.setup()
+
+      render(
+        <Panel
+          cwd="/repo"
+          selectedFile={{ path: 'src/foo.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+        />
+      )
+
+      await user.click(
+        within(screen.getByTestId('changed-files-pane')).getByRole('button', {
+          name: 'Comment on file foo.ts',
+        })
+      )
+
+      expect(
+        screen.getByRole('dialog', { name: 'Comment on file src/foo.ts' })
+      ).toBeInTheDocument()
+    })
+
+    test('submitting a file-level comment stores an explicit file-scope annotation', async (): Promise<void> => {
+      const user = userEvent.setup()
+      const addAnnotation = vi.fn(() => 'ok' as const)
+
+      const feedbackBatch: UseFeedbackBatchReturn = {
+        batch: new Map(),
+        annotationsForFile: () => [],
+        addAnnotation,
+        updateAnnotation: vi.fn(),
+        removeAnnotation: vi.fn(),
+        clearBatch: vi.fn(),
+        totalAnnotations: () => 0,
+      }
+
+      render(
+        <Panel
+          cwd="/repo"
+          selectedFile={{ path: 'src/foo.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+          feedbackBatch={feedbackBatch}
+        />
+      )
+
+      fireEvent.keyDown(screen.getByTestId('multi-file-diff'), {
+        key: 'I',
+        shiftKey: true,
+      })
+
+      expect(
+        within(screen.getByTestId('changed-files-pane')).queryByRole('textbox')
+      ).not.toBeInTheDocument()
+
+      expect(screen.getByTestId('diff-right-pane')).toContainElement(
+        screen.getByTestId('file-comment-popover-anchor')
+      )
+
+      const dialog = screen.getByRole('dialog', {
+        name: 'Comment on file src/foo.ts',
+      })
+      const textarea = within(dialog).getByPlaceholderText('Request change')
+
+      await user.type(textarea, 'Review the whole file')
+      await user.keyboard('{Enter}')
+
+      expect(addAnnotation).toHaveBeenCalledWith(
+        '/repo',
+        'src/foo.ts',
+        false,
+        expect.objectContaining({
+          lineNumber: 0,
+          side: 'additions',
+          metadata: expect.objectContaining({
+            text: 'Review the whole file',
+            target: { scope: 'file' },
+          }),
+        })
+      )
+    })
+
+    test('renders submitted file-level comments in the right pane, not the file list', async (): Promise<void> => {
+      const user = userEvent.setup()
+
+      render(
+        <Panel
+          cwd="/repo"
+          selectedFile={{ path: 'src/foo.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+        />
+      )
+
+      fireEvent.keyDown(screen.getByTestId('multi-file-diff'), {
+        key: 'I',
+        shiftKey: true,
+      })
+
+      const dialog = screen.getByRole('dialog', {
+        name: 'Comment on file src/foo.ts',
+      })
+
+      await user.type(
+        within(dialog).getByPlaceholderText('Request change'),
+        'Review the whole file'
+      )
+      await user.keyboard('{Enter}')
+
+      const fileCommentsPanel = await screen.findByTestId(
+        'file-level-comments-panel'
+      )
+
+      expect(
+        within(fileCommentsPanel).getByText('Commented on file')
+      ).toBeInTheDocument()
+
+      expect(
+        within(fileCommentsPanel).getByText('Review the whole file')
+      ).toBeInTheDocument()
+
+      expect(
+        within(screen.getByTestId('changed-files-pane')).queryByText(
+          'Review the whole file'
+        )
+      ).not.toBeInTheDocument()
+    })
+
+    test('keyboard Shift+U edits the selected file-level comment', async (): Promise<void> => {
+      const user = userEvent.setup()
+
+      render(
+        <Panel
+          cwd="/repo"
+          selectedFile={{ path: 'src/foo.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+        />
+      )
+
+      fireEvent.keyDown(screen.getByTestId('multi-file-diff'), {
+        key: 'I',
+        shiftKey: true,
+      })
+
+      await user.type(
+        within(
+          screen.getByRole('dialog', {
+            name: 'Comment on file src/foo.ts',
+          })
+        ).getByPlaceholderText('Request change'),
+        'Review the whole file'
+      )
+      await user.keyboard('{Enter}')
+
+      fireEvent.keyDown(screen.getByTestId('multi-file-diff'), {
+        key: 'U',
+        shiftKey: true,
+      })
+
+      const editDialog = screen.getByRole('dialog', {
+        name: 'Comment on file src/foo.ts',
+      })
+      const textarea = within(editDialog).getByPlaceholderText('Request change')
+
+      expect(textarea).toHaveValue('Review the whole file')
+
+      await user.clear(textarea)
+      await user.type(textarea, 'Updated file comment')
+      await user.keyboard('{Enter}')
+
+      const fileCommentsPanel = screen.getByTestId('file-level-comments-panel')
+
+      expect(
+        within(fileCommentsPanel).getByText('Updated file comment')
+      ).toBeInTheDocument()
+
+      expect(
+        within(fileCommentsPanel).queryByText('Review the whole file')
+      ).not.toBeInTheDocument()
+    })
+
+    test('hides a file-level draft when another file is selected', async (): Promise<void> => {
+      const user = userEvent.setup()
+
+      vi.spyOn(useGitStatusModule, 'useGitStatus').mockReturnValue({
+        files: [
+          { path: 'src/foo.ts', status: 'modified', staged: false },
+          { path: 'src/bar.ts', status: 'modified', staged: false },
+        ],
+        filesCwd: '/repo',
+        loading: false,
+        error: null,
+        refresh: vi.fn(),
+        idle: false,
+      })
+
+      const onSelectedFileChange = vi.fn()
+
+      const props = {
+        cwd: '/repo',
+        selectedFile: { path: 'src/foo.ts', staged: false, cwd: '/repo' },
+        onSelectedFileChange,
+      } as const
+
+      const { rerender } = render(<Panel {...props} />)
+
+      fireEvent.keyDown(screen.getByTestId('multi-file-diff'), {
+        key: 'I',
+        shiftKey: true,
+      })
+
+      await user.type(
+        within(
+          screen.getByRole('dialog', {
+            name: 'Comment on file src/foo.ts',
+          })
+        ).getByPlaceholderText('Request change'),
+        'Draft for foo'
+      )
+
+      rerender(
+        <Panel
+          {...props}
+          selectedFile={{ path: 'src/bar.ts', staged: false, cwd: '/repo' }}
+        />
+      )
+
+      expect(
+        screen.queryByRole('dialog', { name: 'Comment on file src/foo.ts' })
+      ).not.toBeInTheDocument()
+
+      expect(screen.getByTestId('diff-draft-recovery')).toHaveTextContent(
+        'Draft preserved for file src/foo.ts'
+      )
+    })
+
     test('Focus: stays in the Diff View for comment edit, comment editor exit, and comment delete operations', async (): Promise<void> => {
       const user = userEvent.setup()
 
@@ -3122,6 +3356,27 @@ describe('Panel', () => {
 
       expect(
         screen.getByRole('dialog', { name: /Comment on line R2/ })
+      ).toBeInTheDocument()
+    })
+
+    test('Shift+I opens the file-level comment editor for the selected file', (): void => {
+      render(
+        <Panel
+          cwd="/repo"
+          selectedFile={{ path: 'src/foo.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+        />
+      )
+
+      setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
+
+      fireEvent.keyDown(screen.getByTestId('multi-file-diff'), {
+        key: 'I',
+        shiftKey: true,
+      })
+
+      expect(
+        screen.getByRole('dialog', { name: 'Comment on file src/foo.ts' })
       ).toBeInTheDocument()
     })
 

--- a/src/features/diff/Panel.tsx
+++ b/src/features/diff/Panel.tsx
@@ -13,6 +13,7 @@ import type {
   DiffLineAnnotation,
   SelectedLineRange,
 } from '@pierre/diffs'
+import { Popover } from '@/components/Popover'
 import { useGitStatus, type UseGitStatusReturn } from './hooks/useGitStatus'
 import { useFileDiff } from './hooks/useFileDiff'
 import { ChangedFilesList } from './components/ChangedFilesList'
@@ -22,6 +23,9 @@ import { createGitService } from './services/gitService'
 import { useNotifyInfo } from '../workspace/hooks/useNotifyInfo'
 import type { ChangedFile, SelectedDiffFile } from './types'
 import {
+  FILE_COMMENT_LINE_NUMBER,
+  isFileLevelReviewAnnotation,
+  isLineLevelReviewAnnotation,
   useFeedbackBatch,
   parseBatchKey,
   type FeedbackDraftStore,
@@ -39,6 +43,7 @@ import {
   type FeedbackDispatchTarget,
 } from './services/activePanePicker'
 import {
+  isFileAnnotationTarget,
   isSameAnnotationTarget,
   useReviewCommentDraft,
   type AnnotationTarget,
@@ -47,6 +52,8 @@ import { useToolbarState } from './hooks/useToolbarState'
 import { useReviewTargetNavigation } from './hooks/useReviewTargetNavigation'
 import { Notifier } from './components/Notifier'
 import { PanelBody } from './components/PanelBody'
+import { ReviewCommentEditor } from './components/ReviewCommentEditor'
+import { ReviewCommentRow } from './components/ReviewCommentRow'
 
 const DIFF_NATIVE_FOCUS_SELECTOR =
   'button, input, textarea, select, [contenteditable], [role="textbox"]'
@@ -316,6 +323,9 @@ export const Panel = ({
   const diffRootRef = useRef<HTMLDivElement>(null)
   const diffScrollBodyRef = useRef<HTMLDivElement>(null)
 
+  const [fileCommentAnchor, setFileCommentAnchor] =
+    useState<HTMLDivElement | null>(null)
+
   // Stable focus owner for handoffs before focused diff/comment nodes unmount.
   const focusDiffRoot = useCallback((): void => {
     diffRootRef.current?.focus({ preventScroll: true })
@@ -368,10 +378,30 @@ export const Panel = ({
   }, [response, repoRootRef])
 
   // Real annotations for the currently selected file.
-  const realAnnotations = feedback.annotationsForFile(
+  const annotationsForSelectedFile = feedback.annotationsForFile(
     cwd,
     selectedFilePath ?? '',
     selectedFileStaged
+  )
+
+  const realAnnotations = useMemo(
+    (): DiffLineAnnotation<ReviewComment>[] =>
+      annotationsForSelectedFile.filter(isLineLevelReviewAnnotation),
+    [annotationsForSelectedFile]
+  )
+
+  const fileCommentsForSelectedFile = useMemo(
+    (): DiffLineAnnotation<ReviewComment>[] =>
+      selectedFileEntry === undefined
+        ? []
+        : feedback
+            .annotationsForFile(
+              cwd,
+              selectedFileEntry.path,
+              selectedFileEntry.staged
+            )
+            .filter(isFileLevelReviewAnnotation),
+    [cwd, feedback, selectedFileEntry]
   )
 
   const {
@@ -392,8 +422,20 @@ export const Panel = ({
     focusDiffRoot,
   })
 
+  const fileCommentDraftTarget =
+    annotationTarget !== null && isFileAnnotationTarget(annotationTarget)
+      ? annotationTarget
+      : null
+
+  const fileCommentDraftIsVisible =
+    fileCommentDraftTarget !== null &&
+    selectedFileEntry?.path === fileCommentDraftTarget.filePath &&
+    selectedFileEntry.staged === fileCommentDraftTarget.staged
+
   const recoverableCommentDraftTarget =
-    commentDraftIsRecoverable && annotationTarget !== null
+    commentDraftIsRecoverable &&
+    annotationTarget !== null &&
+    !fileCommentDraftIsVisible
       ? annotationTarget
       : null
 
@@ -420,6 +462,48 @@ export const Panel = ({
   const confirmCommentEditor = useCallback(
     (text: string): void => {
       if (annotationTarget === null) {
+        return
+      }
+
+      if (isFileAnnotationTarget(annotationTarget)) {
+        if (annotationTarget.editId !== undefined) {
+          feedback.updateAnnotation(
+            cwd,
+            annotationTarget.filePath,
+            annotationTarget.staged,
+            annotationTarget.editId,
+            { text }
+          )
+          closeCommentEditor()
+
+          return
+        }
+
+        const result = feedback.addAnnotation(
+          cwd,
+          annotationTarget.filePath,
+          annotationTarget.staged,
+          {
+            side: 'additions',
+            lineNumber: FILE_COMMENT_LINE_NUMBER,
+            metadata: {
+              id: nextFeedbackCommentId(),
+              text,
+              author: 'self',
+              createdAt: Date.now(),
+              target: { scope: 'file' },
+            },
+          }
+        )
+
+        if (result === 'cap-reached') {
+          notifyInfo(
+            'Feedback limit reached (50 comments). Finish or discard before adding more.'
+          )
+        } else {
+          closeCommentEditor()
+        }
+
         return
       }
 
@@ -1055,6 +1139,46 @@ export const Panel = ({
     setCommentDraftText,
   ])
 
+  const openFileCommentEditor = useCallback(
+    (file: Pick<ChangedFile, 'path' | 'staged'>): void => {
+      const nextTarget: AnnotationTarget = {
+        scope: 'file',
+        filePath: file.path,
+        staged: file.staged,
+      }
+
+      setCommentDraftText((current) => {
+        if (annotationTarget === null) {
+          return ''
+        }
+
+        return isSameAnnotationTarget(annotationTarget, nextTarget)
+          ? current
+          : ''
+      }, false)
+      setAnnotationTarget(nextTarget)
+    },
+    [annotationTarget, setAnnotationTarget, setCommentDraftText]
+  )
+
+  const openSelectedFileComment = useCallback((): void => {
+    if (selectedFileEntry === undefined) {
+      notifyInfo('No file selected.')
+
+      return
+    }
+
+    openFileCommentEditor(selectedFileEntry)
+  }, [notifyInfo, openFileCommentEditor, selectedFileEntry])
+
+  const handleAddFileComment = useCallback(
+    (file: ChangedFile): void => {
+      selectDiffFile(file)
+      openFileCommentEditor(file)
+    },
+    [openFileCommentEditor, selectDiffFile]
+  )
+
   const moveReviewTargetSide = useCallback(
     (side: AnnotationSide): void => {
       moveTargetSide(side)
@@ -1157,6 +1281,32 @@ export const Panel = ({
     setCommentDraftText,
   ])
 
+  const updateSelectedFileComment = useCallback((): void => {
+    if (selectedFilePath === null || fileCommentsForSelectedFile.length === 0) {
+      notifyInfo('No file comment selected.')
+
+      return
+    }
+
+    const fileCommentToEdit =
+      fileCommentsForSelectedFile[fileCommentsForSelectedFile.length - 1]
+
+    setAnnotationTarget({
+      scope: 'file',
+      filePath: selectedFilePath,
+      staged: selectedFileStaged,
+      editId: fileCommentToEdit.metadata.id,
+    })
+    setCommentDraftText(fileCommentToEdit.metadata.text, false)
+  }, [
+    fileCommentsForSelectedFile,
+    notifyInfo,
+    selectedFilePath,
+    selectedFileStaged,
+    setAnnotationTarget,
+    setCommentDraftText,
+  ])
+
   // Deletes the annotation on the selected review target.
   const deleteSelectedComment = useCallback((): void => {
     if (
@@ -1192,7 +1342,9 @@ export const Panel = ({
     onPreviousHunk: (): void => moveReviewTargetHunk(-1),
     onNextHunk: (): void => moveReviewTargetHunk(1),
     onComment: openSelectedComment,
+    onFileComment: openSelectedFileComment,
     onUpdateComment: updateSelectedComment,
+    onUpdateFileComment: updateSelectedFileComment,
     onDeleteComment: deleteSelectedComment,
     onFinishReview: (): void => {
       if (feedback.totalAnnotations() > 0) {
@@ -1387,8 +1539,11 @@ export const Panel = ({
       onPointerDownCapture={handleDiffRootPointerDown}
       className="flex h-full w-full min-h-0 min-w-0 flex-1 overflow-hidden focus:outline-none"
     >
-      {/* Left: Changed files list (~240px fixed) */}
-      <div className="w-60 shrink-0 border-r border-wash-subtle overflow-y-auto">
+      {/* Left: Changed files list */}
+      <div
+        data-testid="changed-files-pane"
+        className="w-60 shrink-0 overflow-y-auto"
+      >
         <ChangedFilesList
           files={effectiveFiles}
           selectedFile={
@@ -1402,6 +1557,7 @@ export const Panel = ({
           onSelectFile={(file: ChangedFile): void => {
             selectDiffFile(file)
           }}
+          onAddFileComment={handleAddFileComment}
         />
       </div>
 
@@ -1452,6 +1608,77 @@ export const Panel = ({
           onCancelKeyboardConfirm={cancelKeyboardConfirm}
           onConfirmKeyboardAction={confirmKeyboardAction}
         />
+        <div
+          ref={setFileCommentAnchor}
+          data-testid="file-comment-popover-anchor"
+          className="h-0 w-0 shrink-0"
+        />
+        <Popover
+          anchor={fileCommentAnchor}
+          open={fileCommentDraftIsVisible}
+          onOpenChange={(open): void => {
+            if (!open) {
+              closeCommentEditor()
+            }
+          }}
+          placement="bottom-start"
+          width={560}
+          middleware={{ ancestorScroll: false }}
+          aria-label={
+            fileCommentDraftTarget === null
+              ? 'Comment on file'
+              : `Comment on file ${fileCommentDraftTarget.filePath}`
+          }
+        >
+          <ReviewCommentEditor
+            targetLabel={`file ${fileCommentDraftTarget?.filePath ?? ''}`}
+            chrome="plain"
+            surfaceRole="none"
+            value={commentDraftText}
+            onTextChange={(text): void => {
+              setCommentDraftText(text, false)
+            }}
+            onConfirm={confirmCommentEditor}
+            onCancel={closeCommentEditor}
+          />
+        </Popover>
+        {selectedFileEntry !== undefined &&
+        fileCommentsForSelectedFile.length > 0 ? (
+          <div
+            data-testid="file-level-comments-panel"
+            className="flex shrink-0 flex-col gap-1 px-4 pb-3 pt-2"
+          >
+            <div className="px-2 text-xs font-medium text-on-surface-variant">
+              Commented on file
+            </div>
+            {fileCommentsForSelectedFile.map((annotation) => (
+              <ReviewCommentRow
+                key={annotation.metadata.id}
+                comment={annotation.metadata}
+                editShortcut="Shift+U"
+                deleteShortcut={null}
+                onEdit={(): void => {
+                  setAnnotationTarget({
+                    scope: 'file',
+                    filePath: selectedFileEntry.path,
+                    staged: selectedFileEntry.staged,
+                    editId: annotation.metadata.id,
+                  })
+                  setCommentDraftText(annotation.metadata.text, false)
+                }}
+                onDelete={(): void => {
+                  focusDiffRoot()
+                  feedback.removeAnnotation(
+                    cwd,
+                    selectedFileEntry.path,
+                    selectedFileEntry.staged,
+                    annotation.metadata.id
+                  )
+                }}
+              />
+            ))}
+          </div>
+        ) : null}
         <PanelBody
           scrollBodyRef={diffScrollBodyRef}
           diffError={diffError}

--- a/src/features/diff/Panel.tsx
+++ b/src/features/diff/Panel.tsx
@@ -1646,37 +1646,42 @@ export const Panel = ({
         fileCommentsForSelectedFile.length > 0 ? (
           <div
             data-testid="file-level-comments-panel"
-            className="flex shrink-0 flex-col gap-1 px-4 pb-3 pt-2"
+            className="flex max-h-56 shrink-0 flex-col gap-1 px-4 pb-3 pt-2"
           >
             <div className="px-2 text-xs font-medium text-on-surface-variant">
               Commented on file
             </div>
-            {fileCommentsForSelectedFile.map((annotation) => (
-              <ReviewCommentRow
-                key={annotation.metadata.id}
-                comment={annotation.metadata}
-                editShortcut="Shift+U"
-                deleteShortcut={null}
-                onEdit={(): void => {
-                  setAnnotationTarget({
-                    scope: 'file',
-                    filePath: selectedFileEntry.path,
-                    staged: selectedFileEntry.staged,
-                    editId: annotation.metadata.id,
-                  })
-                  setCommentDraftText(annotation.metadata.text, false)
-                }}
-                onDelete={(): void => {
-                  focusDiffRoot()
-                  feedback.removeAnnotation(
-                    cwd,
-                    selectedFileEntry.path,
-                    selectedFileEntry.staged,
-                    annotation.metadata.id
-                  )
-                }}
-              />
-            ))}
+            <div
+              data-testid="file-level-comments-list"
+              className="flex min-h-0 flex-col gap-1 overflow-y-auto pr-1"
+            >
+              {fileCommentsForSelectedFile.map((annotation) => (
+                <ReviewCommentRow
+                  key={annotation.metadata.id}
+                  comment={annotation.metadata}
+                  editShortcut="Shift+U"
+                  deleteShortcut={null}
+                  onEdit={(): void => {
+                    setAnnotationTarget({
+                      scope: 'file',
+                      filePath: selectedFileEntry.path,
+                      staged: selectedFileEntry.staged,
+                      editId: annotation.metadata.id,
+                    })
+                    setCommentDraftText(annotation.metadata.text, false)
+                  }}
+                  onDelete={(): void => {
+                    focusDiffRoot()
+                    feedback.removeAnnotation(
+                      cwd,
+                      selectedFileEntry.path,
+                      selectedFileEntry.staged,
+                      annotation.metadata.id
+                    )
+                  }}
+                />
+              ))}
+            </div>
           </div>
         ) : null}
         <PanelBody

--- a/src/features/diff/components/ChangedFilesList.test.tsx
+++ b/src/features/diff/components/ChangedFilesList.test.tsx
@@ -56,6 +56,9 @@ describe('ChangedFilesList', () => {
     expect(screen.getByText(/NavBar\.tsx/)).toBeInTheDocument()
     expect(screen.getByText(/api-helper\.rs/)).toBeInTheDocument()
     expect(screen.getByText(/tsconfig\.json/)).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /comment on file/i })
+    ).not.toBeInTheDocument()
 
     // Check file icons are rendered (Material Symbols)
     const icons = screen.getAllByRole('img', { hidden: true })
@@ -120,6 +123,30 @@ describe('ChangedFilesList', () => {
     expect(handleSelect).toHaveBeenCalledWith(mockFiles[0])
   })
 
+  test('calls onAddFileComment from the file comment affordance without selecting the file', async () => {
+    const handleSelect = vi.fn()
+    const handleAddFileComment = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <ChangedFilesList
+        files={mockFiles}
+        selectedFile={null}
+        onSelectFile={handleSelect}
+        onAddFileComment={handleAddFileComment}
+      />
+    )
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Comment on file NavBar.tsx',
+      })
+    )
+
+    expect(handleAddFileComment).toHaveBeenCalledWith(mockFiles[0])
+    expect(handleSelect).not.toHaveBeenCalled()
+  })
+
   test('renders files in the order provided (sorting done by parent)', () => {
     const orderedFiles: ChangedFile[] = [
       {
@@ -174,9 +201,11 @@ describe('ChangedFilesList', () => {
 
     // Check that hover classes exist
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    const fileButton = container.querySelector('button')
+    const row = container.querySelector(
+      '.hover\\:bg-surface-container-highest\\/20'
+    )
 
-    expect(fileButton).toHaveClass('hover:bg-surface-container-highest/20')
+    expect(row).toBeInTheDocument()
   })
 
   test('truncates long file paths', () => {

--- a/src/features/diff/components/ChangedFilesList.tsx
+++ b/src/features/diff/components/ChangedFilesList.tsx
@@ -1,10 +1,19 @@
 import type { ReactElement } from 'react'
+import { IconButton } from '@/components/IconButton'
 import type { ChangedFile } from '../types'
 
 export interface ChangedFilesListProps {
   files: ChangedFile[]
   selectedFile: { path: string; staged: boolean } | null
   onSelectFile: (file: ChangedFile) => void
+  onAddFileComment?: (file: ChangedFile) => void
+}
+
+interface ChangedFileItemProps {
+  file: ChangedFile
+  selected: boolean
+  onSelectFile: (file: ChangedFile) => void
+  onAddFileComment?: (file: ChangedFile) => void
 }
 
 const getDisplayName = (path: string): string => {
@@ -45,6 +54,61 @@ const getFileIcon = (filename: string): string => {
   }
 }
 
+const ChangedFileItem = ({
+  file,
+  selected,
+  onSelectFile,
+  onAddFileComment = undefined,
+}: ChangedFileItemProps): ReactElement => {
+  const fileName = getDisplayName(file.path)
+  const icon = getFileIcon(fileName)
+
+  return (
+    <div
+      className={`flex items-center gap-2 rounded-lg px-3 py-2 text-left transition-colors ${
+        selected
+          ? 'bg-surface-container-highest/40'
+          : 'hover:bg-surface-container-highest/20'
+      }`}
+    >
+      <button
+        onClick={(): void => onSelectFile(file)}
+        className={`flex min-w-0 flex-1 items-center gap-2 text-left ${
+          selected ? 'bg-surface-container-highest/40' : ''
+        }`}
+      >
+        <span
+          className="material-symbols-outlined text-[1.25rem] text-on-surface-variant"
+          role="img"
+          aria-hidden="true"
+        >
+          {icon}
+        </span>
+        <span className="min-w-0 flex-1 truncate font-label text-sm text-on-surface">
+          {fileName}
+        </span>
+        <div className="flex items-center gap-2 font-code text-xs">
+          {(file.insertions ?? 0) > 0 && (
+            <span className="text-vcs-added">+{file.insertions}</span>
+          )}
+          {(file.deletions ?? 0) > 0 && (
+            <span className="text-vcs-deleted">-{file.deletions}</span>
+          )}
+        </div>
+      </button>
+      {onAddFileComment !== undefined ? (
+        <IconButton
+          icon="add_comment"
+          label={`Comment on file ${fileName}`}
+          size="sm"
+          shortcut={['Shift', 'I']}
+          onClick={(): void => onAddFileComment(file)}
+        />
+      ) : null}
+    </div>
+  )
+}
+
 /**
  * ChangedFilesList component for the diff view sidebar.
  * Displays all files with git changes, sorted by status.
@@ -53,6 +117,7 @@ export const ChangedFilesList = ({
   files,
   selectedFile,
   onSelectFile,
+  onAddFileComment = undefined,
 }: ChangedFilesListProps): ReactElement => (
   <div className="flex h-full flex-col p-4">
     {/* Header — stays fixed */}
@@ -63,49 +128,18 @@ export const ChangedFilesList = ({
 
     {/* File List — scrollable with thin scrollbar */}
     <div className="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto pr-1">
-      {files.map((file) => {
-        const isActive =
-          selectedFile?.path === file.path &&
-          selectedFile.staged === file.staged
-        const fileName = getDisplayName(file.path)
-        const icon = getFileIcon(fileName)
-
-        return (
-          <button
-            key={`${file.path}:${file.staged}`}
-            onClick={(): void => onSelectFile(file)}
-            className={`flex items-center gap-2 rounded-lg px-3 py-2 text-left transition-colors ${
-              isActive
-                ? 'bg-surface-container-highest/40'
-                : 'hover:bg-surface-container-highest/20'
-            }`}
-          >
-            {/* File Icon */}
-            <span
-              className="material-symbols-outlined text-[1.25rem] text-on-surface-variant"
-              role="img"
-              aria-hidden="true"
-            >
-              {icon}
-            </span>
-
-            {/* File Name */}
-            <span className="min-w-0 flex-1 truncate font-label text-sm text-on-surface">
-              {fileName}
-            </span>
-
-            {/* Insertion/Deletion Counts */}
-            <div className="flex items-center gap-2 font-code text-xs">
-              {(file.insertions ?? 0) > 0 && (
-                <span className="text-vcs-added">+{file.insertions}</span>
-              )}
-              {(file.deletions ?? 0) > 0 && (
-                <span className="text-vcs-deleted">-{file.deletions}</span>
-              )}
-            </div>
-          </button>
-        )
-      })}
+      {files.map((file) => (
+        <ChangedFileItem
+          key={`${file.path}:${file.staged}`}
+          file={file}
+          selected={
+            selectedFile?.path === file.path &&
+            selectedFile.staged === file.staged
+          }
+          onSelectFile={onSelectFile}
+          onAddFileComment={onAddFileComment}
+        />
+      ))}
     </div>
   </div>
 )

--- a/src/features/diff/components/Notifier.tsx
+++ b/src/features/diff/components/Notifier.tsx
@@ -4,7 +4,10 @@ import { Popover } from '@/components/Popover'
 import { DiffChipToolbar, type DiffChipToolbarProps } from './toolbar'
 import { FinishFeedbackPopover } from './FinishFeedbackPopover'
 import type { PaneCandidate, ResolveResult } from '../services/activePanePicker'
-import type { AnnotationTarget } from '../hooks/useReviewCommentDraft'
+import {
+  isFileAnnotationTarget,
+  type AnnotationTarget,
+} from '../hooks/useReviewCommentDraft'
 
 interface FinishFeedbackState {
   open: boolean
@@ -79,9 +82,13 @@ export const Notifier = ({
           data-testid="diff-draft-recovery"
           className="mx-3 mb-2 rounded-md bg-surface-container-high/70 px-3 py-2 text-[11px] leading-4 text-on-surface-variant"
         >
-          Draft preserved for line{' '}
-          {recoverableDraft.target.side === 'deletions' ? 'L' : 'R'}
-          {recoverableDraft.target.lineNumber}:{' '}
+          Draft preserved for{' '}
+          {isFileAnnotationTarget(recoverableDraft.target)
+            ? `file ${recoverableDraft.target.filePath}`
+            : `line ${
+                recoverableDraft.target.side === 'deletions' ? 'L' : 'R'
+              }${recoverableDraft.target.lineNumber}`}
+          :{' '}
           <span className="font-medium text-on-surface">
             {recoverableDraft.text}
           </span>

--- a/src/features/diff/components/ReviewCommentEditor.test.tsx
+++ b/src/features/diff/components/ReviewCommentEditor.test.tsx
@@ -34,6 +34,21 @@ describe('ReviewCommentEditor', () => {
     expect(screen.getByText('Comment on line L42')).toBeInTheDocument()
   })
 
+  test('renders a file-level target label', () => {
+    render(
+      <ReviewCommentEditor
+        targetLabel="file src/foo.ts"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Comment on file src/foo.ts')).toBeInTheDocument()
+    expect(
+      screen.getByRole('dialog', { name: 'Comment on file src/foo.ts' })
+    ).toBeInTheDocument()
+  })
+
   test('renders the textarea pre-filled with initialText', () => {
     render(
       <ReviewCommentEditor

--- a/src/features/diff/components/ReviewCommentEditor.tsx
+++ b/src/features/diff/components/ReviewCommentEditor.tsx
@@ -1,17 +1,32 @@
 import { useEffect, useRef, useState, type ReactElement } from 'react'
-import type { AnnotationSide } from '@pierre/diffs'
 
-interface ReviewCommentEditorProps {
-  /** 1-based line number the comment is anchored to. */
-  lineNumber: number
-  /** Which side of the diff the line lives on (additions => R, deletions => L). */
-  side: AnnotationSide
+type CommentSide = 'deletions' | 'additions'
+
+interface ReviewCommentEditorBaseProps {
+  chrome?: 'card' | 'plain'
+  surfaceRole?: 'dialog' | 'none'
   initialText?: string
   value?: string
   onTextChange?: (text: string) => void
   onConfirm: (text: string) => void
   onCancel: () => void
 }
+
+type ReviewCommentEditorProps = ReviewCommentEditorBaseProps &
+  (
+    | {
+        /** 1-based line number the comment is anchored to. */
+        lineNumber: number
+        /** Which side of the diff the line lives on (additions => R, deletions => L). */
+        side: CommentSide
+        targetLabel?: undefined
+      }
+    | {
+        targetLabel: string
+        lineNumber?: undefined
+        side?: undefined
+      }
+  )
 
 export const moveTextareaCursorVertically = (
   textarea: HTMLTextAreaElement,
@@ -84,6 +99,9 @@ const insertTextareaNewline = (
 export const ReviewCommentEditor = ({
   lineNumber,
   side,
+  targetLabel = undefined,
+  chrome = 'card',
+  surfaceRole = 'dialog',
   initialText = '',
   value = undefined,
   onTextChange = undefined,
@@ -119,13 +137,20 @@ export const ReviewCommentEditor = ({
     }
   }
 
-  const lineRef = `${side === 'deletions' ? 'L' : 'R'}${lineNumber}`
+  const targetDescription =
+    targetLabel ?? `line ${side === 'deletions' ? 'L' : 'R'}${lineNumber}`
+
+  const className =
+    chrome === 'card'
+      ? 'mx-2 my-1 flex flex-col gap-2 rounded-lg bg-surface-container-high/80 p-3'
+      : 'flex flex-col gap-3 p-4'
 
   return (
     <div
-      role="dialog"
-      aria-label={`Comment on line ${lineRef}`}
-      className="mx-2 my-1 flex flex-col gap-2 rounded-lg bg-surface-container-high/80 p-3"
+      {...(surfaceRole === 'dialog'
+        ? { role: 'dialog', 'aria-label': `Comment on ${targetDescription}` }
+        : {})}
+      className={className}
     >
       <div className="flex items-center justify-between">
         <span className="flex items-center gap-1.5 text-xs font-medium text-on-surface">
@@ -137,8 +162,8 @@ export const ReviewCommentEditor = ({
           </span>
           Local comment
         </span>
-        <span className="text-on-surface-variant text-[0.7rem]">
-          Comment on line {lineRef}
+        <span className="min-w-0 truncate text-right text-on-surface-variant text-[0.7rem]">
+          Comment on {targetDescription}
         </span>
       </div>
       <textarea

--- a/src/features/diff/components/ReviewCommentRow.test.tsx
+++ b/src/features/diff/components/ReviewCommentRow.test.tsx
@@ -38,6 +38,31 @@ describe('ReviewCommentRow', () => {
     expect(handleEdit).toHaveBeenCalledTimes(1)
   })
 
+  test('accepts file-level shortcut overrides', () => {
+    render(
+      <ReviewCommentRow
+        comment={{
+          id: 'file-1',
+          text: 'File-level comment',
+          author: 'self',
+          createdAt: 2000,
+        }}
+        editShortcut="Shift+U"
+        deleteShortcut={null}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    )
+
+    expect(
+      screen.getByRole('button', { name: 'Edit comment' })
+    ).toHaveAttribute('aria-keyshortcuts', 'Shift+U')
+
+    expect(
+      screen.getByRole('button', { name: 'Delete comment' })
+    ).not.toHaveAttribute('aria-keyshortcuts')
+  })
+
   test('clicking Delete button fires onDelete once', async () => {
     const user = userEvent.setup()
     const handleDelete = vi.fn()

--- a/src/features/diff/components/ReviewCommentRow.tsx
+++ b/src/features/diff/components/ReviewCommentRow.tsx
@@ -4,12 +4,16 @@ import type { ReviewComment } from '../hooks/useFeedbackBatch'
 
 interface ReviewCommentRowProps {
   comment: ReviewComment
+  editShortcut?: 'u' | 'Shift+U'
+  deleteShortcut?: 'x' | null
   onEdit: () => void
   onDelete: () => void
 }
 
 export const ReviewCommentRow = ({
   comment,
+  editShortcut = 'u',
+  deleteShortcut = 'x',
   onEdit,
   onDelete,
 }: ReviewCommentRowProps): ReactElement => (
@@ -22,8 +26,8 @@ export const ReviewCommentRow = ({
         icon="edit"
         label="Edit comment"
         size="sm"
-        shortcut="u"
-        aria-keyshortcuts="u"
+        shortcut={editShortcut === 'Shift+U' ? ['Shift', 'U'] : 'u'}
+        aria-keyshortcuts={editShortcut}
         onClick={(): void => onEdit()}
       />
       <IconButton
@@ -31,8 +35,8 @@ export const ReviewCommentRow = ({
         label="Delete comment"
         variant="danger"
         size="sm"
-        shortcut="x"
-        aria-keyshortcuts="x"
+        shortcut={deleteShortcut ?? undefined}
+        aria-keyshortcuts={deleteShortcut ?? undefined}
         onClick={(): void => onDelete()}
       />
     </div>

--- a/src/features/diff/hooks/useFeedbackBatch.ts
+++ b/src/features/diff/hooks/useFeedbackBatch.ts
@@ -19,6 +19,7 @@ export interface ReviewComment {
   text: string
   author: 'self'
   createdAt: number
+  target?: { scope: 'file' }
 }
 
 /**
@@ -70,6 +71,16 @@ export const parseBatchKey = (key: string): ParsedBatchKey => {
 }
 
 const SOFT_CAP = 50
+
+export const FILE_COMMENT_LINE_NUMBER = 0
+
+export const isFileLevelReviewAnnotation = (
+  annotation: DiffLineAnnotation<ReviewComment>
+): boolean => annotation.metadata.target?.scope === 'file'
+
+export const isLineLevelReviewAnnotation = (
+  annotation: DiffLineAnnotation<ReviewComment>
+): boolean => !isFileLevelReviewAnnotation(annotation)
 
 const countAnnotationsInBatch = (batch: FeedbackBatch): number => {
   let count = 0
@@ -206,15 +217,23 @@ export interface FeedbackRepoRootStoreRef {
   repoRootForCwd: (cwd: string) => string
 }
 
-export interface FeedbackDraft {
+interface FeedbackDraftBase {
   cwd: string
   filePath: string
   staged: boolean
-  side: AnnotationSide
-  lineNumber: number
   editId?: string
   text: string
 }
+
+export type FeedbackDraft =
+  | (FeedbackDraftBase & {
+      scope?: 'line'
+      side: AnnotationSide
+      lineNumber: number
+    })
+  | (FeedbackDraftBase & {
+      scope: 'file'
+    })
 
 export interface FeedbackDraftStore {
   draft: FeedbackDraft | null

--- a/src/features/diff/hooks/useKeyboard.test.ts
+++ b/src/features/diff/hooks/useKeyboard.test.ts
@@ -70,7 +70,9 @@ const renderKeyboard = (
     onPreviousHunk: vi.fn(),
     onNextHunk: vi.fn(),
     onComment: vi.fn(),
+    onFileComment: vi.fn(),
     onUpdateComment: vi.fn(),
+    onUpdateFileComment: vi.fn(),
     onDeleteComment: vi.fn(),
     onFinishReview: vi.fn(),
     onStageHunk: vi.fn(),
@@ -135,6 +137,15 @@ describe('useKeyboard', () => {
     expect(props.onComment).toHaveBeenCalledOnce()
   })
 
+  test('Shift+I opens comment editor for the selected file', () => {
+    const { props } = renderKeyboard()
+
+    dispatch('I')
+
+    expect(props.onFileComment).toHaveBeenCalledOnce()
+    expect(props.onComment).not.toHaveBeenCalled()
+  })
+
   test('u and x update or delete the selected comment', () => {
     const { props } = renderKeyboard()
 
@@ -143,6 +154,15 @@ describe('useKeyboard', () => {
 
     expect(props.onUpdateComment).toHaveBeenCalledOnce()
     expect(props.onDeleteComment).toHaveBeenCalledOnce()
+  })
+
+  test('Shift+U updates the selected file comment', () => {
+    const { props } = renderKeyboard()
+
+    dispatch('U')
+
+    expect(props.onUpdateFileComment).toHaveBeenCalledOnce()
+    expect(props.onUpdateComment).not.toHaveBeenCalled()
   })
 
   test('Y opens finish review', () => {
@@ -316,7 +336,9 @@ describe('useKeyboard', () => {
       onPreviousHunk: vi.fn(),
       onNextHunk: vi.fn(),
       onComment: vi.fn(),
+      onFileComment: vi.fn(),
       onUpdateComment: vi.fn(),
+      onUpdateFileComment: vi.fn(),
       onDeleteComment: vi.fn(),
       onFinishReview: vi.fn(),
       onStageHunk: vi.fn(),

--- a/src/features/diff/hooks/useKeyboard.ts
+++ b/src/features/diff/hooks/useKeyboard.ts
@@ -15,7 +15,9 @@ export interface UseKeyboardOptions {
   onPreviousHunk: () => void
   onNextHunk: () => void
   onComment: () => void
+  onFileComment: () => void
   onUpdateComment: () => void
+  onUpdateFileComment: () => void
   onDeleteComment: () => void
   onFinishReview: () => void
   onStageHunk: () => void
@@ -57,7 +59,9 @@ export const useKeyboard = (options: UseKeyboardOptions): void => {
     onPreviousHunk,
     onNextHunk,
     onComment,
+    onFileComment,
     onUpdateComment,
+    onUpdateFileComment,
     onDeleteComment,
     onFinishReview,
     onStageHunk,
@@ -151,7 +155,9 @@ export const useKeyboard = (options: UseKeyboardOptions): void => {
         '[': onPreviousHunk,
         ']': onNextHunk,
         i: onComment,
+        I: onFileComment,
         u: onUpdateComment,
+        U: onUpdateFileComment,
         x: onDeleteComment,
         Y: onFinishReview,
         s: onStageHunk,
@@ -186,7 +192,9 @@ export const useKeyboard = (options: UseKeyboardOptions): void => {
     onPreviousHunk,
     onNextHunk,
     onComment,
+    onFileComment,
     onUpdateComment,
+    onUpdateFileComment,
     onDeleteComment,
     onFinishReview,
     onStageHunk,

--- a/src/features/diff/hooks/useReviewCommentDraft.test.ts
+++ b/src/features/diff/hooks/useReviewCommentDraft.test.ts
@@ -54,6 +54,12 @@ const target: AnnotationTarget = {
   staged: false,
 }
 
+const fileTarget: AnnotationTarget = {
+  scope: 'file',
+  filePath: 'src/foo.ts',
+  staged: false,
+}
+
 interface DraftHookRender {
   result: {
     current: UseReviewCommentDraftReturn & { draft: FeedbackDraft | null }
@@ -193,6 +199,23 @@ describe('useReviewCommentDraft', () => {
     expect(result.current.lineAnnotations[1]?.metadata.id).toBe(DRAFT_ID)
   })
 
+  test('stores file-level drafts without creating a Pierre line annotation', () => {
+    const { result } = renderDraftHook()
+
+    act(() => {
+      result.current.setAnnotationTarget(fileTarget, false)
+    })
+
+    expect(result.current.draft).toEqual({
+      cwd: '/repo',
+      filePath: 'src/foo.ts',
+      staged: false,
+      scope: 'file',
+      text: '',
+    })
+    expect(result.current.lineAnnotations).toEqual([existingAnnotation])
+  })
+
   test('compares target identity by file, side, line, staged state, and edit id', () => {
     expect(isSameAnnotationTarget(target, { ...target })).toBe(true)
     expect(
@@ -201,5 +224,6 @@ describe('useReviewCommentDraft', () => {
         editId: 'comment-1',
       })
     ).toBe(false)
+    expect(isSameAnnotationTarget(fileTarget, target)).toBe(false)
   })
 })

--- a/src/features/diff/hooks/useReviewCommentDraft.ts
+++ b/src/features/diff/hooks/useReviewCommentDraft.ts
@@ -27,13 +27,27 @@ import {
   type ReviewComment,
 } from './useFeedbackBatch'
 
-export interface AnnotationTarget {
+interface LineAnnotationTarget {
   lineNumber: number
   side: AnnotationSide
   filePath: string
   staged: boolean
+  scope?: 'line'
   editId?: string
 }
+
+interface FileAnnotationTarget {
+  scope: 'file'
+  filePath: string
+  staged: boolean
+  editId?: string
+}
+
+export type AnnotationTarget = LineAnnotationTarget | FileAnnotationTarget
+
+export const isFileAnnotationTarget = (
+  target: AnnotationTarget
+): target is FileAnnotationTarget => target.scope === 'file'
 
 interface UseReviewCommentDraftArgs {
   cwd: string
@@ -69,6 +83,20 @@ const resolveStateAction = <T>(next: SetStateAction<T>, current: T): T =>
 // Persisted drafts use the storage model; the renderer wants an annotation
 // target. Keep that translation in one place so component code stays declarative.
 const draftToAnnotationTarget = (draft: FeedbackDraft): AnnotationTarget => {
+  if (draft.scope === 'file') {
+    const target: AnnotationTarget = {
+      scope: 'file',
+      filePath: draft.filePath,
+      staged: draft.staged,
+    }
+
+    if (draft.editId !== undefined) {
+      target.editId = draft.editId
+    }
+
+    return target
+  }
+
   const target: AnnotationTarget = {
     lineNumber: draft.lineNumber,
     side: draft.side,
@@ -88,6 +116,22 @@ const annotationTargetToDraft = (
   target: AnnotationTarget,
   text: string
 ): FeedbackDraft => {
+  if (isFileAnnotationTarget(target)) {
+    const draft: FeedbackDraft = {
+      cwd,
+      filePath: target.filePath,
+      staged: target.staged,
+      scope: 'file',
+      text,
+    }
+
+    if (target.editId !== undefined) {
+      draft.editId = target.editId
+    }
+
+    return draft
+  }
+
   const draft: FeedbackDraft = {
     cwd,
     filePath: target.filePath,
@@ -106,10 +150,17 @@ const annotationTargetToDraft = (
 
 // This is intentionally not object identity: callers rebuild target objects
 // from keyboard navigation, gutter hover, and restored drafts.
-const annotationTargetKey = (target: AnnotationTarget): string =>
-  `${target.filePath}:${target.staged}:${target.side}:${target.lineNumber}:${
-    target.editId ?? 'draft'
-  }`
+const annotationTargetKey = (target: AnnotationTarget): string => {
+  if (isFileAnnotationTarget(target)) {
+    return `${target.filePath}:${target.staged}:file:${
+      target.editId ?? 'draft'
+    }`
+  }
+
+  return `${target.filePath}:${target.staged}:line:${target.side}:${
+    target.lineNumber
+  }:${target.editId ?? 'draft'}`
+}
 
 export const isSameAnnotationTarget = (
   left: AnnotationTarget,
@@ -120,6 +171,10 @@ const diffContainsAnnotationTarget = (
   fileDiff: FileDiff,
   target: AnnotationTarget
 ): boolean => {
+  if (isFileAnnotationTarget(target)) {
+    return true
+  }
+
   for (const hunk of fileDiff.hunks) {
     let oldLine = hunk.oldStart
     let newLine = hunk.newStart
@@ -290,18 +345,25 @@ export const useReviewCommentDraft = ({
       return false
     }
 
+    if (isFileAnnotationTarget(annotationTarget)) {
+      return true
+    }
+
     return diffContainsAnnotationTarget(activeFileDiff, annotationTarget)
   }, [activeFileDiff, annotationTarget, annotationTargetIsCurrentFile])
 
   const commentDraftIsRecoverable =
     annotationTarget !== null &&
     commentDraftText.trim().length > 0 &&
-    activeFileDiff !== null &&
-    (!annotationTargetIsCurrentFile || !annotationTargetLineExists)
+    (isFileAnnotationTarget(annotationTarget)
+      ? !annotationTargetIsCurrentFile
+      : activeFileDiff !== null &&
+        (!annotationTargetIsCurrentFile || !annotationTargetLineExists))
 
   const lineAnnotations = useMemo((): DiffLineAnnotation<ReviewComment>[] => {
     if (
       annotationTarget !== null &&
+      !isFileAnnotationTarget(annotationTarget) &&
       annotationTarget.editId === undefined &&
       annotationTargetIsCurrentFile &&
       (activeFileDiff === null || annotationTargetLineExists)

--- a/src/features/diff/services/feedbackDispatch.test.ts
+++ b/src/features/diff/services/feedbackDispatch.test.ts
@@ -22,6 +22,20 @@ const makeAnnotation = (
   },
 })
 
+const makeFileAnnotation = (
+  text: string
+): DiffLineAnnotation<ReviewComment> => ({
+  lineNumber: 0,
+  side: 'additions',
+  metadata: {
+    id: 'file-comment',
+    text,
+    author: 'self',
+    createdAt: Date.now(),
+    target: { scope: 'file' },
+  },
+})
+
 test('1 comment across 1 file -> header contains singular wording', () => {
   const entries: DispatchEntry[] = [
     {
@@ -109,6 +123,19 @@ test('each entry line is labelled with its staged/unstaged diff view', () => {
   // different comparisons — the [staged]/[unstaged] tag keeps them distinct.
   expect(payload).toContain('> src/App.tsx:5 (additions) [staged]')
   expect(payload).toContain('> src/App.tsx:8 (additions) [unstaged]')
+})
+
+test('file-level comments emit an explicit file target instead of a line target', () => {
+  const payload = formatFeedbackPayload([
+    {
+      filePath: 'src/App.tsx',
+      staged: false,
+      annotations: [makeFileAnnotation('Review the module boundary')],
+    },
+  ])
+
+  expect(payload).toContain('> src/App.tsx (file) [unstaged]')
+  expect(payload).not.toContain('src/App.tsx:0')
 })
 
 test('dispatchFeedbackBatch calls writePty once with paste-bracketed payload', async () => {

--- a/src/features/diff/services/feedbackDispatch.ts
+++ b/src/features/diff/services/feedbackDispatch.ts
@@ -1,5 +1,8 @@
 import type { DiffLineAnnotation } from '@pierre/diffs'
-import type { ReviewComment } from '../hooks/useFeedbackBatch'
+import {
+  isFileLevelReviewAnnotation,
+  type ReviewComment,
+} from '../hooks/useFeedbackBatch'
 
 const PASTE_START = '\x1b[200~'
 const PASTE_END = '\x1b[201~'
@@ -32,6 +35,20 @@ export interface DispatchEntry {
   annotations: DiffLineAnnotation<ReviewComment>[]
 }
 
+const formatAnnotationTarget = (
+  entry: DispatchEntry,
+  annotation: DiffLineAnnotation<ReviewComment>
+): string => {
+  const filePath = stripControls(entry.filePath)
+  const stagedLabel = entry.staged ? 'staged' : 'unstaged'
+
+  if (isFileLevelReviewAnnotation(annotation)) {
+    return `> ${filePath} (file) [${stagedLabel}]`
+  }
+
+  return `> ${filePath}:${annotation.lineNumber} (${annotation.side}) [${stagedLabel}]`
+}
+
 export const formatFeedbackPayload = (entries: DispatchEntry[]): string => {
   const totalCount = entries.reduce((s, e) => s + e.annotations.length, 0)
   const fileCount = entries.length
@@ -44,11 +61,7 @@ export const formatFeedbackPayload = (entries: DispatchEntry[]): string => {
           .split('\n')
           .map((line) => `> ─ ${stripControls(line)}`)
 
-        return [
-          `> ${stripControls(entry.filePath)}:${a.lineNumber} (${a.side}) [${entry.staged ? 'staged' : 'unstaged'}]`,
-          ...lines,
-          '>',
-        ].join('\n')
+        return [formatAnnotationTarget(entry, a), ...lines, '>'].join('\n')
       })
     )
     .join('\n')


### PR DESCRIPTION
## Summary
- Add file-level review comments from the changed-file row, with Shift+I for create and Shift+U for edit.
- Render saved file comments in the main diff panel as Commented on file entries.
- Extend feedback dispatch and draft state for file-scoped review comments.

## Test plan
- npx eslint on changed diff files and DockPanel test
- npx vitest run for changed diff tests and DockPanel regression coverage
- npm run type-check
- git diff --check
- pre-push npm test: 357 files, 4416 passed, 3 skipped