### PR TITLE
feat(terminal): Remove terminal pane highlight

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -45,7 +45,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | ---------------------------------------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md)                                                     | security           | 28       | 8    | 2026-06-22   |
 | [Native Surface Occlusion](patterns/native-surface-occlusion.md)                                     | correctness        | 4        | 0    | 2026-06-30   |
-| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 65       | 63   | 2026-06-30   |
+| [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 65       | 64   | 2026-06-30   |
 | [Imperative Animation Ownership](patterns/imperative-animation-ownership.md)                         | react-patterns     | 7        | 3    | 2026-06-17   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Fixed-Position Portals](patterns/fixed-position-portals.md)                                         | react-patterns     | 2        | 1    | 2026-06-22   |
@@ -61,7 +61,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 94       | 91   | 2026-06-28   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 84       | 83   | 2026-06-30   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
-| [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 79       | 76   | 2026-06-30   |
+| [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 79       | 77   | 2026-07-01   |
 | [Canonical Path Dedupe](patterns/canonical-path-dedupe.md)                                           | correctness        | 2        | 0    | 2026-06-14   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)                                       | backend            | 4        | 2    | 2026-06-14   |
 | [Command Injection](patterns/command-injection.md)                                                   | security           | 8        | 3    | 2026-06-16   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -79,7 +79,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Error Surfacing](patterns/error-surfacing.md)                                                       | error-handling     | 47       | 46   | 2026-06-28   |
 | [File Tree Paths](patterns/file-tree-paths.md)                                                       | files              | 4        | 0    | 2026-04-10   |
 | [Scope Boundary](patterns/scope-boundary.md)                                                         | review-process     | 8        | 3    | 2026-06-01   |
