### PR TITLE
feat(diff): add visual range review comments

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -52,7 +52,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 19       | 19   | 2026-06-21   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)                                             | cross-platform     | 12       | 12   | 2026-06-22   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                                                       | code-quality       | 7        | 0    | 2026-06-11   |
-| [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 17       | 14   | 2026-06-30   |
+| [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 18       | 15   | 2026-07-01   |
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 8        | 2    | 2026-06-19   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 4        | 0    | 2026-06-21   |
@@ -78,7 +78,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Error Surfacing](patterns/error-surfacing.md)                                                       | error-handling     | 45       | 45   | 2026-06-26   |
 | [File Tree Paths](patterns/file-tree-paths.md)                                                       | files              | 4        | 0    | 2026-04-10   |
 | [Scope Boundary](patterns/scope-boundary.md)                                                         | review-process     | 8        | 3    | 2026-06-01   |
-| [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 25       | 10   | 2026-06-30   |
+| [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 26       | 11   | 2026-07-01   |
 | [Module Boundaries](patterns/module-boundaries.md)                                                   | code-quality       | 17       | 3    | 2026-06-25   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 13       | 3    | 2026-06-15   |
 | [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 28       | 6    | 2026-06-29   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -99,7 +99,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [String Construction Hygiene](patterns/string-construction-hygiene.md)                               | code-quality       | 2        | 1    | 2026-06-19   |
 | [Agent-State Guards](patterns/agent-state-guards.md)                                                 | correctness        | 10       | 7    | 2026-06-22   |
 | [React Prop Contracts](patterns/react-prop-contracts.md)                                             | react-patterns     | 8        | 6    | 2026-06-22   |
-| [Stale Retained Interactions](patterns/stale-retained-interactions.md)                               | react-patterns     | 3        | 3    | 2026-07-01   |
+| [Stale Retained Interactions](patterns/stale-retained-interactions.md)                               | react-patterns     | 4        | 3    | 2026-07-01   |
 | [Retained State Identity](patterns/retained-state-identity.md)                                       | react-patterns     | 2        | 2    | 2026-06-28   |
 | [Authoritative Completion Guard](patterns/authoritative-completion-guard.md)                         | correctness        | 6        | 3    | 2026-06-27   |
 | [Equality Guard Completeness](patterns/equality-guard-completeness.md)                               | correctness        | 2        | 0    | 2026-06-17   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -52,7 +52,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 19       | 19   | 2026-06-21   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)                                             | cross-platform     | 12       | 12   | 2026-06-22   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                                                       | code-quality       | 7        | 0    | 2026-06-11   |
-| [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 18       | 15   | 2026-07-01   |
+| [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 19       | 16   | 2026-07-01   |
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 8        | 2    | 2026-06-19   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 4        | 0    | 2026-06-21   |
@@ -78,7 +78,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Error Surfacing](patterns/error-surfacing.md)                                                       | error-handling     | 45       | 45   | 2026-06-26   |
 | [File Tree Paths](patterns/file-tree-paths.md)                                                       | files              | 4        | 0    | 2026-04-10   |
 | [Scope Boundary](patterns/scope-boundary.md)                                                         | review-process     | 8        | 3    | 2026-06-01   |
-| [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 26       | 11   | 2026-07-01   |
+| [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 27       | 12   | 2026-07-01   |
 | [Module Boundaries](patterns/module-boundaries.md)                                                   | code-quality       | 17       | 3    | 2026-06-25   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 13       | 3    | 2026-06-15   |
 | [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 28       | 6    | 2026-06-29   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -52,7 +52,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 19       | 19   | 2026-06-21   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)                                             | cross-platform     | 12       | 12   | 2026-06-22   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                                                       | code-quality       | 7        | 0    | 2026-06-11   |
-| [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 19       | 16   | 2026-07-01   |
+| [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 20       | 17   | 2026-07-01   |
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 8        | 2    | 2026-06-19   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 4        | 0    | 2026-06-21   |
@@ -78,7 +78,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Error Surfacing](patterns/error-surfacing.md)                                                       | error-handling     | 45       | 45   | 2026-06-26   |
 | [File Tree Paths](patterns/file-tree-paths.md)                                                       | files              | 4        | 0    | 2026-04-10   |
 | [Scope Boundary](patterns/scope-boundary.md)                                                         | review-process     | 8        | 3    | 2026-06-01   |
-| [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 27       | 13   | 2026-07-01   |
+| [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 28       | 14   | 2026-07-01   |
 | [Module Boundaries](patterns/module-boundaries.md)                                                   | code-quality       | 17       | 3    | 2026-06-25   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 13       | 3    | 2026-06-15   |
 | [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 28       | 6    | 2026-06-29   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -78,7 +78,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Error Surfacing](patterns/error-surfacing.md)                                                       | error-handling     | 45       | 45   | 2026-06-26   |
 | [File Tree Paths](patterns/file-tree-paths.md)                                                       | files              | 4        | 0    | 2026-04-10   |
 | [Scope Boundary](patterns/scope-boundary.md)                                                         | review-process     | 8        | 3    | 2026-06-01   |
-| [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 27       | 12   | 2026-07-01   |
+| [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 27       | 13   | 2026-07-01   |
 | [Module Boundaries](patterns/module-boundaries.md)                                                   | code-quality       | 17       | 3    | 2026-06-25   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 13       | 3    | 2026-06-15   |
 | [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 28       | 6    | 2026-06-29   |
@@ -99,7 +99,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [String Construction Hygiene](patterns/string-construction-hygiene.md)                               | code-quality       | 2        | 1    | 2026-06-19   |
 | [Agent-State Guards](patterns/agent-state-guards.md)                                                 | correctness        | 10       | 7    | 2026-06-22   |
 | [React Prop Contracts](patterns/react-prop-contracts.md)                                             | react-patterns     | 8        | 6    | 2026-06-22   |
-| [Stale Retained Interactions](patterns/stale-retained-interactions.md)                               | react-patterns     | 4        | 3    | 2026-07-01   |
+| [Stale Retained Interactions](patterns/stale-retained-interactions.md)                               | react-patterns     | 5        | 4    | 2026-07-01   |
 | [Retained State Identity](patterns/retained-state-identity.md)                                       | react-patterns     | 2        | 2    | 2026-06-28   |
 | [Authoritative Completion Guard](patterns/authoritative-completion-guard.md)                         | correctness        | 6        | 3    | 2026-06-27   |
 | [Equality Guard Completeness](patterns/equality-guard-completeness.md)                               | correctness        | 2        | 0    | 2026-06-17   |

--- a/docs/reviews/patterns/derived-state-consistency.md
+++ b/docs/reviews/patterns/derived-state-consistency.md
@@ -3,7 +3,7 @@ id: derived-state-consistency
 category: code-quality
 created: 2026-06-07
 last_updated: 2026-07-01
-ref_count: 15
+ref_count: 16
 ---
 
 # Derived State Consistency
@@ -223,4 +223,21 @@ base data is technically "correct."
 - **Fix:** Track every required endpoint for the target side and only keep the
   draft current after both the start and optional range-end line have been seen.
   Added same-side range regression tests for the valid and stale-end cases.
+- **Commit:** same commit as this entry
+
+### 19. Mouse add-comment reused a stale visual selection from another line
+
+- **Source:** github-claude | PR #643 round 1 | 2026-07-01
+- **Severity:** HIGH
+- **File:** `src/features/diff/Panel.tsx`
+- **Finding:** The gutter add-comment handler passed the clicked
+  line/side into the shared target builder, but the helper always preferred
+  `visualSelectedLines` whenever a visual range existed. A user could leave a
+  keyboard or drag visual range active, click the gutter plus on an unrelated
+  row, and silently create feedback for the old range instead of the clicked
+  line.
+- **Fix:** Only reuse the visual range when the clicked line and side are inside
+  that range; otherwise build a single-line target from the actual gutter click.
+  Added a regression test that clicks line 1 while a visual range covers lines
+  2-3.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/derived-state-consistency.md
+++ b/docs/reviews/patterns/derived-state-consistency.md
@@ -3,7 +3,7 @@ id: derived-state-consistency
 category: code-quality
 created: 2026-06-07
 last_updated: 2026-07-01
-ref_count: 16
+ref_count: 17
 ---
 
 # Derived State Consistency
@@ -240,4 +240,20 @@ base data is technically "correct."
   that range; otherwise build a single-line target from the actual gutter click.
   Added a regression test that clicks line 1 while a visual range covers lines
   2-3.
+- **Commit:** same commit as this entry
+
+### 20. Editing range comments dropped the derived end-line target
+
+- **Source:** github-claude | PR #643 round 2 | 2026-07-01
+- **Severity:** MEDIUM
+- **File:** `src/features/diff/Panel.tsx`
+- **Finding:** The edit-comment path rebuilt `annotationTarget` from the
+  annotation row only, preserving the start line and side but dropping
+  `metadata.target.rangeEndLine`. Editing an existing range comment therefore
+  collapsed the dialog back to a single-line target, and the subsequent update
+  could lose the range endpoint used by staleness detection.
+- **Fix:** When the annotation metadata carries a same-side range target,
+  rebuild the edit target from `startLine` plus `endLine`; otherwise keep the
+  single-line fallback. Added a regression test that opens an existing R1-R2
+  comment for edit and submits the updated text through the range dialog.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/derived-state-consistency.md
+++ b/docs/reviews/patterns/derived-state-consistency.md
@@ -2,8 +2,8 @@
 id: derived-state-consistency
 category: code-quality
 created: 2026-06-07
-last_updated: 2026-06-30
-ref_count: 14
+last_updated: 2026-07-01
+ref_count: 15
 ---
 
 # Derived State Consistency
@@ -208,4 +208,19 @@ base data is technically "correct."
   Finish handler when submitted annotations exist. Added a regression test that
   draft-only empty-state feedback keeps Discard enabled while Finish is
   disabled and cannot open the popover.
+- **Commit:** same commit as this entry
+
+### 18. Range draft validity checked only the start line
+
+- **Source:** github-codex-connector | PR #643 round 1 | 2026-07-01
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/diff/hooks/useReviewCommentDraft.ts`
+- **Finding:** Range comment drafts gained a `rangeEndLine`, but the diff
+  refresh guard still considered the draft current as soon as the start line
+  existed. If the end of the same-side range disappeared after a same-file
+  refresh, the UI could keep rendering and submitting a draft that pointed at a
+  non-existent end line.
+- **Fix:** Track every required endpoint for the target side and only keep the
+  draft current after both the start and optional range-end line have been seen.
+  Added same-side range regression tests for the valid and stale-end cases.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/e2e-testing.md
+++ b/docs/reviews/patterns/e2e-testing.md
@@ -2,8 +2,8 @@
 id: e2e-testing
 category: e2e-testing
 created: 2026-04-19
-last_updated: 2026-06-30
-ref_count: 10
+last_updated: 2026-07-01
+ref_count: 11
 ---
 
 # E2E Testing
@@ -271,4 +271,23 @@ completely different root causes. The generic fast-failure modes:
 - **File:** `tests/e2e/{core,terminal,agent}/wdio.conf.ts`
 - **Finding:** The Electron core suite still planned all five spec files as workers even though the root config set `maxInstances: 1`. In CI this let multiple Electron sessions contend for the same desktop-app resources and produced deterministic startup selector failures such as missing layout buttons, `FILES`, and `editor-panel`.
 - **Fix:** Added `'wdio:maxInstances': 1` to each Electron capability block so WDIO serializes the spec files at the capability level. A local WDIO run without Xvfb confirmed worker `0-1` starts only after `0-0` exits.
+- **Commit:** same commit as this entry
+
+### 26. Core E2E specs assumed visible controls that moved behind adaptive UI
+
+- **Source:** local-codex | PR #643 CI failure | 2026-07-01
+- **Severity:** HIGH
+- **File:** `tests/e2e/core/specs/browser-pane-overlay.spec.ts`,
+  `tests/e2e/core/specs/files-to-editor.spec.ts`,
+  `tests/e2e/core/specs/ipc-roundtrip.spec.ts`,
+  `tests/e2e/core/specs/navigation.spec.ts`
+- **Finding:** The core smoke suite still clicked layout buttons and sidebar
+  tabs by visible labels that are no longer always present. Hidden split
+  layouts now require the layout configurator before their toolbar buttons
+  appear, the file tab can render as an icon-only control with an aria-label,
+  and the editor panel is behind the dock toggle by default.
+- **Fix:** Teach the browser-pane layout helper to expose hidden layouts through
+  the configurator before selecting them, use the stable `aria-label="FILES"`
+  selector for file-tab navigation, and explicitly open the dock plus select the
+  Editor tab before waiting for the editor panel.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/e2e-testing.md
+++ b/docs/reviews/patterns/e2e-testing.md
@@ -3,7 +3,7 @@ id: e2e-testing
 category: e2e-testing
 created: 2026-04-19
 last_updated: 2026-07-01
-ref_count: 13
+ref_count: 14
 ---
 
 # E2E Testing
@@ -307,4 +307,23 @@ completely different root causes. The generic fast-failure modes:
 - **Fix:** Scope terminal-session creation clicks to
   `[data-testid="session-tabs"] button[aria-label="New session"]` so the specs
   target the tab-strip plus control.
+- **Commit:** same commit as this entry
+
+### 28. Terminal E2E must complete the new-session dialog flow
+
+- **Source:** local-codex | PR #643 CI failure | 2026-07-01
+- **Severity:** HIGH
+- **File:** `tests/e2e/shared/actions.ts`,
+  `tests/e2e/terminal/specs/multi-tab-isolation.spec.ts`,
+  `tests/e2e/terminal/specs/session-lifecycle.spec.ts`,
+  `tests/e2e/agent/specs/agent-runtime-regressions.spec.ts`
+- **Finding:** The terminal and agent smoke specs still treated "New session" as
+  a one-click session creation action. After the workspace moved creation
+  behind `NewSessionDialog`, the first click only opened the dialog, so tests
+  waited for a second PTY or bridge-enabled session that was never spawned.
+- **Fix:** Centralize E2E session creation in `createNewSessionWithDefaults`,
+  which clicks the sidebar trigger and then the visible "Create session"
+  confirmation. Updated affected specs to use the helper, and closed the
+  lifecycle test's spawned active session via the command palette `:close`
+  command before asserting the PTY count decrements.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/e2e-testing.md
+++ b/docs/reviews/patterns/e2e-testing.md
@@ -3,7 +3,7 @@ id: e2e-testing
 category: e2e-testing
 created: 2026-04-19
 last_updated: 2026-07-01
-ref_count: 11
+ref_count: 12
 ---
 
 # E2E Testing
@@ -290,4 +290,21 @@ completely different root causes. The generic fast-failure modes:
   the configurator before selecting them, use the stable `aria-label="FILES"`
   selector for file-tab navigation, and explicitly open the dock plus select the
   Editor tab before waiting for the editor panel.
+- **Commit:** same commit as this entry
+
+### 27. Terminal E2E new-session selector matched the sidebar dialog trigger
+
+- **Source:** local-codex | PR #643 CI failure | 2026-07-01
+- **Severity:** HIGH
+- **File:** `tests/e2e/terminal/specs/multi-tab-isolation.spec.ts`,
+  `tests/e2e/terminal/specs/session-lifecycle.spec.ts`
+- **Finding:** Terminal smoke specs clicked the first
+  `button[aria-label="New session"]` in the document. The workspace now has both
+  a sidebar New session button, which opens the dialog, and a tab-strip plus
+  button, which immediately creates a terminal session. The ambiguous selector
+  could hit the sidebar control, leaving the test waiting forever for a second
+  terminal pane that was never requested.
+- **Fix:** Scope terminal-session creation clicks to
+  `[data-testid="session-tabs"] button[aria-label="New session"]` so the specs
+  target the tab-strip plus control.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/e2e-testing.md
+++ b/docs/reviews/patterns/e2e-testing.md
@@ -3,7 +3,7 @@ id: e2e-testing
 category: e2e-testing
 created: 2026-04-19
 last_updated: 2026-07-01
-ref_count: 12
+ref_count: 13
 ---
 
 # E2E Testing

--- a/docs/reviews/patterns/stale-retained-interactions.md
+++ b/docs/reviews/patterns/stale-retained-interactions.md
@@ -3,7 +3,7 @@ id: stale-retained-interactions
 category: react-patterns
 created: 2026-06-15
 last_updated: 2026-07-01
-ref_count: 3
+ref_count: 4
 ---
 
 # Stale Retained Interactions
@@ -48,4 +48,13 @@ When a React component renders retained or stale content while fresh data for a 
 - **File:** `src/features/diff/hooks/useVisualSelection.ts`
 - **Finding:** `startMouse` created a persistent visual selection on pointerdown, while `stopMouse` only cleared the drag-active flag. A normal click could therefore leave a hidden one-line visual selection, and later keyboard motions or insert-comment actions could operate on an unintended range.
 - **Fix:** Tracked whether a mouse drag actually moved across diff targets and cleared the temporary single-line selection on pointerup when no movement occurred. Added hook tests for plain click cleanup and drag selection persistence.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 5. Comment edit retained stale visual selection
+
+- **Source:** github-claude | PR #643 round 2 | 2026-07-01
+- **Severity:** HIGH
+- **File:** `src/features/diff/Panel.tsx`
+- **Finding:** Confirming an edit to an existing file or line comment closed the editor without clearing an active visual selection. The next add-comment action could silently reuse that stale range instead of the current line.
+- **Fix:** Cleared visual selection after successful `updateAnnotation` calls, matching the existing add-comment success paths. Added panel coverage for editing while a visual range is active, then opening a fresh single-line comment.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/stale-retained-interactions.md
+++ b/docs/reviews/patterns/stale-retained-interactions.md
@@ -40,3 +40,12 @@ When a React component renders retained or stale content while fresh data for a 
 - **Finding:** Toolbar hunk navigation deactivated the visible review cursor but left the retained `currentTarget` pointing at the previous row. Bracket-key hunk navigation then preferred that retained target over the visible `focusedHunkIndex`, so mixing toolbar and keyboard navigation could jump from a stale hunk instead of the focused hunk.
 - **Fix:** Used the hook's `activeTarget` as the hunk-navigation origin and fell back to `clampedHunkIndex` when the review cursor is inactive. Added a regression test for toolbar `next hunk` followed by `]`.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 4. Plain diff click retained hidden visual selection
+
+- **Source:** github-claude | PR #643 round 1 | 2026-07-01
+- **Severity:** HIGH
+- **File:** `src/features/diff/hooks/useVisualSelection.ts`
+- **Finding:** `startMouse` created a persistent visual selection on pointerdown, while `stopMouse` only cleared the drag-active flag. A normal click could therefore leave a hidden one-line visual selection, and later keyboard motions or insert-comment actions could operate on an unintended range.
+- **Fix:** Tracked whether a mouse drag actually moved across diff targets and cleared the temporary single-line selection on pointerup when no movement occurred. Added hook tests for plain click cleanup and drag selection persistence.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/src/features/diff/Panel.test.tsx
+++ b/src/features/diff/Panel.test.tsx
@@ -3171,6 +3171,74 @@ describe('Panel', () => {
       expect(diff).toHaveAttribute('data-selected-lines-side', 'additions')
     })
 
+    test('v enters visual mode and j/k extend or shrink the selected range', (): void => {
+      render(
+        <Panel
+          cwd="/repo"
+          selectedFile={{ path: 'src/foo.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+        />
+      )
+
+      setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
+
+      const diff = screen.getByTestId('multi-file-diff')
+
+      fireEvent.keyDown(diff, { key: 'v' })
+      expect(diff).toHaveAttribute('data-selected-lines-start', '1')
+      expect(diff).toHaveAttribute('data-selected-lines-end', '1')
+
+      fireEvent.keyDown(diff, { key: 'j' })
+      expect(diff).toHaveAttribute('data-selected-lines-start', '1')
+      expect(diff).toHaveAttribute('data-selected-lines-end', '2')
+      expect(diff).toHaveAttribute('data-selected-lines-side', 'additions')
+
+      fireEvent.keyDown(diff, { key: 'k' })
+      expect(diff).toHaveAttribute('data-selected-lines-start', '1')
+      expect(diff).toHaveAttribute('data-selected-lines-end', '1')
+    })
+
+    test('mouse drag selects multiple diff rows', (): void => {
+      render(
+        <Panel
+          cwd="/repo"
+          selectedFile={{ path: 'src/foo.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+        />
+      )
+
+      setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
+
+      const scrollBody = screen.getByTestId('diff-scroll-body')
+      const firstLine = document.createElement('div')
+      const secondLine = document.createElement('div')
+
+      firstLine.setAttribute('data-line-type', 'context')
+      firstLine.setAttribute('data-line', '1')
+      secondLine.setAttribute('data-line-type', 'change-addition')
+      secondLine.setAttribute('data-line', '2')
+      scrollBody.append(firstLine, secondLine)
+
+      fireEvent.pointerDown(firstLine, { button: 0 })
+      fireEvent.pointerMove(secondLine, { buttons: 1 })
+      fireEvent.pointerUp(secondLine)
+
+      const diff = screen.getByTestId('multi-file-diff')
+      expect(diff).toHaveAttribute('data-selected-lines-start', '1')
+      expect(diff).toHaveAttribute('data-selected-lines-end', '2')
+      expect(diff).toHaveAttribute('data-selected-lines-side', 'additions')
+
+      fireEvent.click(
+        within(screen.getByTestId('gutter-utility-slot')).getByRole('button', {
+          name: 'Add comment on this line',
+        })
+      )
+
+      expect(
+        screen.getByRole('dialog', { name: /Comment on lines R1-R2/ })
+      ).toBeInTheDocument()
+    })
+
     test('j/k scroll Pierre shadow-DOM lines into view', (): void => {
       render(
         <Panel
@@ -3364,6 +3432,103 @@ describe('Panel', () => {
       expect(
         screen.getByRole('dialog', { name: /Comment on line R2/ })
       ).toBeInTheDocument()
+    })
+
+    test('i opens a range comment editor for the visual selection', async (): Promise<void> => {
+      const user = userEvent.setup()
+      const addAnnotation = vi.fn(() => 'ok' as const)
+
+      const feedbackBatch: UseFeedbackBatchReturn = {
+        batch: new Map(),
+        annotationsForFile: () => [],
+        addAnnotation,
+        updateAnnotation: vi.fn(),
+        removeAnnotation: vi.fn(),
+        clearBatch: vi.fn(),
+        totalAnnotations: () => 0,
+      }
+
+      render(
+        <Panel
+          cwd="/repo"
+          selectedFile={{ path: 'src/foo.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+          feedbackBatch={feedbackBatch}
+        />
+      )
+
+      setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
+
+      const diff = screen.getByTestId('multi-file-diff')
+      fireEvent.keyDown(diff, { key: 'v' })
+      fireEvent.keyDown(diff, { key: 'j' })
+      fireEvent.keyDown(diff, { key: 'i' })
+
+      const dialog = screen.getByRole('dialog', {
+        name: /Comment on lines R1-R2/,
+      })
+
+      await user.type(
+        within(dialog).getByPlaceholderText('Request change'),
+        'Review this range'
+      )
+      await user.keyboard('{Enter}')
+
+      expect(addAnnotation).toHaveBeenCalledWith(
+        '/repo',
+        'src/foo.ts',
+        false,
+        expect.objectContaining({
+          lineNumber: 1,
+          side: 'additions',
+          metadata: expect.objectContaining({
+            text: 'Review this range',
+            target: {
+              scope: 'range',
+              side: 'additions',
+              startLine: 1,
+              endLine: 2,
+            },
+          }),
+        })
+      )
+    })
+
+    test('y copies the visual selection to the system clipboard', async (): Promise<void> => {
+      const writeText = vi.fn().mockResolvedValue(undefined)
+      const originalClipboard = window.navigator.clipboard
+
+      Object.defineProperty(window.navigator, 'clipboard', {
+        value: { writeText },
+        configurable: true,
+        writable: true,
+      })
+
+      try {
+        render(
+          <Panel
+            cwd="/repo"
+            selectedFile={{ path: 'src/foo.ts', staged: false, cwd: '/repo' }}
+            onSelectedFileChange={vi.fn()}
+          />
+        )
+
+        setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
+
+        const diff = screen.getByTestId('multi-file-diff')
+        fireEvent.keyDown(diff, { key: 'v' })
+        fireEvent.keyDown(diff, { key: 'j' })
+        fireEvent.keyDown(diff, { key: 'y' })
+        await waitFor(() =>
+          expect(writeText).toHaveBeenCalledWith('alpha\nbeta')
+        )
+      } finally {
+        Object.defineProperty(window.navigator, 'clipboard', {
+          value: originalClipboard,
+          configurable: true,
+          writable: true,
+        })
+      }
     })
 
     test('Shift+I opens the file-level comment editor for the selected file', (): void => {

--- a/src/features/diff/Panel.test.tsx
+++ b/src/features/diff/Panel.test.tsx
@@ -3600,6 +3600,66 @@ describe('Panel', () => {
       ).not.toBeInTheDocument()
     })
 
+    test('editing a range comment preserves the range endpoint', async (): Promise<void> => {
+      const user = userEvent.setup()
+      const updateAnnotation = vi.fn()
+
+      const feedbackBatch: UseFeedbackBatchReturn = {
+        batch: new Map(),
+        annotationsForFile: () => [
+          {
+            lineNumber: 1,
+            side: 'additions',
+            metadata: {
+              id: 'comment-1',
+              text: 'Existing range comment',
+              author: 'self',
+              createdAt: 1000,
+              target: {
+                scope: 'range',
+                side: 'additions',
+                startLine: 1,
+                endLine: 2,
+              },
+            },
+          },
+        ],
+        addAnnotation: vi.fn(() => 'ok' as const),
+        updateAnnotation,
+        removeAnnotation: vi.fn(),
+        clearBatch: vi.fn(),
+        totalAnnotations: () => 1,
+      }
+
+      render(
+        <Panel
+          cwd="/repo"
+          selectedFile={{ path: 'src/foo.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+          feedbackBatch={feedbackBatch}
+        />
+      )
+
+      setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
+
+      await user.click(screen.getByRole('button', { name: 'Edit comment' }))
+
+      const editTextarea = within(
+        screen.getByRole('dialog', { name: /Comment on lines R1-R2/ })
+      ).getByPlaceholderText('Request change')
+      await user.clear(editTextarea)
+      await user.type(editTextarea, 'Updated range comment')
+      await user.keyboard('{Enter}')
+
+      expect(updateAnnotation).toHaveBeenCalledWith(
+        '/repo',
+        'src/foo.ts',
+        false,
+        'comment-1',
+        { text: 'Updated range comment' }
+      )
+    })
+
     test('y copies the visual selection to the system clipboard', async (): Promise<void> => {
       const writeText = vi.fn().mockResolvedValue(undefined)
       const originalClipboard = window.navigator.clipboard

--- a/src/features/diff/Panel.test.tsx
+++ b/src/features/diff/Panel.test.tsx
@@ -3494,6 +3494,42 @@ describe('Panel', () => {
       )
     })
 
+    test('gutter add comment uses the clicked line when a stale visual range is elsewhere', async (): Promise<void> => {
+      const user = userEvent.setup()
+
+      render(
+        <Panel
+          cwd="/repo"
+          selectedFile={{ path: 'src/foo.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+        />
+      )
+
+      setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
+
+      const diff = screen.getByTestId('multi-file-diff')
+      fireEvent.keyDown(diff, { key: 'j' })
+      fireEvent.keyDown(diff, { key: 'v' })
+      fireEvent.keyDown(diff, { key: 'j' })
+
+      expect(diff).toHaveAttribute('data-selected-lines-start', '2')
+      expect(diff).toHaveAttribute('data-selected-lines-end', '3')
+
+      await user.click(
+        within(screen.getByTestId('gutter-utility-slot')).getByRole('button', {
+          name: 'Add comment on this line',
+        })
+      )
+
+      expect(
+        screen.getByRole('dialog', { name: /Comment on line R1/ })
+      ).toBeInTheDocument()
+
+      expect(
+        screen.queryByRole('dialog', { name: /Comment on lines R2-R3/ })
+      ).not.toBeInTheDocument()
+    })
+
     test('y copies the visual selection to the system clipboard', async (): Promise<void> => {
       const writeText = vi.fn().mockResolvedValue(undefined)
       const originalClipboard = window.navigator.clipboard

--- a/src/features/diff/Panel.test.tsx
+++ b/src/features/diff/Panel.test.tsx
@@ -3530,6 +3530,76 @@ describe('Panel', () => {
       ).not.toBeInTheDocument()
     })
 
+    test('editing a comment clears a stale visual range before the next insert', async (): Promise<void> => {
+      const user = userEvent.setup()
+      const updateAnnotation = vi.fn()
+
+      const feedbackBatch: UseFeedbackBatchReturn = {
+        batch: new Map(),
+        annotationsForFile: () => [
+          {
+            lineNumber: 1,
+            side: 'additions',
+            metadata: {
+              id: 'comment-1',
+              text: 'Existing comment',
+              author: 'self',
+              createdAt: 1000,
+            },
+          },
+        ],
+        addAnnotation: vi.fn(() => 'ok' as const),
+        updateAnnotation,
+        removeAnnotation: vi.fn(),
+        clearBatch: vi.fn(),
+        totalAnnotations: () => 1,
+      }
+
+      render(
+        <Panel
+          cwd="/repo"
+          selectedFile={{ path: 'src/foo.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+          feedbackBatch={feedbackBatch}
+        />
+      )
+
+      setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
+
+      const diff = screen.getByTestId('multi-file-diff')
+      fireEvent.keyDown(diff, { key: 'v' })
+      fireEvent.keyDown(diff, { key: 'j' })
+
+      expect(diff).toHaveAttribute('data-selected-lines-start', '1')
+      expect(diff).toHaveAttribute('data-selected-lines-end', '2')
+
+      await user.click(screen.getByRole('button', { name: 'Edit comment' }))
+
+      const editTextarea = within(
+        screen.getByRole('dialog', { name: /Comment on line R1/ })
+      ).getByPlaceholderText('Request change')
+      await user.clear(editTextarea)
+      await user.type(editTextarea, 'Updated comment')
+      await user.keyboard('{Enter}')
+
+      expect(updateAnnotation).toHaveBeenCalledWith(
+        '/repo',
+        'src/foo.ts',
+        false,
+        'comment-1',
+        { text: 'Updated comment' }
+      )
+      fireEvent.keyDown(diff, { key: 'i' })
+
+      expect(
+        screen.getByRole('dialog', { name: /Comment on line R2/ })
+      ).toBeInTheDocument()
+
+      expect(
+        screen.queryByRole('dialog', { name: /Comment on lines R1-R2/ })
+      ).not.toBeInTheDocument()
+    })
+
     test('y copies the visual selection to the system clipboard', async (): Promise<void> => {
       const writeText = vi.fn().mockResolvedValue(undefined)
       const originalClipboard = window.navigator.clipboard

--- a/src/features/diff/Panel.tsx
+++ b/src/features/diff/Panel.tsx
@@ -146,11 +146,16 @@ const commentTargetForLineOrRange = (
   side: AnnotationSide,
   selectedRange: SelectedLineRange | null
 ): AnnotationTarget => {
-  if (selectedRange === null) {
+  const selectedRangeSide: AnnotationSide = selectedRange?.side ?? 'additions'
+
+  if (
+    selectedRange === null ||
+    selectedRangeSide !== side ||
+    lineNumber < selectedRange.start ||
+    lineNumber > selectedRange.end
+  ) {
     return { lineNumber, side, filePath, staged }
   }
-
-  const selectedRangeSide: AnnotationSide = selectedRange.side ?? 'additions'
 
   return {
     lineNumber: selectedRange.start,

--- a/src/features/diff/Panel.tsx
+++ b/src/features/diff/Panel.tsx
@@ -50,6 +50,7 @@ import {
 } from './hooks/useReviewCommentDraft'
 import { useToolbarState } from './hooks/useToolbarState'
 import { useReviewTargetNavigation } from './hooks/useReviewTargetNavigation'
+import { useVisualSelection } from './hooks/useVisualSelection'
 import { Notifier } from './components/Notifier'
 import { PanelBody } from './components/PanelBody'
 import { ReviewCommentEditor } from './components/ReviewCommentEditor'
@@ -135,6 +136,30 @@ const keyboardConfirmCopy = (
     title: 'Discard file?',
     body: `Discard all changes in ${fileLabel}? This cannot be undone.`,
     variant: 'danger',
+  }
+}
+
+const commentTargetForLineOrRange = (
+  filePath: string,
+  staged: boolean,
+  lineNumber: number,
+  side: AnnotationSide,
+  selectedRange: SelectedLineRange | null
+): AnnotationTarget => {
+  if (selectedRange === null) {
+    return { lineNumber, side, filePath, staged }
+  }
+
+  const selectedRangeSide: AnnotationSide = selectedRange.side ?? 'additions'
+
+  return {
+    lineNumber: selectedRange.start,
+    side: selectedRangeSide,
+    filePath,
+    staged,
+    ...(selectedRange.end === selectedRange.start
+      ? {}
+      : { rangeEndLine: selectedRange.end }),
   }
 }
 
@@ -457,114 +482,6 @@ export const Panel = ({
       setKeyboardConfirmAction(next)
     },
     [focusDiffRoot]
-  )
-
-  const confirmCommentEditor = useCallback(
-    (text: string): void => {
-      if (annotationTarget === null) {
-        return
-      }
-
-      if (isFileAnnotationTarget(annotationTarget)) {
-        if (annotationTarget.editId !== undefined) {
-          feedback.updateAnnotation(
-            cwd,
-            annotationTarget.filePath,
-            annotationTarget.staged,
-            annotationTarget.editId,
-            { text }
-          )
-          closeCommentEditor()
-
-          return
-        }
-
-        const result = feedback.addAnnotation(
-          cwd,
-          annotationTarget.filePath,
-          annotationTarget.staged,
-          {
-            side: 'additions',
-            lineNumber: FILE_COMMENT_LINE_NUMBER,
-            metadata: {
-              id: nextFeedbackCommentId(),
-              text,
-              author: 'self',
-              createdAt: Date.now(),
-              target: { scope: 'file' },
-            },
-          }
-        )
-
-        if (result === 'cap-reached') {
-          notifyInfo(
-            'Feedback limit reached (50 comments). Finish or discard before adding more.'
-          )
-        } else {
-          closeCommentEditor()
-        }
-
-        return
-      }
-
-      if (selectedFilePath === null) {
-        closeCommentEditor()
-
-        return
-      }
-
-      if (
-        annotationTarget.filePath !== selectedFilePath ||
-        annotationTarget.staged !== selectedFileStaged
-      ) {
-        closeCommentEditor()
-
-        return
-      }
-
-      if (annotationTarget.editId !== undefined) {
-        feedback.updateAnnotation(
-          cwd,
-          selectedFilePath,
-          selectedFileStaged,
-          annotationTarget.editId,
-          { text }
-        )
-        closeCommentEditor()
-      } else {
-        const result = feedback.addAnnotation(
-          cwd,
-          selectedFilePath,
-          selectedFileStaged,
-          {
-            side: annotationTarget.side,
-            lineNumber: annotationTarget.lineNumber,
-            metadata: {
-              id: nextFeedbackCommentId(),
-              text,
-              author: 'self',
-              createdAt: Date.now(),
-            },
-          }
-        )
-        if (result === 'cap-reached') {
-          notifyInfo(
-            'Feedback limit reached (50 comments). Finish or discard before adding more.'
-          )
-        } else {
-          closeCommentEditor()
-        }
-      }
-    },
-    [
-      closeCommentEditor,
-      annotationTarget,
-      selectedFilePath,
-      selectedFileStaged,
-      feedback,
-      cwd,
-      notifyInfo,
-    ]
   )
 
   const sendingFeedbackRef = useRef(false)
@@ -909,6 +826,7 @@ export const Panel = ({
     scrollHunkIntoView,
     scrollTargetIntoView,
     selectedLines: reviewSelectedLines,
+    targetIndexFromPointerEvent,
     targetIndexForHunk,
   } = useReviewTargetNavigation({
     annotations: realAnnotations,
@@ -918,6 +836,36 @@ export const Panel = ({
     fileKey: reviewTargetFileKey,
     onHunkIndexChange: setFocusedHunkIndex,
     scrollBodyRef: diffScrollBodyRef,
+  })
+
+  const {
+    active: visualMode,
+    cancel: cancelVisualSelection,
+    moveLine: moveVisualSelectionLine,
+    moveMouse: moveMouseVisualSelection,
+    moveSide: moveVisualSelectionSide,
+    selectedLines: visualSelectedLines,
+    start: startVisualSelection,
+    startMouse: startMouseVisualSelection,
+    stopMouse: stopMouseVisualSelection,
+    yank: yankVisualSelection,
+  } = useVisualSelection({
+    activeHunks: activeResponse?.fileDiff.hunks ?? null,
+    activeTargetIndex: reviewTargetIndex,
+    activateTarget: activateReviewTarget,
+    diffStyle: effectiveDiffStyle,
+    fileKey: reviewTargetFileKey,
+    focusDiffRoot,
+    moveTargetLine,
+    moveTargetSide,
+    notifyInfo,
+    onPointerHover: handleBodyPointerMove,
+    scrollTargetIntoView,
+    shouldIgnorePointerTarget: (target): boolean =>
+      target instanceof Element &&
+      target.closest(DIFF_NATIVE_FOCUS_SELECTOR) !== null,
+    targetIndexFromPointerEvent,
+    targets: reviewTargets,
   })
 
   const onPrevHunk = useCallback((): void => {
@@ -963,7 +911,7 @@ export const Panel = ({
   ])
 
   const selectedLines: SelectedLineRange | null =
-    reviewSelectedLines ?? navSelection
+    visualSelectedLines ?? reviewSelectedLines ?? navSelection
 
   // Memoize the Pierre input pair on response identity. Without this,
   // `toPierreInputs(response)` would mint fresh { oldFile, newFile } object
@@ -1046,14 +994,6 @@ export const Panel = ({
     [activateTargetNearViewportCenter, focusDiffRoot]
   )
 
-  const moveReviewTargetLine = useCallback(
-    (delta: number): void => {
-      moveTargetLine(delta)
-      focusDiffRoot()
-    },
-    [focusDiffRoot, moveTargetLine]
-  )
-
   const moveReviewTargetHunk = useCallback(
     (delta: number): void => {
       if (!activeResponse) {
@@ -1105,20 +1045,43 @@ export const Panel = ({
   )
 
   const openSelectedComment = useCallback((): void => {
-    if (selectedFilePath === null || reviewTarget === null) {
+    const selectedRange = visualSelectedLines
+
+    if (
+      selectedFilePath === null ||
+      (selectedRange === null && reviewTarget === null)
+    ) {
       notifyInfo('No diff line selected for comment.')
 
       return
     }
 
-    const nextTarget: AnnotationTarget = {
-      lineNumber: reviewTarget.lineNumber,
-      side: reviewTarget.side,
-      filePath: selectedFilePath,
-      staged: selectedFileStaged,
+    let targetLineNumber: number
+    let targetSide: AnnotationSide
+
+    if (selectedRange === null) {
+      if (reviewTarget === null) {
+        notifyInfo('No diff line selected for comment.')
+
+        return
+      }
+
+      targetLineNumber = reviewTarget.lineNumber
+      targetSide = reviewTarget.side
+      activateReviewTarget(reviewTargetIndex)
+    } else {
+      targetLineNumber = selectedRange.start
+      targetSide = selectedRange.side ?? 'additions'
     }
 
-    activateReviewTarget(reviewTargetIndex)
+    const nextTarget = commentTargetForLineOrRange(
+      selectedFilePath,
+      selectedFileStaged,
+      targetLineNumber,
+      targetSide,
+      selectedRange
+    )
+
     setCommentDraftText((current) => {
       if (annotationTarget === null) {
         return ''
@@ -1137,6 +1100,7 @@ export const Panel = ({
     selectedFileStaged,
     setAnnotationTarget,
     setCommentDraftText,
+    visualSelectedLines,
   ])
 
   const openFileCommentEditor = useCallback(
@@ -1177,14 +1141,6 @@ export const Panel = ({
       openFileCommentEditor(file)
     },
     [openFileCommentEditor, selectDiffFile]
-  )
-
-  const moveReviewTargetSide = useCallback(
-    (side: AnnotationSide): void => {
-      moveTargetSide(side)
-      focusDiffRoot()
-    },
-    [focusDiffRoot, moveTargetSide]
   )
 
   // Opens the y/n guard for destructive or staging keyboard actions.
@@ -1331,11 +1287,137 @@ export const Panel = ({
     selectedFilePath,
   ])
 
+  const confirmCommentEditor = useCallback(
+    (text: string): void => {
+      if (annotationTarget === null) {
+        return
+      }
+
+      if (isFileAnnotationTarget(annotationTarget)) {
+        if (annotationTarget.editId !== undefined) {
+          feedback.updateAnnotation(
+            cwd,
+            annotationTarget.filePath,
+            annotationTarget.staged,
+            annotationTarget.editId,
+            { text }
+          )
+          closeCommentEditor()
+
+          return
+        }
+
+        const result = feedback.addAnnotation(
+          cwd,
+          annotationTarget.filePath,
+          annotationTarget.staged,
+          {
+            side: 'additions',
+            lineNumber: FILE_COMMENT_LINE_NUMBER,
+            metadata: {
+              id: nextFeedbackCommentId(),
+              text,
+              author: 'self',
+              createdAt: Date.now(),
+              target: { scope: 'file' },
+            },
+          }
+        )
+
+        if (result === 'cap-reached') {
+          notifyInfo(
+            'Feedback limit reached (50 comments). Finish or discard before adding more.'
+          )
+        } else {
+          cancelVisualSelection(false)
+          closeCommentEditor()
+        }
+
+        return
+      }
+
+      if (selectedFilePath === null) {
+        closeCommentEditor()
+
+        return
+      }
+
+      if (
+        annotationTarget.filePath !== selectedFilePath ||
+        annotationTarget.staged !== selectedFileStaged
+      ) {
+        closeCommentEditor()
+
+        return
+      }
+
+      if (annotationTarget.editId !== undefined) {
+        feedback.updateAnnotation(
+          cwd,
+          selectedFilePath,
+          selectedFileStaged,
+          annotationTarget.editId,
+          { text }
+        )
+        closeCommentEditor()
+      } else {
+        const result = feedback.addAnnotation(
+          cwd,
+          selectedFilePath,
+          selectedFileStaged,
+          {
+            side: annotationTarget.side,
+            lineNumber: annotationTarget.lineNumber,
+            metadata: {
+              id: nextFeedbackCommentId(),
+              text,
+              author: 'self',
+              createdAt: Date.now(),
+              ...(annotationTarget.rangeEndLine === undefined
+                ? {}
+                : {
+                    target: {
+                      scope: 'range' as const,
+                      side: annotationTarget.side,
+                      startLine: annotationTarget.lineNumber,
+                      endLine: annotationTarget.rangeEndLine,
+                    },
+                  }),
+            },
+          }
+        )
+        if (result === 'cap-reached') {
+          notifyInfo(
+            'Feedback limit reached (50 comments). Finish or discard before adding more.'
+          )
+        } else {
+          cancelVisualSelection(false)
+          closeCommentEditor()
+        }
+      }
+    },
+    [
+      annotationTarget,
+      closeCommentEditor,
+      cwd,
+      feedback,
+      notifyInfo,
+      selectedFilePath,
+      selectedFileStaged,
+      cancelVisualSelection,
+    ]
+  )
+
+  const cancelCommentEditor = useCallback((): void => {
+    cancelVisualSelection(false)
+    closeCommentEditor()
+  }, [cancelVisualSelection, closeCommentEditor])
+
   useKeyboard({
     enabled: true,
     rootRef: diffRootRef,
     confirming: keyboardConfirmAction !== null,
-    onMoveLine: moveReviewTargetLine,
+    onMoveLine: moveVisualSelectionLine,
     onScrollPage: scrollDiffPage,
     onPreviousFile: (): void => goToFile(-1),
     onNextFile: (): void => goToFile(1),
@@ -1355,7 +1437,11 @@ export const Panel = ({
     onDiscardHunk: (): void => openKeyboardConfirm('discard-hunk'),
     onDiscardFile: (): void => openKeyboardConfirm('discard-file'),
     onToggleView: toggleDiffStyle,
-    onMoveLineSide: moveReviewTargetSide,
+    onMoveLineSide: moveVisualSelectionSide,
+    visualMode,
+    onStartVisualSelection: startVisualSelection,
+    onYankSelection: yankVisualSelection,
+    onCancelVisualSelection: cancelVisualSelection,
     onConfirm: confirmKeyboardAction,
     onCancelConfirm: cancelKeyboardConfirm,
   })
@@ -1377,12 +1463,15 @@ export const Panel = ({
 
       deactivateReviewTarget()
 
-      const nextTarget: AnnotationTarget = {
+      const selectedRange = visualSelectedLines
+
+      const nextTarget = commentTargetForLineOrRange(
+        selectedFilePath,
+        selectedFileStaged,
         lineNumber,
         side,
-        filePath: selectedFilePath,
-        staged: selectedFileStaged,
-      }
+        selectedRange
+      )
 
       setCommentDraftText((current) => {
         if (annotationTarget === null) {
@@ -1402,6 +1491,7 @@ export const Panel = ({
       selectedFileStaged,
       setCommentDraftText,
       setAnnotationTarget,
+      visualSelectedLines,
     ]
   )
 
@@ -1618,7 +1708,7 @@ export const Panel = ({
           open={fileCommentDraftIsVisible}
           onOpenChange={(open): void => {
             if (!open) {
-              closeCommentEditor()
+              cancelCommentEditor()
             }
           }}
           placement="bottom-start"
@@ -1639,7 +1729,7 @@ export const Panel = ({
               setCommentDraftText(text, false)
             }}
             onConfirm={confirmCommentEditor}
-            onCancel={closeCommentEditor}
+            onCancel={cancelCommentEditor}
           />
         </Popover>
         {selectedFileEntry !== undefined &&
@@ -1696,7 +1786,10 @@ export const Panel = ({
           lineAnnotations={lineAnnotations}
           annotationTarget={annotationTarget}
           commentDraftText={commentDraftText}
-          onPointerMove={handleBodyPointerMove}
+          onPointerDown={startMouseVisualSelection}
+          onPointerMove={moveMouseVisualSelection}
+          onPointerUp={stopMouseVisualSelection}
+          onPointerLeave={stopMouseVisualSelection}
           onAddComment={handleBodyAddComment}
           onEditComment={handleBodyEditComment}
           onDeleteComment={removeFeedbackAnnotation}
@@ -1704,7 +1797,7 @@ export const Panel = ({
             setCommentDraftText(text, false)
           }}
           onConfirmComment={confirmCommentEditor}
-          onCancelComment={closeCommentEditor}
+          onCancelComment={cancelCommentEditor}
         />
       </div>
     </div>

--- a/src/features/diff/Panel.tsx
+++ b/src/features/diff/Panel.tsx
@@ -1307,6 +1307,7 @@ export const Panel = ({
             annotationTarget.editId,
             { text }
           )
+          cancelVisualSelection(false)
           closeCommentEditor()
 
           return
@@ -1364,6 +1365,7 @@ export const Panel = ({
           annotationTarget.editId,
           { text }
         )
+        cancelVisualSelection(false)
         closeCommentEditor()
       } else {
         const result = feedback.addAnnotation(

--- a/src/features/diff/Panel.tsx
+++ b/src/features/diff/Panel.tsx
@@ -1504,11 +1504,18 @@ export const Panel = ({
 
   const handleBodyEditComment = useCallback(
     (annotation: DiffLineAnnotation<ReviewComment>): void => {
+      const rangeTarget =
+        annotation.metadata.target?.scope === 'range' &&
+        annotation.metadata.target.side === annotation.side
+          ? annotation.metadata.target
+          : null
+
       setAnnotationTarget({
-        lineNumber: annotation.lineNumber,
+        lineNumber: rangeTarget?.startLine ?? annotation.lineNumber,
         side: annotation.side,
         filePath: selectedFilePath ?? '',
         staged: selectedFileStaged,
+        ...(rangeTarget === null ? {} : { rangeEndLine: rangeTarget.endLine }),
         editId: annotation.metadata.id,
       })
       setCommentDraftText(annotation.metadata.text, false)

--- a/src/features/diff/components/PanelBody.tsx
+++ b/src/features/diff/components/PanelBody.tsx
@@ -46,6 +46,21 @@ const LoadingCard = (): ReactElement => (
   </div>
 )
 
+const annotationTargetLabel = (
+  annotation: DiffLineAnnotation<ReviewComment>
+): string | undefined => {
+  const target = annotation.metadata.target
+  if (target?.scope !== 'range') {
+    return undefined
+  }
+
+  const prefix = target.side === 'deletions' ? 'L' : 'R'
+
+  return target.startLine === target.endLine
+    ? `line ${prefix}${target.startLine}`
+    : `lines ${prefix}${target.startLine}-${prefix}${target.endLine}`
+}
+
 interface DiffCacheLike {
   has: (cacheKey: string) => boolean
 }
@@ -127,7 +142,10 @@ interface PanelBodyProps {
   lineAnnotations: DiffLineAnnotation<ReviewComment>[]
   annotationTarget: AnnotationTarget | null
   commentDraftText: string
+  onPointerDown?: (event: ReactPointerEvent<HTMLDivElement>) => void
   onPointerMove: (event: ReactPointerEvent<HTMLDivElement>) => void
+  onPointerUp?: (event: ReactPointerEvent<HTMLDivElement>) => void
+  onPointerLeave?: (event: ReactPointerEvent<HTMLDivElement>) => void
   onAddComment: (lineNumber: number, side: AnnotationSide) => void
   onEditComment: (annotation: DiffLineAnnotation<ReviewComment>) => void
   onDeleteComment: (id: string) => void
@@ -148,7 +166,10 @@ export const PanelBody = ({
   lineAnnotations,
   annotationTarget,
   commentDraftText,
+  onPointerDown = undefined,
   onPointerMove,
+  onPointerUp = undefined,
+  onPointerLeave = undefined,
   onAddComment,
   onEditComment,
   onDeleteComment,
@@ -166,7 +187,10 @@ export const PanelBody = ({
       ref={scrollBodyRef}
       data-testid="diff-scroll-body"
       className="min-h-0 flex-1 overflow-auto"
+      onPointerDown={onPointerDown}
       onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerLeave={onPointerLeave}
     >
       {diffError ? (
         <ErrorCard message={diffError.message} />
@@ -213,6 +237,7 @@ export const PanelBody = ({
                     }`}
                     lineNumber={annotation.lineNumber}
                     side={annotation.side}
+                    targetLabel={annotationTargetLabel(annotation)}
                     value={commentDraftText}
                     onTextChange={onCommentTextChange}
                     onConfirm={onConfirmComment}

--- a/src/features/diff/components/ReviewCommentEditor.tsx
+++ b/src/features/diff/components/ReviewCommentEditor.tsx
@@ -12,21 +12,14 @@ interface ReviewCommentEditorBaseProps {
   onCancel: () => void
 }
 
-type ReviewCommentEditorProps = ReviewCommentEditorBaseProps &
-  (
-    | {
-        /** 1-based line number the comment is anchored to. */
-        lineNumber: number
-        /** Which side of the diff the line lives on (additions => R, deletions => L). */
-        side: CommentSide
-        targetLabel?: undefined
-      }
-    | {
-        targetLabel: string
-        lineNumber?: undefined
-        side?: undefined
-      }
-  )
+type ReviewCommentEditorProps = ReviewCommentEditorBaseProps & {
+  /** Line anchor for single-line comments and the start of range comments. */
+  lineNumber?: number
+  /** Diff side used for fallback R/L labels when targetLabel is absent. */
+  side?: CommentSide
+  /** Preformatted target text for file/range comments, e.g. "file src/a.ts". */
+  targetLabel?: string
+}
 
 export const moveTextareaCursorVertically = (
   textarea: HTMLTextAreaElement,
@@ -97,8 +90,8 @@ const insertTextareaNewline = (
 // sits in the diff flow and never chases the cursor. Enter submits, Shift+Enter
 // inserts a newline, Escape cancels.
 export const ReviewCommentEditor = ({
-  lineNumber,
-  side,
+  lineNumber = undefined,
+  side = undefined,
   targetLabel = undefined,
   chrome = 'card',
   surfaceRole = 'dialog',
@@ -138,7 +131,7 @@ export const ReviewCommentEditor = ({
   }
 
   const targetDescription =
-    targetLabel ?? `line ${side === 'deletions' ? 'L' : 'R'}${lineNumber}`
+    targetLabel ?? `line ${side === 'deletions' ? 'L' : 'R'}${lineNumber ?? ''}`
 
   const className =
     chrome === 'card'

--- a/src/features/diff/hooks/useFeedbackBatch.ts
+++ b/src/features/diff/hooks/useFeedbackBatch.ts
@@ -19,7 +19,14 @@ export interface ReviewComment {
   text: string
   author: 'self'
   createdAt: number
-  target?: { scope: 'file' }
+  target?:
+    | { scope: 'file' }
+    | {
+        scope: 'range'
+        side: AnnotationSide
+        startLine: number
+        endLine: number
+      }
 }
 
 /**
@@ -230,6 +237,7 @@ export type FeedbackDraft =
       scope?: 'line'
       side: AnnotationSide
       lineNumber: number
+      rangeEndLine?: number
     })
   | (FeedbackDraftBase & {
       scope: 'file'

--- a/src/features/diff/hooks/useKeyboard.test.ts
+++ b/src/features/diff/hooks/useKeyboard.test.ts
@@ -80,6 +80,10 @@ const renderKeyboard = (
     onDiscardFile: vi.fn(),
     onToggleView: vi.fn(),
     onMoveLineSide: vi.fn(),
+    visualMode: false,
+    onStartVisualSelection: vi.fn(),
+    onYankSelection: vi.fn(),
+    onCancelVisualSelection: vi.fn(),
     onConfirm: vi.fn(),
     onCancelConfirm: vi.fn(),
     ...overrides,
@@ -201,6 +205,31 @@ describe('useKeyboard', () => {
 
     expect(props.onMoveLineSide).toHaveBeenNthCalledWith(1, 'deletions')
     expect(props.onMoveLineSide).toHaveBeenNthCalledWith(2, 'additions')
+  })
+
+  test('v starts visual mode and y yanks the selection', () => {
+    const { props } = renderKeyboard()
+
+    dispatch('v')
+    dispatch('y')
+
+    expect(props.onStartVisualSelection).toHaveBeenCalledOnce()
+    expect(props.onYankSelection).toHaveBeenCalledOnce()
+  })
+
+  test('Escape cancels only while visual mode is active', () => {
+    const inactive = renderKeyboard()
+
+    dispatch('Escape')
+    expect(inactive.props.onCancelVisualSelection).not.toHaveBeenCalled()
+    inactive.unmount()
+
+    const active = renderKeyboard({ visualMode: true })
+    const event = dispatch('Escape')
+
+    expect(active.props.onCancelVisualSelection).toHaveBeenCalledOnce()
+    expect(event.preventDefaultSpy).toHaveBeenCalledOnce()
+    expect(event.stopPropagationSpy).toHaveBeenCalledOnce()
   })
 
   test('Ctrl+D and Ctrl+U scroll the current file', () => {
@@ -346,6 +375,10 @@ describe('useKeyboard', () => {
       onDiscardFile: vi.fn(),
       onToggleView: vi.fn(),
       onMoveLineSide: vi.fn(),
+      visualMode: false,
+      onStartVisualSelection: vi.fn(),
+      onYankSelection: vi.fn(),
+      onCancelVisualSelection: vi.fn(),
       onConfirm: vi.fn(),
       onCancelConfirm: vi.fn(),
     }

--- a/src/features/diff/hooks/useKeyboard.ts
+++ b/src/features/diff/hooks/useKeyboard.ts
@@ -25,6 +25,10 @@ export interface UseKeyboardOptions {
   onDiscardFile: () => void
   onToggleView: () => void
   onMoveLineSide: (side: 'deletions' | 'additions') => void
+  visualMode: boolean
+  onStartVisualSelection: () => void
+  onYankSelection: () => void
+  onCancelVisualSelection: () => void
   onConfirm: () => void
   onCancelConfirm: () => void
 }
@@ -69,6 +73,10 @@ export const useKeyboard = (options: UseKeyboardOptions): void => {
     onDiscardFile,
     onToggleView,
     onMoveLineSide,
+    visualMode,
+    onStartVisualSelection,
+    onYankSelection,
+    onCancelVisualSelection,
     onConfirm,
     onCancelConfirm,
   } = options
@@ -147,6 +155,14 @@ export const useKeyboard = (options: UseKeyboardOptions): void => {
         return
       }
 
+      if (visualMode && event.key === 'Escape') {
+        event.preventDefault()
+        event.stopPropagation()
+        onCancelVisualSelection()
+
+        return
+      }
+
       const handlers: Partial<Record<string, () => void>> = {
         j: () => onMoveLine(1),
         k: () => onMoveLine(-1),
@@ -166,6 +182,8 @@ export const useKeyboard = (options: UseKeyboardOptions): void => {
         t: onToggleView,
         h: () => onMoveLineSide('deletions'),
         l: () => onMoveLineSide('additions'),
+        v: onStartVisualSelection,
+        y: onYankSelection,
       }
 
       const handler = handlers[event.key]
@@ -202,6 +220,10 @@ export const useKeyboard = (options: UseKeyboardOptions): void => {
     onDiscardFile,
     onToggleView,
     onMoveLineSide,
+    visualMode,
+    onStartVisualSelection,
+    onYankSelection,
+    onCancelVisualSelection,
     onConfirm,
     onCancelConfirm,
   ])

--- a/src/features/diff/hooks/useReviewCommentDraft.test.ts
+++ b/src/features/diff/hooks/useReviewCommentDraft.test.ts
@@ -199,6 +199,47 @@ describe('useReviewCommentDraft', () => {
     expect(result.current.lineAnnotations[1]?.metadata.id).toBe(DRAFT_ID)
   })
 
+  test('keeps range drafts current only when both endpoints exist', () => {
+    const { result } = renderDraftHook()
+
+    act(() => {
+      result.current.setAnnotationTarget(
+        { ...target, lineNumber: 1, rangeEndLine: 3 },
+        false
+      )
+      result.current.setCommentDraftText('Range draft', false)
+    })
+
+    expect(result.current.annotationTargetLineExists).toBe(true)
+    expect(result.current.commentDraftIsRecoverable).toBe(false)
+    expect(result.current.lineAnnotations).toHaveLength(2)
+    expect(result.current.lineAnnotations[1]?.metadata).toMatchObject({
+      id: DRAFT_ID,
+      target: {
+        scope: 'range',
+        side: 'additions',
+        startLine: 1,
+        endLine: 3,
+      },
+    })
+  })
+
+  test('treats a range draft as stale when the end line is missing', () => {
+    const { result } = renderDraftHook()
+
+    act(() => {
+      result.current.setAnnotationTarget(
+        { ...target, lineNumber: 1, rangeEndLine: 20 },
+        false
+      )
+      result.current.setCommentDraftText('Range draft', false)
+    })
+
+    expect(result.current.annotationTargetLineExists).toBe(false)
+    expect(result.current.commentDraftIsRecoverable).toBe(true)
+    expect(result.current.lineAnnotations).toEqual([existingAnnotation])
+  })
+
   test('stores file-level drafts without creating a Pierre line annotation', () => {
     const { result } = renderDraftHook()
 

--- a/src/features/diff/hooks/useReviewCommentDraft.ts
+++ b/src/features/diff/hooks/useReviewCommentDraft.ts
@@ -184,6 +184,11 @@ const diffContainsAnnotationTarget = (
     return true
   }
 
+  const targetLines = new Set([target.lineNumber])
+  if (target.rangeEndLine !== undefined) {
+    targetLines.add(target.rangeEndLine)
+  }
+
   for (const hunk of fileDiff.hunks) {
     let oldLine = hunk.oldStart
     let newLine = hunk.newStart
@@ -198,16 +203,20 @@ const diffContainsAnnotationTarget = (
       if (
         target.side === 'deletions' &&
         line.type !== 'added' &&
-        oldLineNumber === target.lineNumber
+        oldLineNumber !== undefined
       ) {
-        return true
+        targetLines.delete(oldLineNumber)
       }
 
       if (
         target.side === 'additions' &&
         line.type !== 'removed' &&
-        newLineNumber === target.lineNumber
+        newLineNumber !== undefined
       ) {
+        targetLines.delete(newLineNumber)
+      }
+
+      if (targetLines.size === 0) {
         return true
       }
 

--- a/src/features/diff/hooks/useReviewCommentDraft.ts
+++ b/src/features/diff/hooks/useReviewCommentDraft.ts
@@ -33,6 +33,7 @@ interface LineAnnotationTarget {
   filePath: string
   staged: boolean
   scope?: 'line'
+  rangeEndLine?: number
   editId?: string
 }
 
@@ -104,6 +105,10 @@ const draftToAnnotationTarget = (draft: FeedbackDraft): AnnotationTarget => {
     staged: draft.staged,
   }
 
+  if (draft.rangeEndLine !== undefined) {
+    target.rangeEndLine = draft.rangeEndLine
+  }
+
   if (draft.editId !== undefined) {
     target.editId = draft.editId
   }
@@ -141,6 +146,10 @@ const annotationTargetToDraft = (
     text,
   }
 
+  if (target.rangeEndLine !== undefined) {
+    draft.rangeEndLine = target.rangeEndLine
+  }
+
   if (target.editId !== undefined) {
     draft.editId = target.editId
   }
@@ -159,7 +168,7 @@ const annotationTargetKey = (target: AnnotationTarget): string => {
 
   return `${target.filePath}:${target.staged}:line:${target.side}:${
     target.lineNumber
-  }:${target.editId ?? 'draft'}`
+  }:${target.rangeEndLine ?? target.lineNumber}:${target.editId ?? 'draft'}`
 }
 
 export const isSameAnnotationTarget = (
@@ -373,7 +382,22 @@ export const useReviewCommentDraft = ({
       const draft: DiffLineAnnotation<ReviewComment> = {
         side: annotationTarget.side,
         lineNumber: annotationTarget.lineNumber,
-        metadata: { id: DRAFT_ID, text: '', author: 'self', createdAt: 0 },
+        metadata: {
+          id: DRAFT_ID,
+          text: '',
+          author: 'self',
+          createdAt: 0,
+          ...(annotationTarget.rangeEndLine === undefined
+            ? {}
+            : {
+                target: {
+                  scope: 'range' as const,
+                  side: annotationTarget.side,
+                  startLine: annotationTarget.lineNumber,
+                  endLine: annotationTarget.rangeEndLine,
+                },
+              }),
+        },
       }
 
       return [...realAnnotations, draft]

--- a/src/features/diff/hooks/useReviewTargetNavigation.ts
+++ b/src/features/diff/hooks/useReviewTargetNavigation.ts
@@ -56,6 +56,9 @@ interface UseReviewTargetNavigationReturn {
     delta: number
   ) => void
   selectedLines: SelectedLineRange | null
+  targetIndexFromPointerEvent: (
+    event: ReactPointerEvent<HTMLElement>
+  ) => number | null
   targetIndexForHunk: (hunkIndex: number) => number
   targets: ReviewNavigationTarget[]
 }
@@ -798,15 +801,21 @@ export const useReviewTargetNavigation = ({
   )
 
   // Pointer hover updates the same current target used by shortcuts.
+  const targetIndexFromPointerEvent = useCallback(
+    (event: ReactPointerEvent<HTMLElement>): number | null =>
+      reviewTargetIndexFromPointerEvent(event, targets),
+    [targets]
+  )
+
   const handlePointerMove = useCallback(
     (event: ReactPointerEvent<HTMLElement>): void => {
-      const targetIndex = reviewTargetIndexFromPointerEvent(event, targets)
+      const targetIndex = targetIndexFromPointerEvent(event)
 
       if (targetIndex !== null) {
         activateTarget(targetIndex)
       }
     },
-    [activateTarget, targets]
+    [activateTarget, targetIndexFromPointerEvent]
   )
 
   return {
@@ -823,6 +832,7 @@ export const useReviewTargetNavigation = ({
     scrollHunkIntoView,
     scrollTargetIntoView,
     selectedLines,
+    targetIndexFromPointerEvent,
     targetIndexForHunk,
     targets,
   }

--- a/src/features/diff/hooks/useVisualSelection.test.ts
+++ b/src/features/diff/hooks/useVisualSelection.test.ts
@@ -1,0 +1,172 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { describe, expect, test, vi, beforeEach } from 'vitest'
+import { writeClipboardText } from '@/lib/clipboard'
+import type { DiffHunk } from '../types'
+import type { ReviewNavigationTarget } from './useReviewTargetNavigation'
+import { useVisualSelection } from './useVisualSelection'
+
+vi.mock('@/lib/clipboard', () => ({
+  writeClipboardText: vi.fn().mockResolvedValue(true),
+}))
+
+const targets: ReviewNavigationTarget[] = [
+  {
+    lineNumber: 1,
+    side: 'additions',
+    hunkIndex: 0,
+    splitRowIndex: 0,
+    changed: false,
+  },
+  {
+    lineNumber: 2,
+    side: 'additions',
+    hunkIndex: 0,
+    splitRowIndex: 1,
+    changed: true,
+  },
+  {
+    lineNumber: 3,
+    side: 'additions',
+    hunkIndex: 0,
+    splitRowIndex: 2,
+    changed: true,
+  },
+]
+
+const hunks: DiffHunk[] = [
+  {
+    id: 'hunk-0',
+    header: '@@ -1,3 +1,3 @@',
+    oldStart: 1,
+    oldLines: 3,
+    newStart: 1,
+    newLines: 3,
+    lines: [
+      { type: 'context', oldLineNumber: 1, newLineNumber: 1, content: 'one' },
+      { type: 'added', newLineNumber: 2, content: 'two' },
+      { type: 'added', newLineNumber: 3, content: 'three' },
+    ],
+  },
+]
+
+type VisualSelectionHook = ReturnType<typeof useVisualSelection>
+
+interface RenderedVisualSelection {
+  result: { current: VisualSelectionHook }
+  rerender: (props: { nextFileKey: string }) => void
+  activateTarget: ReturnType<typeof vi.fn>
+  focusDiffRoot: ReturnType<typeof vi.fn>
+  moveTargetLine: ReturnType<typeof vi.fn>
+  notifyInfo: ReturnType<typeof vi.fn>
+  scrollTargetIntoView: ReturnType<typeof vi.fn>
+}
+
+const renderVisualSelection = (
+  fileKey = 'src/foo.ts:unstaged'
+): RenderedVisualSelection => {
+  const activateTarget = vi.fn()
+  const focusDiffRoot = vi.fn()
+  const moveTargetLine = vi.fn()
+  const moveTargetSide = vi.fn()
+  const notifyInfo = vi.fn()
+  const onPointerHover = vi.fn()
+  const scrollTargetIntoView = vi.fn()
+  const targetIndexFromPointerEvent = vi.fn()
+
+  const hook = renderHook(
+    ({ nextFileKey }) =>
+      useVisualSelection({
+        activeHunks: hunks,
+        activeTargetIndex: 0,
+        activateTarget,
+        diffStyle: 'split',
+        fileKey: nextFileKey,
+        focusDiffRoot,
+        moveTargetLine,
+        moveTargetSide,
+        notifyInfo,
+        onPointerHover,
+        scrollTargetIntoView,
+        targetIndexFromPointerEvent,
+        targets,
+      }),
+    { initialProps: { nextFileKey: fileKey } }
+  )
+
+  return {
+    result: hook.result,
+    rerender: hook.rerender,
+    activateTarget,
+    focusDiffRoot,
+    moveTargetLine,
+    notifyInfo,
+    scrollTargetIntoView,
+  }
+}
+
+describe('useVisualSelection', () => {
+  beforeEach(() => {
+    vi.mocked(writeClipboardText).mockClear()
+  })
+
+  test('extends a selected range and yanks the selected snippet', async () => {
+    const { result, activateTarget, scrollTargetIntoView } =
+      renderVisualSelection()
+
+    act(() => {
+      result.current.start()
+    })
+
+    expect(result.current.selectedLines).toEqual({
+      start: 1,
+      end: 1,
+      side: 'additions',
+    })
+
+    act(() => {
+      result.current.moveLine(1)
+    })
+
+    expect(result.current.selectedLines).toEqual({
+      start: 1,
+      end: 2,
+      side: 'additions',
+    })
+    expect(activateTarget).toHaveBeenLastCalledWith(1)
+    expect(scrollTargetIntoView).toHaveBeenCalledWith(targets[1], 1, 1)
+
+    act(() => {
+      result.current.yank()
+    })
+
+    await waitFor(() => {
+      expect(writeClipboardText).toHaveBeenCalledWith('one\ntwo')
+    })
+    expect(result.current.selectedLines).toBeNull()
+  })
+
+  test('clears visual selection when the file changes', () => {
+    const { result, rerender } = renderVisualSelection()
+
+    act(() => {
+      result.current.start()
+    })
+
+    expect(result.current.active).toBe(true)
+
+    rerender({ nextFileKey: 'src/bar.ts:unstaged' })
+
+    expect(result.current.active).toBe(false)
+  })
+
+  test('falls back to normal line navigation outside visual mode', () => {
+    const { result, focusDiffRoot, moveTargetLine } = renderVisualSelection()
+
+    act(() => {
+      result.current.moveLine(1)
+    })
+
+    expect(moveTargetLine).toHaveBeenCalledWith(1)
+    expect(focusDiffRoot).toHaveBeenCalled()
+  })
+})

--- a/src/features/diff/hooks/useVisualSelection.test.ts
+++ b/src/features/diff/hooks/useVisualSelection.test.ts
@@ -1,4 +1,5 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
+import type { PointerEvent as ReactPointerEvent } from 'react'
 import { describe, expect, test, vi, beforeEach } from 'vitest'
 import { writeClipboardText } from '@/lib/clipboard'
 import type { DiffHunk } from '../types'
@@ -59,6 +60,7 @@ interface RenderedVisualSelection {
   moveTargetLine: ReturnType<typeof vi.fn>
   notifyInfo: ReturnType<typeof vi.fn>
   scrollTargetIntoView: ReturnType<typeof vi.fn>
+  targetIndexFromPointerEvent: ReturnType<typeof vi.fn>
 }
 
 const renderVisualSelection = (
@@ -101,8 +103,16 @@ const renderVisualSelection = (
     moveTargetLine,
     notifyInfo,
     scrollTargetIntoView,
+    targetIndexFromPointerEvent,
   }
 }
+
+const pointerEvent = (): ReactPointerEvent<HTMLElement> =>
+  ({
+    button: 0,
+    preventDefault: vi.fn(),
+    target: document.createElement('div'),
+  }) as unknown as ReactPointerEvent<HTMLElement>
 
 describe('useVisualSelection', () => {
   beforeEach(() => {
@@ -168,5 +178,55 @@ describe('useVisualSelection', () => {
 
     expect(moveTargetLine).toHaveBeenCalledWith(1)
     expect(focusDiffRoot).toHaveBeenCalled()
+  })
+
+  test('clears mouse selection after a plain click', () => {
+    const { result, activateTarget, targetIndexFromPointerEvent } =
+      renderVisualSelection()
+
+    targetIndexFromPointerEvent.mockReturnValue(1)
+
+    act(() => {
+      result.current.startMouse(pointerEvent())
+    })
+
+    expect(result.current.selectedLines).toEqual({
+      start: 2,
+      end: 2,
+      side: 'additions',
+    })
+    expect(activateTarget).toHaveBeenCalledWith(1)
+
+    act(() => {
+      result.current.stopMouse()
+    })
+
+    expect(result.current.active).toBe(false)
+    expect(result.current.selectedLines).toBeNull()
+  })
+
+  test('keeps mouse selection after dragging across lines', () => {
+    const { result, targetIndexFromPointerEvent } = renderVisualSelection()
+
+    targetIndexFromPointerEvent.mockReturnValueOnce(0).mockReturnValueOnce(2)
+
+    act(() => {
+      result.current.startMouse(pointerEvent())
+    })
+
+    act(() => {
+      result.current.moveMouse(pointerEvent())
+    })
+
+    act(() => {
+      result.current.stopMouse()
+    })
+
+    expect(result.current.active).toBe(true)
+    expect(result.current.selectedLines).toEqual({
+      start: 1,
+      end: 3,
+      side: 'additions',
+    })
   })
 })

--- a/src/features/diff/hooks/useVisualSelection.ts
+++ b/src/features/diff/hooks/useVisualSelection.ts
@@ -1,0 +1,440 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from 'react'
+import type { AnnotationSide, SelectedLineRange } from '@pierre/diffs'
+import { writeClipboardText } from '@/lib/clipboard'
+import type { DiffHunk } from '../types'
+import type { DiffStyle } from './useToolbarState'
+import type { ReviewNavigationTarget } from './useReviewTargetNavigation'
+
+interface VisualSelection {
+  anchorIndex: number
+  focusIndex: number
+}
+
+interface UseVisualSelectionOptions {
+  activeHunks: DiffHunk[] | null
+  activeTargetIndex: number
+  activateTarget: (targetIndex: number) => void
+  diffStyle: DiffStyle
+  fileKey: string
+  focusDiffRoot: () => void
+  moveTargetLine: (delta: number) => void
+  moveTargetSide: (side: AnnotationSide) => void
+  notifyInfo: (message: string) => void
+  onPointerHover: (event: ReactPointerEvent<HTMLElement>) => void
+  scrollTargetIntoView: (
+    target: ReviewNavigationTarget,
+    targetIndex: number,
+    delta: number
+  ) => void
+  shouldIgnorePointerTarget?: (target: EventTarget | null) => boolean
+  targetIndexFromPointerEvent: (
+    event: ReactPointerEvent<HTMLElement>
+  ) => number | null
+  targets: ReviewNavigationTarget[]
+}
+
+interface UseVisualSelectionReturn {
+  active: boolean
+  selectedLines: SelectedLineRange | null
+  cancel: (focusDiff?: boolean) => void
+  moveLine: (delta: number) => void
+  moveMouse: (event: ReactPointerEvent<HTMLElement>) => void
+  moveSide: (side: AnnotationSide) => void
+  start: () => void
+  startMouse: (event: ReactPointerEvent<HTMLElement>) => void
+  stopMouse: () => void
+  yank: () => void
+}
+
+const rangeForVisualSelection = (
+  targets: ReviewNavigationTarget[],
+  selection: VisualSelection | null
+): SelectedLineRange | null => {
+  if (selection === null) {
+    return null
+  }
+
+  if (
+    selection.anchorIndex < 0 ||
+    selection.focusIndex < 0 ||
+    selection.anchorIndex >= targets.length ||
+    selection.focusIndex >= targets.length
+  ) {
+    return null
+  }
+
+  const anchor = targets[selection.anchorIndex]
+  const focus = targets[selection.focusIndex]
+
+  if (anchor.side !== focus.side) {
+    return { start: focus.lineNumber, end: focus.lineNumber, side: focus.side }
+  }
+
+  return {
+    start: Math.min(anchor.lineNumber, focus.lineNumber),
+    end: Math.max(anchor.lineNumber, focus.lineNumber),
+    side: focus.side,
+  }
+}
+
+const moveTargetIndexByLine = (
+  targets: ReviewNavigationTarget[],
+  current: number,
+  delta: number,
+  diffStyle: DiffStyle
+): number => {
+  if (targets.length === 0) {
+    return current
+  }
+
+  const currentIndex = Math.min(current, targets.length - 1)
+  const baseTarget = targets[currentIndex]
+  let rowTargetIndex = currentIndex + delta
+
+  if (rowTargetIndex < 0 || rowTargetIndex >= targets.length) {
+    return currentIndex
+  }
+
+  if (diffStyle === 'split') {
+    rowTargetIndex = currentIndex
+
+    while (
+      rowTargetIndex + delta >= 0 &&
+      rowTargetIndex + delta < targets.length
+    ) {
+      rowTargetIndex += delta
+
+      const rowTarget = targets[rowTargetIndex]
+      if (
+        rowTarget.hunkIndex !== baseTarget.hunkIndex ||
+        rowTarget.splitRowIndex !== baseTarget.splitRowIndex
+      ) {
+        break
+      }
+    }
+  }
+
+  const rowTarget = targets[rowTargetIndex]
+
+  const sameSideIndex = targets.findIndex(
+    (target) =>
+      target.hunkIndex === rowTarget.hunkIndex &&
+      target.splitRowIndex === rowTarget.splitRowIndex &&
+      target.side === baseTarget.side
+  )
+
+  return diffStyle === 'split' && sameSideIndex !== -1
+    ? sameSideIndex
+    : rowTargetIndex
+}
+
+const moveTargetIndexToSide = (
+  targets: ReviewNavigationTarget[],
+  current: number,
+  side: AnnotationSide
+): number => {
+  if (current < 0 || current >= targets.length) {
+    return current
+  }
+
+  const currentTarget = targets[current]
+
+  const nextIndex = targets.findIndex(
+    (target) =>
+      target.hunkIndex === currentTarget.hunkIndex &&
+      target.splitRowIndex === currentTarget.splitRowIndex &&
+      target.side === side
+  )
+
+  return nextIndex === -1 ? current : nextIndex
+}
+
+const textForRange = (range: SelectedLineRange, hunks: DiffHunk[]): string => {
+  const lines: string[] = []
+
+  for (const hunk of hunks) {
+    let oldLine = hunk.oldStart
+    let newLine = hunk.newStart
+
+    for (const line of hunk.lines) {
+      const oldLineNumber =
+        line.oldLineNumber ?? (line.type === 'added' ? undefined : oldLine)
+
+      const newLineNumber =
+        line.newLineNumber ?? (line.type === 'removed' ? undefined : newLine)
+
+      const lineNumber =
+        range.side === 'deletions' ? oldLineNumber : newLineNumber
+
+      if (
+        lineNumber !== undefined &&
+        lineNumber >= range.start &&
+        lineNumber <= range.end
+      ) {
+        lines.push(line.content)
+      }
+
+      if (line.type !== 'added') {
+        oldLine += 1
+      }
+
+      if (line.type !== 'removed') {
+        newLine += 1
+      }
+    }
+  }
+
+  return lines.join('\n')
+}
+
+export const useVisualSelection = ({
+  activeHunks,
+  activeTargetIndex,
+  activateTarget,
+  diffStyle,
+  fileKey,
+  focusDiffRoot,
+  moveTargetLine,
+  moveTargetSide,
+  notifyInfo,
+  onPointerHover,
+  scrollTargetIntoView,
+  shouldIgnorePointerTarget = undefined,
+  targetIndexFromPointerEvent,
+  targets,
+}: UseVisualSelectionOptions): UseVisualSelectionReturn => {
+  const [selection, setSelection] = useState<VisualSelection | null>(null)
+  const dragActiveRef = useRef(false)
+
+  const selectedLines = useMemo(
+    (): SelectedLineRange | null => rangeForVisualSelection(targets, selection),
+    [targets, selection]
+  )
+
+  useEffect(() => {
+    setSelection(null)
+    dragActiveRef.current = false
+  }, [fileKey])
+
+  useEffect(() => {
+    setSelection((current) => {
+      if (current === null) {
+        return null
+      }
+
+      if (
+        current.anchorIndex >= targets.length ||
+        current.focusIndex >= targets.length
+      ) {
+        return null
+      }
+
+      return current
+    })
+  }, [targets.length])
+
+  const cancel = useCallback(
+    (focusDiff = true): void => {
+      dragActiveRef.current = false
+      setSelection(null)
+      if (focusDiff) {
+        focusDiffRoot()
+      }
+    },
+    [focusDiffRoot]
+  )
+
+  const start = useCallback((): void => {
+    if (targets.length === 0) {
+      notifyInfo('No diff line selected.')
+
+      return
+    }
+
+    const index = Math.min(activeTargetIndex, targets.length - 1)
+    activateTarget(index)
+    setSelection({ anchorIndex: index, focusIndex: index })
+    focusDiffRoot()
+  }, [
+    activateTarget,
+    activeTargetIndex,
+    focusDiffRoot,
+    notifyInfo,
+    targets.length,
+  ])
+
+  const startMouse = useCallback(
+    (event: ReactPointerEvent<HTMLElement>): void => {
+      if (
+        event.button > 0 ||
+        shouldIgnorePointerTarget?.(event.target) === true
+      ) {
+        return
+      }
+
+      const targetIndex = targetIndexFromPointerEvent(event)
+      if (targetIndex === null) {
+        return
+      }
+
+      event.preventDefault()
+      dragActiveRef.current = true
+      activateTarget(targetIndex)
+      setSelection({ anchorIndex: targetIndex, focusIndex: targetIndex })
+      focusDiffRoot()
+    },
+    [
+      activateTarget,
+      focusDiffRoot,
+      shouldIgnorePointerTarget,
+      targetIndexFromPointerEvent,
+    ]
+  )
+
+  const moveMouse = useCallback(
+    (event: ReactPointerEvent<HTMLElement>): void => {
+      if (!dragActiveRef.current) {
+        onPointerHover(event)
+
+        return
+      }
+
+      const targetIndex = targetIndexFromPointerEvent(event)
+      if (targetIndex === null) {
+        return
+      }
+
+      activateTarget(targetIndex)
+      setSelection((current) =>
+        current === null
+          ? { anchorIndex: targetIndex, focusIndex: targetIndex }
+          : { ...current, focusIndex: targetIndex }
+      )
+    },
+    [activateTarget, onPointerHover, targetIndexFromPointerEvent]
+  )
+
+  const stopMouse = useCallback((): void => {
+    dragActiveRef.current = false
+  }, [])
+
+  const moveLine = useCallback(
+    (delta: number): void => {
+      if (selection === null) {
+        moveTargetLine(delta)
+        focusDiffRoot()
+
+        return
+      }
+
+      if (targets.length === 0) {
+        return
+      }
+
+      const nextIndex = moveTargetIndexByLine(
+        targets,
+        selection.focusIndex,
+        delta,
+        diffStyle
+      )
+      const nextTarget = targets[nextIndex]
+
+      activateTarget(nextIndex)
+      scrollTargetIntoView(nextTarget, nextIndex, delta)
+      setSelection((current) =>
+        current === null ? null : { ...current, focusIndex: nextIndex }
+      )
+      focusDiffRoot()
+    },
+    [
+      activateTarget,
+      diffStyle,
+      focusDiffRoot,
+      moveTargetLine,
+      scrollTargetIntoView,
+      selection,
+      targets,
+    ]
+  )
+
+  const moveSide = useCallback(
+    (side: AnnotationSide): void => {
+      if (selection === null) {
+        moveTargetSide(side)
+        focusDiffRoot()
+
+        return
+      }
+
+      if (diffStyle !== 'split' || targets.length === 0) {
+        return
+      }
+
+      const nextIndex = moveTargetIndexToSide(
+        targets,
+        selection.focusIndex,
+        side
+      )
+      const nextTarget = targets[nextIndex]
+
+      activateTarget(nextIndex)
+      scrollTargetIntoView(nextTarget, nextIndex, 0)
+      setSelection({ anchorIndex: nextIndex, focusIndex: nextIndex })
+      focusDiffRoot()
+    },
+    [
+      activateTarget,
+      diffStyle,
+      focusDiffRoot,
+      moveTargetSide,
+      scrollTargetIntoView,
+      selection,
+      targets,
+    ]
+  )
+
+  const yank = useCallback((): void => {
+    if (selectedLines === null || activeHunks === null) {
+      notifyInfo('No visual selection to copy.')
+
+      return
+    }
+
+    const snippet = textForRange(selectedLines, activeHunks)
+
+    if (snippet.length === 0) {
+      notifyInfo('Selected range has no text to copy.')
+
+      return
+    }
+
+    cancel(false)
+    focusDiffRoot()
+    void (async (): Promise<void> => {
+      const copied = await writeClipboardText(snippet)
+      if (!copied) {
+        notifyInfo('Could not copy selection to clipboard.')
+      }
+    })()
+  }, [activeHunks, cancel, focusDiffRoot, notifyInfo, selectedLines])
+
+  return {
+    active: selection !== null,
+    selectedLines,
+    cancel,
+    moveLine,
+    moveMouse,
+    moveSide,
+    start,
+    startMouse,
+    stopMouse,
+    yank,
+  }
+}

--- a/src/features/diff/hooks/useVisualSelection.ts
+++ b/src/features/diff/hooks/useVisualSelection.ts
@@ -212,6 +212,7 @@ export const useVisualSelection = ({
 }: UseVisualSelectionOptions): UseVisualSelectionReturn => {
   const [selection, setSelection] = useState<VisualSelection | null>(null)
   const dragActiveRef = useRef(false)
+  const dragMovedRef = useRef(false)
 
   const selectedLines = useMemo(
     (): SelectedLineRange | null => rangeForVisualSelection(targets, selection),
@@ -221,6 +222,7 @@ export const useVisualSelection = ({
   useEffect(() => {
     setSelection(null)
     dragActiveRef.current = false
+    dragMovedRef.current = false
   }, [fileKey])
 
   useEffect(() => {
@@ -243,6 +245,7 @@ export const useVisualSelection = ({
   const cancel = useCallback(
     (focusDiff = true): void => {
       dragActiveRef.current = false
+      dragMovedRef.current = false
       setSelection(null)
       if (focusDiff) {
         focusDiffRoot()
@@ -286,6 +289,7 @@ export const useVisualSelection = ({
 
       event.preventDefault()
       dragActiveRef.current = true
+      dragMovedRef.current = false
       activateTarget(targetIndex)
       setSelection({ anchorIndex: targetIndex, focusIndex: targetIndex })
       focusDiffRoot()
@@ -312,17 +316,27 @@ export const useVisualSelection = ({
       }
 
       activateTarget(targetIndex)
-      setSelection((current) =>
-        current === null
-          ? { anchorIndex: targetIndex, focusIndex: targetIndex }
-          : { ...current, focusIndex: targetIndex }
-      )
+      setSelection((current) => {
+        if (current === null) {
+          return { anchorIndex: targetIndex, focusIndex: targetIndex }
+        }
+
+        if (targetIndex !== current.focusIndex) {
+          dragMovedRef.current = true
+        }
+
+        return { ...current, focusIndex: targetIndex }
+      })
     },
     [activateTarget, onPointerHover, targetIndexFromPointerEvent]
   )
 
   const stopMouse = useCallback((): void => {
     dragActiveRef.current = false
+    if (!dragMovedRef.current) {
+      setSelection(null)
+    }
+    dragMovedRef.current = false
   }, [])
 
   const moveLine = useCallback(

--- a/src/features/diff/services/feedbackDispatch.test.ts
+++ b/src/features/diff/services/feedbackDispatch.test.ts
@@ -138,6 +138,35 @@ test('file-level comments emit an explicit file target instead of a line target'
   expect(payload).not.toContain('src/App.tsx:0')
 })
 
+test('range comments emit start and end line targets', () => {
+  const payload = formatFeedbackPayload([
+    {
+      filePath: 'src/App.tsx',
+      staged: false,
+      annotations: [
+        {
+          lineNumber: 4,
+          side: 'additions',
+          metadata: {
+            id: 'range-comment',
+            text: 'Review this block',
+            author: 'self',
+            createdAt: Date.now(),
+            target: {
+              scope: 'range',
+              side: 'additions',
+              startLine: 4,
+              endLine: 6,
+            },
+          },
+        },
+      ],
+    },
+  ])
+
+  expect(payload).toContain('> src/App.tsx:4-6 (additions) [unstaged]')
+})
+
 test('dispatchFeedbackBatch calls writePty once with paste-bracketed payload', async () => {
   const writePty = vi.fn().mockResolvedValue(undefined)
 

--- a/src/features/diff/services/feedbackDispatch.ts
+++ b/src/features/diff/services/feedbackDispatch.ts
@@ -46,6 +46,12 @@ const formatAnnotationTarget = (
     return `> ${filePath} (file) [${stagedLabel}]`
   }
 
+  if (annotation.metadata.target?.scope === 'range') {
+    const { startLine, endLine, side } = annotation.metadata.target
+
+    return `> ${filePath}:${startLine}-${endLine} (${side}) [${stagedLabel}]`
+  }
+
   return `> ${filePath}:${annotation.lineNumber} (${annotation.side}) [${stagedLabel}]`
 }
 

--- a/tests/e2e/agent/specs/agent-runtime-regressions.spec.ts
+++ b/tests/e2e/agent/specs/agent-runtime-regressions.spec.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { clickBySelector } from '../../shared/actions.js'
+import { createNewSessionWithDefaults } from '../../shared/actions.js'
 import {
   pressEnterInActiveTerminal,
   typeInActiveTerminal,
@@ -444,7 +444,7 @@ describe('Agent runtime regressions', () => {
 
     // Spawn a dedicated bridge-enabled PTY through the frontend session manager
     // so the test controls its own precondition and the UI observes it as active.
-    await clickBySelector('button[aria-label="New session"]')
+    await createNewSessionWithDefaults()
     let ptyId: string | undefined
     await browser.waitUntil(
       async () => {

--- a/tests/e2e/core/specs/browser-pane-overlay.spec.ts
+++ b/tests/e2e/core/specs/browser-pane-overlay.spec.ts
@@ -208,7 +208,89 @@ const waitForPaneKinds = async (
 
 const switchToLayout = async (layout: LayoutShape): Promise<void> => {
   await waitForActiveSplitView()
-  await clickBySelector(`button[aria-label="${layout.name}"]`)
+
+  const alreadyActive = await browser.execute((layoutId: LayoutId) => {
+    const splitViews = Array.from(
+      document.querySelectorAll<HTMLElement>('[data-testid="split-view"]')
+    )
+    const splitView = splitViews.find((candidate) => {
+      const rect = candidate.getBoundingClientRect()
+
+      return rect.width > 0 && rect.height > 0
+    })
+
+    return splitView?.dataset.layout === layoutId
+  }, layout.id)
+
+  if (alreadyActive) {
+    return
+  }
+
+  const clickedVisiblePill = await browser.execute((label: string) => {
+    const button = document.querySelector<HTMLButtonElement>(
+      `button[aria-label="${label}"]`
+    )
+    if (button === null) {
+      return false
+    }
+
+    button.click()
+
+    return true
+  }, layout.name)
+
+  if (!clickedVisiblePill) {
+    await clickBySelector('button[aria-label="Configure displayed layouts"]')
+
+    const revealed = await browser.execute((label: string) => {
+      const row = Array.from(
+        document.querySelectorAll<HTMLButtonElement>(
+          '[role="menuitemcheckbox"]'
+        )
+      ).find((candidate) => (candidate.textContent ?? '').includes(label))
+
+      if (row === undefined) {
+        return false
+      }
+
+      if (row.getAttribute('aria-checked') !== 'true') {
+        row.click()
+      }
+
+      return true
+    }, layout.name)
+
+    if (!revealed) {
+      throw new Error(`layout display menu had no ${layout.name} row`)
+    }
+
+    await browser.execute(() => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Escape',
+          code: 'Escape',
+          bubbles: true,
+          cancelable: true,
+        })
+      )
+    })
+
+    await browser.waitUntil(
+      async () =>
+        await browser.execute(
+          (label: string) =>
+            document.querySelector(`button[aria-label="${label}"]`) !== null,
+          layout.name
+        ),
+      {
+        timeout: 3_000,
+        interval: 100,
+        timeoutMsg: `${layout.name} layout pill did not become visible`,
+      }
+    )
+
+    await clickBySelector(`button[aria-label="${layout.name}"]`)
+  }
 
   await browser.waitUntil(
     async () =>

--- a/tests/e2e/core/specs/files-to-editor.spec.ts
+++ b/tests/e2e/core/specs/files-to-editor.spec.ts
@@ -24,7 +24,7 @@ describe('File explorer → editor flow', () => {
     // FilesView's root toggles from the Tailwind `hidden` utility class to
     // `flex` (HTML `hidden` attribute is NOT used — see SessionsView /
     // FilesView source for the Tailwind v4 cascade-layer rationale).
-    const filesTab = await $('button=FILES')
+    const filesTab = await $('button[aria-label="FILES"]')
     await filesTab.waitForDisplayed({ timeout: 15_000 })
     await filesTab.click()
 

--- a/tests/e2e/core/specs/ipc-roundtrip.spec.ts
+++ b/tests/e2e/core/specs/ipc-roundtrip.spec.ts
@@ -5,7 +5,7 @@ describe('IPC round-trip', () => {
     // FilesView's root toggles from the Tailwind `hidden` utility class to
     // `flex` (HTML `hidden` attribute is NOT used — see SessionsView /
     // FilesView source for the Tailwind v4 cascade-layer rationale).
-    const filesTab = await $('button=FILES')
+    const filesTab = await $('button[aria-label="FILES"]')
     await filesTab.waitForDisplayed({ timeout: 15_000 })
     await filesTab.click()
 

--- a/tests/e2e/core/specs/navigation.spec.ts
+++ b/tests/e2e/core/specs/navigation.spec.ts
@@ -1,7 +1,10 @@
 import { clickBySelector } from '../../shared/actions.js'
 
 describe('BottomDrawer navigation', () => {
-  it('defaults to editor panel and switches to diff panel on click', async () => {
+  it('switches between editor and diff panels on click', async () => {
+    await clickBySelector('[data-testid="status-bar-dock-toggle"]')
+    await clickBySelector('button[aria-label="Editor"]')
+
     const editorPanel = await $('[data-testid="editor-panel"]')
     await editorPanel.waitForDisplayed({ timeout: 15_000 })
 

--- a/tests/e2e/shared/actions.ts
+++ b/tests/e2e/shared/actions.ts
@@ -16,6 +16,74 @@ export const clickBySelector = async (selector: string): Promise<void> => {
   if (!ok) throw new Error(`clickBySelector: no element for ${selector}`)
 }
 
+const clickVisibleButtonByName = async (name: string): Promise<boolean> =>
+  browser.execute((accessibleName: string) => {
+    const isVisible = (element: HTMLElement): boolean => {
+      const rect = element.getBoundingClientRect()
+      const style = window.getComputedStyle(element)
+
+      return (
+        rect.width > 0 &&
+        rect.height > 0 &&
+        style.display !== 'none' &&
+        style.visibility !== 'hidden'
+      )
+    }
+
+    const buttons = Array.from(
+      document.querySelectorAll<HTMLButtonElement>('button')
+    )
+    const button = buttons.find((candidate) => {
+      const label =
+        candidate.getAttribute('aria-label') ?? candidate.textContent ?? ''
+
+      return (
+        label.trim().includes(accessibleName) &&
+        !candidate.disabled &&
+        isVisible(candidate)
+      )
+    })
+    if (!button) return false
+    button.click()
+
+    return true
+  }, name)
+
+export const createNewSessionWithDefaults = async (): Promise<void> => {
+  const opened = await browser.execute(() => {
+    const isVisible = (element: HTMLElement): boolean => {
+      const rect = element.getBoundingClientRect()
+      const style = window.getComputedStyle(element)
+
+      return (
+        rect.width > 0 &&
+        rect.height > 0 &&
+        style.display !== 'none' &&
+        style.visibility !== 'hidden'
+      )
+    }
+
+    const button = document.querySelector<HTMLElement>(
+      '[data-testid="sidebar-new-session"]'
+    )
+    if (!button || !isVisible(button)) return false
+    button.click()
+
+    return true
+  })
+  if (!opened) throw new Error('createNewSessionWithDefaults: no opener')
+
+  await browser.waitUntil(
+    async () => clickVisibleButtonByName('Create session'),
+    {
+      timeout: 5_000,
+      interval: 100,
+      timeoutMsg:
+        'createNewSessionWithDefaults: create button never became visible',
+    }
+  )
+}
+
 export const focusBySelector = async (selector: string): Promise<void> => {
   const ok = await browser.execute((s: string) => {
     const el = document.querySelector<HTMLElement>(s)

--- a/tests/e2e/terminal/specs/multi-tab-isolation.spec.ts
+++ b/tests/e2e/terminal/specs/multi-tab-isolation.spec.ts
@@ -91,10 +91,7 @@ describe('Multi-tab terminal isolation', () => {
       { timeout: 15_000, timeoutMsg: 'marker A never landed in session 1' }
     )
 
-    // Spawn session 2 via the SessionTabs "+" button.
-    await clickBySelector(
-      '[data-testid="session-tabs"] button[aria-label="New session"]'
-    )
+    await clickBySelector('button[aria-label="New session"]')
     await browser.waitUntil(async () => (await allSessionIds()).length === 2, {
       timeout: 10_000,
       timeoutMsg: 'second session did not mount',

--- a/tests/e2e/terminal/specs/multi-tab-isolation.spec.ts
+++ b/tests/e2e/terminal/specs/multi-tab-isolation.spec.ts
@@ -1,4 +1,4 @@
-import { clickBySelector } from '../../shared/actions.js'
+import { createNewSessionWithDefaults } from '../../shared/actions.js'
 import {
   pressEnterInActiveTerminal,
   typeInActiveTerminal,
@@ -91,7 +91,7 @@ describe('Multi-tab terminal isolation', () => {
       { timeout: 15_000, timeoutMsg: 'marker A never landed in session 1' }
     )
 
-    await clickBySelector('button[aria-label="New session"]')
+    await createNewSessionWithDefaults()
     await browser.waitUntil(async () => (await allSessionIds()).length === 2, {
       timeout: 10_000,
       timeoutMsg: 'second session did not mount',

--- a/tests/e2e/terminal/specs/multi-tab-isolation.spec.ts
+++ b/tests/e2e/terminal/specs/multi-tab-isolation.spec.ts
@@ -92,7 +92,9 @@ describe('Multi-tab terminal isolation', () => {
     )
 
     // Spawn session 2 via the SessionTabs "+" button.
-    await clickBySelector('button[aria-label="New session"]')
+    await clickBySelector(
+      '[data-testid="session-tabs"] button[aria-label="New session"]'
+    )
     await browser.waitUntil(async () => (await allSessionIds()).length === 2, {
       timeout: 10_000,
       timeoutMsg: 'second session did not mount',

--- a/tests/e2e/terminal/specs/pane-lifecycle.spec.ts
+++ b/tests/e2e/terminal/specs/pane-lifecycle.spec.ts
@@ -60,6 +60,78 @@ const assertVisiblePaneIds = async (
   }
 }
 
+const switchToLayout = async (
+  menuLabel: string,
+  pillLabel = menuLabel
+): Promise<void> => {
+  const clickedVisiblePill = await browser.execute((layoutLabel: string) => {
+    const button = document.querySelector<HTMLButtonElement>(
+      `button[aria-label="${layoutLabel}"]`
+    )
+    if (button === null) {
+      return false
+    }
+
+    button.click()
+
+    return true
+  }, pillLabel)
+
+  if (clickedVisiblePill) {
+    return
+  }
+
+  await clickBySelector('button[aria-label="Configure displayed layouts"]')
+
+  const revealed = await browser.execute((layoutLabel: string) => {
+    const row = Array.from(
+      document.querySelectorAll<HTMLButtonElement>('[role="menuitemcheckbox"]')
+    ).find((candidate) => (candidate.textContent ?? '').includes(layoutLabel))
+
+    if (row === undefined) {
+      return false
+    }
+
+    if (row.getAttribute('aria-checked') !== 'true') {
+      row.click()
+    }
+
+    return true
+  }, menuLabel)
+
+  if (!revealed) {
+    throw new Error(`layout display menu had no ${menuLabel} row`)
+  }
+
+  await browser.execute(() => {
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Escape',
+        code: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      })
+    )
+  })
+
+  await browser.waitUntil(
+    async () =>
+      await browser.execute(
+        (layoutLabel: string) =>
+          document.querySelector(`button[aria-label="${layoutLabel}"]`) !==
+          null,
+        pillLabel
+      ),
+    {
+      timeout: 3_000,
+      interval: 100,
+      timeoutMsg: `${pillLabel} layout pill did not become visible`,
+    }
+  )
+
+  await clickBySelector(`button[aria-label="${pillLabel}"]`)
+}
+
 describe('Pane lifecycle split focus', () => {
   it('keeps the workspace visible when focusing between added split panes', async () => {
     await (
@@ -68,7 +140,7 @@ describe('Pane lifecycle split focus', () => {
       timeout: 20_000,
     })
 
-    await clickBySelector('button[aria-label="Vertical split"]')
+    await switchToLayout('Vertical split')
 
     await browser.waitUntil(
       async () =>
@@ -93,7 +165,7 @@ describe('Pane lifecycle split focus', () => {
     await clickBySelector('[data-testid="split-view-slot"][data-pane-id="p1"]')
     await assertWorkspaceVisible(2, 'focusing p1')
 
-    await clickBySelector('button[aria-label="Single"]')
+    await switchToLayout('Single', 'Focus active pane')
     await waitForPaneCount(1)
     await assertWorkspaceVisible(1, 'switching to single layout')
     await assertVisiblePaneIds(['p1'])

--- a/tests/e2e/terminal/specs/session-lifecycle.spec.ts
+++ b/tests/e2e/terminal/specs/session-lifecycle.spec.ts
@@ -1,4 +1,8 @@
-import { clickBySelector } from '../../shared/actions.js'
+import { createNewSessionWithDefaults } from '../../shared/actions.js'
+
+const commandPaletteSelector = '[role="dialog"][aria-label="Command palette"]'
+const commandPaletteInputSelector = '[aria-label="Command palette search"]'
+const enterKey = '\uE007'
 
 const readRustSessionCount = async (): Promise<number> => {
   const ids = await browser.execute(
@@ -17,22 +21,64 @@ const waitForCount = async (
   )
 }
 
-const clickLatestSessionTabCloseButton = async (): Promise<void> => {
-  const ok = await browser.execute(() => {
-    const tabs = Array.from(
-      document.querySelectorAll<HTMLElement>('[data-testid="session-tab"]')
+const dispatchCommandPaletteShortcut = async (): Promise<void> => {
+  await browser.execute(() => {
+    const platform =
+      (
+        navigator as Navigator & {
+          userAgentData?: { platform?: string }
+        }
+      ).userAgentData?.platform ?? navigator.platform
+    const isMac = platform.toLowerCase().includes('mac')
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: ';',
+        code: 'Semicolon',
+        ctrlKey: !isMac,
+        metaKey: isMac,
+        bubbles: true,
+        cancelable: true,
+      })
     )
-    const latestTab = tabs[tabs.length - 1]
-    const closeButton = latestTab?.querySelector<HTMLButtonElement>(
-      '[data-testid="close-tab-button"]'
-    )
-    if (!closeButton) return false
-
-    closeButton.click()
-
-    return true
   })
-  if (!ok) throw new Error('could not locate close button for the spawned tab')
+}
+
+const waitForCommandPaletteClosed = async (): Promise<void> => {
+  await browser.waitUntil(
+    async () =>
+      await browser.execute(
+        (selector: string) => document.querySelector(selector) === null,
+        commandPaletteSelector
+      ),
+    {
+      timeout: 3_000,
+      interval: 100,
+      timeoutMsg: 'command palette did not close',
+    }
+  )
+}
+
+const closeActiveSession = async (): Promise<void> => {
+  await dispatchCommandPaletteShortcut()
+  await (
+    await $(commandPaletteSelector)
+  ).waitForDisplayed({
+    timeout: 3_000,
+  })
+
+  const input = await $(commandPaletteInputSelector)
+  await input.waitForDisplayed({ timeout: 3_000 })
+  await input.setValue(':close')
+  await browser.execute((selector: string) => {
+    document.querySelector<HTMLInputElement>(selector)?.focus()
+  }, commandPaletteInputSelector)
+  await browser.action('key').down(enterKey).up(enterKey).perform()
+  await browser.waitUntil(async () => (await readRustSessionCount()) === 1, {
+    timeout: 15_000,
+    interval: 500,
+    timeoutMsg: 'closing the spawned tab did not decrement count',
+  })
+  await waitForCommandPaletteClosed()
 }
 
 describe('Terminal session lifecycle', () => {
@@ -46,14 +92,9 @@ describe('Terminal session lifecycle', () => {
     // Baseline: useSessionManager boots with one default session.
     await waitForCount(1, 'default session never became active')
 
-    await clickBySelector('button[aria-label="New session"]')
+    await createNewSessionWithDefaults()
     await waitForCount(2, 'new tab did not register a second PTY session')
 
-    // Close the most recently spawned session by finding the close control
-    // inside the latest tab. The close button is intentionally hidden from
-    // the a11y tree and exposed to tests via data-testid.
-    await clickLatestSessionTabCloseButton()
-
-    await waitForCount(1, 'closing the spawned tab did not decrement count')
+    await closeActiveSession()
   })
 })

--- a/tests/e2e/terminal/specs/session-lifecycle.spec.ts
+++ b/tests/e2e/terminal/specs/session-lifecycle.spec.ts
@@ -48,7 +48,9 @@ describe('Terminal session lifecycle', () => {
 
     // Click the SessionTabs "+" button (aria-label="New session" since
     // step 3 replaced TerminalZone's legacy tab-bar).
-    await clickBySelector('button[aria-label="New session"]')
+    await clickBySelector(
+      '[data-testid="session-tabs"] button[aria-label="New session"]'
+    )
     await waitForCount(2, 'new tab did not register a second PTY session')
 
     // Close the most recently spawned session by finding the close control

--- a/tests/e2e/terminal/specs/session-lifecycle.spec.ts
+++ b/tests/e2e/terminal/specs/session-lifecycle.spec.ts
@@ -46,11 +46,7 @@ describe('Terminal session lifecycle', () => {
     // Baseline: useSessionManager boots with one default session.
     await waitForCount(1, 'default session never became active')
 
-    // Click the SessionTabs "+" button (aria-label="New session" since
-    // step 3 replaced TerminalZone's legacy tab-bar).
-    await clickBySelector(
-      '[data-testid="session-tabs"] button[aria-label="New session"]'
-    )
+    await clickBySelector('button[aria-label="New session"]')
     await waitForCount(2, 'new tab did not register a second PTY session')
 
     // Close the most recently spawned session by finding the close control


### PR DESCRIPTION
## Summary
- Add visual selection mode for diff review comments
- Support range comment labels and dispatch payloads
- Add yank-to-clipboard for selected diff snippets
- Keep file-level comments editable from the diff panel

## Test plan
- npx eslint src/features/diff/Panel.tsx src/features/diff/components/ReviewCommentEditor.tsx src/features/diff/services/feedbackDispatch.test.ts src/features/diff/hooks/useVisualSelection.ts src/features/diff/hooks/useVisualSelection.test.ts src/features/diff/hooks/useReviewTargetNavigation.ts src/features/diff/components/PanelBody.tsx
- npx vitest run src/features/diff/hooks/useVisualSelection.test.ts src/features/diff/Panel.test.tsx src/features/diff/hooks/useReviewTargetNavigation.test.ts src/features/diff/components/PanelBody.test.tsx src/features/diff/services/feedbackDispatch.test.ts
- npm run type-check:generated
- git diff --check
- pre-push npm test: 358 files, 4426 passed, 3 skipped