### PR TITLE
feat: add native overlay command palette dialog

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -61,7 +61,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 94       | 91   | 2026-06-28   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 84       | 83   | 2026-06-30   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
-| [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 79       | 77   | 2026-07-01   |
+| [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 81       | 77   | 2026-07-01   |
 | [Canonical Path Dedupe](patterns/canonical-path-dedupe.md)                                           | correctness        | 2        | 0    | 2026-06-14   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)                                       | backend            | 4        | 2    | 2026-06-14   |
 | [Command Injection](patterns/command-injection.md)                                                   | security           | 8        | 3    | 2026-06-16   |

--- a/docs/reviews/patterns/async-race-conditions.md
+++ b/docs/reviews/patterns/async-race-conditions.md
@@ -843,3 +843,31 @@ prevent showing previous data.
   targets keep their own event semantics without activating the pane first.
   Added regression coverage for inactive-pane Close and Collapse clicks.
 - **Commit:** same commit as this entry
+
+### 80. Rapid dialog content updates race the single-slot overlay ready map
+
+- **Source:** github-claude | PR #644 round 1 | 2026-07-01
+- **Severity:** HIGH
+- **File:** `src/components/Dialog.tsx`
+- **Finding:** Native dialog payload changes started overlapping same-surface
+  overlay opens on every command-palette update. Those concurrent opens could
+  collide with main-process ready bookkeeping and let stale completions mark a
+  working native overlay as failed.
+- **Fix:** Serialized native dialog opens through a per-dialog promise queue and
+  guarded completions with a generation token. Superseded updates no longer
+  mutate local native state after a newer generation starts.
+- **Commit:** same commit as this entry
+
+### 81. Close pending native dialog when dismissal wins the race
+
+- **Source:** github-codex-connector | PR #644 round 1 | 2026-07-01
+- **Severity:** P2 / MEDIUM
+- **File:** `src/components/Dialog.tsx`
+- **Finding:** If the React dialog closed before its first native open resolved,
+  the immediate close request could be ignored before main registered the
+  surface. A late accepted open could leave the native command palette visible
+  after React state had dismissed it.
+- **Fix:** Reused the dialog generation guard to detect accepted stale opens
+  after dismissal or unmount and explicitly close that surface, while leaving
+  superseded same-surface content updates open for the queued replacement.
+- **Commit:** same commit as this entry

--- a/electron/command-palette-shortcut.test.ts
+++ b/electron/command-palette-shortcut.test.ts
@@ -4,6 +4,7 @@ import {
   COMMAND_PALETTE_GLOBAL_ACCELERATORS,
   commandPaletteShortcutConfigForPlatform,
   type CommandPaletteShortcutOverrideOptions,
+  dispatchCommandPaletteShortcutForWindow,
   installCommandPaletteShortcutOverride,
   isCommandPaletteShortcutInput,
 } from './command-palette-shortcut'
@@ -26,6 +27,7 @@ type WindowHandler = () => void
 
 interface FakeWindowFixture {
   beforeInputHandlers: BeforeInputHandler[]
+  focus: ReturnType<typeof vi.fn>
   send: ReturnType<typeof vi.fn>
   win: Parameters<typeof installCommandPaletteShortcutOverride>[0]
   windowHandlers: Map<string, WindowHandler[]>
@@ -41,6 +43,7 @@ interface ShortcutRegistryFixture {
 const createFakeWindow = (focused = false): FakeWindowFixture => {
   const beforeInputHandlers: BeforeInputHandler[] = []
   const windowHandlers = new Map<string, WindowHandler[]>()
+  const focus = vi.fn()
   const send = vi.fn()
 
   const webContentsOn = vi.fn(
@@ -59,9 +62,15 @@ const createFakeWindow = (focused = false): FakeWindowFixture => {
 
   return {
     beforeInputHandlers,
+    focus,
     send,
     win: {
-      webContents: { on: webContentsOn, send },
+      webContents: {
+        focus,
+        isDestroyed: vi.fn(() => false),
+        on: webContentsOn,
+        send,
+      },
       on,
       isFocused: vi.fn(() => focused),
       isDestroyed: vi.fn(() => false),
@@ -161,6 +170,22 @@ describe('command palette shortcut override', () => {
     ).toBe(true)
   })
 
+  test('matches Cmd+; by physical Semicolon code from native key events', () => {
+    expect(
+      isCommandPaletteShortcutInput(
+        {
+          type: 'keyDown',
+          key: 'Semicolon',
+          code: 'Semicolon',
+          control: false,
+          meta: true,
+          alt: false,
+        },
+        commandPaletteShortcutConfigForPlatform('darwin')
+      )
+    ).toBe(true)
+  })
+
   test('ignores Cmd+Shift+; keydown on macOS', () => {
     expect(
       isCommandPaletteShortcutInput(
@@ -240,6 +265,46 @@ describe('command palette shortcut override', () => {
         commandPaletteShortcutConfigForPlatform('linux')
       )
     ).toBe(false)
+  })
+
+  test('dispatches a matched shortcut through the shared window helper', () => {
+    const { focus, send, win } = createFakeWindow()
+
+    const handled = dispatchCommandPaletteShortcutForWindow(
+      win,
+      {
+        type: 'keyDown',
+        key: ';',
+        control: false,
+        meta: true,
+        alt: false,
+      },
+      commandPaletteShortcutConfigForPlatform('darwin')
+    )
+
+    expect(handled).toBe(true)
+    expect(focus).toHaveBeenCalledOnce()
+    expect(send).toHaveBeenCalledWith(COMMAND_PALETTE_TOGGLE)
+  })
+
+  test('does not dispatch unmatched shortcuts through the shared window helper', () => {
+    const { focus, send, win } = createFakeWindow()
+
+    const handled = dispatchCommandPaletteShortcutForWindow(
+      win,
+      {
+        type: 'keyDown',
+        key: '2',
+        control: false,
+        meta: true,
+        alt: false,
+      },
+      commandPaletteShortcutConfigForPlatform('darwin')
+    )
+
+    expect(handled).toBe(false)
+    expect(focus).not.toHaveBeenCalled()
+    expect(send).not.toHaveBeenCalled()
   })
 
   test('prevents renderer Ctrl+; keydown and sends palette toggle IPC on Linux', () => {

--- a/electron/command-palette-shortcut.ts
+++ b/electron/command-palette-shortcut.ts
@@ -1,9 +1,10 @@
 import { globalShortcut, type BrowserWindow } from 'electron'
 import { COMMAND_PALETTE_TOGGLE } from './ipc-channels'
 
-interface ShortcutInput {
+export interface CommandPaletteShortcutInput {
   type: string
   key: string
+  code?: string
   control: boolean
   meta: boolean
   alt: boolean
@@ -44,8 +45,11 @@ export const COMMAND_PALETTE_GLOBAL_ACCELERATORS =
 
 const SHORTCUT_TOGGLE_DEDUPLICATION_MS = 100
 
+const isSemicolonShortcut = (input: CommandPaletteShortcutInput): boolean =>
+  input.key === ';' || input.code === 'Semicolon'
+
 export const isCommandPaletteShortcutInput = (
-  input: ShortcutInput,
+  input: CommandPaletteShortcutInput,
   config: CommandPaletteShortcutConfig = commandPaletteShortcutConfigForPlatform(
     process.platform
   )
@@ -57,7 +61,7 @@ export const isCommandPaletteShortcutInput = (
   !input.alt &&
   input.shift !== true &&
   !input.isAutoRepeat &&
-  input.key === ';'
+  isSemicolonShortcut(input)
 
 const sendCommandPaletteToggle = (win: BrowserWindow): void => {
   if (win.isDestroyed()) {
@@ -100,6 +104,25 @@ export const commandPaletteToggleDispatcherForWindow = (
   return dispatcher
 }
 
+export const dispatchCommandPaletteShortcutForWindow = (
+  win: BrowserWindow,
+  input: CommandPaletteShortcutInput,
+  config: CommandPaletteShortcutConfig = commandPaletteShortcutConfigForPlatform(
+    process.platform
+  )
+): boolean => {
+  if (!isCommandPaletteShortcutInput(input, config)) {
+    return false
+  }
+
+  if (!win.isDestroyed() && !win.webContents.isDestroyed()) {
+    win.webContents.focus()
+    commandPaletteToggleDispatcherForWindow(win)()
+  }
+
+  return true
+}
+
 export const installCommandPaletteShortcutOverride = (
   win: BrowserWindow,
   options: CommandPaletteShortcutOverrideOptions = {}
@@ -140,7 +163,7 @@ export const installCommandPaletteShortcutOverride = (
     }
 
     event.preventDefault()
-    dispatchCommandPaletteToggle()
+    dispatchCommandPaletteShortcutForWindow(win, input, shortcutConfig)
   })
 
   win.on('focus', registerFocusedLinuxShortcuts)

--- a/electron/ghostty-native-parent.test.ts
+++ b/electron/ghostty-native-parent.test.ts
@@ -6,7 +6,7 @@ import {
   GHOSTTY_NATIVE_FOCUS,
   GHOSTTY_NATIVE_UPDATE,
 } from './ghostty-native-channels'
-import { BACKEND_EVENT } from './ipc-channels'
+import { BACKEND_EVENT, COMMAND_PALETTE_TOGGLE } from './ipc-channels'
 import type { Sidecar } from './sidecar'
 import {
   isGhosttyNativeParentEnabled,
@@ -535,6 +535,68 @@ describe('ghostty native parent', () => {
       'data-vimeflow-shortcut-proxy'
     )
     expect(addon.focus).toHaveBeenCalledWith(surface)
+
+    controller.dispose()
+  })
+
+  test('opens command palette directly from native Ghostty shortcut', () => {
+    const callbacks: {
+      onShortcut?: (
+        key: string,
+        code: string,
+        control: boolean,
+        meta: boolean,
+        alt: boolean,
+        shift: boolean
+      ) => void
+    } = {}
+    const surface = { id: 'surface-1' }
+
+    const addon = {
+      create: vi.fn(
+        (_bridge, _handle, _input, _resize, _contextMenu, _focus, shortcut) => {
+          callbacks.onShortcut = shortcut
+
+          return surface
+        }
+      ),
+      setFrame: vi.fn(),
+      write: vi.fn(),
+      focus: vi.fn(),
+      destroy: vi.fn(),
+    }
+
+    const sidecar = {
+      invoke: vi.fn(() => Promise.resolve(undefined)),
+      onEvent: vi.fn(() => vi.fn()),
+      shutdown: vi.fn(() => Promise.resolve()),
+    } as unknown as Sidecar
+
+    const controller = setupGhosttyNativeParent({
+      sidecar,
+      platform: 'darwin',
+      env: { VITE_GHOSTTY_NATIVE_MACOS_PARENT: '1' },
+      addon,
+    })
+
+    handlers.get(GHOSTTY_NATIVE_UPDATE)?.(
+      { sender: {} },
+      {
+        sessionId: 'pty-1',
+        paneId: 'pane-1',
+        cwd: '/tmp',
+        visible: true,
+        bounds: { x: 10, y: 20, width: 300, height: 200 },
+      }
+    )
+
+    const isMac = process.platform === 'darwin'
+    callbacks.onShortcut?.(';', 'Semicolon', !isMac, isMac, false, false)
+
+    expect(webContentsFocus).toHaveBeenCalledOnce()
+    expect(webContentsSend).toHaveBeenCalledWith(COMMAND_PALETTE_TOGGLE)
+    expect(webContentsExecuteJavaScript).not.toHaveBeenCalled()
+    expect(addon.focus).not.toHaveBeenCalled()
 
     controller.dispose()
   })

--- a/electron/ghostty-native-parent.ts
+++ b/electron/ghostty-native-parent.ts
@@ -10,6 +10,7 @@ import {
   GHOSTTY_NATIVE_FOCUS,
   GHOSTTY_NATIVE_UPDATE,
 } from './ghostty-native-channels'
+import { dispatchCommandPaletteShortcutForWindow } from './command-palette-shortcut'
 import { BACKEND_EVENT } from './ipc-channels'
 import type { Sidecar } from './sidecar'
 import {
@@ -505,6 +506,20 @@ export class GhosttyNativeParentController {
       },
       (key, code, control, meta, alt, shift) => {
         if (win.isDestroyed() || !this.surfaces.has(this.paneKey(state.pane))) {
+          return
+        }
+
+        if (
+          dispatchCommandPaletteShortcutForWindow(win, {
+            type: 'keyDown',
+            key,
+            code,
+            control,
+            meta,
+            alt,
+            shift,
+          })
+        ) {
           return
         }
 

--- a/electron/native-overlay.test.ts
+++ b/electron/native-overlay.test.ts
@@ -10,6 +10,7 @@ import {
   NATIVE_OVERLAY_READY,
   NATIVE_OVERLAY_RENDER,
 } from './native-overlay-channels'
+import { COMMAND_PALETTE_TOGGLE } from './ipc-channels'
 import { NativeOverlayController } from './native-overlay'
 
 type IpcHandler = (
@@ -253,6 +254,32 @@ const tooltipRequest = {
   },
 } as const
 
+const dialogRequest = {
+  surfaceId: 'dialog-1',
+  kind: 'dialog',
+  anchorRect: { x: 0, y: 0, width: 900, height: 600 },
+  placement: 'top',
+  payload: {
+    kind: 'dialog',
+    dialog: 'command-palette',
+    ariaLabel: 'Command palette',
+    query: ':',
+    selectedIndex: 0,
+    results: [
+      {
+        id: 'help',
+        label: ':help',
+        description: 'Show command reference',
+        icon: 'help',
+      },
+    ],
+    actions: {
+      selectIndex: 'command-palette:select-index',
+      executeIndex: 'command-palette:execute-index',
+    },
+  },
+} as const
+
 const menuOverlayUrl = 'vimeflow://app/index.html?nativeOverlay=menu'
 const tooltipOverlayUrl = 'vimeflow://app/index.html?nativeOverlay=tooltip'
 
@@ -421,6 +448,27 @@ describe('NativeOverlayController', () => {
     expect(menuWindow.hide).not.toHaveBeenCalled()
   })
 
+  test('opens dialog requests on the interactive menu layer', async () => {
+    const openPromise = handler(NATIVE_OVERLAY_OPEN)(
+      { sender: electronMock.owner.webContents },
+      dialogRequest
+    )
+    const menuWindow = finishOverlayLoad()
+    finishOverlayLoad(1)
+
+    await Promise.resolve()
+    expect(menuWindow.webContents.send).toHaveBeenCalledWith(
+      NATIVE_OVERLAY_RENDER,
+      dialogRequest
+    )
+
+    await acknowledgeOverlayReady(menuWindow, dialogRequest.surfaceId)
+    await expect(openPromise).resolves.toEqual({ accepted: true })
+    expect(menuWindow.loadURL).toHaveBeenCalledWith(menuOverlayUrl)
+    expect(menuWindow.setIgnoreMouseEvents).toHaveBeenCalledWith(false)
+    expect(menuWindow.setAlwaysOnTop).toHaveBeenCalledWith(true, 'screen-saver')
+  })
+
   test('relays owner menu keydown events to the non-focusable menu layer', async () => {
     const openPromise = handler(NATIVE_OVERLAY_OPEN)(
       { sender: electronMock.owner.webContents },
@@ -460,6 +508,47 @@ describe('NativeOverlayController', () => {
         shiftKey: true,
         repeat: true,
       }
+    )
+  })
+
+  test('dispatches command palette shortcut instead of menu key forwarding', async () => {
+    const openPromise = handler(NATIVE_OVERLAY_OPEN)(
+      { sender: electronMock.owner.webContents },
+      request
+    )
+    const menuWindow = finishOverlayLoad()
+    await acknowledgeOverlayReady(menuWindow)
+    await openPromise
+
+    menuWindow.webContents.send.mockClear()
+    electronMock.owner.webContents.send.mockClear()
+    electronMock.owner.webContents.focus.mockClear()
+    const event = { preventDefault: vi.fn() }
+    const isMac = process.platform === 'darwin'
+
+    electronMock.owner.webContents.emit('before-input-event', event, {
+      type: 'keyDown',
+      key: ';',
+      code: 'Semicolon',
+      isAutoRepeat: false,
+      isComposing: false,
+      shift: false,
+      control: !isMac,
+      alt: false,
+      meta: isMac,
+      location: 0,
+      modifiers: [],
+    })
+
+    expect(event.preventDefault).toHaveBeenCalledOnce()
+    expect(electronMock.owner.webContents.focus).toHaveBeenCalledOnce()
+    expect(electronMock.owner.webContents.send).toHaveBeenCalledWith(
+      COMMAND_PALETTE_TOGGLE
+    )
+
+    expect(menuWindow.webContents.send).not.toHaveBeenCalledWith(
+      NATIVE_OVERLAY_KEYDOWN,
+      expect.anything()
     )
   })
 

--- a/electron/native-overlay.ts
+++ b/electron/native-overlay.ts
@@ -20,14 +20,15 @@ import {
   NATIVE_OVERLAY_READY,
   NATIVE_OVERLAY_RENDER,
 } from './native-overlay-channels'
+import { dispatchCommandPaletteShortcutForWindow } from './command-palette-shortcut'
 
 // cspell:ignore AppKit Ghostty minimizable maximizable fullscreenable NSView
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
-// TODO: add popover/dialog here when they get serializable native overlay
-// payloads and host renderers.
-export type NativeOverlayKind = 'menu' | 'tooltip'
+// TODO: add popover here when it gets a serializable native overlay payload
+// and host renderer.
+export type NativeOverlayKind = 'menu' | 'tooltip' | 'dialog'
 
 type NativeOverlayCloseReason =
   | 'outside'
@@ -112,9 +113,38 @@ interface NativeOverlayTooltipPayload {
   maxWidth?: number
 }
 
+interface NativeOverlayCommandPaletteItem {
+  id: string
+  label: string
+  description?: string
+  hint?: string
+  icon: string
+  shortcut?: string[]
+}
+
+interface NativeOverlayCommandPaletteActions {
+  selectIndex: string
+  executeIndex: string
+}
+
+interface NativeOverlayCommandPaletteDialogPayload {
+  kind: 'dialog'
+  dialog: 'command-palette'
+  ariaLabel: string
+  query: string
+  selectedIndex: number
+  activeDescendantId?: string
+  argumentPlaceholder?: string
+  results: NativeOverlayCommandPaletteItem[]
+  actions: NativeOverlayCommandPaletteActions
+}
+
+type NativeOverlayDialogPayload = NativeOverlayCommandPaletteDialogPayload
+
 type SerializableOverlayPayload =
   | NativeOverlayMenuPayload
   | NativeOverlayTooltipPayload
+  | NativeOverlayDialogPayload
 
 interface NativeOverlayThemeSnapshot {
   id?: string
@@ -141,6 +171,7 @@ interface NativeOverlayActionEvent {
   actionId: string
   closeOnSelect?: boolean
   feedback?: 'copy'
+  index?: number
 }
 
 interface NativeOverlayActionResultEvent {
@@ -329,6 +360,39 @@ const isTooltipPayload = (
   isString(value.text) &&
   (value.maxWidth === undefined || isFiniteNumber(value.maxWidth))
 
+const isCommandPaletteItem = (
+  value: unknown
+): value is NativeOverlayCommandPaletteItem =>
+  isRecord(value) &&
+  isString(value.id) &&
+  isString(value.label) &&
+  (value.description === undefined || typeof value.description === 'string') &&
+  (value.hint === undefined || typeof value.hint === 'string') &&
+  isString(value.icon) &&
+  (value.shortcut === undefined ||
+    (Array.isArray(value.shortcut) &&
+      value.shortcut.every((entry) => typeof entry === 'string')))
+
+const isCommandPaletteActions = (
+  value: unknown
+): value is NativeOverlayCommandPaletteActions =>
+  isRecord(value) && isString(value.selectIndex) && isString(value.executeIndex)
+
+const isDialogPayload = (value: unknown): value is NativeOverlayDialogPayload =>
+  isRecord(value) &&
+  value.kind === 'dialog' &&
+  value.dialog === 'command-palette' &&
+  isString(value.ariaLabel) &&
+  typeof value.query === 'string' &&
+  isFiniteNumber(value.selectedIndex) &&
+  (value.activeDescendantId === undefined ||
+    typeof value.activeDescendantId === 'string') &&
+  (value.argumentPlaceholder === undefined ||
+    typeof value.argumentPlaceholder === 'string') &&
+  Array.isArray(value.results) &&
+  value.results.every(isCommandPaletteItem) &&
+  isCommandPaletteActions(value.actions)
+
 const isThemeSnapshot = (value: unknown): value is NativeOverlayThemeSnapshot =>
   isRecord(value) &&
   (value.id === undefined || typeof value.id === 'string') &&
@@ -340,14 +404,17 @@ const isSerializablePayloadForKind = (
   payload: unknown
 ): payload is SerializableOverlayPayload =>
   (kind === 'menu' && isMenuPayload(payload)) ||
-  (kind === 'tooltip' && isTooltipPayload(payload))
+  (kind === 'tooltip' && isTooltipPayload(payload)) ||
+  (kind === 'dialog' && isDialogPayload(payload))
 
 const isNativeOverlayRequest = (
   value: unknown
 ): value is NativeOverlayRequest =>
   isRecord(value) &&
   isString(value.surfaceId) &&
-  (value.kind === 'menu' || value.kind === 'tooltip') &&
+  (value.kind === 'menu' ||
+    value.kind === 'tooltip' ||
+    value.kind === 'dialog') &&
   isRect(value.anchorRect) &&
   isString(value.placement) &&
   isSerializablePayloadForKind(value.kind, value.payload) &&
@@ -371,7 +438,8 @@ const isActionEvent = (value: unknown): value is NativeOverlayActionEvent =>
   isString(value.actionId) &&
   (value.closeOnSelect === undefined ||
     typeof value.closeOnSelect === 'boolean') &&
-  (value.feedback === undefined || value.feedback === 'copy')
+  (value.feedback === undefined || value.feedback === 'copy') &&
+  (value.index === undefined || isFiniteNumber(value.index))
 
 const isActionResultEvent = (
   value: unknown
@@ -493,7 +561,10 @@ export class NativeOverlayController {
     record: NativeOverlayRecord,
     payload: NativeOverlayRequest
   ): Promise<NativeOverlayOpenResult> {
-    if (record.activeSurfaceId !== null) {
+    if (
+      record.activeSurfaceId !== null &&
+      record.activeSurfaceId !== payload.surfaceId
+    ) {
       this.closeSurface(record.activeSurfaceId, 'replaced', true)
     }
 
@@ -510,7 +581,7 @@ export class NativeOverlayController {
     this.surfaces.set(payload.surfaceId, {
       owner,
       parentId: parent.id,
-      kind: 'menu',
+      kind: payload.kind,
     })
 
     const readyPromise = this.waitForReady(payload.surfaceId)
@@ -613,7 +684,7 @@ export class NativeOverlayController {
       return
     }
 
-    if (surface.kind !== 'menu') {
+    if (surface.kind !== 'menu' && surface.kind !== 'dialog') {
       return
     }
 
@@ -755,6 +826,12 @@ export class NativeOverlayController {
 
       const surfaceId = activeRecord.activeSurfaceId
       const surface = this.surfaces.get(surfaceId)
+      if (dispatchCommandPaletteShortcutForWindow(parent, input)) {
+        event.preventDefault()
+
+        return
+      }
+
       if (surface?.kind !== 'menu') {
         return
       }
@@ -924,7 +1001,11 @@ export class NativeOverlayController {
     }
 
     if (!surface.owner.isDestroyed()) {
-      if (surface.kind === 'menu' && isActiveSurface && restoreOwnerFocus) {
+      if (
+        (surface.kind === 'menu' || surface.kind === 'dialog') &&
+        isActiveSurface &&
+        restoreOwnerFocus
+      ) {
         surface.owner.focus()
       }
       if (notifyOwner) {

--- a/native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift
+++ b/native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift
@@ -312,6 +312,21 @@ private final class EmbeddedGhosttySurface: NSObject {
             return false
         }
 
+        if !flags.contains(.option),
+           !flags.contains(.shift),
+           event.charactersIgnoringModifiers == ";" {
+            callbacks.forwardShortcut(
+                key: ";",
+                code: "Semicolon",
+                control: flags.contains(.control),
+                meta: flags.contains(.command),
+                alt: flags.contains(.option),
+                shift: flags.contains(.shift)
+            )
+
+            return true
+        }
+
         guard let digit = Self.shortcutDigitByKeyCode[event.keyCode] else {
             return false
         }

--- a/src/components/Dialog.test.tsx
+++ b/src/components/Dialog.test.tsx
@@ -48,12 +48,14 @@ const setNavigatorPlatform = (platform: string): void => {
 }
 
 const installNativeOverlayBridge = (
-  accepted: boolean
+  result: boolean | Promise<{ accepted: boolean }>
 ): {
   open: ReturnType<typeof vi.fn>
   close: ReturnType<typeof vi.fn>
 } => {
-  const open = vi.fn(() => Promise.resolve({ accepted }))
+  const open = vi.fn(() =>
+    typeof result === 'boolean' ? Promise.resolve({ accepted: result }) : result
+  )
   const close = vi.fn(() => Promise.resolve())
 
   window.vimeflow = {
@@ -69,6 +71,19 @@ const installNativeOverlayBridge = (
   }
 
   return { open, close }
+}
+
+const deferredOpen = (): {
+  promise: Promise<{ accepted: boolean }>
+  resolve: (value: { accepted: boolean }) => void
+} => {
+  let resolveOpen: (value: { accepted: boolean }) => void = () => undefined
+
+  const promise = new Promise<{ accepted: boolean }>((resolve) => {
+    resolveOpen = resolve
+  })
+
+  return { promise, resolve: resolveOpen }
 }
 
 afterEach(() => {
@@ -169,6 +184,101 @@ describe('Dialog', () => {
       expect(bridge.open).toHaveBeenCalledOnce()
       expect(dialog).not.toHaveClass('opacity-0')
       expect(screen.getByText('Local body')).toBeInTheDocument()
+    })
+  })
+
+  test('serializes native dialog updates for the same surface', async () => {
+    vi.stubEnv('VITE_NATIVE_OVERLAY', '1')
+    setNavigatorPlatform('MacIntel')
+    const firstOpen = deferredOpen()
+    const bridge = installNativeOverlayBridge(firstOpen.promise)
+
+    const updatedPayload: NativeOverlayCommandPaletteDialogPayload = {
+      ...nativeDialogPayload,
+      query: ':open',
+    }
+
+    const { rerender } = render(
+      <Dialog
+        open
+        nativeOverlay
+        nativeOverlayPayload={nativeDialogPayload}
+        onOpenChange={vi.fn()}
+        aria-label="Command palette"
+      >
+        <p>Local body</p>
+      </Dialog>
+    )
+
+    await waitFor(() => expect(bridge.open).toHaveBeenCalledOnce())
+
+    rerender(
+      <Dialog
+        open
+        nativeOverlay
+        nativeOverlayPayload={updatedPayload}
+        onOpenChange={vi.fn()}
+        aria-label="Command palette"
+      >
+        <p>Local body</p>
+      </Dialog>
+    )
+
+    expect(bridge.open).toHaveBeenCalledOnce()
+    firstOpen.resolve({ accepted: true })
+
+    await waitFor(() => expect(bridge.open).toHaveBeenCalledTimes(2))
+    expect(bridge.close).not.toHaveBeenCalled()
+  })
+
+  test('closes a late accepted native dialog after dismissal', async () => {
+    vi.stubEnv('VITE_NATIVE_OVERLAY', '1')
+    setNavigatorPlatform('MacIntel')
+    const open = deferredOpen()
+    const closed = false
+    const bridge = installNativeOverlayBridge(open.promise)
+
+    const { rerender } = render(
+      <Dialog
+        open
+        nativeOverlay
+        nativeOverlayPayload={nativeDialogPayload}
+        onOpenChange={vi.fn()}
+        aria-label="Command palette"
+      >
+        <p>Local body</p>
+      </Dialog>
+    )
+
+    await waitFor(() => expect(bridge.open).toHaveBeenCalledOnce())
+
+    const request = bridge.open.mock.calls[0]?.[0] as
+      | { surfaceId: string }
+      | undefined
+
+    if (request === undefined) {
+      throw new Error('expected native overlay open request')
+    }
+
+    rerender(
+      <Dialog
+        open={closed}
+        nativeOverlay
+        nativeOverlayPayload={nativeDialogPayload}
+        onOpenChange={vi.fn()}
+        aria-label="Command palette"
+      >
+        <p>Local body</p>
+      </Dialog>
+    )
+
+    open.resolve({ accepted: true })
+
+    await waitFor(() => {
+      expect(bridge.close).toHaveBeenCalledWith({
+        surfaceId: request.surfaceId,
+        reason: 'renderer',
+      })
     })
   })
 

--- a/src/components/Dialog.test.tsx
+++ b/src/components/Dialog.test.tsx
@@ -1,8 +1,83 @@
 import { createRef, useState, type ReactElement } from 'react'
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, test, vi } from 'vitest'
-import { Dialog } from './Dialog'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { __resetNativeOverlayForTest } from '@/components/base/floating/nativeOverlay'
+import { Dialog, type NativeOverlayCommandPaletteDialogPayload } from './Dialog'
+
+const nativeDialogPayload: NativeOverlayCommandPaletteDialogPayload = {
+  kind: 'dialog',
+  dialog: 'command-palette',
+  ariaLabel: 'Command palette',
+  query: ':',
+  selectedIndex: 0,
+  results: [
+    {
+      id: 'help',
+      label: ':help',
+      description: 'Show help',
+      icon: 'help',
+    },
+  ],
+  actions: {
+    selectIndex: 'command-palette:select-index',
+    executeIndex: 'command-palette:execute-index',
+  },
+}
+
+let restorePlatform: (() => void) | null = null
+
+const setNavigatorPlatform = (platform: string): void => {
+  restorePlatform?.()
+  const original = Object.getOwnPropertyDescriptor(window.navigator, 'platform')
+
+  Object.defineProperty(window.navigator, 'platform', {
+    configurable: true,
+    value: platform,
+  })
+
+  restorePlatform = (): void => {
+    if (original === undefined) {
+      delete (window.navigator as unknown as { platform?: string }).platform
+
+      return
+    }
+
+    Object.defineProperty(window.navigator, 'platform', original)
+  }
+}
+
+const installNativeOverlayBridge = (
+  accepted: boolean
+): {
+  open: ReturnType<typeof vi.fn>
+  close: ReturnType<typeof vi.fn>
+} => {
+  const open = vi.fn(() => Promise.resolve({ accepted }))
+  const close = vi.fn(() => Promise.resolve())
+
+  window.vimeflow = {
+    invoke: <T,>(): Promise<T> => Promise.resolve(null as T),
+    listen: vi.fn(() => Promise.resolve(vi.fn())),
+    nativeOverlay: {
+      open,
+      close,
+      actionResult: vi.fn(() => Promise.resolve()),
+      onAction: vi.fn(() => vi.fn()),
+      onClose: vi.fn(() => vi.fn()),
+    },
+  }
+
+  return { open, close }
+}
+
+afterEach(() => {
+  __resetNativeOverlayForTest()
+  vi.unstubAllEnvs()
+  restorePlatform?.()
+  restorePlatform = null
+  delete window.vimeflow
+})
 
 describe('Dialog', () => {
   test('renders nothing when open is false', () => {
@@ -28,6 +103,73 @@ describe('Dialog', () => {
     const dialog = screen.getByRole('dialog', { name: 'Settings' })
     expect(dialog).toHaveAttribute('aria-modal', 'true')
     expect(screen.getByText('Dialog body')).toBeInTheDocument()
+  })
+
+  test('hides local dialog while native overlay is active and closes on unmount', async () => {
+    vi.stubEnv('VITE_NATIVE_OVERLAY', '1')
+    setNavigatorPlatform('MacIntel')
+    const bridge = installNativeOverlayBridge(true)
+
+    const { unmount } = render(
+      <Dialog
+        open
+        nativeOverlay
+        nativeOverlayPayload={nativeDialogPayload}
+        onOpenChange={vi.fn()}
+        aria-label="Command palette"
+      >
+        <p>Local body</p>
+      </Dialog>
+    )
+
+    const dialog = screen.getByRole('dialog', { name: 'Command palette' })
+
+    await waitFor(() => {
+      expect(bridge.open).toHaveBeenCalledOnce()
+      expect(dialog).toHaveClass('opacity-0')
+    })
+
+    const request = bridge.open.mock.calls[0]?.[0] as
+      | { surfaceId: string }
+      | undefined
+
+    if (request === undefined) {
+      throw new Error('expected native overlay open request')
+    }
+
+    const surfaceId = request.surfaceId
+    unmount()
+
+    expect(bridge.close).toHaveBeenCalledWith({
+      surfaceId,
+      reason: 'renderer',
+    })
+  })
+
+  test('keeps local dialog visible when native overlay is rejected', async () => {
+    vi.stubEnv('VITE_NATIVE_OVERLAY', '1')
+    setNavigatorPlatform('MacIntel')
+    const bridge = installNativeOverlayBridge(false)
+
+    render(
+      <Dialog
+        open
+        nativeOverlay
+        nativeOverlayPayload={nativeDialogPayload}
+        onOpenChange={vi.fn()}
+        aria-label="Command palette"
+      >
+        <p>Local body</p>
+      </Dialog>
+    )
+
+    const dialog = screen.getByRole('dialog', { name: 'Command palette' })
+
+    await waitFor(() => {
+      expect(bridge.open).toHaveBeenCalledOnce()
+      expect(dialog).not.toHaveClass('opacity-0')
+      expect(screen.getByText('Local body')).toBeInTheDocument()
+    })
   })
 
   test('supports aria-labelledby and aria-describedby wiring', () => {
@@ -70,7 +212,10 @@ describe('Dialog', () => {
       </Dialog>
     )
 
-    await user.click(screen.getByTestId('dialog-backdrop'))
+    const backdrop = screen.getByTestId('dialog-backdrop')
+    expect(backdrop).toHaveClass('bg-scrim/40')
+
+    await user.click(backdrop)
 
     expect(onOpenChange).toHaveBeenCalledWith(false)
   })

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -2,15 +2,28 @@ import { AnimatePresence, motion } from 'framer-motion'
 import {
   useCallback,
   useEffect,
+  useId,
   useRef,
+  useState,
   type ReactElement,
   type ReactNode,
   type RefObject,
 } from 'react'
 import { createPortal } from 'react-dom'
 import {
+  closeNativeOverlay,
+  NATIVE_OVERLAY_KINDS,
+  nativeOverlayThemeSnapshot,
+  openNativeOverlay,
   selectFloatingTransport,
+  type NativeOverlayActionHandler,
+  type NativeOverlayDialogPayload,
   warnNativeOverlayFallback,
+} from '@/components/base/floating/nativeOverlay'
+
+export type {
+  NativeOverlayActionHandler,
+  NativeOverlayCommandPaletteDialogPayload,
 } from '@/components/base/floating/nativeOverlay'
 
 type DialogPlacement = 'center' | 'top'
@@ -34,6 +47,8 @@ interface DialogProps {
   /** Extra classes appended to the panel (e.g. a custom width). Last-wins over the size class. */
   panelClassName?: string
   nativeOverlay?: boolean
+  nativeOverlayPayload?: NativeOverlayDialogPayload
+  nativeOverlayActions?: ReadonlyMap<string, NativeOverlayActionHandler>
   children: ReactNode
 }
 
@@ -62,6 +77,11 @@ const PANEL_SIZE_CLASSES: Record<DialogSize, string> = {
 const DIALOG_PANEL_CLASSES =
   'relative w-full mx-4 bg-surface-container/90 glass-panel rounded-2xl ' +
   'border border-outline-variant/30 shadow-2xl overflow-hidden'
+
+const EMPTY_NATIVE_OVERLAY_ACTIONS = new Map<
+  string,
+  NativeOverlayActionHandler
+>()
 
 const FOCUSABLE_SELECTOR = [
   'a[href]',
@@ -247,23 +267,103 @@ const DialogRoot = ({
   backdropTestId = undefined,
   panelClassName = undefined,
   nativeOverlay = false,
+  nativeOverlayPayload = undefined,
+  nativeOverlayActions = EMPTY_NATIVE_OVERLAY_ACTIONS,
   children,
 }: DialogProps): ReactElement | null => {
+  const surfaceId = useId()
   const dialogRef = useRef<HTMLDivElement | null>(null)
   const previousFocusRef = useRef<HTMLElement | null>(null)
   const wasOpenRef = useRef(false)
   const restoreFocusRef = useRef(restoreFocus)
+
+  const [nativeAttempt, setNativeAttempt] = useState<
+    'idle' | 'pending' | 'active' | 'failed'
+  >('idle')
   restoreFocusRef.current = restoreFocus
 
+  const transport = selectFloatingTransport(nativeOverlay)
+
+  const nativeUnsupportedReason =
+    nativeOverlayPayload === undefined ? 'unsupported dialog content' : null
+
+  const canAttemptNative =
+    open && transport === 'native-overlay' && nativeUnsupportedReason === null
+
+  const hideLocalForNative =
+    nativeAttempt === 'pending' || nativeAttempt === 'active'
+
   useEffect(() => {
-    if (
-      open &&
-      nativeOverlay &&
-      selectFloatingTransport(nativeOverlay) === 'native-overlay'
-    ) {
-      warnNativeOverlayFallback('dialog native overlay is not in v0')
+    if (!open) {
+      closeNativeOverlay(surfaceId)
+      setNativeAttempt('idle')
+
+      return
     }
-  }, [nativeOverlay, open])
+
+    if (
+      nativeOverlay &&
+      transport === 'native-overlay' &&
+      nativeUnsupportedReason !== null
+    ) {
+      warnNativeOverlayFallback(nativeUnsupportedReason)
+    }
+  }, [nativeOverlay, nativeUnsupportedReason, open, surfaceId, transport])
+
+  useEffect(
+    () => (): void => {
+      closeNativeOverlay(surfaceId)
+    },
+    [surfaceId]
+  )
+
+  useEffect(() => {
+    if (!canAttemptNative || nativeOverlayPayload === undefined) {
+      return
+    }
+
+    const cancelled = { current: false }
+    setNativeAttempt((current) => (current === 'active' ? 'active' : 'pending'))
+
+    void (async (): Promise<void> => {
+      const accepted = await openNativeOverlay(
+        {
+          surfaceId,
+          kind: NATIVE_OVERLAY_KINDS.dialog,
+          anchorRect: {
+            x: 0,
+            y: 0,
+            width: window.innerWidth,
+            height: window.innerHeight,
+          },
+          placement,
+          payload: nativeOverlayPayload,
+          theme: nativeOverlayThemeSnapshot(),
+        },
+        {
+          actions: nativeOverlayActions,
+          onClose: (): void => onOpenChange(false),
+        }
+      )
+
+      if (cancelled.current) {
+        return
+      }
+
+      setNativeAttempt(accepted ? 'active' : 'failed')
+    })()
+
+    return (): void => {
+      cancelled.current = true
+    }
+  }, [
+    canAttemptNative,
+    nativeOverlayActions,
+    nativeOverlayPayload,
+    onOpenChange,
+    placement,
+    surfaceId,
+  ])
 
   const requestClose = useCallback((): void => {
     if (dismissDisabled) {
@@ -361,7 +461,9 @@ const DialogRoot = ({
           aria-describedby={ariaDescribedBy}
           tabIndex={-1}
           data-testid={testId}
-          className={`fixed inset-0 z-[100] flex ${PLACEMENT_CLASSES[placement]}`}
+          className={`fixed inset-0 z-[100] flex ${PLACEMENT_CLASSES[placement]}${
+            hideLocalForNative ? ' pointer-events-none opacity-0' : ''
+          }`}
         >
           <motion.div
             aria-hidden="true"
@@ -370,7 +472,7 @@ const DialogRoot = ({
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             transition={{ duration: 0.15 }}
-            className="absolute inset-0 backdrop-blur-sm bg-surface-container-lowest/40"
+            className="absolute inset-0 backdrop-blur-sm bg-scrim/40"
             onClick={closeOnBackdrop ? requestClose : undefined}
           />
           <motion.div

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -83,6 +83,17 @@ const EMPTY_NATIVE_OVERLAY_ACTIONS = new Map<
   NativeOverlayActionHandler
 >()
 
+const closeAcceptedNativeOverlayIfDismissed = (
+  surfaceId: string,
+  canAttemptNativeRef: RefObject<boolean>
+): void => {
+  if (canAttemptNativeRef.current) {
+    return
+  }
+
+  closeNativeOverlay(surfaceId)
+}
+
 const FOCUSABLE_SELECTOR = [
   'a[href]',
   'button:not([disabled])',
@@ -276,6 +287,9 @@ const DialogRoot = ({
   const previousFocusRef = useRef<HTMLElement | null>(null)
   const wasOpenRef = useRef(false)
   const restoreFocusRef = useRef(restoreFocus)
+  const nativeOverlayQueueRef = useRef<Promise<void>>(Promise.resolve())
+  const nativeOverlayGenerationRef = useRef(0)
+  const canAttemptNativeRef = useRef(false)
 
   const [nativeAttempt, setNativeAttempt] = useState<
     'idle' | 'pending' | 'active' | 'failed'
@@ -289,12 +303,14 @@ const DialogRoot = ({
 
   const canAttemptNative =
     open && transport === 'native-overlay' && nativeUnsupportedReason === null
+  canAttemptNativeRef.current = canAttemptNative
 
   const hideLocalForNative =
     nativeAttempt === 'pending' || nativeAttempt === 'active'
 
   useEffect(() => {
     if (!open) {
+      nativeOverlayGenerationRef.current += 1
       closeNativeOverlay(surfaceId)
       setNativeAttempt('idle')
 
@@ -312,6 +328,8 @@ const DialogRoot = ({
 
   useEffect(
     () => (): void => {
+      canAttemptNativeRef.current = false
+      nativeOverlayGenerationRef.current += 1
       closeNativeOverlay(surfaceId)
     },
     [surfaceId]
@@ -322,10 +340,23 @@ const DialogRoot = ({
       return
     }
 
+    const generation = nativeOverlayGenerationRef.current + 1
     const cancelled = { current: false }
+    nativeOverlayGenerationRef.current = generation
     setNativeAttempt((current) => (current === 'active' ? 'active' : 'pending'))
 
-    void (async (): Promise<void> => {
+    const openAfterPrevious = async (): Promise<void> => {
+      const previousOpen = nativeOverlayQueueRef.current
+
+      await previousOpen
+
+      if (
+        cancelled.current ||
+        nativeOverlayGenerationRef.current !== generation
+      ) {
+        return
+      }
+
       const accepted = await openNativeOverlay(
         {
           surfaceId,
@@ -346,12 +377,21 @@ const DialogRoot = ({
         }
       )
 
-      if (cancelled.current) {
+      if (nativeOverlayGenerationRef.current !== generation) {
+        if (accepted) {
+          closeAcceptedNativeOverlayIfDismissed(surfaceId, canAttemptNativeRef)
+        }
+
         return
       }
 
       setNativeAttempt(accepted ? 'active' : 'failed')
-    })()
+    }
+
+    const currentOpen = openAfterPrevious()
+
+    nativeOverlayQueueRef.current = currentOpen
+    void currentOpen
 
     return (): void => {
       cancelled.current = true

--- a/src/components/NativeOverlayHost.test.tsx
+++ b/src/components/NativeOverlayHost.test.tsx
@@ -150,6 +150,34 @@ const tooltipRequest: NativeOverlayRequest = {
   },
 }
 
+const commandPaletteRequest: NativeOverlayRequest = {
+  surfaceId: 'dialog-1',
+  kind: 'dialog',
+  anchorRect: { x: 0, y: 0, width: 900, height: 600 },
+  placement: 'top',
+  payload: {
+    kind: 'dialog',
+    dialog: 'command-palette',
+    ariaLabel: 'Command palette',
+    query: ':',
+    selectedIndex: 0,
+    activeDescendantId: 'command-help',
+    results: [
+      {
+        id: 'help',
+        label: ':help',
+        description: 'Show command reference',
+        icon: 'help',
+        shortcut: ['Cmd', ';'],
+      },
+    ],
+    actions: {
+      selectIndex: 'command-palette:select-index',
+      executeIndex: 'command-palette:execute-index',
+    },
+  },
+}
+
 let cleanupHostBridgeEvents: (() => void) | null = null
 
 const installNativeOverlayHostBridge = (): {
@@ -309,6 +337,88 @@ describe('NativeOverlayHost', () => {
     bridge.emitClear()
 
     expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+  })
+
+  test('renders command palette dialog requests on the menu layer', async () => {
+    const user = userEvent.setup()
+    const bridge = installNativeOverlayHostBridge()
+    render(<NativeOverlayHost />)
+
+    bridge.emitRender(commandPaletteRequest)
+
+    const dialog = await screen.findByRole('dialog', {
+      name: 'Command palette',
+    })
+    expect(dialog).toBeInTheDocument()
+    expect(dialog).toHaveClass('bg-scrim/40')
+    expect(screen.getByRole('combobox')).toHaveValue(':')
+    expect(screen.getByRole('combobox')).toHaveAttribute('readonly')
+    expect(screen.getByRole('option', { name: /:help/i })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    )
+
+    await user.click(screen.getByRole('option', { name: /:help/i }))
+
+    expect(bridge.action).toHaveBeenCalledWith({
+      surfaceId: 'dialog-1',
+      actionId: 'command-palette:execute-index',
+      closeOnSelect: false,
+      index: 0,
+    })
+
+    expect(screen.getByRole('dialog', { name: 'Command palette' })).toBe(dialog)
+  })
+
+  test('scrolls the selected command palette row into view', async () => {
+    const scrollIntoView = vi.spyOn(Element.prototype, 'scrollIntoView')
+    const bridge = installNativeOverlayHostBridge()
+    render(<NativeOverlayHost />)
+
+    try {
+      bridge.emitRender({
+        ...commandPaletteRequest,
+        payload: {
+          kind: 'dialog',
+          dialog: 'command-palette',
+          ariaLabel: 'Command palette',
+          query: ':',
+          selectedIndex: 1,
+          activeDescendantId: 'command-open',
+          results: [
+            {
+              id: 'help',
+              label: ':help',
+              description: 'Show command reference',
+              icon: 'help',
+            },
+            {
+              id: 'open',
+              label: ':open',
+              description: 'Open file',
+              icon: 'folder_open',
+            },
+          ],
+          actions: {
+            selectIndex: 'command-palette:select-index',
+            executeIndex: 'command-palette:execute-index',
+          },
+        },
+      })
+
+      expect(
+        await screen.findByRole('option', { name: /:open/i })
+      ).toHaveAttribute('aria-selected', 'true')
+
+      await waitFor(() => {
+        expect(scrollIntoView).toHaveBeenCalledWith({
+          block: 'nearest',
+          inline: 'nearest',
+        })
+      })
+    } finally {
+      scrollIntoView.mockRestore()
+    }
   })
 
   test('dispatches forwarded menu keydown events to the active menu', async () => {

--- a/src/components/NativeOverlayHost.tsx
+++ b/src/components/NativeOverlayHost.tsx
@@ -9,6 +9,7 @@ import {
 import { IconButton } from '@/components/IconButton'
 import { Menu } from '@/components/Menu'
 import type {
+  NativeOverlayDialogRequest,
   NativeOverlayMenuItem,
   NativeOverlayMenuRequest,
   NativeOverlayMenuSection,
@@ -25,6 +26,7 @@ interface NativeOverlayHostBridge {
     actionId: string
     closeOnSelect?: boolean
     feedback?: 'copy'
+    index?: number
   }) => Promise<unknown>
   close: (request: { surfaceId: string; reason: 'outside' }) => Promise<unknown>
   onRender: (callback: (payload: unknown) => void) => () => void
@@ -66,6 +68,16 @@ const isTooltipRequest = (
   (value as { payload?: { kind?: unknown; text?: unknown } }).payload?.kind ===
     'tooltip' &&
   typeof (value as { payload?: { text?: unknown } }).payload?.text === 'string'
+
+const isDialogRequest = (value: unknown): value is NativeOverlayDialogRequest =>
+  typeof value === 'object' &&
+  value !== null &&
+  !Array.isArray(value) &&
+  (value as { kind?: unknown }).kind === 'dialog' &&
+  (value as { payload?: { kind?: unknown; dialog?: unknown } }).payload
+    ?.kind === 'dialog' &&
+  (value as { payload?: { dialog?: unknown } }).payload?.dialog ===
+    'command-palette'
 
 const isCopyActionResult = (
   value: unknown
@@ -140,6 +152,45 @@ const OVERLAY_TOOLTIP_CLASSES =
   'pointer-events-none rounded-md px-3 py-1.5 text-xs text-on-surface ' +
   'whitespace-nowrap shadow-lg bg-surface-container-high/90 backdrop-blur-md ' +
   'backdrop-saturate-150 border border-outline-variant/20'
+
+const OVERLAY_DIALOG_BACKDROP_CLASSES =
+  'fixed inset-0 flex items-start justify-center pt-[15vh] backdrop-blur-sm ' +
+  'bg-scrim/40'
+
+const OVERLAY_COMMAND_PALETTE_CLASSES =
+  'w-full max-w-2xl mx-4 bg-surface-container/90 glass-panel rounded-2xl ' +
+  'border border-outline-variant/30 shadow-2xl overflow-hidden'
+
+const OVERLAY_COMMAND_PALETTE_INPUT_CLASSES =
+  'relative w-full flex-1 bg-transparent border-none p-0 outline-none ' +
+  'font-mono text-[13.5px] leading-[18px] placeholder:text-on-surface-muted'
+
+const OVERLAY_COMMAND_PALETTE_ROW_CLASSES =
+  'group flex items-center gap-[12px] px-[12px] py-[9px] my-[2px] ' +
+  'rounded-[8px] border transition-colors cursor-pointer'
+
+const OVERLAY_COMMAND_PALETTE_KEY_CLASSES =
+  'inline-flex min-w-[16px] h-[16px] px-[4px] items-center justify-center ' +
+  'rounded-[4px] border font-mono text-[9.5px] font-semibold'
+
+const overlayCommandPaletteRowClass = (selected: boolean): string =>
+  `${OVERLAY_COMMAND_PALETTE_ROW_CLASSES} ${
+    selected
+      ? 'bg-primary-container/10 border-primary-container/25'
+      : 'border-transparent hover:bg-surface-container-high/40'
+  }`
+
+const overlayCommandPaletteKeyClass = (selected: boolean): string =>
+  `${OVERLAY_COMMAND_PALETTE_KEY_CLASSES} ${
+    selected
+      ? 'bg-primary-container/[0.08] text-primary border-primary-container/40'
+      : 'bg-surface-container-lowest/60 text-on-surface-muted border-outline-variant/40'
+  }`
+
+const OVERLAY_COMMAND_PALETTE_FOOTER_KEY_CLASSES =
+  'inline-flex min-w-[18px] h-[18px] px-[5px] items-center justify-center ' +
+  'rounded-[4px] border font-mono text-[10px] font-semibold ' +
+  'bg-surface-container-highest/60 text-on-surface-variant border-outline-variant/60'
 
 const OVERLAY_MENU_COMPOSITE_PRIMARY_CLASSES =
   'flex min-w-0 flex-1 items-center gap-2.5 rounded text-left outline-none ' +
@@ -295,6 +346,209 @@ const tooltipStyleForRequest = (
   }
 }
 
+const NativeOverlayCommandPalette = ({
+  request,
+  close,
+}: {
+  request: NativeOverlayDialogRequest
+  close: () => void
+}): ReactElement => {
+  const rowRefs = useRef(new Map<string, HTMLDivElement>())
+  const payload = request.payload
+  const selectedIndex = payload.selectedIndex
+
+  const selectedCommand =
+    selectedIndex >= 0 && selectedIndex < payload.results.length
+      ? payload.results[selectedIndex]
+      : undefined
+
+  const activeDescendantId =
+    payload.activeDescendantId ??
+    (selectedCommand === undefined
+      ? undefined
+      : `command-${selectedCommand.id}`)
+
+  const showArgumentPlaceholder =
+    payload.argumentPlaceholder !== undefined && payload.query.endsWith(' ')
+
+  useEffect(() => {
+    if (selectedCommand === undefined) {
+      return
+    }
+
+    rowRefs.current
+      .get(selectedCommand.id)
+      ?.scrollIntoView({ block: 'nearest', inline: 'nearest' })
+  }, [selectedCommand])
+
+  const setRowRef =
+    (commandId: string) =>
+    (node: HTMLDivElement | null): void => {
+      if (node === null) {
+        rowRefs.current.delete(commandId)
+
+        return
+      }
+
+      rowRefs.current.set(commandId, node)
+    }
+
+  const dispatchAction = (
+    actionId: string,
+    options: { index?: number } = {}
+  ): void => {
+    void nativeOverlayHostBridge()?.action({
+      surfaceId: request.surfaceId,
+      actionId,
+      closeOnSelect: false,
+      ...options,
+    })
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={payload.ariaLabel}
+      className={OVERLAY_DIALOG_BACKDROP_CLASSES}
+      onMouseDown={(event): void => {
+        if (event.target === event.currentTarget) {
+          event.preventDefault()
+          close()
+        }
+      }}
+    >
+      <div className={OVERLAY_COMMAND_PALETTE_CLASSES}>
+        <div className="flex items-center gap-[10px] px-[16px] py-[14px]">
+          <span
+            aria-hidden="true"
+            className="material-symbols-outlined text-[16px] text-primary-container"
+          >
+            terminal
+          </span>
+          <div className="relative flex-1 min-w-0">
+            {showArgumentPlaceholder ? (
+              <span
+                aria-hidden="true"
+                className="pointer-events-none absolute inset-0 flex items-center font-mono text-[13.5px] leading-[18px]"
+              >
+                <span className="whitespace-pre text-on-surface">
+                  {payload.query}
+                </span>
+                <span className="text-on-surface-muted">
+                  {payload.argumentPlaceholder}
+                </span>
+              </span>
+            ) : null}
+            <input
+              type="text"
+              value={payload.query}
+              readOnly
+              className={`${OVERLAY_COMMAND_PALETTE_INPUT_CLASSES} ${
+                showArgumentPlaceholder
+                  ? 'text-transparent caret-on-surface'
+                  : 'text-on-surface'
+              }`}
+              placeholder="type a command, : prefix, or search files..."
+              role="combobox"
+              aria-label="Command palette search"
+              aria-expanded
+              aria-controls="command-palette-listbox"
+              aria-activedescendant={activeDescendantId}
+            />
+          </div>
+          <span className={OVERLAY_COMMAND_PALETTE_FOOTER_KEY_CLASSES}>
+            ESC
+          </span>
+        </div>
+        <div className="h-px bg-outline-variant/25" />
+        <div
+          id="command-palette-listbox"
+          role="listbox"
+          className="p-[6px] overflow-y-auto max-h-[60vh]"
+        >
+          {payload.results.map((command, index) => {
+            const selected = index === selectedIndex
+
+            return (
+              <div
+                key={command.id}
+                ref={setRowRef(command.id)}
+                id={`command-${command.id}`}
+                role="option"
+                aria-selected={selected}
+                onMouseEnter={(): void => {
+                  dispatchAction(payload.actions.selectIndex, { index })
+                }}
+                onMouseDown={(event): void => event.preventDefault()}
+                onClick={(): void => {
+                  dispatchAction(payload.actions.executeIndex, { index })
+                }}
+                className={overlayCommandPaletteRowClass(selected)}
+              >
+                <span
+                  className={`material-symbols-outlined text-[15px] shrink-0 ${
+                    selected ? 'text-primary' : 'text-on-surface-muted'
+                  }`}
+                  style={{
+                    fontVariationSettings: selected ? '"FILL" 1' : '"FILL" 0',
+                  }}
+                >
+                  {command.icon}
+                </span>
+                <span className="font-mono text-[11.5px] text-primary w-[120px] shrink-0 truncate">
+                  {command.label}
+                </span>
+                <span className="text-[12.5px] text-on-surface flex-1 min-w-0 truncate">
+                  {command.description}
+                </span>
+                {command.hint === undefined ? null : (
+                  <span className="hidden text-[11px] text-on-surface-muted truncate sm:block">
+                    {command.hint}
+                  </span>
+                )}
+                {command.shortcut === undefined ||
+                command.shortcut.length === 0 ? null : (
+                  <div className="flex items-center gap-[3px] shrink-0">
+                    {command.shortcut.map((key, keyIndex) => (
+                      <span
+                        key={`${command.id}:key:${String(keyIndex)}`}
+                        className={overlayCommandPaletteKeyClass(selected)}
+                      >
+                        {key}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+        <div className="h-px bg-outline-variant/25" />
+        <div className="flex items-center gap-[14px] px-[14px] py-[8px] bg-surface-container-lowest/50 font-mono text-[10px] text-on-surface-muted">
+          <span className="flex items-center gap-[6px]">
+            <span className={OVERLAY_COMMAND_PALETTE_FOOTER_KEY_CLASSES}>
+              Enter
+            </span>
+            run
+          </span>
+          <span className="flex items-center gap-[6px]">
+            <span className="flex gap-[3px]">
+              <span className={OVERLAY_COMMAND_PALETTE_FOOTER_KEY_CLASSES}>
+                Up
+              </span>
+              <span className={OVERLAY_COMMAND_PALETTE_FOOTER_KEY_CLASSES}>
+                Down
+              </span>
+            </span>
+            navigate
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export const NativeOverlayHost = ({
   mode = 'menu',
 }: {
@@ -351,7 +605,10 @@ export const NativeOverlayHost = ({
     }
 
     const cleanupRender = bridge.onRender((payload) => {
-      if (mode === 'menu' && isMenuRequest(payload)) {
+      const isMenuLayerRequest =
+        mode === 'menu' && (isMenuRequest(payload) || isDialogRequest(payload))
+
+      if (isMenuLayerRequest) {
         applyThemeSnapshot(payload.theme)
         clearCopyFeedback()
         setRequest(payload)
@@ -448,6 +705,10 @@ export const NativeOverlayHost = ({
   }
 
   if (!isMenuRequest(request)) {
+    if (isDialogRequest(request)) {
+      return <NativeOverlayCommandPalette request={request} close={close} />
+    }
+
     return null
   }
 

--- a/src/components/base/floating/nativeOverlay.ts
+++ b/src/components/base/floating/nativeOverlay.ts
@@ -97,12 +97,43 @@ export interface NativeOverlayTooltipPayload {
   maxWidth?: number
 }
 
+export interface NativeOverlayCommandPaletteItem {
+  id: string
+  label: string
+  description?: string
+  hint?: string
+  icon: string
+  shortcut?: string[]
+}
+
+export interface NativeOverlayCommandPaletteActions {
+  selectIndex: string
+  executeIndex: string
+}
+
+export interface NativeOverlayCommandPaletteDialogPayload {
+  kind: 'dialog'
+  dialog: 'command-palette'
+  ariaLabel: string
+  query: string
+  selectedIndex: number
+  activeDescendantId?: string
+  argumentPlaceholder?: string
+  results: NativeOverlayCommandPaletteItem[]
+  actions: NativeOverlayCommandPaletteActions
+}
+
+export type NativeOverlayDialogPayload =
+  NativeOverlayCommandPaletteDialogPayload
+
 // Native overlay payloads are plain data only. Menu and tooltip are supported
-// today; popover/dialog should join this union only after they get their own
-// serializable models instead of arbitrary React children.
+// today; dialog has a narrow command-palette model. Popover and future dialog
+// variants should join this union only after they get their own serializable
+// models instead of arbitrary React children.
 export type SerializableOverlayPayload =
   | NativeOverlayMenuPayload
   | NativeOverlayTooltipPayload
+  | NativeOverlayDialogPayload
 
 export interface NativeOverlayRequest {
   surfaceId: string
@@ -123,11 +154,17 @@ export type NativeOverlayTooltipRequest = NativeOverlayRequest & {
   payload: NativeOverlayTooltipPayload
 }
 
+export type NativeOverlayDialogRequest = NativeOverlayRequest & {
+  kind: typeof NATIVE_OVERLAY_KINDS.dialog
+  payload: NativeOverlayDialogPayload
+}
+
 export interface NativeOverlayActionEvent {
   surfaceId: string
   actionId: string
   closeOnSelect?: boolean
   feedback?: 'copy'
+  index?: number
 }
 
 export interface NativeOverlayActionResultEvent {
@@ -194,10 +231,10 @@ interface NativeOverlayBridge {
 export type NativeOverlayActionResult = boolean | void | Promise<boolean | void>
 
 export type NativeOverlayActionHandler =
-  | (() => NativeOverlayActionResult)
+  | ((event?: NativeOverlayActionEvent) => NativeOverlayActionResult)
   | {
       retainSession: true
-      run: () => NativeOverlayActionResult
+      run: (event?: NativeOverlayActionEvent) => NativeOverlayActionResult
     }
 
 interface NativeOverlaySession {
@@ -219,7 +256,8 @@ const isActionEvent = (value: unknown): value is NativeOverlayActionEvent =>
   typeof value.actionId === 'string' &&
   (value.closeOnSelect === undefined ||
     typeof value.closeOnSelect === 'boolean') &&
-  (value.feedback === undefined || value.feedback === 'copy')
+  (value.feedback === undefined || value.feedback === 'copy') &&
+  (value.index === undefined || typeof value.index === 'number')
 
 const isCloseEvent = (value: unknown): value is NativeOverlayCloseEvent =>
   isRecord(value) &&
@@ -247,11 +285,11 @@ const reportActionResult = (
 
 const runActionAndReport = (
   event: NativeOverlayActionEvent,
-  run: () => NativeOverlayActionResult
+  run: (event: NativeOverlayActionEvent) => NativeOverlayActionResult
 ): void => {
   void (async (): Promise<void> => {
     try {
-      const result = await run()
+      const result = await run(event)
       reportActionResult(event, result === true)
     } catch (error) {
       reportActionResult(event, false)

--- a/src/features/command-palette/CommandPalette.test.tsx
+++ b/src/features/command-palette/CommandPalette.test.tsx
@@ -1,8 +1,10 @@
-import { describe, expect, test } from 'vitest'
-import { screen } from '@testing-library/react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import { useState, type ReactElement } from 'react'
 import userEvent from '@testing-library/user-event'
+import { CommandPalette } from './CommandPalette'
 import { renderPalette } from './CommandPalette.testUtils'
-import type { Command } from './registry/types'
+import type { Command, CommandPaletteState } from './registry/types'
 
 const sampleCommand: Command = {
   id: 'help',
@@ -10,6 +12,94 @@ const sampleCommand: Command = {
   description: 'Show command reference',
   icon: 'help',
 }
+
+let restorePlatform: (() => void) | null = null
+let closeNativeOverlaySession: (() => void) | null = null
+
+interface CommandPaletteNativeRequest {
+  surfaceId: string
+  payload: {
+    actions: {
+      selectIndex: string
+      executeIndex: string
+    }
+  }
+}
+
+const setNavigatorPlatform = (platform: string): void => {
+  restorePlatform?.()
+  const original = Object.getOwnPropertyDescriptor(window.navigator, 'platform')
+
+  Object.defineProperty(window.navigator, 'platform', {
+    configurable: true,
+    value: platform,
+  })
+
+  restorePlatform = (): void => {
+    if (original === undefined) {
+      delete (window.navigator as unknown as { platform?: string }).platform
+
+      return
+    }
+
+    Object.defineProperty(window.navigator, 'platform', original)
+  }
+}
+
+const installNativeOverlayBridge = (): {
+  open: ReturnType<typeof vi.fn>
+  action: (event: unknown) => void
+} => {
+  let actionListener: ((event: unknown) => void) | null = null
+  let closeListener: ((event: unknown) => void) | null = null
+  const open = vi.fn().mockResolvedValue({ accepted: true })
+
+  window.vimeflow = {
+    invoke: <T,>(): Promise<T> => Promise.resolve(null as T),
+    listen: vi.fn(() => Promise.resolve(vi.fn())),
+    nativeOverlay: {
+      open,
+      close: vi.fn(() => Promise.resolve()),
+      actionResult: vi.fn(() => Promise.resolve()),
+      onAction: vi.fn((callback: (event: unknown) => void) => {
+        actionListener = callback
+
+        return vi.fn()
+      }),
+      onClose: vi.fn((callback: (event: unknown) => void) => {
+        closeListener = callback
+
+        return vi.fn()
+      }),
+    },
+  }
+
+  closeNativeOverlaySession = (): void => {
+    const request = open.mock.calls[0]?.[0] as
+      | CommandPaletteNativeRequest
+      | undefined
+
+    if (request !== undefined) {
+      closeListener?.({ surfaceId: request.surfaceId, reason: 'test' })
+    }
+  }
+
+  return {
+    open,
+    action: (event): void => {
+      actionListener?.(event)
+    },
+  }
+}
+
+afterEach(() => {
+  closeNativeOverlaySession?.()
+  closeNativeOverlaySession = null
+  vi.unstubAllEnvs()
+  restorePlatform?.()
+  restorePlatform = null
+  delete window.vimeflow
+})
 
 describe('CommandPalette', () => {
   test('does not render the dialog when state.isOpen is false', () => {
@@ -123,5 +213,110 @@ describe('CommandPalette', () => {
     })
 
     expect(input).not.toHaveAttribute('aria-activedescendant')
+  })
+
+  test('sends a native overlay dialog payload and dispatches overlay actions', async () => {
+    vi.stubEnv('VITE_NATIVE_OVERLAY', '1')
+    setNavigatorPlatform('MacIntel')
+    const nativeBridge = installNativeOverlayBridge()
+
+    const { selectIndex, executeAt } = renderPalette({
+      state: { isOpen: true, query: ':he' },
+      filteredResults: [sampleCommand],
+      clampedSelectedIndex: 0,
+    })
+
+    await waitFor(() => expect(nativeBridge.open).toHaveBeenCalled())
+
+    const request = nativeBridge.open.mock
+      .calls[0][0] as CommandPaletteNativeRequest
+
+    expect(request).toMatchObject({
+      kind: 'dialog',
+      placement: 'top',
+      payload: {
+        kind: 'dialog',
+        dialog: 'command-palette',
+        ariaLabel: 'Command palette',
+        query: ':he',
+        selectedIndex: 0,
+        results: [
+          {
+            id: 'help',
+            label: ':help',
+            description: 'Show command reference',
+            icon: 'help',
+          },
+        ],
+      },
+    })
+
+    act(() => {
+      nativeBridge.action({
+        surfaceId: request.surfaceId,
+        actionId: request.payload.actions.selectIndex,
+        index: 0,
+      })
+
+      nativeBridge.action({
+        surfaceId: request.surfaceId,
+        actionId: request.payload.actions.executeIndex,
+        index: 0,
+      })
+    })
+
+    expect(selectIndex).toHaveBeenCalledWith(0)
+    expect(executeAt).toHaveBeenCalledWith(0)
+  })
+
+  test('does not reopen the native overlay on unrelated parent rerenders', async () => {
+    vi.stubEnv('VITE_NATIVE_OVERLAY', '1')
+    setNavigatorPlatform('MacIntel')
+    const nativeBridge = installNativeOverlayBridge()
+
+    const state: CommandPaletteState = {
+      isOpen: true,
+      query: ':he',
+      selectedIndex: 0,
+      currentNamespace: null,
+    }
+    const filteredResults = [sampleCommand]
+    const close = vi.fn()
+    const setQuery = vi.fn()
+    const selectIndex = vi.fn()
+    const executeAt = vi.fn()
+
+    const Harness = (): ReactElement => {
+      const [, setTick] = useState(0)
+
+      return (
+        <>
+          <button
+            type="button"
+            onClick={(): void => setTick((value) => value + 1)}
+          >
+            Re-render
+          </button>
+          <CommandPalette
+            state={state}
+            filteredResults={filteredResults}
+            clampedSelectedIndex={0}
+            close={close}
+            setQuery={setQuery}
+            selectIndex={selectIndex}
+            executeAt={executeAt}
+          />
+        </>
+      )
+    }
+
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    await waitFor(() => expect(nativeBridge.open).toHaveBeenCalledOnce())
+
+    await user.click(screen.getByRole('button', { name: 'Re-render' }))
+
+    expect(nativeBridge.open).toHaveBeenCalledOnce()
   })
 })

--- a/src/features/command-palette/CommandPalette.tsx
+++ b/src/features/command-palette/CommandPalette.tsx
@@ -1,4 +1,8 @@
-import type { ReactElement } from 'react'
+import { useCallback, useMemo, type ReactElement } from 'react'
+import type {
+  NativeOverlayActionHandler,
+  NativeOverlayCommandPaletteDialogPayload,
+} from '@/components/Dialog'
 import { Dialog } from '@/components/Dialog'
 import { CommandInput } from './components/CommandInput'
 import { CommandResults } from './components/CommandResults'
@@ -53,6 +57,9 @@ const getArgumentPlaceholder = (
 
 const DIALOG_CLOSE_ON_ESCAPE = false
 
+const NATIVE_ACTION_SELECT_INDEX = 'command-palette:select-index'
+const NATIVE_ACTION_EXECUTE_INDEX = 'command-palette:execute-index'
+
 export const CommandPalette = ({
   state,
   filteredResults,
@@ -61,44 +68,124 @@ export const CommandPalette = ({
   setQuery,
   selectIndex,
   executeAt,
-}: CommandPaletteProps): ReactElement | null => (
-  <Dialog
-    open={state.isOpen}
-    onOpenChange={(open): void => {
+}: CommandPaletteProps): ReactElement | null => {
+  const activeDescendantId = getActiveDescendantId(
+    clampedSelectedIndex,
+    filteredResults
+  )
+
+  const argumentPlaceholder = getArgumentPlaceholder(
+    state,
+    clampedSelectedIndex,
+    filteredResults
+  )
+
+  const nativeOverlayPayload =
+    useMemo((): NativeOverlayCommandPaletteDialogPayload => {
+      const results = filteredResults.map((command) => ({
+        id: command.id,
+        label: command.label,
+        ...(command.description === undefined
+          ? {}
+          : { description: command.description }),
+        ...(command.hint === undefined ? {} : { hint: command.hint }),
+        icon: command.icon,
+        ...(command.shortcut === undefined
+          ? {}
+          : { shortcut: command.shortcut }),
+      }))
+
+      return {
+        kind: 'dialog',
+        dialog: 'command-palette',
+        ariaLabel: 'Command palette',
+        query: state.query,
+        selectedIndex: clampedSelectedIndex,
+        ...(activeDescendantId === undefined ? {} : { activeDescendantId }),
+        ...(argumentPlaceholder === undefined ? {} : { argumentPlaceholder }),
+        results,
+        actions: {
+          selectIndex: NATIVE_ACTION_SELECT_INDEX,
+          executeIndex: NATIVE_ACTION_EXECUTE_INDEX,
+        },
+      }
+    }, [
+      activeDescendantId,
+      argumentPlaceholder,
+      clampedSelectedIndex,
+      filteredResults,
+      state.query,
+    ])
+
+  const nativeOverlayActions = useMemo(
+    (): ReadonlyMap<string, NativeOverlayActionHandler> =>
+      new Map([
+        [
+          NATIVE_ACTION_SELECT_INDEX,
+          {
+            retainSession: true,
+            run: (event): void => {
+              if (event?.index !== undefined) {
+                selectIndex(event.index)
+              }
+            },
+          },
+        ],
+        [
+          NATIVE_ACTION_EXECUTE_INDEX,
+          {
+            retainSession: true,
+            run: (event): void => {
+              if (event?.index !== undefined) {
+                executeAt(event.index)
+              }
+            },
+          },
+        ],
+      ]),
+    [executeAt, selectIndex]
+  )
+
+  const handleOpenChange = useCallback(
+    (open: boolean): void => {
       if (!open) {
         close()
       }
-    }}
-    placement="top"
-    size="lg"
-    closeOnEscape={DIALOG_CLOSE_ON_ESCAPE}
-    aria-label="Command palette"
-    backdropTestId="command-palette-backdrop"
-  >
-    <CommandInput
-      value={state.query}
-      onChange={setQuery}
-      activeDescendantId={getActiveDescendantId(
-        clampedSelectedIndex,
-        filteredResults
-      )}
-      argumentPlaceholder={getArgumentPlaceholder(
-        state,
-        clampedSelectedIndex,
-        filteredResults
-      )}
-    />
+    },
+    [close]
+  )
 
-    <div className="h-px bg-outline-variant/25" />
+  return (
+    <Dialog
+      open={state.isOpen}
+      onOpenChange={handleOpenChange}
+      placement="top"
+      size="lg"
+      closeOnEscape={DIALOG_CLOSE_ON_ESCAPE}
+      aria-label="Command palette"
+      backdropTestId="command-palette-backdrop"
+      nativeOverlay
+      nativeOverlayPayload={nativeOverlayPayload}
+      nativeOverlayActions={nativeOverlayActions}
+    >
+      <CommandInput
+        value={state.query}
+        onChange={setQuery}
+        activeDescendantId={activeDescendantId}
+        argumentPlaceholder={argumentPlaceholder}
+      />
 
-    <CommandResults
-      filteredResults={filteredResults}
-      selectedIndex={clampedSelectedIndex}
-      onSelect={selectIndex}
-      onExecute={executeAt}
-    />
+      <div className="h-px bg-outline-variant/25" />
 
-    <div className="h-px bg-outline-variant/25" />
-    <CommandFooter />
-  </Dialog>
-)
+      <CommandResults
+        filteredResults={filteredResults}
+        selectedIndex={clampedSelectedIndex}
+        onSelect={selectIndex}
+        onExecute={executeAt}
+      />
+
+      <div className="h-px bg-outline-variant/25" />
+      <CommandFooter />
+    </Dialog>
+  )
+}

--- a/tests/e2e/shared/actions.ts
+++ b/tests/e2e/shared/actions.ts
@@ -5,15 +5,23 @@
  * → unsupported operation) on Linux. These helpers dispatch the underlying
  * DOM events via `browser.execute` so tests stay readable.
  */
+// cspell:ignore menuitemcheckbox
 
 export const clickBySelector = async (selector: string): Promise<void> => {
   const ok = await browser.execute((s: string) => {
     const el = document.querySelector<HTMLElement>(s)
-    if (!el) return false
+    if (!el) {
+      return false
+    }
+
     el.click()
+
     return true
   }, selector)
-  if (!ok) throw new Error(`clickBySelector: no element for ${selector}`)
+
+  if (!ok) {
+    throw new Error(`clickBySelector: no element for ${selector}`)
+  }
 }
 
 const hasElement = async (selector: string): Promise<boolean> =>
@@ -22,27 +30,46 @@ const hasElement = async (selector: string): Promise<boolean> =>
     selector
   )
 
+const waitForLayoutDisplayMenuItem = async (
+  layoutName: string
+): Promise<void> => {
+  const menuSelector = '[role="menu"][aria-label="Displayed layouts"]'
+  const itemSelector = layoutDisplayMenuItemSelector(layoutName)
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    if (await hasElement(itemSelector)) {
+      return
+    }
+
+    await clickBySelector('button[aria-label="Configure displayed layouts"]')
+
+    try {
+      await browser.waitUntil(
+        async () =>
+          (await hasElement(menuSelector)) && (await hasElement(itemSelector)),
+        {
+          timeout: 5_000,
+          interval: 100,
+          timeoutMsg: `layout display menu did not show ${layoutName}`,
+        }
+      )
+
+      return
+    } catch (error) {
+      if (attempt === 1) {
+        throw error
+      }
+    }
+  }
+}
+
 export const clickLayoutButton = async (layoutName: string): Promise<void> => {
   const layoutButtonSelector = `[data-testid="layout-switcher"] button[aria-label="${layoutName}"]`
 
   if (!(await hasElement(layoutButtonSelector))) {
-    await clickBySelector('button[aria-label="Configure displayed layouts"]')
+    await waitForLayoutDisplayMenuItem(layoutName)
 
-    await browser.waitUntil(
-      async () =>
-        await hasElement(
-          `button[role="menuitemcheckbox"][aria-label="${layoutName}"]`
-        ),
-      {
-        timeout: 5_000,
-        interval: 100,
-        timeoutMsg: `layout display menu did not show ${layoutName}`,
-      }
-    )
-
-    await clickBySelector(
-      `button[role="menuitemcheckbox"][aria-label="${layoutName}"]`
-    )
+    await clickBySelector(layoutDisplayMenuItemSelector(layoutName))
 
     await browser.waitUntil(
       async () => await hasElement(layoutButtonSelector),
@@ -60,9 +87,19 @@ export const clickLayoutButton = async (layoutName: string): Promise<void> => {
 export const focusBySelector = async (selector: string): Promise<void> => {
   const ok = await browser.execute((s: string) => {
     const el = document.querySelector<HTMLElement>(s)
-    if (!el) return false
+    if (!el) {
+      return false
+    }
+
     el.focus()
+
     return true
   }, selector)
-  if (!ok) throw new Error(`focusBySelector: no element for ${selector}`)
+
+  if (!ok) {
+    throw new Error(`focusBySelector: no element for ${selector}`)
+  }
 }
+
+const layoutDisplayMenuItemSelector = (layoutName: string): string =>
+  `button[role="menuitemcheckbox"][aria-label="${layoutName}"]`


### PR DESCRIPTION
## Summary
- adds native-overlay dialog payload support for the command palette
- renders the command palette in the menu overlay BrowserWindow so it can appear above Ghostty
- forwards Ghostty/overlay command-palette shortcuts back to the owner Electron renderer while keeping the overlay non-focusable

## Why
The command palette needs the same above-Ghostty native overlay path as menu surfaces, without making the overlay BrowserWindow own keyboard focus.

## Validation
- `npm run lint`
- `npm run type-check:generated`
- `npx vitest run src/components/NativeOverlayHost.test.tsx src/components/Dialog.test.tsx src/features/command-palette/CommandPalette.test.tsx src/components/base/floating/nativeOverlay.test.ts electron/native-overlay.test.ts electron/command-palette-shortcut.test.ts electron/ghostty-native-parent.test.ts`
- pre-push `npm test` hook: 365 files passed, 4488 tests passed, 3 skipped


Refs VIM-266