-| [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 24       | 10   | 2026-06-19   |
+| [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 25       | 10   | 2026-07-01   |
 | [Module Boundaries](patterns/module-boundaries.md)                                                   | code-quality       | 18       | 7    | 2026-06-28   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 13       | 3    | 2026-06-15   |
 | [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 24       | 3    | 2026-06-26   |
@@ -109,7 +109,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Shared Controller Segmentation](patterns/shared-controller-segmentation.md)                         | react-patterns     | 2        | 0    | 2026-06-18   |
 | [Vite HMR Static Dependencies](patterns/vite-hmr-static-deps.md)                                     | code-quality       | 3        | 2    | 2026-06-18   |
 | [Custom Pane Layout Preservation](patterns/custom-pane-layout-preservation.md)                       | correctness        | 13       | 5    | 2026-06-22   |
-| [Pane Slot Identity](patterns/pane-slot-identity.md)                                                 | correctness        | 3        | 1    | 2026-06-22   |
+| [Pane Slot Identity](patterns/pane-slot-identity.md)                                                 | correctness        | 4        | 1    | 2026-07-01   |
 | [Transient UI Side Effects](patterns/transient-ui-side-effects.md)                                   | react-patterns     | 9        | 4    | 2026-06-30   |
 | [Async Global State Mutation](patterns/async-global-state-mutation.md)                               | backend            | 1        | 0    | 2026-06-19   |
 | [Boolean Sentinel Consistency](patterns/boolean-sentinel-consistency.md)                             | code-quality       | 5        | 2    | 2026-06-30   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -82,7 +82,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 25       | 10   | 2026-07-01   |
 | [Module Boundaries](patterns/module-boundaries.md)                                                   | code-quality       | 18       | 7    | 2026-06-28   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 13       | 3    | 2026-06-15   |
-| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 24       | 3    | 2026-06-26   |
+| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 25       | 4    | 2026-07-01   |
 | [Verify Render Target](patterns/verify-render-target.md)                                             | code-quality       | 2        | 0    | 2026-05-24   |
 | [UI Visual Regression](patterns/ui-visual-regression.md)                                             | code-quality       | 17       | 10   | 2026-06-28   |
 | [Status Indicator Display](patterns/status-indicator-display.md)                                     | code-quality       | 3        | 0    | 2026-05-26   |

--- a/docs/reviews/patterns/async-race-conditions.md
+++ b/docs/reviews/patterns/async-race-conditions.md
@@ -2,8 +2,8 @@
 id: async-race-conditions
 category: react-patterns
 created: 2026-04-09
-last_updated: 2026-06-30
-ref_count: 76
+last_updated: 2026-07-01
+ref_count: 77
 ---
 
 # Async Race Conditions
@@ -826,4 +826,20 @@ prevent showing previous data.
 - **Fix:** Disabled focus-triggered opens for the native overlay path and kept
   explicit click, Enter, Space, and ArrowDown activation. Added regression
   coverage that restored focus alone does not call the native overlay bridge.
+- **Commit:** same commit as this entry
+
+### 79. Pane wrapper mousedown activated inactive panes before controls clicked
+
+- **Source:** github-claude | PR #642 round 2 | 2026-07-01
+- **Severity:** HIGH
+- **File:** `src/features/terminal/components/TerminalPane/index.tsx`
+- **Finding:** The pane wrapper activated inactive panes on every descendant
+  mousedown, while header controls only stopped click propagation. Clicking
+  Close or Collapse on a background pane could therefore activate that pane
+  before the control action ran, causing close-active-pane reassignment and
+  unexpected focus theft.
+- **Fix:** Added an interactive-descendant guard to the wrapper mousedown
+  handler so button, link, form, ARIA control, focusable, and contenteditable
+  targets keep their own event semantics without activating the pane first.
+  Added regression coverage for inactive-pane Close and Collapse clicks.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/e2e-testing.md
+++ b/docs/reviews/patterns/e2e-testing.md
@@ -2,7 +2,7 @@
 id: e2e-testing
 category: e2e-testing
 created: 2026-04-19
-last_updated: 2026-06-19
+last_updated: 2026-07-01
 ref_count: 10
 ---
 
@@ -262,4 +262,13 @@ completely different root causes. The generic fast-failure modes:
 - **File:** `tests/e2e/agent/specs/agent-runtime-regressions.spec.ts`
 - **Finding:** The "ingests app-data status files" scenario called `waitForVisiblePtyId()` to reuse the app's initial terminal PTY, then asserted `info.statusFile` was populated. `statusFile` is only non-null when the PTY was spawned with `enable_agent_bridge: true`. The assertion therefore depended on the E2E launch configuration rather than the test itself, and a violation would fail with a confusing "statusFile should be populated" message.
 - **Fix:** Replaced the ambient-PTY reuse with a frontend-driven new session (`button[aria-label="New session"]`), waited for the visible PTY to change, and used that dedicated bridge-enabled session for the watcher/UI assertions. Added cleanup that closes the spawned tab after the scenario.
+- **Commit:** same commit as this entry
+
+### 25. E2E helper selector collides with an open configuration menu
+
+- **Source:** deterministic CI failure | PR #642 round 1 | 2026-07-01
+- **Severity:** MEDIUM
+- **File:** `tests/e2e/shared/actions.ts`, `tests/e2e/core/specs/navigation.spec.ts`
+- **Finding:** `clickLayoutButton` queried `button[aria-label="<layout>"]` globally. Hidden-layout menu checkboxes share those labels with the real layout switcher pills, so an open configuration menu could absorb the follow-up click and leave the split layout unchanged. The navigation smoke test also asserted dock content before opening the now-closed-by-default dock.
+- **Fix:** Scoped layout-button clicks to `[data-testid="layout-switcher"]` so menu items cannot match, and made the navigation smoke open the dock via the real status-bar toggle before asserting the default Diff tab.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/keyboard-shortcut-guards.md
+++ b/docs/reviews/patterns/keyboard-shortcut-guards.md
@@ -2,8 +2,8 @@
 id: keyboard-shortcut-guards
 category: keyboard-shortcuts
 created: 2026-05-18
-last_updated: 2026-06-26
-ref_count: 3
+last_updated: 2026-07-01
+ref_count: 4
 ---
 
 # Keyboard Shortcut Guards
@@ -330,4 +330,18 @@ against three classes of false-fire:
   plumbing, so the nested control did not receive its expected activation.
 - **Fix:** Stop propagation for keyboard events that originate from nested focusable
   controls while preserving the row's own Enter/Space activation.
+- **Commit:** same commit as this entry
+
+### 25. Native Cmd+digit shortcut used layout-sensitive characters
+
+- **Source:** github-claude | PR #642 round 1 | 2026-07-01
+- **Severity:** MEDIUM
+- **File:** `native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift`
+- **Finding:** The native Ghostty keydown monitor matched Cmd+digit shortcuts from
+  `event.charactersIgnoringModifiers`, so non-US layouts could produce punctuation
+  for the physical digit row while the renderer shortcut path continued to use
+  layout-independent `KeyboardEvent.code` values.
+- **Fix:** Map AppKit `NSEvent.keyCode` values for physical ANSI digit-row keys 1
+  through 9 to the forwarded `DigitN` payload, preserving the existing
+  allowed-digit filter.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/pane-slot-identity.md
+++ b/docs/reviews/patterns/pane-slot-identity.md
@@ -2,7 +2,7 @@
 id: pane-slot-identity
 category: correctness
 created: 2026-06-19
-last_updated: 2026-06-22
+last_updated: 2026-07-01
 ref_count: 1
 ---
 
@@ -55,4 +55,13 @@ pass the `slotId` through every layer that needs to act on a specific cell.
 - **File:** `src/features/terminal/hooks/usePaneShortcuts.ts` L89-164
 - **Finding:** SplitView advertised focus shortcuts by visual slot after drag-to-slot placements, but `usePaneShortcuts` still mapped `Digit1` through `Digit6` to `activeSession.panes[index]`. Swapped panes could show `Mod+1` on one slot while the shortcut focused a different pane, and custom 3x3 layouts advertised `Mod+7` through `Mod+9` that were not handled.
 - **Fix:** Resolve digit shortcuts through the active layout's `addOrder` and `resolvePanePlacement`, then focus the pane assigned to the requested visual slot. The hook now accepts the workspace layout registry and supports slots 1 through 9.
+- **Commit:** same commit as this entry
+
+### 4. Native shortcut context reused pane-order assignments for slot shortcuts
+
+- **Source:** github-codex-connector | PR #642 round 1 | 2026-07-01
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/terminal/components/SplitView/SplitView.tsx`
+- **Finding:** The native Ghostty shortcut context derived `paneIds` from `resolvePanePlacement().assignments`, whose order follows the visible pane array rather than `layout.definition.addOrder`. Explicit placements could therefore map native digit shortcuts to the wrong visual slot.
+- **Fix:** Added a slot-ordered pane-id helper that projects assignments through `layout.definition.addOrder`, used it for `NativeGhosttyShortcutContext`, and covered swapped placements with a unit regression.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/react-lifecycle.md
+++ b/docs/reviews/patterns/react-lifecycle.md
@@ -3,7 +3,7 @@ id: react-lifecycle
 category: react-patterns
 created: 2026-04-09
 last_updated: 2026-06-30
-ref_count: 63
+ref_count: 64
 ---
 
 # React Lifecycle

--- a/electron/ghostty-native-parent.test.ts
+++ b/electron/ghostty-native-parent.test.ts
@@ -17,9 +17,24 @@ const handlers = new Map<string, (...args: unknown[]) => unknown>()
 const nativeHandle = Buffer.alloc(8)
 nativeHandle.writeBigUInt64LE(1n)
 
-const { existsSync, isDestroyed, webContentsSend } = vi.hoisted(() => ({
+const {
+  existsSync,
+  isDestroyed,
+  webContentsExecuteJavaScript,
+  webContentsFocus,
+  webContentsIsDestroyed,
+  webContentsSend,
+} = vi.hoisted(() => ({
   existsSync: vi.fn(() => false),
   isDestroyed: vi.fn(() => false),
+  webContentsExecuteJavaScript: vi.fn((script: string, gesture?: boolean) => {
+    void script
+    void gesture
+
+    return Promise.resolve(false)
+  }),
+  webContentsFocus: vi.fn(),
+  webContentsIsDestroyed: vi.fn(() => false),
   webContentsSend: vi.fn(),
 }))
 
@@ -33,7 +48,12 @@ vi.mock('electron', () => ({
     fromWebContents: vi.fn(() => ({
       getNativeWindowHandle: (): Buffer => nativeHandle,
       isDestroyed,
-      webContents: { send: webContentsSend },
+      webContents: {
+        executeJavaScript: webContentsExecuteJavaScript,
+        focus: webContentsFocus,
+        isDestroyed: webContentsIsDestroyed,
+        send: webContentsSend,
+      },
     })),
   },
   ipcMain: {
@@ -55,6 +75,11 @@ describe('ghostty native parent', () => {
     existsSync.mockReturnValue(false)
     isDestroyed.mockReset()
     isDestroyed.mockReturnValue(false)
+    webContentsExecuteJavaScript.mockReset()
+    webContentsExecuteJavaScript.mockResolvedValue(false)
+    webContentsFocus.mockClear()
+    webContentsIsDestroyed.mockReset()
+    webContentsIsDestroyed.mockReturnValue(false)
     webContentsSend.mockClear()
   })
 
@@ -288,19 +313,83 @@ describe('ghostty native parent', () => {
     controller.dispose()
   })
 
+  test('updates native shortcut digits only for real pane switches', () => {
+    const surface = {}
+
+    const addon = {
+      create: vi.fn(() => surface),
+      setFrame: vi.fn(),
+      setShortcutDigits: vi.fn(),
+      write: vi.fn(),
+      focus: vi.fn(),
+      destroy: vi.fn(),
+    }
+
+    const sidecar = {
+      invoke: <T>(): Promise<T> => Promise.resolve(undefined as T),
+      onEvent: vi.fn(() => vi.fn()),
+      shutdown: vi.fn(() => Promise.resolve()),
+    } satisfies Sidecar
+
+    const controller = setupGhosttyNativeParent({
+      sidecar,
+      platform: 'darwin',
+      env: { VITE_GHOSTTY_NATIVE_MACOS_PARENT: '1' },
+      addon,
+    })
+
+    handlers.get(GHOSTTY_NATIVE_UPDATE)?.(
+      { sender: {} },
+      {
+        sessionId: 'pty-1',
+        paneId: 'pane-1',
+        cwd: '/tmp',
+        visible: true,
+        bounds: { x: 10, y: 20, width: 300, height: 200 },
+        shortcutContext: {
+          paneIds: ['pane-1', 'pane-2', 'pane-3'],
+          activePaneId: 'pane-1',
+        },
+      }
+    )
+
+    expect(addon.setShortcutDigits).toHaveBeenLastCalledWith(surface, '23')
+
+    handlers.get(GHOSTTY_NATIVE_UPDATE)?.(
+      { sender: {} },
+      {
+        sessionId: 'pty-1',
+        paneId: 'pane-1',
+        cwd: '/tmp',
+        visible: true,
+        bounds: { x: 10, y: 20, width: 300, height: 200 },
+        shortcutContext: {
+          paneIds: ['pane-1', 'pane-2', 'pane-3'],
+          activePaneId: 'pane-2',
+        },
+      }
+    )
+
+    expect(addon.setShortcutDigits).toHaveBeenLastCalledWith(surface, '')
+
+    controller.dispose()
+  })
+
   test('creates parented surface and forwards native input plus resize', () => {
     const callbacks: {
       onInput?: (data: string) => void
       onResize?: (cols: number, rows: number) => void
       onContextMenu?: (x: number, y: number) => void
+      onFocus?: () => void
     } = {}
     const surface = {}
 
     const addon = {
-      create: vi.fn((_bridge, _handle, input, resize, contextMenu) => {
+      create: vi.fn((_bridge, _handle, input, resize, contextMenu, focus) => {
         callbacks.onInput = input
         callbacks.onResize = resize
         callbacks.onContextMenu = contextMenu
+        callbacks.onFocus = focus
 
         return surface
       }),
@@ -341,6 +430,8 @@ describe('ghostty native parent', () => {
       nativeHandle,
       expect.any(Function),
       expect.any(Function),
+      expect.any(Function),
+      expect.any(Function),
       expect.any(Function)
     )
     expect(addon.setFrame).toHaveBeenCalledWith(surface, 10, 20, 300, 200)
@@ -349,6 +440,7 @@ describe('ghostty native parent', () => {
     callbacks.onResize?.(80, 24)
     callbacks.onResize?.(80, 24)
     callbacks.onContextMenu?.(15, 25)
+    callbacks.onFocus?.()
 
     expect(sidecar.invoke).toHaveBeenCalledWith('write_pty', {
       request: { sessionId: 'pty-1', data: 'a' },
@@ -367,7 +459,82 @@ describe('ghostty native parent', () => {
       event: 'ghostty-native-context-menu',
       payload: { sessionId: 'pty-1', paneId: 'pane-1', x: 15, y: 25 },
     })
+
+    expect(webContentsSend).toHaveBeenCalledWith(BACKEND_EVENT, {
+      event: 'ghostty-native-focus',
+      payload: { sessionId: 'pty-1', paneId: 'pane-1' },
+    })
     expect(sidecar.invoke).toHaveBeenCalledTimes(2)
+
+    controller.dispose()
+  })
+
+  test('forwards native command digit shortcuts into the app renderer', async () => {
+    const callbacks: {
+      onShortcut?: (
+        key: string,
+        code: string,
+        control: boolean,
+        meta: boolean,
+        alt: boolean,
+        shift: boolean
+      ) => void
+    } = {}
+    const surface = { id: 'surface-1' }
+
+    const addon = {
+      create: vi.fn(
+        (_bridge, _handle, _input, _resize, _contextMenu, _focus, shortcut) => {
+          callbacks.onShortcut = shortcut
+
+          return surface
+        }
+      ),
+      setFrame: vi.fn(),
+      write: vi.fn(),
+      focus: vi.fn(),
+      destroy: vi.fn(),
+    }
+
+    const sidecar = {
+      invoke: vi.fn(() => Promise.resolve(undefined)),
+      onEvent: vi.fn(() => vi.fn()),
+      shutdown: vi.fn(() => Promise.resolve()),
+    } as unknown as Sidecar
+
+    const controller = setupGhosttyNativeParent({
+      sidecar,
+      platform: 'darwin',
+      env: { VITE_GHOSTTY_NATIVE_MACOS_PARENT: '1' },
+      addon,
+    })
+
+    handlers.get(GHOSTTY_NATIVE_UPDATE)?.(
+      { sender: {} },
+      {
+        sessionId: 'pty-1',
+        paneId: 'pane-1',
+        cwd: '/tmp',
+        visible: true,
+        bounds: { x: 10, y: 20, width: 300, height: 200 },
+      }
+    )
+
+    webContentsExecuteJavaScript.mockResolvedValue(true)
+    callbacks.onShortcut?.('2', 'Digit2', false, true, false, false)
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0)
+    })
+
+    expect(webContentsFocus).toHaveBeenCalledOnce()
+    expect(webContentsExecuteJavaScript).toHaveBeenCalledOnce()
+    expect(webContentsExecuteJavaScript.mock.calls[0]?.[0]).toContain('Digit2')
+    expect(webContentsExecuteJavaScript.mock.calls[0]?.[0]).toContain('metaKey')
+    expect(webContentsExecuteJavaScript.mock.calls[0]?.[0]).toContain(
+      'data-vimeflow-shortcut-proxy'
+    )
+    expect(addon.focus).toHaveBeenCalledWith(surface)
 
     controller.dispose()
   })

--- a/electron/ghostty-native-parent.ts
+++ b/electron/ghostty-native-parent.ts
@@ -19,6 +19,7 @@ import {
   isString,
   type GhosttyNativeDataRequest,
   type GhosttyNativePaneRequest,
+  type GhosttyNativeShortcutContext,
   type GhosttyNativeUpdateRequest,
 } from './ghostty-native-shared'
 
@@ -35,7 +36,16 @@ interface GhosttyNativeParentAddon {
     nativeHandle: Buffer,
     onInput: (data: string) => void,
     onResize: (cols: number, rows: number) => void,
-    onContextMenu: (x: number, y: number) => void
+    onContextMenu: (x: number, y: number) => void,
+    onFocus: () => void,
+    onShortcut: (
+      key: string,
+      code: string,
+      control: boolean,
+      meta: boolean,
+      alt: boolean,
+      shift: boolean
+    ) => void
   ) => unknown
   setFrame: (
     surface: unknown,
@@ -44,6 +54,7 @@ interface GhosttyNativeParentAddon {
     width: number,
     height: number
   ) => void
+  setShortcutDigits?: (surface: unknown, digits: string) => void
   write: (surface: unknown, data: string) => void
   focus: (surface: unknown) => void
   destroy: (surface: unknown) => void
@@ -63,6 +74,15 @@ interface GhosttyNativeSurfaceState {
   surface: unknown
   pendingData: string[]
   lastResize: { cols: number; rows: number } | null
+}
+
+interface GhosttyNativeShortcutInput {
+  key: string
+  code: string
+  control: boolean
+  meta: boolean
+  alt: boolean
+  shift: boolean
 }
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -89,6 +109,43 @@ const addonPath = (dir: string): string =>
 
 const bridgePath = (dir: string): string =>
   path.join(dir, 'libGhosttyElectronBridge.dylib')
+
+const ghosttyShortcutEventInit = (
+  input: GhosttyNativeShortcutInput
+): Record<string, boolean | string> => ({
+  key: input.key,
+  code: input.code,
+  ctrlKey: input.control,
+  metaKey: input.meta,
+  altKey: input.alt,
+  shiftKey: input.shift,
+  bubbles: true,
+  cancelable: true,
+})
+
+const isShortcutContext = (
+  value: unknown
+): value is GhosttyNativeShortcutContext =>
+  isRecord(value) &&
+  Array.isArray(value.paneIds) &&
+  value.paneIds.every(isNonEmptyString) &&
+  (value.activePaneId === null || isNonEmptyString(value.activePaneId))
+
+const shortcutDigitsForPane = (
+  paneId: string,
+  context: GhosttyNativeShortcutContext | null
+): string => {
+  if (context?.activePaneId !== paneId) {
+    return ''
+  }
+
+  return context.paneIds
+    .slice(0, 9)
+    .flatMap((targetPaneId, index) =>
+      targetPaneId === paneId ? [] : String(index + 1)
+    )
+    .join('')
+}
 
 const loadAddon = (dir: string): GhosttyNativeParentAddon => {
   const addon = addonPath(dir)
@@ -127,7 +184,9 @@ function isNativePayload<TKind extends keyof GhosttyNativePayloadByKind>(
       return (
         isString(value.cwd) &&
         isBounds(value.bounds) &&
-        typeof value.visible === 'boolean'
+        typeof value.visible === 'boolean' &&
+        (value.shortcutContext === undefined ||
+          isShortcutContext(value.shortcutContext))
       )
     case 'data':
       return typeof value.data === 'string'
@@ -232,6 +291,11 @@ export class GhosttyNativeParentController {
 
     const surface = this.getOrCreateSurface(addon, win, state)
 
+    const shortcutDigits = shortcutDigitsForPane(
+      state.pane.paneId,
+      payload.shortcutContext ?? null
+    )
+
     const roundedWidth = Math.round(payload.bounds.width)
     const roundedHeight = Math.round(payload.bounds.height)
 
@@ -245,6 +309,7 @@ export class GhosttyNativeParentController {
       height: frameVisible ? roundedHeight : 0,
     }
     addon.setFrame(surface, frame.x, frame.y, frame.width, frame.height)
+    addon.setShortcutDigits?.(surface, shortcutDigits)
     this.flushPendingData(addon, state)
 
     return { enabled: true }
@@ -427,10 +492,91 @@ export class GhosttyNativeParentController {
           event: 'ghostty-native-context-menu',
           payload: { ...state.pane, x, y },
         })
+      },
+      () => {
+        if (win.isDestroyed() || !this.surfaces.has(this.paneKey(state.pane))) {
+          return
+        }
+
+        win.webContents.send(BACKEND_EVENT, {
+          event: 'ghostty-native-focus',
+          payload: state.pane,
+        })
+      },
+      (key, code, control, meta, alt, shift) => {
+        if (win.isDestroyed() || !this.surfaces.has(this.paneKey(state.pane))) {
+          return
+        }
+
+        void this.forwardShortcutToAppRenderer(addon, win, state, {
+          key,
+          code,
+          control,
+          meta,
+          alt,
+          shift,
+        })
       }
     )
 
     return state.surface
+  }
+
+  private async forwardShortcutToAppRenderer(
+    addon: GhosttyNativeParentAddon,
+    win: BrowserWindow,
+    state: GhosttyNativeSurfaceState,
+    input: GhosttyNativeShortcutInput
+  ): Promise<void> {
+    if (win.isDestroyed() || win.webContents.isDestroyed() || !state.surface) {
+      return
+    }
+
+    win.webContents.focus()
+    const eventInit = JSON.stringify(ghosttyShortcutEventInit(input))
+    try {
+      const shouldRefocus: unknown = await win.webContents.executeJavaScript(
+        `(() => {
+          const existingTarget = document.querySelector('[data-vimeflow-shortcut-proxy]')
+          const target = existingTarget ?? (() => {
+            const node = document.createElement('button')
+            node.type = 'button'
+            node.tabIndex = -1
+            node.setAttribute('aria-hidden', 'true')
+            node.setAttribute('data-vimeflow-shortcut-proxy', 'true')
+            node.style.position = 'fixed'
+            node.style.width = '1px'
+            node.style.height = '1px'
+            node.style.opacity = '0'
+            node.style.pointerEvents = 'none'
+            document.body.appendChild(node)
+            return node
+          })()
+          if (target instanceof HTMLElement) {
+            target.focus({ preventScroll: true })
+          }
+          target.dispatchEvent(new KeyboardEvent('keydown', ${eventInit}))
+          return new Promise((resolve) => {
+            requestAnimationFrame(() => {
+              const activeGhosttyPane = Array.from(
+                document.querySelectorAll('[data-pane-kind="shell"][data-pane-active="true"]')
+              ).some((node) =>
+                node.getAttribute('data-pane-id') === ${JSON.stringify(state.pane.paneId)} &&
+                node.getAttribute('data-pty-id') === ${JSON.stringify(state.pane.sessionId)}
+              )
+              resolve(activeGhosttyPane)
+            })
+          })
+        })()`,
+        false
+      )
+
+      if (shouldRefocus === true) {
+        addon.focus(state.surface)
+      }
+    } catch {
+      // Best effort: native shortcut forwarding should not tear down the pane.
+    }
   }
 
   private flushPendingData(

--- a/electron/ghostty-native-shared.ts
+++ b/electron/ghostty-native-shared.ts
@@ -11,10 +11,16 @@ export interface GhosttyNativePaneRequest {
   paneId: string
 }
 
+export interface GhosttyNativeShortcutContext {
+  paneIds: string[]
+  activePaneId: string | null
+}
+
 export interface GhosttyNativeUpdateRequest extends GhosttyNativePaneRequest {
   cwd: string
   bounds: GhosttyNativeBounds
   visible: boolean
+  shortcutContext?: GhosttyNativeShortcutContext
 }
 
 export interface GhosttyNativeDataRequest extends GhosttyNativePaneRequest {

--- a/native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift
+++ b/native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift
@@ -20,6 +20,20 @@ public typealias VimeflowGhosttyContextMenuCallback = @convention(c) (
     Double
 ) -> Void
 
+public typealias VimeflowGhosttyFocusCallback = @convention(c) (
+    UnsafeMutableRawPointer?
+) -> Void
+
+public typealias VimeflowGhosttyShortcutCallback = @convention(c) (
+    UnsafeMutableRawPointer?,
+    UnsafePointer<CChar>?,
+    UnsafePointer<CChar>?,
+    Bool,
+    Bool,
+    Bool,
+    Bool
+) -> Void
+
 private func mainActorSync<T: Sendable>(_ body: @MainActor () -> T) -> T {
     if Thread.isMainThread {
         return MainActor.assumeIsolated(body)
@@ -38,6 +52,8 @@ private final class CallbackBox: @unchecked Sendable {
     private let inputCallback: VimeflowGhosttyInputCallback?
     private let resizeCallback: VimeflowGhosttyResizeCallback?
     private let contextMenuCallback: VimeflowGhosttyContextMenuCallback?
+    private let focusCallback: VimeflowGhosttyFocusCallback?
+    private let shortcutCallback: VimeflowGhosttyShortcutCallback?
     private let callbackContext: UnsafeMutableRawPointer?
     private var lastColumns = 0
     private var lastRows = 0
@@ -46,11 +62,15 @@ private final class CallbackBox: @unchecked Sendable {
         inputCallback: VimeflowGhosttyInputCallback?,
         resizeCallback: VimeflowGhosttyResizeCallback?,
         contextMenuCallback: VimeflowGhosttyContextMenuCallback?,
+        focusCallback: VimeflowGhosttyFocusCallback?,
+        shortcutCallback: VimeflowGhosttyShortcutCallback?,
         callbackContext: UnsafeMutableRawPointer?
     ) {
         self.inputCallback = inputCallback
         self.resizeCallback = resizeCallback
         self.contextMenuCallback = contextMenuCallback
+        self.focusCallback = focusCallback
+        self.shortcutCallback = shortcutCallback
         self.callbackContext = callbackContext
     }
 
@@ -78,6 +98,33 @@ private final class CallbackBox: @unchecked Sendable {
     func openContextMenu(x: Double, y: Double) {
         contextMenuCallback?(callbackContext, x, y)
     }
+
+    func focusSurface() {
+        focusCallback?(callbackContext)
+    }
+
+    func forwardShortcut(
+        key: String,
+        code: String,
+        control: Bool,
+        meta: Bool,
+        alt: Bool,
+        shift: Bool
+    ) {
+        key.withCString { keyPointer in
+            code.withCString { codePointer in
+                shortcutCallback?(
+                    callbackContext,
+                    keyPointer,
+                    codePointer,
+                    control,
+                    meta,
+                    alt,
+                    shift
+                )
+            }
+        }
+    }
 }
 
 @MainActor
@@ -85,7 +132,10 @@ private final class EmbeddedGhosttySurface: NSObject {
     private let parentView: NSView
     private let container = NSView(frame: .zero)
     private let callbacks: CallbackBox
+    private var focusMonitor: Any?
     private var contextMenuMonitor: Any?
+    private var shortcutMonitor: Any?
+    private var shortcutDigits = Set<Character>()
 
     private lazy var controller = TerminalController()
 
@@ -115,6 +165,8 @@ private final class EmbeddedGhosttySurface: NSObject {
         inputCallback: VimeflowGhosttyInputCallback?,
         resizeCallback: VimeflowGhosttyResizeCallback?,
         contextMenuCallback: VimeflowGhosttyContextMenuCallback?,
+        focusCallback: VimeflowGhosttyFocusCallback?,
+        shortcutCallback: VimeflowGhosttyShortcutCallback?,
         callbackContext: UnsafeMutableRawPointer?
     ) {
         self.parentView = parentView
@@ -122,6 +174,8 @@ private final class EmbeddedGhosttySurface: NSObject {
             inputCallback: inputCallback,
             resizeCallback: resizeCallback,
             contextMenuCallback: contextMenuCallback,
+            focusCallback: focusCallback,
+            shortcutCallback: shortcutCallback,
             callbackContext: callbackContext
         )
         super.init()
@@ -144,6 +198,16 @@ private final class EmbeddedGhosttySurface: NSObject {
         container.isHidden = safeWidth <= 0 || safeHeight <= 0
     }
 
+    func setShortcutDigits(_ digits: String) {
+        shortcutDigits = Set(digits.filter { character in
+            guard let value = character.wholeNumberValue else {
+                return false
+            }
+
+            return (1...9).contains(value)
+        })
+    }
+
     func receive(_ text: String) {
         session.receive(text)
     }
@@ -153,9 +217,17 @@ private final class EmbeddedGhosttySurface: NSObject {
     }
 
     func destroy() {
+        if let focusMonitor {
+            NSEvent.removeMonitor(focusMonitor)
+            self.focusMonitor = nil
+        }
         if let contextMenuMonitor {
             NSEvent.removeMonitor(contextMenuMonitor)
             self.contextMenuMonitor = nil
+        }
+        if let shortcutMonitor {
+            NSEvent.removeMonitor(shortcutMonitor)
+            self.shortcutMonitor = nil
         }
         container.removeFromSuperview()
     }
@@ -165,11 +237,32 @@ private final class EmbeddedGhosttySurface: NSObject {
         container.layer?.backgroundColor = NSColor.black.cgColor
         container.addSubview(terminalView)
         parentView.addSubview(container, positioned: .above, relativeTo: nil)
+        focusMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown]) { [weak self] event in
+            self?.handleMouseDown(event)
+
+            return event
+        }
         contextMenuMonitor = NSEvent.addLocalMonitorForEvents(matching: [.rightMouseDown]) { [weak self] event in
             self?.handleRightMouse(event)
 
             return event
         }
+        shortcutMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown]) { [weak self] event in
+            self?.handleKeyDown(event) == true ? nil : event
+        }
+    }
+
+    private func handleMouseDown(_ event: NSEvent) {
+        guard let window = terminalView.window, event.window === window else {
+            return
+        }
+
+        let terminalLocation = terminalView.convert(event.locationInWindow, from: nil)
+        guard terminalView.bounds.contains(terminalLocation) else {
+            return
+        }
+
+        callbacks.focusSurface()
     }
 
     private func handleRightMouse(_ event: NSEvent) {
@@ -187,6 +280,50 @@ private final class EmbeddedGhosttySurface: NSObject {
         let y = parentView.bounds.height - parentLocation.y
         callbacks.openContextMenu(x: x, y: y)
     }
+
+    private func handleKeyDown(_ event: NSEvent) -> Bool {
+        guard let window = terminalView.window, event.window === window else {
+            return false
+        }
+
+        guard let firstResponder = window.firstResponder as? NSView else {
+            return false
+        }
+
+        if firstResponder !== terminalView,
+           !firstResponder.isDescendant(of: terminalView) {
+            return false
+        }
+
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        guard flags.contains(.command), !flags.contains(.control) else {
+            return false
+        }
+
+        guard
+            let key = event.charactersIgnoringModifiers,
+            key.count == 1,
+            let digit = key.first,
+            ("1"..."9").contains(String(digit))
+        else {
+            return false
+        }
+
+        guard shortcutDigits.contains(digit) else {
+            return false
+        }
+
+        callbacks.forwardShortcut(
+            key: String(digit),
+            code: "Digit\(digit)",
+            control: flags.contains(.control),
+            meta: flags.contains(.command),
+            alt: flags.contains(.option),
+            shift: flags.contains(.shift)
+        )
+
+        return true
+    }
 }
 
 @_cdecl("vimeflow_ghostty_create")
@@ -195,6 +332,8 @@ public func vimeflowGhosttyCreate(
     _ inputCallback: VimeflowGhosttyInputCallback?,
     _ resizeCallback: VimeflowGhosttyResizeCallback?,
     _ contextMenuCallback: VimeflowGhosttyContextMenuCallback?,
+    _ focusCallback: VimeflowGhosttyFocusCallback?,
+    _ shortcutCallback: VimeflowGhosttyShortcutCallback?,
     _ callbackContext: UnsafeMutableRawPointer?
 ) -> UnsafeMutableRawPointer? {
     guard let parentViewPointer else {
@@ -212,6 +351,8 @@ public func vimeflowGhosttyCreate(
             inputCallback: inputCallback,
             resizeCallback: resizeCallback,
             contextMenuCallback: contextMenuCallback,
+            focusCallback: focusCallback,
+            shortcutCallback: shortcutCallback,
             callbackContext: contextPointer.value
         )
 
@@ -239,6 +380,25 @@ public func vimeflowGhosttySetFrame(
             .fromOpaque(pointer.value!)
             .takeUnretainedValue()
         surface.setFrame(x: x, y: y, width: width, height: height)
+    }
+}
+
+@_cdecl("vimeflow_ghostty_set_shortcut_digits")
+public func vimeflowGhosttySetShortcutDigits(
+    _ surfacePointer: UnsafeMutableRawPointer?,
+    _ digitsPointer: UnsafePointer<CChar>?
+) {
+    guard let surfacePointer, let digitsPointer else {
+        return
+    }
+
+    let pointer = SendablePointer(value: surfacePointer)
+    let digits = String(cString: digitsPointer)
+    mainActorSync {
+        let surface = Unmanaged<EmbeddedGhosttySurface>
+            .fromOpaque(pointer.value!)
+            .takeUnretainedValue()
+        surface.setShortcutDigits(digits)
     }
 }
 

--- a/native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift
+++ b/native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift
@@ -129,6 +129,18 @@ private final class CallbackBox: @unchecked Sendable {
 
 @MainActor
 private final class EmbeddedGhosttySurface: NSObject {
+    private static let shortcutDigitByKeyCode: [UInt16: Character] = [
+        18: "1",
+        19: "2",
+        20: "3",
+        21: "4",
+        23: "5",
+        22: "6",
+        26: "7",
+        28: "8",
+        25: "9"
+    ]
+
     private let parentView: NSView
     private let container = NSView(frame: .zero)
     private let callbacks: CallbackBox
@@ -300,12 +312,7 @@ private final class EmbeddedGhosttySurface: NSObject {
             return false
         }
 
-        guard
-            let key = event.charactersIgnoringModifiers,
-            key.count == 1,
-            let digit = key.first,
-            ("1"..."9").contains(String(digit))
-        else {
+        guard let digit = Self.shortcutDigitByKeyCode[event.keyCode] else {
             return false
         }
 

--- a/native/ghostty-parent/ghostty_native_parent.cc
+++ b/native/ghostty-parent/ghostty_native_parent.cc
@@ -13,9 +13,14 @@ namespace {
 using InputCallback = void (*)(void *, const unsigned char *, int);
 using ResizeCallback = void (*)(void *, int, int);
 using ContextMenuCallback = void (*)(void *, double, double);
+using FocusCallback = void (*)(void *);
+using ShortcutCallback = void (*)(void *, const char *, const char *, bool,
+                                  bool, bool, bool);
 using CreateFn = void *(*)(void *, InputCallback, ResizeCallback,
-                           ContextMenuCallback, void *);
+                           ContextMenuCallback, FocusCallback,
+                           ShortcutCallback, void *);
 using SetFrameFn = void (*)(void *, double, double, double, double);
+using SetShortcutDigitsFn = void (*)(void *, const char *);
 using WriteFn = void (*)(void *, const unsigned char *, int);
 using FocusFn = void (*)(void *);
 using DestroyFn = void (*)(void *);
@@ -25,6 +30,7 @@ struct BridgeApi {
   std::string loaded_path;
   CreateFn create = nullptr;
   SetFrameFn set_frame = nullptr;
+  SetShortcutDigitsFn set_shortcut_digits = nullptr;
   WriteFn write = nullptr;
   FocusFn focus = nullptr;
   DestroyFn destroy = nullptr;
@@ -35,6 +41,8 @@ struct SurfaceHandle {
   napi_threadsafe_function input_tsfn = nullptr;
   napi_threadsafe_function resize_tsfn = nullptr;
   napi_threadsafe_function context_menu_tsfn = nullptr;
+  napi_threadsafe_function focus_tsfn = nullptr;
+  napi_threadsafe_function shortcut_tsfn = nullptr;
   void *swift_surface = nullptr;
   std::atomic_bool callbacks_released = false;
   std::mutex callback_mutex;
@@ -52,6 +60,15 @@ struct ResizePayload {
 struct ContextMenuPayload {
   double x = 0;
   double y = 0;
+};
+
+struct ShortcutPayload {
+  std::string key;
+  std::string code;
+  bool control = false;
+  bool meta = false;
+  bool alt = false;
+  bool shift = false;
 };
 
 BridgeApi bridge;
@@ -99,6 +116,8 @@ bool EnsureBridge(napi_env env, const std::string &path) {
                  reinterpret_cast<void **>(&bridge.create)) &&
       LoadSymbol(env, "vimeflow_ghostty_set_frame",
                  reinterpret_cast<void **>(&bridge.set_frame)) &&
+      LoadSymbol(env, "vimeflow_ghostty_set_shortcut_digits",
+                 reinterpret_cast<void **>(&bridge.set_shortcut_digits)) &&
       LoadSymbol(env, "vimeflow_ghostty_write",
                  reinterpret_cast<void **>(&bridge.write)) &&
       LoadSymbol(env, "vimeflow_ghostty_focus",
@@ -218,6 +237,49 @@ void OnContextMenu(void *context, double x, double y) {
   napi_release_threadsafe_function(tsfn, napi_tsfn_release);
 }
 
+void OnFocus(void *context) {
+  if (context == nullptr) {
+    return;
+  }
+
+  auto *surface = static_cast<SurfaceHandle *>(context);
+  napi_threadsafe_function tsfn =
+      AcquireSurfaceCallback(surface, &SurfaceHandle::focus_tsfn);
+  if (tsfn == nullptr) {
+    return;
+  }
+
+  napi_call_threadsafe_function(tsfn, nullptr, napi_tsfn_nonblocking);
+  napi_release_threadsafe_function(tsfn, napi_tsfn_release);
+}
+
+void OnShortcut(void *context, const char *key, const char *code, bool control,
+                bool meta, bool alt, bool shift) {
+  if (context == nullptr || key == nullptr || code == nullptr) {
+    return;
+  }
+
+  auto *surface = static_cast<SurfaceHandle *>(context);
+  napi_threadsafe_function tsfn =
+      AcquireSurfaceCallback(surface, &SurfaceHandle::shortcut_tsfn);
+  if (tsfn == nullptr) {
+    return;
+  }
+
+  auto payload = std::make_unique<ShortcutPayload>();
+  payload->key = key;
+  payload->code = code;
+  payload->control = control;
+  payload->meta = meta;
+  payload->alt = alt;
+  payload->shift = shift;
+  if (napi_call_threadsafe_function(tsfn, payload.get(),
+                                    napi_tsfn_nonblocking) == napi_ok) {
+    payload.release();
+  }
+  napi_release_threadsafe_function(tsfn, napi_tsfn_release);
+}
+
 void CallJsInput(napi_env env, napi_value callback, void *, void *data) {
   std::unique_ptr<InputPayload> payload(static_cast<InputPayload *>(data));
   if (env == nullptr || callback == nullptr || payload == nullptr) {
@@ -267,6 +329,40 @@ void CallJsContextMenu(napi_env env, napi_value callback, void *, void *data) {
   }
 }
 
+void CallJsFocus(napi_env env, napi_value callback, void *, void *) {
+  if (env == nullptr || callback == nullptr) {
+    return;
+  }
+
+  napi_value global;
+  if (napi_get_global(env, &global) == napi_ok) {
+    napi_value ignored;
+    napi_call_function(env, global, callback, 0, nullptr, &ignored);
+  }
+}
+
+void CallJsShortcut(napi_env env, napi_value callback, void *, void *data) {
+  std::unique_ptr<ShortcutPayload> payload(static_cast<ShortcutPayload *>(data));
+  if (env == nullptr || callback == nullptr || payload == nullptr) {
+    return;
+  }
+
+  napi_value global;
+  napi_value argv[6];
+  if (napi_get_global(env, &global) == napi_ok &&
+      napi_create_string_utf8(env, payload->key.data(), payload->key.size(),
+                              &argv[0]) == napi_ok &&
+      napi_create_string_utf8(env, payload->code.data(), payload->code.size(),
+                              &argv[1]) == napi_ok &&
+      napi_get_boolean(env, payload->control, &argv[2]) == napi_ok &&
+      napi_get_boolean(env, payload->meta, &argv[3]) == napi_ok &&
+      napi_get_boolean(env, payload->alt, &argv[4]) == napi_ok &&
+      napi_get_boolean(env, payload->shift, &argv[5]) == napi_ok) {
+    napi_value ignored;
+    napi_call_function(env, global, callback, 6, argv, &ignored);
+  }
+}
+
 bool CreateThreadsafeFunction(napi_env env, napi_value callback,
                               const char *name,
                               napi_threadsafe_function_call_js call_js,
@@ -309,14 +405,20 @@ void ReleaseSurfaceCallbacks(SurfaceHandle *surface) {
   napi_threadsafe_function input_tsfn = nullptr;
   napi_threadsafe_function resize_tsfn = nullptr;
   napi_threadsafe_function context_menu_tsfn = nullptr;
+  napi_threadsafe_function focus_tsfn = nullptr;
+  napi_threadsafe_function shortcut_tsfn = nullptr;
   {
     std::lock_guard<std::mutex> lock(surface->callback_mutex);
     input_tsfn = surface->input_tsfn;
     resize_tsfn = surface->resize_tsfn;
     context_menu_tsfn = surface->context_menu_tsfn;
+    focus_tsfn = surface->focus_tsfn;
+    shortcut_tsfn = surface->shortcut_tsfn;
     surface->input_tsfn = nullptr;
     surface->resize_tsfn = nullptr;
     surface->context_menu_tsfn = nullptr;
+    surface->focus_tsfn = nullptr;
+    surface->shortcut_tsfn = nullptr;
   }
 
   if (input_tsfn != nullptr) {
@@ -328,16 +430,22 @@ void ReleaseSurfaceCallbacks(SurfaceHandle *surface) {
   if (context_menu_tsfn != nullptr) {
     napi_release_threadsafe_function(context_menu_tsfn, napi_tsfn_abort);
   }
+  if (focus_tsfn != nullptr) {
+    napi_release_threadsafe_function(focus_tsfn, napi_tsfn_abort);
+  }
+  if (shortcut_tsfn != nullptr) {
+    napi_release_threadsafe_function(shortcut_tsfn, napi_tsfn_abort);
+  }
 }
 
 napi_value Create(napi_env env, napi_callback_info info) {
-  size_t argc = 5;
-  napi_value args[5];
+  size_t argc = 7;
+  napi_value args[7];
   napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
-  if (argc < 5) {
+  if (argc < 7) {
     return Throw(
         env,
-        "create(path, nativeHandle, onInput, onResize, onContextMenu) expected");
+        "create(path, nativeHandle, onInput, onResize, onContextMenu, onFocus, onShortcut) expected");
   }
 
   const std::string bridge_path = GetString(env, args[0]);
@@ -366,12 +474,17 @@ napi_value Create(napi_env env, napi_callback_info info) {
                                 CallJsResize, &surface->resize_tsfn) ||
       !CreateThreadsafeFunction(env, args[4], "vimeflow-ghostty-context-menu",
                                 CallJsContextMenu,
-                                &surface->context_menu_tsfn)) {
+                                &surface->context_menu_tsfn) ||
+      !CreateThreadsafeFunction(env, args[5], "vimeflow-ghostty-focus",
+                                CallJsFocus, &surface->focus_tsfn) ||
+      !CreateThreadsafeFunction(env, args[6], "vimeflow-ghostty-shortcut",
+                                CallJsShortcut, &surface->shortcut_tsfn)) {
     FinalizeSurface(env, surface, nullptr);
     return Throw(env, "failed to create Ghostty native callbacks");
   }
   surface->swift_surface =
-      bridge.create(parent_view, OnInput, OnResize, OnContextMenu, surface);
+      bridge.create(parent_view, OnInput, OnResize, OnContextMenu, OnFocus,
+                    OnShortcut, surface);
   if (surface->swift_surface == nullptr) {
     FinalizeSurface(env, surface, nullptr);
     return Throw(env, "failed to create Ghostty native surface");
@@ -409,6 +522,25 @@ napi_value SetFrame(napi_env env, napi_callback_info info) {
   napi_get_value_double(env, args[3], &width);
   napi_get_value_double(env, args[4], &height);
   bridge.set_frame(surface->swift_surface, x, y, width, height);
+
+  return nullptr;
+}
+
+napi_value SetShortcutDigits(napi_env env, napi_callback_info info) {
+  size_t argc = 2;
+  napi_value args[2];
+  napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+  if (argc < 2) {
+    return Throw(env, "setShortcutDigits(surface, digits) expected");
+  }
+
+  SurfaceHandle *surface = GetSurface(env, args[0]);
+  if (surface == nullptr || surface->swift_surface == nullptr) {
+    return nullptr;
+  }
+
+  const std::string digits = GetString(env, args[1]);
+  bridge.set_shortcut_digits(surface->swift_surface, digits.c_str());
 
   return nullptr;
 }
@@ -466,6 +598,8 @@ napi_value Init(napi_env env, napi_value exports) {
        nullptr},
       {"setFrame", nullptr, SetFrame, nullptr, nullptr, nullptr, napi_default,
        nullptr},
+      {"setShortcutDigits", nullptr, SetShortcutDigits, nullptr, nullptr,
+       nullptr, napi_default, nullptr},
       {"write", nullptr, Write, nullptr, nullptr, nullptr, napi_default,
        nullptr},
       {"focus", nullptr, Focus, nullptr, nullptr, nullptr, napi_default,

--- a/scripts/build-ghostty-native-parent.js
+++ b/scripts/build-ghostty-native-parent.js
@@ -1,5 +1,5 @@
-// cspell:ignore codesign ghostty Ghostty mmacosx otool swiftpm xcrun
-import { existsSync, mkdirSync, copyFileSync } from 'node:fs'
+// cspell:ignore codesign ghostty Ghostty libghostty mmacosx otool swiftpm xcframework xcrun
+import { existsSync, mkdirSync, copyFileSync, rmSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { execFileSync } from 'node:child_process'
@@ -18,6 +18,12 @@ const addonSource = join(
 const addonOutput = join(outputDir, 'ghostty_native_parent.node')
 const bridgeOutput = join(outputDir, 'libGhosttyElectronBridge.dylib')
 
+const ghosttyScratchXcframework = join(
+  scratchDir,
+  'artifacts/libghostty-spm/libghostty/GhosttyKit.xcframework'
+)
+const ghosttyScratchPlist = join(ghosttyScratchXcframework, 'Info.plist')
+
 const nodeIncludeDir = [
   join(dirname(dirname(process.execPath)), 'include/node'),
   '/usr/local/include/node',
@@ -29,6 +35,10 @@ if (!nodeIncludeDir) {
 }
 
 mkdirSync(outputDir, { recursive: true })
+
+if (existsSync(ghosttyScratchXcframework) && !existsSync(ghosttyScratchPlist)) {
+  rmSync(scratchDir, { recursive: true, force: true })
+}
 
 execFileSync(
   'swift',

--- a/src/features/terminal/components/SplitView/SplitView.test.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.test.tsx
@@ -11,6 +11,7 @@ import {
   selectVisiblePanes,
   canClosePane,
   resolveLayoutRatios,
+  getSlotOrderedPaneIds,
   type SplitViewHandle,
 } from './SplitView'
 import type {
@@ -26,6 +27,7 @@ import {
   PaneLayoutRegistry,
   type PaneLayoutDefinition,
 } from '../../layout-registry'
+import { resolvePanePlacement } from '../../../sessions/utils/panePlacements'
 
 class MockResizeObserver {
   observe = vi.fn()
@@ -512,6 +514,26 @@ describe('SplitView - multi-pane layouts', () => {
     expect(slots[0]).toHaveStyle({ gridArea: 'p3' })
     expect(slots[1]).toHaveAttribute('data-pane-id', 'p1')
     expect(slots[1]).toHaveStyle({ gridArea: 'p0' })
+  })
+
+  test('shortcut pane ids follow slot order when placements reorder panes', () => {
+    const session = {
+      ...makeSession('quad', 2),
+      placements: [
+        { paneId: 'p0', slotId: 'slot:p3' },
+        { paneId: 'p1', slotId: 'slot:p0' },
+      ],
+    } satisfies Session
+
+    const resolution = resolvePanePlacement(
+      session.panes,
+      LAYOUTS.quad,
+      session.placements
+    )
+
+    expect(getSlotOrderedPaneIds(resolution.assignments, LAYOUTS.quad)).toEqual(
+      ['p1', 'p0']
+    )
   })
 
   test('focus marker follows pane.active and inactive panes are dimmed', () => {

--- a/src/features/terminal/components/SplitView/SplitView.test.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.test.tsx
@@ -532,26 +532,6 @@ describe('SplitView - multi-pane layouts', () => {
 
     expect(inactiveWrapper).not.toHaveAttribute('data-focused')
     expect(inactiveWrapper).toHaveStyle({ opacity: '0.78' })
-    expect(activeWrapper).toHaveAttribute('data-focused', 'true')
-    expect(activeWrapper).toHaveStyle({ opacity: '1' })
-  })
-
-  test('showPaneFocusHighlight=false suppresses active pane marker without dimming active pane', () => {
-    const showPaneFocusHighlight = false
-
-    render(
-      <SplitView
-        session={makeSession('vsplit', 2, 1)}
-        service={makeMockService()}
-        isActive
-        showPaneFocusHighlight={showPaneFocusHighlight}
-      />
-    )
-
-    const activeWrapper = within(
-      screen.getAllByTestId('split-view-slot')[1]
-    ).getByTestId('terminal-pane-wrapper')
-
     expect(activeWrapper).not.toHaveAttribute('data-focused')
     expect(activeWrapper).toHaveStyle({ opacity: '1' })
   })

--- a/src/features/terminal/components/SplitView/SplitView.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useImperativeHandle,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
   type DragEvent,
@@ -28,6 +29,7 @@ import {
 import { BrowserPane, focusBrowserPane } from '../../../browser'
 import type { NotifyPaneReady } from '../../hooks/useTerminal'
 import type { BurnerTarget } from '../../hooks/useBurnerTerminals'
+import type { NativeGhosttyShortcutContext } from '../../nativeGhosttyClient'
 import type { ITerminalService } from '../../services/terminalService'
 import {
   TerminalPane,
@@ -91,7 +93,6 @@ export interface SplitViewProps {
   /** Pane-keys with a live burner shell (idle or active) — drives a11y state (VIM-53). */
   runningBurnerPaneKeys?: ReadonlySet<string>
   deferTerminalFit?: boolean
-  showPaneFocusHighlight?: boolean
 }
 
 export interface SplitViewHandle {
@@ -169,7 +170,6 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
       activeBurnerPaneKeys = undefined,
       runningBurnerPaneKeys = undefined,
       deferTerminalFit = false,
-      showPaneFocusHighlight = true,
     }: SplitViewProps,
     ref
   ): ReactElement {
@@ -285,6 +285,26 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
 
     const { assignments: visiblePaneAssignments, emptySlotIds } =
       resolvePanePlacement(visiblePanes, layout, session.placements)
+
+    const visibleShortcutPaneIds = visiblePaneAssignments.map(
+      ({ pane }) => pane.id
+    )
+
+    const visibleShortcutPaneIdsKey = visibleShortcutPaneIds.join('\u0000')
+
+    const activePaneId =
+      session.panes.find((sessionPane) => sessionPane.active)?.id ?? null
+
+    const nativeShortcutContext = useMemo<NativeGhosttyShortcutContext>(
+      () => ({
+        paneIds:
+          visibleShortcutPaneIdsKey.length > 0
+            ? visibleShortcutPaneIdsKey.split('\u0000')
+            : [],
+        activePaneId,
+      }),
+      [activePaneId, visibleShortcutPaneIdsKey]
+    )
 
     const gridTemplateAreas = grid.areas
       .map((row) => `"${row.join(' ')}"`)
@@ -620,7 +640,6 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
                             onRequestActive={onSetActivePane}
                             onRequestFocus={onRequestFocus}
                             onUrlChange={onBrowserPaneUrlChange}
-                            showFocusHighlight={showPaneFocusHighlight}
                           />
                         </>
                       ) : (
@@ -640,11 +659,12 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
                           onClose={closeHandler}
                           onBurner={onBurner}
                           onRequestActive={onSetActivePane}
+                          onRequestFocus={onRequestFocus}
                           activeBurnerPaneKeys={activeBurnerPaneKeys}
                           runningBurnerPaneKeys={runningBurnerPaneKeys}
                           isActive={isActive}
+                          shortcutContext={nativeShortcutContext}
                           deferFit={deferTerminalFit}
-                          showFocusHighlight={showPaneFocusHighlight}
                           paneDraggable={dndEnabled}
                           onHeaderDragStart={(event): void =>
                             handlePaneDragStart(pane.id, event)

--- a/src/features/terminal/components/SplitView/SplitView.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.tsx
@@ -25,6 +25,7 @@ import {
   movePaneToSlot,
   resolvePanePlacement,
   swapPanePlacements,
+  type PaneSlotAssignment,
 } from '../../../sessions/utils/panePlacements'
 import { BrowserPane, focusBrowserPane } from '../../../browser'
 import type { NotifyPaneReady } from '../../hooks/useTerminal'
@@ -147,6 +148,21 @@ export const resolveLayoutRatios = (
   }
 
   return layout.defaultRatios
+}
+
+export const getSlotOrderedPaneIds = (
+  assignments: readonly PaneSlotAssignment[],
+  layout: LayoutShape
+): string[] => {
+  const paneIdBySlotId = new Map(
+    assignments.map(({ pane, slotId }) => [slotId, pane.id])
+  )
+
+  return layout.definition.addOrder.flatMap((slotId) => {
+    const paneId = paneIdBySlotId.get(slotId)
+
+    return paneId === undefined ? [] : [paneId]
+  })
 }
 
 export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
@@ -286,8 +302,9 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
     const { assignments: visiblePaneAssignments, emptySlotIds } =
       resolvePanePlacement(visiblePanes, layout, session.placements)
 
-    const visibleShortcutPaneIds = visiblePaneAssignments.map(
-      ({ pane }) => pane.id
+    const visibleShortcutPaneIds = getSlotOrderedPaneIds(
+      visiblePaneAssignments,
+      layout
     )
 
     const visibleShortcutPaneIdsKey = visibleShortcutPaneIds.join('\u0000')

--- a/src/features/terminal/components/TerminalPane/GhosttyBody.test.tsx
+++ b/src/features/terminal/components/TerminalPane/GhosttyBody.test.tsx
@@ -182,6 +182,30 @@ describe('GhosttyBody', () => {
     expect(destroyNativeGhostty).toHaveBeenCalledWith(paneRef)
   })
 
+  test('sends shortcut context with native frame updates', async () => {
+    const shortcutContext = {
+      paneIds: ['pane-1', 'pane-2'],
+      activePaneId: 'pane-1',
+    }
+
+    render(
+      <GhosttyBody
+        paneId="pane-1"
+        ptyId="pty-1"
+        cwd="/tmp"
+        active
+        shortcutContext={shortcutContext}
+        service={createService()}
+      />
+    )
+
+    await waitFor(() => {
+      expect(updateNativeGhostty).toHaveBeenCalledWith(
+        expect.objectContaining({ shortcutContext })
+      )
+    })
+  })
+
   test('absorbs native destroy failures during unmount cleanup', async () => {
     vi.mocked(destroyNativeGhostty).mockRejectedValueOnce(new Error('disposed'))
 
@@ -449,6 +473,37 @@ describe('GhosttyBody', () => {
     })
 
     expect(onCommandSubmit).toHaveBeenCalledWith('pty-1', '/clear')
+  })
+
+  test('requests pane activation from native focus events', async () => {
+    const onRequestActive = vi.fn()
+    const onRequestFocus = vi.fn()
+
+    render(
+      <GhosttyBody
+        paneId="pane-1"
+        ptyId="pty-1"
+        cwd="/tmp"
+        active={inactive}
+        service={createService()}
+        onRequestActive={onRequestActive}
+        onRequestFocus={onRequestFocus}
+      />
+    )
+
+    await waitFor(() => {
+      expect(backendListeners.has('ghostty-native-focus')).toBe(true)
+    })
+
+    act(() => {
+      backendListeners.get('ghostty-native-focus')?.({
+        sessionId: 'pty-1',
+        paneId: 'pane-1',
+      })
+    })
+
+    expect(onRequestFocus).toHaveBeenCalledOnce()
+    expect(onRequestActive).toHaveBeenCalledOnce()
   })
 
   test('opens terminal context menu from native right-click event', async () => {

--- a/src/features/terminal/components/TerminalPane/GhosttyBody.tsx
+++ b/src/features/terminal/components/TerminalPane/GhosttyBody.tsx
@@ -17,6 +17,7 @@ import {
   focusNativeGhostty,
   sendNativeGhosttyData,
   updateNativeGhostty,
+  type NativeGhosttyShortcutContext,
 } from '../../nativeGhosttyClient'
 import { TerminalContextMenu } from '../TerminalContextMenu'
 import {
@@ -39,6 +40,9 @@ interface GhosttyBodyProps {
   onCwdChange?: (cwd: string) => void
   onPaneReady?: NotifyPaneReady
   onCommandSubmit?: (ptyId: string, command: string) => void
+  onRequestActive?: () => void
+  onRequestFocus?: () => void
+  shortcutContext?: NativeGhosttyShortcutContext
   onUnavailable?: () => void
 }
 
@@ -53,6 +57,11 @@ interface GhosttyNativeContextMenuEvent {
   paneId: string
   x: number
   y: number
+}
+
+interface GhosttyNativeFocusEvent {
+  sessionId: string
+  paneId: string
 }
 
 const TERMINAL_INPUT_CONTROL_SEQUENCE_PATTERN =
@@ -93,6 +102,9 @@ export const GhosttyBody = ({
   onCwdChange = undefined,
   onPaneReady = undefined,
   onCommandSubmit = undefined,
+  onRequestActive = undefined,
+  onRequestFocus = undefined,
+  shortcutContext = undefined,
   onUnavailable = undefined,
 }: GhosttyBodyProps): ReactElement => {
   const containerRef = useRef<HTMLDivElement | null>(null)
@@ -356,6 +368,7 @@ export const GhosttyBody = ({
           height: rect.height,
         },
         visible: true,
+        ...(shortcutContext ? { shortcutContext } : {}),
       })
 
       if (!enabled) {
@@ -364,7 +377,7 @@ export const GhosttyBody = ({
     } catch {
       onUnavailable?.()
     }
-  }, [cwd, onUnavailable, paneRef])
+  }, [cwd, onUnavailable, paneRef, shortcutContext])
 
   const scheduleNativeFrameUpdate = useCallback((): void => {
     if (frameIdRef.current !== null) {
@@ -405,6 +418,41 @@ export const GhosttyBody = ({
       void focusNativeSurface()
     }
   }, [active, focusNativeSurface])
+
+  useEffect(() => {
+    let cancelled = false
+    let unlisten: (() => void) | null = null
+
+    const attachFocusListener = async (): Promise<void> => {
+      const cleanup = await listen<GhosttyNativeFocusEvent>(
+        'ghostty-native-focus',
+        (payload) => {
+          if (
+            payload.sessionId === paneRef.sessionId &&
+            payload.paneId === paneRef.paneId
+          ) {
+            onRequestFocus?.()
+            onRequestActive?.()
+          }
+        }
+      )
+
+      if (cancelled) {
+        cleanup()
+
+        return
+      }
+
+      unlisten = cleanup
+    }
+
+    void attachFocusListener()
+
+    return (): void => {
+      cancelled = true
+      unlisten?.()
+    }
+  }, [onRequestActive, onRequestFocus, paneRef])
 
   useEffect(() => {
     let cancelled = false

--- a/src/features/terminal/components/TerminalPane/Header.test.tsx
+++ b/src/features/terminal/components/TerminalPane/Header.test.tsx
@@ -43,44 +43,75 @@ const session: Session = {
 const baseProps = {
   agent: AGENTS.claude,
   session,
-  isFocused: true,
+  isActive: true,
   isCollapsed: false,
   ptyId: 's1',
   onToggleCollapse: vi.fn(),
 }
 
 describe('Header', () => {
-  test('renders agent chip with short name and glyph', () => {
+  test('renders compact glyph-only agent chip', () => {
     render(<Header {...baseProps} />)
 
-    expect(screen.getByText('CLAUDE')).toBeInTheDocument()
+    expect(screen.getByTestId('agent-glyph-label')).toHaveTextContent('CLAUDE')
+    expect(screen.getByTestId('agent-glyph-label')).toHaveClass('hidden')
 
     const glyphChip = screen.getByTestId('agent-glyph-chip')
+    expect(glyphChip).toHaveClass('h-[22px]')
+    expect(glyphChip).toHaveClass('w-[22px]')
+    expect(glyphChip).toHaveClass('justify-center')
     // eslint-disable-next-line testing-library/no-node-access -- claude renders an svg brand mark
     const brandMark = glyphChip.querySelector('svg')
 
     expect(brandMark).toBeInTheDocument()
   })
 
-  test('agent chip sheds its label to glyph-only on a narrow pane', () => {
+  test('header uses compact spacing by default', () => {
     render(<Header {...baseProps} />)
 
-    // The short-name label hides via a container query below the narrow-pane
-    // threshold (same 280px breakpoint the status bar uses to go compact)...
-    expect(screen.getByTestId('agent-glyph-label')).toHaveClass(
-      '@max-[280px]/pane:hidden'
-    )
+    const header = screen.getByTestId('terminal-pane-header')
+    expect(header).toHaveClass('gap-1.5')
+    expect(header).toHaveClass('px-2')
+    expect(header).toHaveClass('py-1')
+  })
 
-    // ...while the glyph itself always renders, so the chip never goes empty.
+  test('collapsed status does not change the compact header', () => {
+    render(<Header {...baseProps} isCollapsed />)
+
+    const header = screen.getByTestId('terminal-pane-header')
+    expect(header).toHaveClass('gap-1.5')
+    expect(header).toHaveClass('px-2')
+    expect(header).toHaveClass('py-1')
+
     const glyphChip = screen.getByTestId('agent-glyph-chip')
-    // eslint-disable-next-line testing-library/no-node-access -- the glyph is an svg brand mark
-    expect(glyphChip.querySelector('svg')).toBeInTheDocument()
+    expect(glyphChip).toHaveClass('h-[22px]')
+    expect(glyphChip).toHaveClass('w-[22px]')
+    expect(glyphChip).toHaveClass('justify-center')
+    expect(screen.getByTestId('agent-glyph-label')).toHaveClass('hidden')
   })
 
   test('renders pane title from session.name', () => {
     render(<Header {...baseProps} />)
 
     expect(screen.getByText('auth refactor')).toBeInTheDocument()
+  })
+
+  test('uses the theme active surface tone', () => {
+    render(<Header {...baseProps} />)
+
+    expect(screen.getByTestId('terminal-pane-header')).toHaveClass(
+      'bg-primary-container/15'
+    )
+  })
+
+  test('does not tint inactive pane headers', () => {
+    const inactiveProps = { ...baseProps, isActive: false }
+
+    render(<Header {...inactiveProps} />)
+
+    expect(screen.getByTestId('terminal-pane-header')).not.toHaveClass(
+      'bg-primary-container/15'
+    )
   })
 
   test('renders paneAgentTitle when provided', () => {
@@ -186,15 +217,6 @@ describe('Header', () => {
     expect(
       screen.getByRole('button', { name: /close pane/i })
     ).toBeInTheDocument()
-  })
-
-  test('focused state applies header gradient marker', () => {
-    render(<Header {...baseProps} isFocused />)
-
-    expect(screen.getByTestId('terminal-pane-header')).toHaveAttribute(
-      'data-focused',
-      'true'
-    )
   })
 
   test('is not draggable by default', () => {

--- a/src/features/terminal/components/TerminalPane/Header.tsx
+++ b/src/features/terminal/components/TerminalPane/Header.tsx
@@ -10,7 +10,7 @@ import { HeaderActions } from './HeaderActions'
 export interface HeaderProps {
   agent: Agent
   session: Session
-  isFocused: boolean
+  isActive: boolean
   isCollapsed: boolean
   autoCollapsed?: boolean
   hideCollapseToggle?: boolean
@@ -35,7 +35,7 @@ export interface HeaderProps {
 export const Header = ({
   agent,
   session,
-  isFocused,
+  isActive,
   isCollapsed,
   autoCollapsed = false,
   hideCollapseToggle = false,
@@ -68,12 +68,6 @@ export const Header = ({
     onHeaderDragEnd?.(event)
   }
 
-  const headerStyle = isFocused
-    ? {
-        background: `linear-gradient(180deg, ${agent.accentDim}, color-mix(in srgb, var(--color-surface-container-lowest) 0%, transparent))`,
-      }
-    : { background: 'transparent' }
-
   useEffect(() => {
     if (titleRef.current) {
       register(ptyId, titleRef.current)
@@ -85,26 +79,21 @@ export const Header = ({
   return (
     <div
       data-testid="terminal-pane-header"
-      data-focused={isFocused || undefined}
-      data-collapsed={isCollapsed || undefined}
       data-drag-handle={draggable || undefined}
       draggable={draggable}
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
-      style={{
-        ...headerStyle,
-        cursor: draggable ? 'grab' : undefined,
-      }}
-      className={`flex shrink-0 select-none items-center gap-2.5 border-b border-outline-variant/[0.18] font-mono text-[10.5px] ${
-        isCollapsed ? 'px-2.5 py-1.5' : 'pb-2 pl-2.5 pr-3 pt-2'
-      }`}
+      style={{ cursor: draggable ? 'grab' : undefined }}
+      className={`flex shrink-0 select-none items-center border-b border-outline-variant/[0.18] font-mono text-[10.5px] ${
+        isActive ? 'bg-primary-container/15' : ''
+      } gap-1.5 px-2 py-1`}
     >
       <Chip
         data-testid="agent-glyph-chip"
         tone="custom"
         radius="md"
         size="custom"
-        className="shrink-0 gap-1.5 rounded-md border px-2 py-[3px] font-semibold tracking-[0.04em]"
+        className="h-[22px] w-[22px] shrink-0 justify-center rounded-md border p-0 font-semibold tracking-[0.04em]"
         style={{
           background: agent.accentDim,
           borderColor: agent.accentSoft,
@@ -114,11 +103,7 @@ export const Header = ({
         <span className="text-[12px]" aria-hidden="true">
           <AgentGlyph agent={agent} size={12} />
         </span>
-        {/* Label sheds to glyph-only on a narrow pane so the title keeps room. */}
-        <span
-          data-testid="agent-glyph-label"
-          className="@max-[280px]/pane:hidden"
-        >
+        <span data-testid="agent-glyph-label" className="hidden">
           {agent.short}
         </span>
       </Chip>
@@ -128,7 +113,7 @@ export const Header = ({
         {paneUserLabel ?? paneAgentTitle ?? session.name}
       </span>
 
-      <div className="flex shrink-0 items-center gap-2.5">
+      <div className="flex shrink-0 items-center gap-1.5">
         <HeaderActions
           isCollapsed={isCollapsed}
           onToggleCollapse={onToggleCollapse}

--- a/src/features/terminal/components/TerminalPane/PaneStatusBar.test.tsx
+++ b/src/features/terminal/components/TerminalPane/PaneStatusBar.test.tsx
@@ -104,6 +104,26 @@ describe('PaneStatusBar', () => {
     )
 
     expect(screen.getByTestId('terminal-pane-status-bar')).toBeInTheDocument()
+    expect(screen.getByTestId('terminal-pane-status-bar')).not.toHaveClass(
+      'bg-primary-container/15'
+    )
+  })
+
+  test('uses the same active surface tone as the pane header', () => {
+    render(
+      <PaneStatusBar
+        isActive
+        worktreeName={null}
+        branch={null}
+        added={0}
+        removed={0}
+        lastActivityAt={lastActivityAt}
+      />
+    )
+
+    expect(screen.getByTestId('terminal-pane-status-bar')).toHaveClass(
+      'bg-primary-container/15'
+    )
   })
 
   test('clips the git ref while keeping the deltas and time pinned', () => {

--- a/src/features/terminal/components/TerminalPane/PaneStatusBar.tsx
+++ b/src/features/terminal/components/TerminalPane/PaneStatusBar.tsx
@@ -4,6 +4,7 @@ import { formatRelativeTime } from '../../../agent-status/utils/relativeTime'
 import { GitRefChip } from './GitRefChip'
 
 export interface PaneStatusBarProps {
+  isActive?: boolean
   worktreeName: string | null
   branch: string | null
   cwd?: string
@@ -15,7 +16,7 @@ export interface PaneStatusBarProps {
 
 /**
  * Minimal-height bottom bar carrying the pane's git ref, line-change deltas,
- * and last-activity time. Rendered only when the pane header is expanded.
+ * and last-activity time. Rendered only when pane status is expanded.
  *
  * The bar is a size container that sheds the lowest-priority info first as it
  * narrows, so the branch is never crammed against the metadata:
@@ -28,6 +29,7 @@ export interface PaneStatusBarProps {
  * the collapsed state instead of a separate width floor.
  */
 export const PaneStatusBar = ({
+  isActive = false,
   worktreeName,
   branch,
   cwd = undefined,
@@ -41,7 +43,9 @@ export const PaneStatusBar = ({
   return (
     <div
       data-testid="terminal-pane-status-bar"
-      className="flex shrink-0 items-center gap-3 border-t border-outline-variant/[0.18] px-3 py-1 font-mono text-[10.5px] [container-type:inline-size]"
+      className={`flex shrink-0 items-center gap-3 border-t border-outline-variant/[0.18] px-3 py-1 font-mono text-[10.5px] [container-type:inline-size] ${
+        isActive ? 'bg-primary-container/15' : ''
+      }`}
     >
       {/* Ref group is hard-bounded to the leftover space and clips, so the
        * always-visible time on the right is never overlapped. */}

--- a/src/features/terminal/components/TerminalPane/TerminalBody.test.tsx
+++ b/src/features/terminal/components/TerminalPane/TerminalBody.test.tsx
@@ -7,6 +7,7 @@ import {
   type ReactElement,
 } from 'react'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
+import type { NativeGhosttyShortcutContext } from '../../nativeGhosttyClient'
 import type { ITerminalService } from '../../services/terminalService'
 import { TerminalBody } from './TerminalBody'
 
@@ -16,7 +17,11 @@ const nativeMocks = vi.hoisted(() => ({
 }))
 
 const bodyMocks = vi.hoisted(() => ({
-  ghosttyProps: null as { onUnavailable?: () => void } | null,
+  ghosttyProps: null as {
+    onUnavailable?: () => void
+    onRequestFocus?: () => void
+    shortcutContext?: NativeGhosttyShortcutContext
+  } | null,
   xtermFocus: vi.fn(),
 }))
 
@@ -25,10 +30,18 @@ vi.mock('../../nativeGhosttyClient', () => nativeMocks)
 vi.mock('./GhosttyBody', () => {
   const MockGhosttyBody = ({
     onUnavailable = undefined,
+    onRequestFocus = undefined,
+    shortcutContext = undefined,
   }: {
     onUnavailable?: () => void
+    onRequestFocus?: () => void
+    shortcutContext?: NativeGhosttyShortcutContext
   }): ReactElement => {
-    bodyMocks.ghosttyProps = { onUnavailable }
+    bodyMocks.ghosttyProps = {
+      onUnavailable,
+      onRequestFocus,
+      shortcutContext,
+    }
 
     return <div data-testid="ghostty-body" />
   }
@@ -89,6 +102,29 @@ describe('TerminalBody', () => {
     await waitFor(() => {
       expect(screen.getByTestId('xterm-body')).toBeInTheDocument()
     })
+  })
+
+  test('passes shortcut context to native Ghostty body', () => {
+    const shortcutContext = { paneIds: ['p0', 'p1'], activePaneId: 'p0' }
+    const onRequestFocus = vi.fn()
+
+    render(
+      <TerminalBody
+        paneId="pane-1"
+        ptyId="pty-1"
+        cwd="/tmp"
+        active
+        service={createService()}
+        onRequestFocus={onRequestFocus}
+        shortcutContext={shortcutContext}
+        mode="attach"
+        deferFit={deferFit}
+        enableImagePaste={enableImagePaste}
+      />
+    )
+
+    expect(bodyMocks.ghosttyProps?.shortcutContext).toEqual(shortcutContext)
+    expect(bodyMocks.ghosttyProps?.onRequestFocus).toBe(onRequestFocus)
   })
 
   test('falls back to xterm when imperative native focus rejects', async () => {

--- a/src/features/terminal/components/TerminalPane/TerminalBody.tsx
+++ b/src/features/terminal/components/TerminalPane/TerminalBody.tsx
@@ -14,6 +14,7 @@ import type { ITerminalService } from '../../services/terminalService'
 import {
   focusNativeGhostty,
   shouldUseNativeGhostty,
+  type NativeGhosttyShortcutContext,
 } from '../../nativeGhosttyClient'
 import { Body as XtermBody, type BodyHandle, type BodyMode } from './Body'
 import { GhosttyBody } from './GhosttyBody'
@@ -28,6 +29,9 @@ interface TerminalBodyProps {
   onCwdChange?: (cwd: string) => void
   onPaneReady?: NotifyPaneReady
   onCommandSubmit?: (ptyId: string, command: string) => void
+  onRequestActive?: () => void
+  onRequestFocus?: () => void
+  shortcutContext?: NativeGhosttyShortcutContext
   mode: BodyMode
   deferFit: boolean
   enableImagePaste: boolean
@@ -51,6 +55,9 @@ export const TerminalBody = forwardRef<TerminalBodyHandle, TerminalBodyProps>(
       onCwdChange = undefined,
       onPaneReady = undefined,
       onCommandSubmit = undefined,
+      onRequestActive = undefined,
+      onRequestFocus = undefined,
+      shortcutContext = undefined,
       mode,
       deferFit,
       enableImagePaste,
@@ -105,6 +112,9 @@ export const TerminalBody = forwardRef<TerminalBodyHandle, TerminalBodyProps>(
           onCwdChange={onCwdChange}
           onPaneReady={onPaneReady}
           onCommandSubmit={onCommandSubmit}
+          onRequestActive={onRequestActive}
+          onRequestFocus={onRequestFocus}
+          shortcutContext={shortcutContext}
           onUnavailable={handleNativeUnavailable}
         />
       )

--- a/src/features/terminal/components/TerminalPane/index.test.tsx
+++ b/src/features/terminal/components/TerminalPane/index.test.tsx
@@ -176,6 +176,42 @@ describe('TerminalPane index', () => {
     })
   })
 
+  test('clicking an inactive terminal body requests pane activation', async () => {
+    const onRequestActive = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <TerminalPane
+        {...baseProps}
+        pane={{ ...baseProps.pane, active: false }}
+        onRequestActive={onRequestActive}
+      />
+    )
+
+    await user.click(screen.getByTestId('body-mock'))
+
+    expect(onRequestActive).toHaveBeenCalledOnce()
+    expect(onRequestActive).toHaveBeenCalledWith('s1', 'p0')
+  })
+
+  test('clicking an inactive terminal header requests pane activation', async () => {
+    const onRequestActive = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <TerminalPane
+        {...baseProps}
+        pane={{ ...baseProps.pane, active: false }}
+        onRequestActive={onRequestActive}
+      />
+    )
+
+    await user.click(screen.getByTestId('terminal-pane-header'))
+
+    expect(onRequestActive).toHaveBeenCalledOnce()
+    expect(onRequestActive).toHaveBeenCalledWith('s1', 'p0')
+  })
+
   test('renders RestartAffordance when mode is awaiting-restart', () => {
     const completedSession: Session = {
       ...session,
@@ -206,7 +242,8 @@ describe('TerminalPane index', () => {
   test('Header shows agent chip resolved from pane.agentType', () => {
     render(<TerminalPane {...baseProps} />)
 
-    expect(screen.getByText('CLAUDE')).toBeInTheDocument()
+    expect(screen.getByTestId('agent-glyph-label')).toHaveTextContent('CLAUDE')
+    expect(screen.getByTestId('agent-glyph-label')).toHaveClass('hidden')
   })
 
   test('chrome reflects pane.agentType directly (no override prop)', () => {
@@ -218,7 +255,7 @@ describe('TerminalPane index', () => {
       />
     )
 
-    expect(screen.getByText('CODEX')).toBeInTheDocument()
+    expect(screen.getByTestId('agent-glyph-label')).toHaveTextContent('CODEX')
   })
 
   test('generic sessions render the SHELL agent chip', () => {
@@ -230,7 +267,7 @@ describe('TerminalPane index', () => {
       />
     )
 
-    expect(screen.getByText('SHELL')).toBeInTheDocument()
+    expect(screen.getByTestId('agent-glyph-label')).toHaveTextContent('SHELL')
   })
 
   test('status bar shows line changes from git status files', () => {
@@ -254,6 +291,10 @@ describe('TerminalPane index', () => {
     const user = userEvent.setup()
     render(<TerminalPane {...baseProps} />)
 
+    const header = screen.getByTestId('terminal-pane-header')
+    expect(header).toHaveClass('gap-1.5')
+    expect(header).toHaveClass('px-2')
+    expect(header).toHaveClass('py-1')
     expect(screen.getByTestId('terminal-pane-status-bar')).toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: /collapse status/i }))
@@ -261,9 +302,12 @@ describe('TerminalPane index', () => {
     expect(
       screen.queryByTestId('terminal-pane-status-bar')
     ).not.toBeInTheDocument()
+    expect(header).toHaveClass('gap-1.5')
+    expect(header).toHaveClass('px-2')
+    expect(header).toHaveClass('py-1')
   })
 
-  test('auto-collapses (header + status bar) when the pane is narrower than the floor', () => {
+  test('auto-collapses the status bar when the pane is narrower than the floor', () => {
     vi.mocked(usePaneWidth).mockReturnValue(180)
 
     render(<TerminalPane {...baseProps} />)
@@ -272,10 +316,7 @@ describe('TerminalPane index', () => {
       screen.queryByTestId('terminal-pane-status-bar')
     ).not.toBeInTheDocument()
 
-    expect(screen.getByTestId('terminal-pane-header')).toHaveAttribute(
-      'data-collapsed',
-      'true'
-    )
+    expect(screen.getByTestId('terminal-pane-header')).toHaveClass('gap-1.5')
 
     // The collapse toggle is hidden too — it can't expand a too-narrow pane.
     expect(
@@ -289,9 +330,7 @@ describe('TerminalPane index', () => {
     render(<TerminalPane {...baseProps} />)
 
     expect(screen.getByTestId('terminal-pane-status-bar')).toBeInTheDocument()
-    expect(screen.getByTestId('terminal-pane-header')).not.toHaveAttribute(
-      'data-collapsed'
-    )
+    expect(screen.getByTestId('terminal-pane-header')).toHaveClass('gap-1.5')
   })
 
   test('forwards pane.ptyId to Body as sessionId', () => {
@@ -314,18 +353,17 @@ describe('TerminalPane index', () => {
     expect(onClose).toHaveBeenCalledWith('s1', 'p0')
   })
 
-  test('data-focused mirrors pane.active=true', () => {
+  test('active pane keeps semantic active marker without focus marker', () => {
     render(
       <TerminalPane {...baseProps} pane={{ ...baseProps.pane, active: true }} />
     )
 
-    expect(screen.getByTestId('terminal-pane-wrapper')).toHaveAttribute(
-      'data-focused',
-      'true'
-    )
+    const wrapper = screen.getByTestId('terminal-pane-wrapper')
+    expect(wrapper).toHaveAttribute('data-pane-active', 'true')
+    expect(wrapper).not.toHaveAttribute('data-focused')
   })
 
-  test('data-focused absent when pane.active=false', () => {
+  test('inactive pane has no active marker or focus marker', () => {
     render(
       <TerminalPane
         {...baseProps}
@@ -333,21 +371,22 @@ describe('TerminalPane index', () => {
       />
     )
 
-    expect(screen.getByTestId('terminal-pane-wrapper')).not.toHaveAttribute(
-      'data-focused'
-    )
+    const wrapper = screen.getByTestId('terminal-pane-wrapper')
+    expect(wrapper).not.toHaveAttribute('data-pane-active')
+    expect(wrapper).not.toHaveAttribute('data-focused')
   })
 
-  test('renders focus ring overlay above scrollable terminal body', () => {
+  test('renders neutral border overlay above scrollable terminal body', () => {
     render(<TerminalPane {...baseProps} />)
 
     const wrapper = screen.getByTestId('terminal-pane-wrapper')
-    const focusRing = screen.getByTestId('terminal-pane-focus-ring')
+    const border = screen.getByTestId('terminal-pane-border')
 
     expect(wrapper).toHaveClass('isolate')
-    expect(focusRing).toHaveClass('absolute')
-    expect(focusRing).toHaveClass('z-30')
-    expect(focusRing).toHaveClass('pointer-events-none')
+    expect(border).toHaveClass('absolute')
+    expect(border).toHaveClass('z-30')
+    expect(border).toHaveClass('pointer-events-none')
+    expect(border).toHaveClass('border-outline-variant/[0.22]')
   })
 
   test('does not render a message-input footer banner', () => {
@@ -380,12 +419,8 @@ describe('TerminalPane index', () => {
     })
   })
 
-  test('active pane can suppress focus highlight while staying full opacity', () => {
-    const showFocusHighlight = false
-
-    render(
-      <TerminalPane {...baseProps} showFocusHighlight={showFocusHighlight} />
-    )
+  test('active pane uses the neutral border while staying full opacity', () => {
+    render(<TerminalPane {...baseProps} />)
 
     expect(screen.getByTestId('terminal-pane-wrapper')).not.toHaveAttribute(
       'data-focused'
@@ -395,10 +430,9 @@ describe('TerminalPane index', () => {
       opacity: '1',
     })
 
-    expect(screen.getByTestId('terminal-pane-focus-ring')).toHaveStyle({
-      border:
-        '1px solid color-mix(in srgb, var(--color-outline-variant) 22%, transparent)',
-    })
+    expect(screen.getByTestId('terminal-pane-border')).toHaveClass(
+      'border-outline-variant/[0.22]'
+    )
   })
 
   test('focuses on initial mount when pane.active=true', () => {

--- a/src/features/terminal/components/TerminalPane/index.test.tsx
+++ b/src/features/terminal/components/TerminalPane/index.test.tsx
@@ -353,6 +353,45 @@ describe('TerminalPane index', () => {
     expect(onClose).toHaveBeenCalledWith('s1', 'p0')
   })
 
+  test('clicking inactive pane close does not request pane activation', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    const onRequestActive = vi.fn()
+
+    render(
+      <TerminalPane
+        {...baseProps}
+        pane={{ ...baseProps.pane, active: false }}
+        onClose={onClose}
+        onRequestActive={onRequestActive}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'close pane' }))
+
+    expect(onClose).toHaveBeenCalledOnce()
+    expect(onClose).toHaveBeenCalledWith('s1', 'p0')
+    expect(onRequestActive).not.toHaveBeenCalled()
+  })
+
+  test('clicking inactive pane collapse does not request pane activation', async () => {
+    const user = userEvent.setup()
+    const onRequestActive = vi.fn()
+
+    render(
+      <TerminalPane
+        {...baseProps}
+        pane={{ ...baseProps.pane, active: false }}
+        onRequestActive={onRequestActive}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'collapse status' }))
+
+    expect(screen.queryByTestId('terminal-pane-status-bar')).toBeNull()
+    expect(onRequestActive).not.toHaveBeenCalled()
+  })
+
   test('active pane keeps semantic active marker without focus marker', () => {
     render(
       <TerminalPane {...baseProps} pane={{ ...baseProps.pane, active: true }} />

--- a/src/features/terminal/components/TerminalPane/index.tsx
+++ b/src/features/terminal/components/TerminalPane/index.tsx
@@ -9,6 +9,7 @@ import {
   useRef,
   useState,
   type DragEvent,
+  type MouseEvent,
   type ReactElement,
 } from 'react'
 import { useGitBranch } from '../../../diff/hooks/useGitBranch'
@@ -18,6 +19,7 @@ import type { Pane, Session } from '../../../sessions/types'
 import { agentForPane } from '../../../sessions/utils/agentForSession'
 import type { NotifyPaneReady } from '../../hooks/useTerminal'
 import type { BurnerTarget } from '../../hooks/useBurnerTerminals'
+import type { NativeGhosttyShortcutContext } from '../../nativeGhosttyClient'
 import type { ITerminalService } from '../../services/terminalService'
 import { aggregateLineDelta } from './aggregateLineDelta'
 import type { BodyMode } from './Body'
@@ -27,8 +29,7 @@ import { RestartAffordance } from './RestartAffordance'
 import { TerminalBody, type TerminalBodyHandle } from './TerminalBody'
 import { usePaneWidth } from './usePaneWidth'
 
-// A pane narrower than this auto-collapses (header + status bar together) so the
-// collapsed look never drifts out of sync with a real `isCollapsed`. Tunable.
+// A pane narrower than this auto-collapses the bottom status bar. Tunable.
 const AUTO_COLLAPSE_PANE_WIDTH_PX = 220
 
 export type TerminalPaneMode = 'attach' | 'spawn' | 'awaiting-restart'
@@ -45,6 +46,7 @@ export interface TerminalPaneProps {
   onBurner?: (target: BurnerTarget) => void
   /** Make this pane active — the burner button focuses its pane (spec §8). */
   onRequestActive?: (sessionId: string, paneId: string) => void
+  onRequestFocus?: () => void
   /** Pane-keys with a foreground command running — drives the amber button tint (VIM-71). */
   activeBurnerPaneKeys?: ReadonlySet<string>
   /** Pane-keys with a live burner shell (idle or active) — drives a11y state (VIM-53). */
@@ -53,7 +55,7 @@ export interface TerminalPaneProps {
   onCommandSubmit?: (ptyId: string, command: string) => void
   onRestart?: (sessionId: string) => void
   deferFit?: boolean
-  showFocusHighlight?: boolean
+  shortcutContext?: NativeGhosttyShortcutContext
   /**
    * VIM-167: make this pane's header the drag handle for drag-into-slot. The
    * terminal body is never draggable so xterm selection keeps the pointer.
@@ -86,13 +88,14 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
       onClose = undefined,
       onBurner = undefined,
       onRequestActive = undefined,
+      onRequestFocus = undefined,
       activeBurnerPaneKeys = undefined,
       runningBurnerPaneKeys = undefined,
       onCwdChange = undefined,
       onCommandSubmit = undefined,
       onRestart = undefined,
       deferFit = false,
-      showFocusHighlight = true,
+      shortcutContext = undefined,
       paneDraggable = false,
       onHeaderDragStart = undefined,
       onHeaderDragEnd = undefined,
@@ -110,8 +113,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
     const wrapperRef = useRef<HTMLDivElement | null>(null)
     const [manuallyCollapsed, setManuallyCollapsed] = useState(false)
     // Width-driven auto-collapse: a pane too narrow for the expanded chrome
-    // collapses for real (header + status bar together), so the collapsed state
-    // is always in sync with what's shown — never just the bar vanishing.
+    // hides the bottom status bar for real, so the button state stays in sync.
     const paneWidth = usePaneWidth(wrapperRef)
 
     const autoCollapsed =
@@ -131,7 +133,6 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
     }))
 
     const isPaneActive = pane.active
-    const isFocusHighlightVisible = isPaneActive && showFocusHighlight
 
     useEffect(() => {
       // Fire on `undefined → true` (initial mount active) AND `false → true`
@@ -161,15 +162,33 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
       [files, isFresh]
     )
 
-    const handleContainerClick = useCallback((): void => {
-      // SplitView owns click-to-focus state changes. If this pane is inactive,
-      // the slot click flips pane.active first; the rising-edge effect above
-      // moves DOM focus into xterm after React commits the active state.
+    const requestPaneActive = useCallback((): void => {
       if (!pane.active) {
+        onRequestActive?.(session.id, pane.id)
+      }
+    }, [onRequestActive, pane.active, pane.id, session.id])
+
+    const handleContainerClick = useCallback(
+      (event: MouseEvent<HTMLDivElement>): void => {
+        if (!pane.active) {
+          event.stopPropagation()
+
+          return
+        }
+
+        bodyRef.current?.focusTerminal()
+      },
+      [pane.active]
+    )
+
+    const handleContainerMouseDown = useCallback((): void => {
+      if (!pane.active) {
+        requestPaneActive()
+
         return
       }
       bodyRef.current?.focusTerminal()
-    }, [pane.active])
+    }, [pane.active, requestPaneActive])
 
     const handleToggleCollapse = useCallback((): void => {
       setManuallyCollapsed((collapsed) => !collapsed)
@@ -217,22 +236,9 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
     const enableImagePaste = pane.agentType !== 'generic'
     const bodyMode: BodyMode = mode === 'attach' ? 'attach' : 'spawn'
 
-    const containerStyle = isFocusHighlightVisible
-      ? {
-          boxShadow: `0 0 0 6px ${agent.accentDim}, var(--shadow-ambient)`,
-          cursor: 'default' as const,
-        }
-      : {
-          boxShadow: 'none',
-          cursor: isPaneActive ? ('default' as const) : ('pointer' as const),
-        }
-
-    const focusRingStyle = {
-      border: isFocusHighlightVisible
-        ? `2px solid ${agent.accent}`
-        : '1px solid color-mix(in srgb, var(--color-outline-variant) 22%, transparent)',
-      transition:
-        'border-color 180ms ease, box-shadow 220ms ease, opacity 220ms ease',
+    const containerStyle = {
+      boxShadow: 'none',
+      cursor: isPaneActive ? ('default' as const) : ('pointer' as const),
     }
 
     return (
@@ -241,7 +247,8 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
         data-testid="terminal-pane-wrapper"
         data-session-id={session.id}
         data-mode={mode}
-        data-focused={isFocusHighlightVisible || undefined}
+        data-pane-active={isPaneActive || undefined}
+        onMouseDown={handleContainerMouseDown}
         onClick={handleContainerClick}
         style={{
           ...containerStyle,
@@ -255,7 +262,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
         <Header
           agent={agent}
           session={session}
-          isFocused={isFocusHighlightVisible}
+          isActive={isPaneActive}
           isCollapsed={isCollapsed}
           autoCollapsed={autoCollapsed}
           hideCollapseToggle={hideCollapseToggle}
@@ -296,6 +303,9 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
               onCwdChange={onCwdChange}
               onPaneReady={onPaneReady}
               onCommandSubmit={onCommandSubmit}
+              onRequestActive={requestPaneActive}
+              onRequestFocus={onRequestFocus}
+              shortcutContext={shortcutContext}
               mode={bodyMode}
               deferFit={deferFit}
               enableImagePaste={enableImagePaste}
@@ -305,6 +315,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
 
         {!isAwaitingRestart && !isCollapsed && (
           <PaneStatusBar
+            isActive={isPaneActive}
             worktreeName={worktreeName}
             branch={branch}
             cwd={pane.cwd}
@@ -316,10 +327,9 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
         )}
 
         <span
-          data-testid="terminal-pane-focus-ring"
+          data-testid="terminal-pane-border"
           aria-hidden="true"
-          style={focusRingStyle}
-          className="pointer-events-none absolute inset-0 z-30 rounded-[10px]"
+          className="pointer-events-none absolute inset-0 z-30 rounded-[10px] border border-outline-variant/[0.22] transition-opacity"
         />
       </div>
     )

--- a/src/features/terminal/components/TerminalPane/index.tsx
+++ b/src/features/terminal/components/TerminalPane/index.tsx
@@ -32,6 +32,20 @@ import { usePaneWidth } from './usePaneWidth'
 // A pane narrower than this auto-collapses the bottom status bar. Tunable.
 const AUTO_COLLAPSE_PANE_WIDTH_PX = 220
 
+const INTERACTIVE_TARGET_SELECTOR = [
+  'button',
+  'a[href]',
+  'input',
+  'select',
+  'textarea',
+  '[role="button"]',
+  '[role="menuitem"]',
+  '[role="switch"]',
+  '[role="checkbox"]',
+  '[tabindex]:not([tabindex="-1"])',
+  '[contenteditable="true"]',
+].join(',')
+
 export type TerminalPaneMode = 'attach' | 'spawn' | 'awaiting-restart'
 
 export interface TerminalPaneProps {
@@ -181,14 +195,24 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
       [pane.active]
     )
 
-    const handleContainerMouseDown = useCallback((): void => {
-      if (!pane.active) {
-        requestPaneActive()
+    const handleContainerMouseDown = useCallback(
+      (event: MouseEvent<HTMLDivElement>): void => {
+        if (
+          event.target instanceof Element &&
+          event.target.closest(INTERACTIVE_TARGET_SELECTOR)
+        ) {
+          return
+        }
 
-        return
-      }
-      bodyRef.current?.focusTerminal()
-    }, [pane.active, requestPaneActive])
+        if (!pane.active) {
+          requestPaneActive()
+
+          return
+        }
+        bodyRef.current?.focusTerminal()
+      },
+      [pane.active, requestPaneActive]
+    )
 
     const handleToggleCollapse = useCallback((): void => {
       setManuallyCollapsed((collapsed) => !collapsed)

--- a/src/features/terminal/components/TerminalPane/usePaneWidth.ts
+++ b/src/features/terminal/components/TerminalPane/usePaneWidth.ts
@@ -7,7 +7,7 @@ import { useLayoutEffect, useState, type RefObject } from 'react'
  *
  * Used to drive width-responsive React state — e.g. the pane's auto-collapse —
  * that CSS container queries can express visually but cannot feed back into
- * component state (the chevron, `data-collapsed`, the status-bar render gate).
+ * component state (the chevron and the status-bar render gate).
  */
 export const usePaneWidth = <T extends Element>(
   ref: RefObject<T | null>

--- a/src/features/terminal/nativeGhosttyClient.ts
+++ b/src/features/terminal/nativeGhosttyClient.ts
@@ -13,10 +13,16 @@ export interface NativeGhosttyPaneRef {
   paneId: string
 }
 
+export interface NativeGhosttyShortcutContext {
+  paneIds: string[]
+  activePaneId: string | null
+}
+
 export interface NativeGhosttyUpdateRequest extends NativeGhosttyPaneRef {
   cwd: string
   bounds: NativeGhosttyBounds
   visible: boolean
+  shortcutContext?: NativeGhosttyShortcutContext
 }
 
 export interface NativeGhosttyDataRequest extends NativeGhosttyPaneRef {

--- a/src/features/workspace/components/TerminalZone.test.tsx
+++ b/src/features/workspace/components/TerminalZone.test.tsx
@@ -56,7 +56,6 @@ vi.mock('../../terminal/components/TerminalPane', () => ({
       mode,
       onCwdChange,
       deferFit,
-      showFocusHighlight,
       onRestart,
       onClose,
       onCommandSubmit,
@@ -72,7 +71,6 @@ vi.mock('../../terminal/components/TerminalPane', () => ({
         data-restored={pane.restoreData ? 'true' : 'false'}
         data-mode={mode}
         data-defer-fit={deferFit ? 'true' : 'false'}
-        data-show-focus-highlight={showFocusHighlight ? 'true' : 'false'}
         data-session-name={session.name}
         data-is-active={isActive ? 'true' : 'false'}
         data-session-agent-type={session.agentType}
@@ -171,30 +169,11 @@ describe('TerminalZone', () => {
     expect(screen.getByTestId('terminal-zone')).toHaveClass('opacity-[0.65]')
   })
 
-  test('keeps the active pane highlight even when the zone is not focused', () => {
-    // The active pane highlight tracks "which pane is active" and must persist
-    // when focus moves to the dock — the zone still dims, but the highlight
-    // stays so the user never loses the active-pane reference.
-    const isZoneFocused = false
-
-    render(<TerminalZone {...defaultProps} isZoneFocused={isZoneFocused} />)
-
-    expect(screen.getAllByTestId('terminal-pane-mock')[0]).toHaveAttribute(
-      'data-show-focus-highlight',
-      'true'
-    )
-  })
-
   test('isZoneFocused=true by default does not apply dim class', () => {
     render(<TerminalZone {...defaultProps} />)
 
     expect(screen.getByTestId('terminal-zone')).not.toHaveClass(
       'opacity-[0.65]'
-    )
-
-    expect(screen.getAllByTestId('terminal-pane-mock')[0]).toHaveAttribute(
-      'data-show-focus-highlight',
-      'true'
     )
   })
 

--- a/src/features/workspace/components/TerminalZone.tsx
+++ b/src/features/workspace/components/TerminalZone.tsx
@@ -213,11 +213,6 @@ export const TerminalZone = forwardRef<TerminalZoneHandle, TerminalZoneProps>(
                     activeBurnerPaneKeys={activeBurnerPaneKeys}
                     runningBurnerPaneKeys={runningBurnerPaneKeys}
                     deferTerminalFit={deferTerminalFit}
-                    // The active pane keeps its highlight even when the dock
-                    // (or another container) has focus, so the user never
-                    // loses track of which pane is active. The zone still dims
-                    // to signal focus is elsewhere.
-                    showPaneFocusHighlight
                   />
                 </div>
               )

--- a/src/lib/e2e-bridge.test.ts
+++ b/src/lib/e2e-bridge.test.ts
@@ -45,7 +45,7 @@ const makeMockEntry = (rows: readonly string[], viewportY = 0): CacheEntry => {
 
 /**
  * Build a session-level wrapper containing N split-view-slots, each with
- * an inner terminal-pane-wrapper (one carrying `data-focused="true"` when
+ * an inner terminal-pane-wrapper (one carrying `data-pane-active="true"` when
  * `activeIndex` matches) and a `.xterm-rows` child with the provided
  * text content. Mirrors the post-5b DOM shape produced by SplitView →
  * TerminalPane → Body.
@@ -71,7 +71,7 @@ const buildSessionWrapper = (
     const paneWrapper = document.createElement('div')
     paneWrapper.setAttribute('data-testid', 'terminal-pane-wrapper')
     if (i === activeIndex) {
-      paneWrapper.setAttribute('data-focused', 'true')
+      paneWrapper.setAttribute('data-pane-active', 'true')
     }
 
     // Body's inner container — carries data-pty-id (terminalCache key), mirroring production DOM.
@@ -114,7 +114,7 @@ describe('readPaneBuffer', () => {
     expect(readPaneBuffer(wrapper)).toBe('solo-buf')
   })
 
-  test('falls back to first .xterm-rows when no pane carries data-focused', () => {
+  test('falls back to first .xterm-rows when no pane carries data-pane-active', () => {
     // Defensive case — invariant violation (5a guarantees exactly-one
     // active per session). The function must still return SOMETHING
     // (not throw) so e2e specs don't fail cryptically. Returns the

--- a/src/lib/e2e-bridge.ts
+++ b/src/lib/e2e-bridge.ts
@@ -57,26 +57,26 @@ const findActivePane = (): HTMLElement | null => {
 //
 // Multi-pane sessions (post-5b): the session-level wrapper contains a
 // SplitView with N inner TerminalPanes, each carrying an xterm. Prefer
-// the focused pane's xterm (the active pane has `data-focused="true"`
+// the active pane's xterm (the active pane has `data-pane-active="true"`
 // on its inner wrapper) so callers reading by session id always get the
 // active pane's buffer instead of whichever pane happens to be first in
 // DOM. Falls back to the first `.xterm-rows` for single-pane sessions
-// and for the defensive case where no inner wrapper has `data-focused`.
+// and for the defensive case where no inner wrapper has `data-pane-active`.
 //
 // Exported for unit testing — production callers go through
 // `readVisibleTerminalBuffer` / `readTerminalBufferForSession`.
 //
 // `container` is any xterm ancestor element: the session-level
 // `terminal-pane` wrapper (preferred for multi-pane sessions —
-// triggers the `data-focused` first-pass), a single `split-view-slot`
+// triggers the `data-pane-active` first-pass), a single `split-view-slot`
 // (the pty-id lookup path), or any `terminal-pane-wrapper` directly.
 // Renamed from `pane` to remove the pre-5b "single-pane element"
 // connotation — post-5b the function handles all three DOM shapes.
 export const readPaneBuffer = (container: HTMLElement): string => {
-  const focusedWrapper = container.querySelector<HTMLElement>(
-    '[data-testid="terminal-pane-wrapper"][data-focused="true"]'
+  const activeWrapper = container.querySelector<HTMLElement>(
+    '[data-testid="terminal-pane-wrapper"][data-pane-active="true"]'
   )
-  const scope = focusedWrapper ?? container
+  const scope = activeWrapper ?? container
 
   const rows = scope.querySelector<HTMLElement>('.xterm-rows')
   const domText = rows?.textContent ?? ''
@@ -137,15 +137,15 @@ const getVisiblePtyId = (): string | null => {
     return null
   }
 
-  const focusedWrapper = pane.querySelector<HTMLElement>(
-    '[data-testid="terminal-pane-wrapper"][data-focused="true"]'
+  const activeWrapper = pane.querySelector<HTMLElement>(
+    '[data-testid="terminal-pane-wrapper"][data-pane-active="true"]'
   )
 
-  const focusedSlot = focusedWrapper?.closest<HTMLElement>(
+  const activeSlot = activeWrapper?.closest<HTMLElement>(
     '[data-testid="split-view-slot"][data-pty-id]'
   )
-  if (focusedSlot?.dataset.ptyId) {
-    return focusedSlot.dataset.ptyId
+  if (activeSlot?.dataset.ptyId) {
+    return activeSlot.dataset.ptyId
   }
 
   const firstSlot = pane.querySelector<HTMLElement>(

--- a/tests/e2e/core/specs/navigation.spec.ts
+++ b/tests/e2e/core/specs/navigation.spec.ts
@@ -2,6 +2,8 @@ import { clickBySelector } from '../../shared/actions.js'
 
 describe('BottomDrawer navigation', () => {
   it('defaults to diff panel and switches to editor panel on click', async () => {
+    await clickBySelector('button[aria-label="Show editor & diff panel"]')
+
     const initialDiffPanel = await $('[data-testid="diff-panel"]')
     await initialDiffPanel.waitForDisplayed({ timeout: 15_000 })
 

--- a/tests/e2e/shared/actions.ts
+++ b/tests/e2e/shared/actions.ts
@@ -23,7 +23,7 @@ const hasElement = async (selector: string): Promise<boolean> =>
   )
 
 export const clickLayoutButton = async (layoutName: string): Promise<void> => {
-  const layoutButtonSelector = `button[aria-label="${layoutName}"]`
+  const layoutButtonSelector = `[data-testid="layout-switcher"] button[aria-label="${layoutName}"]`
 
   if (!(await hasElement(layoutButtonSelector))) {
     await clickBySelector('button[aria-label="Configure displayed layouts"]')


### PR DESCRIPTION
## Summary
- remove active highlight border/glow from terminal panes while keeping semantic active state
- keep terminal header and bottom status bar background in sync with pane active state
- wire native Ghostty focus and Cmd+digit handling so React pane state and terminal passthrough stay correct
- repair Ghostty native parent scratch rebuild and e2e active-pane lookup after the visual marker removal

## Validation
- pre-commit: lint-staged eslint, prettier, tsc --noEmit
- pre-push: npm test, 365 files passed, 4473 tests passed, 3 skipped
- npm run ghostty:native-parent:build
- npm run type-check:generated
- focused Vitest and ESLint runs for touched terminal/native files
- git diff --check


Refs VIM-265