### PR TITLE
fix(diff): keyboard flow, focus, and sticky-header-aware scrolling

### DIFF
--- a/src/features/diff/Panel.tsx
+++ b/src/features/diff/Panel.tsx
@@ -1023,6 +1023,7 @@ export const Panel = ({
     fileKey: diffSearchFileKey,
     paintEnabled: true,
     focusPanel: focusDiffRoot,
+    scrollContainerRef: diffScrollBodyRef,
   })
 
   const diffSearchPostRenderRef = useRef(diffSearch.handlePostRender)

--- a/src/features/diff/hooks/useDiffSearch.test.ts
+++ b/src/features/diff/hooks/useDiffSearch.test.ts
@@ -56,9 +56,16 @@ const render = (
 ): DiffSearchHookRender => {
   const focusPanel = vi.fn()
 
+  const scrollContainerRef = { current: document.createElement('div') }
+
   const hook = renderHook(
     ({ key, paint }) =>
-      useDiffSearch({ fileKey: key, paintEnabled: paint, focusPanel }),
+      useDiffSearch({
+        fileKey: key,
+        paintEnabled: paint,
+        focusPanel,
+        scrollContainerRef,
+      }),
     { initialProps: { key: fileKey, paint: paintEnabled } }
   )
   // Simulate pierre's first onPostRender so lines are collected.

--- a/src/features/diff/hooks/useDiffSearch.ts
+++ b/src/features/diff/hooks/useDiffSearch.ts
@@ -15,6 +15,8 @@ export interface UseDiffSearchOptions {
   paintEnabled: boolean
   /** Returns focus to the diff panel root. */
   focusPanel: () => void
+  /** The diff scroll body, so match reveals clear the sticky file header. */
+  scrollContainerRef: RefObject<HTMLElement | null>
 }
 
 export interface UseDiffSearchResult {
@@ -46,6 +48,7 @@ export const useDiffSearch = ({
   fileKey,
   paintEnabled,
   focusPanel,
+  scrollContainerRef,
 }: UseDiffSearchOptions): UseDiffSearchResult => {
   const [isOpen, setIsOpen] = useState(false)
   const [query, setQueryState] = useState('')
@@ -209,9 +212,13 @@ export const useDiffSearch = ({
       const next = (activeIndex + direction + matches.length) % matches.length
       hasNavigatedRef.current = true
       setActive(next)
-      scrollToMatch(matches[next], collectedRef.current.elements)
+      scrollToMatch(
+        scrollContainerRef.current,
+        matches[next],
+        collectedRef.current.elements
+      )
     },
-    [activeIndex, matches, setActive]
+    [activeIndex, matches, scrollContainerRef, setActive]
   )
 
   const commit = useCallback(
@@ -221,16 +228,24 @@ export const useDiffSearch = ({
           const next =
             (activeIndex + direction + matches.length) % matches.length
           setActive(next)
-          scrollToMatch(matches[next], collectedRef.current.elements)
+          scrollToMatch(
+            scrollContainerRef.current,
+            matches[next],
+            collectedRef.current.elements
+          )
         } else {
           hasNavigatedRef.current = true
-          scrollToMatch(matches[activeIndex], collectedRef.current.elements)
+          scrollToMatch(
+            scrollContainerRef.current,
+            matches[activeIndex],
+            collectedRef.current.elements
+          )
         }
       }
 
       focusPanel()
     },
-    [activeIndex, focusPanel, matches, setActive]
+    [activeIndex, focusPanel, matches, scrollContainerRef, setActive]
   )
 
   const previousKeyRef = useRef(fileKey)

--- a/src/features/diff/hooks/useReviewTargetNavigation.test.ts
+++ b/src/features/diff/hooks/useReviewTargetNavigation.test.ts
@@ -1,7 +1,10 @@
 import { act, renderHook } from '@testing-library/react'
 import { describe, expect, test, vi } from 'vitest'
 import type { DiffLineAnnotation } from '@pierre/diffs'
-import { useReviewTargetNavigation } from './useReviewTargetNavigation'
+import {
+  isLineRangeFullyVisible,
+  useReviewTargetNavigation,
+} from './useReviewTargetNavigation'
 import type { FileDiff } from '../types'
 import type { ReviewComment } from './useFeedbackBatch'
 
@@ -92,5 +95,86 @@ describe('useReviewTargetNavigation', () => {
 
     expect(result.current.selectedLines).toBeNull()
     expect(result.current.activeTarget).toBeNull()
+  })
+})
+
+const rect = (top: number, bottom: number): DOMRect =>
+  ({
+    top,
+    bottom,
+    height: bottom - top,
+    left: 0,
+    right: 0,
+    width: 0,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  }) as DOMRect
+
+const lineWithRect = (top: number, bottom: number): HTMLElement => {
+  const element = document.createElement('div')
+  element.getBoundingClientRect = (): DOMRect => rect(top, bottom)
+
+  return element
+}
+
+const containerWithViewport = (top: number, bottom: number): HTMLElement => {
+  const element = document.createElement('div')
+  Object.defineProperty(element, 'clientHeight', {
+    value: bottom - top,
+    configurable: true,
+  })
+  element.getBoundingClientRect = (): DOMRect => rect(top, bottom)
+
+  return element
+}
+
+describe('isLineRangeFullyVisible', () => {
+  test('true when the whole hunk range sits inside the viewport', () => {
+    const container = containerWithViewport(0, 500)
+
+    expect(
+      isLineRangeFullyVisible(
+        container,
+        lineWithRect(100, 120),
+        lineWithRect(300, 320)
+      )
+    ).toBe(true)
+  })
+
+  test('false when the range extends below the viewport', () => {
+    const container = containerWithViewport(0, 500)
+
+    expect(
+      isLineRangeFullyVisible(
+        container,
+        lineWithRect(400, 420),
+        lineWithRect(560, 580)
+      )
+    ).toBe(false)
+  })
+
+  test('false when the range starts above the viewport', () => {
+    const container = containerWithViewport(100, 500)
+
+    expect(
+      isLineRangeFullyVisible(
+        container,
+        lineWithRect(40, 60),
+        lineWithRect(200, 220)
+      )
+    ).toBe(false)
+  })
+
+  test('false when the container has no measured height', () => {
+    const container = containerWithViewport(0, 0)
+
+    expect(
+      isLineRangeFullyVisible(
+        container,
+        lineWithRect(10, 20),
+        lineWithRect(30, 40)
+      )
+    ).toBe(false)
   })
 })

--- a/src/features/diff/hooks/useReviewTargetNavigation.test.ts
+++ b/src/features/diff/hooks/useReviewTargetNavigation.test.ts
@@ -1,10 +1,7 @@
 import { act, renderHook } from '@testing-library/react'
 import { describe, expect, test, vi } from 'vitest'
 import type { DiffLineAnnotation } from '@pierre/diffs'
-import {
-  isLineRangeFullyVisible,
-  useReviewTargetNavigation,
-} from './useReviewTargetNavigation'
+import { useReviewTargetNavigation } from './useReviewTargetNavigation'
 import type { FileDiff } from '../types'
 import type { ReviewComment } from './useFeedbackBatch'
 
@@ -95,86 +92,5 @@ describe('useReviewTargetNavigation', () => {
 
     expect(result.current.selectedLines).toBeNull()
     expect(result.current.activeTarget).toBeNull()
-  })
-})
-
-const rect = (top: number, bottom: number): DOMRect =>
-  ({
-    top,
-    bottom,
-    height: bottom - top,
-    left: 0,
-    right: 0,
-    width: 0,
-    x: 0,
-    y: top,
-    toJSON: () => ({}),
-  }) as DOMRect
-
-const lineWithRect = (top: number, bottom: number): HTMLElement => {
-  const element = document.createElement('div')
-  element.getBoundingClientRect = (): DOMRect => rect(top, bottom)
-
-  return element
-}
-
-const containerWithViewport = (top: number, bottom: number): HTMLElement => {
-  const element = document.createElement('div')
-  Object.defineProperty(element, 'clientHeight', {
-    value: bottom - top,
-    configurable: true,
-  })
-  element.getBoundingClientRect = (): DOMRect => rect(top, bottom)
-
-  return element
-}
-
-describe('isLineRangeFullyVisible', () => {
-  test('true when the whole hunk range sits inside the viewport', () => {
-    const container = containerWithViewport(0, 500)
-
-    expect(
-      isLineRangeFullyVisible(
-        container,
-        lineWithRect(100, 120),
-        lineWithRect(300, 320)
-      )
-    ).toBe(true)
-  })
-
-  test('false when the range extends below the viewport', () => {
-    const container = containerWithViewport(0, 500)
-
-    expect(
-      isLineRangeFullyVisible(
-        container,
-        lineWithRect(400, 420),
-        lineWithRect(560, 580)
-      )
-    ).toBe(false)
-  })
-
-  test('false when the range starts above the viewport', () => {
-    const container = containerWithViewport(100, 500)
-
-    expect(
-      isLineRangeFullyVisible(
-        container,
-        lineWithRect(40, 60),
-        lineWithRect(200, 220)
-      )
-    ).toBe(false)
-  })
-
-  test('false when the container has no measured height', () => {
-    const container = containerWithViewport(0, 0)
-
-    expect(
-      isLineRangeFullyVisible(
-        container,
-        lineWithRect(10, 20),
-        lineWithRect(30, 40)
-      )
-    ).toBe(false)
   })
 })

--- a/src/features/diff/hooks/useReviewTargetNavigation.ts
+++ b/src/features/diff/hooks/useReviewTargetNavigation.ts
@@ -407,6 +407,29 @@ const stickyHeaderOffsetForDiffRoot = (root: HTMLElement): number => {
   return height === 0 ? 0 : height + STICKY_HEADER_SCROLL_GAP_PX
 }
 
+// A hunk already sitting fully within the visible viewport (below any sticky
+// header) should not trigger a scroll — moving the cursor is enough. This keeps
+// `[` / `]` from jerking the page when the next hunk is already on screen.
+export const isLineRangeFullyVisible = (
+  container: HTMLElement,
+  firstLine: HTMLElement,
+  lastLine: HTMLElement
+): boolean => {
+  if (container.clientHeight <= 0) {
+    return false
+  }
+
+  const containerRect = container.getBoundingClientRect()
+  const stickyOffset = stickyHeaderOffsetForDiffRoot(container)
+  const firstRect = firstLine.getBoundingClientRect()
+  const lastRect = lastLine.getBoundingClientRect()
+  const top = Math.min(firstRect.top, lastRect.top)
+  const bottom = Math.max(firstRect.bottom, lastRect.bottom)
+  const visibleTop = containerRect.top + stickyOffset
+
+  return top >= visibleTop && bottom <= containerRect.bottom
+}
+
 // Corrects scrollIntoView when the target row lands underneath the sticky
 // header instead of actually being visible.
 const revealLineBelowStickyHeader = (
@@ -649,6 +672,12 @@ export const useReviewTargetNavigation = ({
       const lastLine = findReviewTargetLineElement(node, lastTarget)
       if (firstLine === null || lastLine === null) {
         return false
+      }
+
+      // Already on screen — the cursor moved via activateTarget, so skip the
+      // scroll and report handled to avoid an unnecessary jump (VIM-272).
+      if (isLineRangeFullyVisible(node, firstLine, lastLine)) {
+        return true
       }
 
       firstLine.scrollIntoView({ block: 'start', inline: 'nearest' })

--- a/src/features/diff/hooks/useReviewTargetNavigation.ts
+++ b/src/features/diff/hooks/useReviewTargetNavigation.ts
@@ -14,9 +14,12 @@ import type {
 import type { FileDiff } from '../types'
 import type { DiffStyle } from './useToolbarState'
 import type { ReviewComment } from './useFeedbackBatch'
-
-const PIERRE_DIFF_CONTAINER_SELECTOR = 'diffs-container'
-const STICKY_HEADER_SCROLL_GAP_PX = 4
+import {
+  isLineRangeFullyVisible,
+  lineRangeFitsBelowHeader,
+  PIERRE_DIFF_CONTAINER_SELECTOR,
+  scrollElementIntoViewBelowHeader,
+} from '../scroll/stickyHeaderScroll'
 
 // A review target is the stable comment/navigation address behind a rendered
 // Pierre row. Keyboard and pointer input both resolve to this same shape.
@@ -362,96 +365,6 @@ const findReviewTargetLineElement = (
   return null
 }
 
-// Hunk jumps prefer showing the whole hunk when it can fit in the scroll body.
-const lineRangeFitsContainer = (
-  container: HTMLElement,
-  firstLine: HTMLElement,
-  lastLine: HTMLElement
-): boolean => {
-  if (container.clientHeight <= 0) {
-    return true
-  }
-
-  const firstRect = firstLine.getBoundingClientRect()
-  const lastRect = lastLine.getBoundingClientRect()
-  const top = Math.min(firstRect.top, lastRect.top)
-  const bottom = Math.max(firstRect.bottom, lastRect.bottom)
-
-  return bottom - top <= container.clientHeight
-}
-
-// Sticky Pierre headers can cover the first visible row after scrollIntoView,
-// so measure the active header before nudging rows clear of it.
-const stickyHeaderOffsetForDiffRoot = (root: HTMLElement): number => {
-  const headers = [
-    ...root.querySelectorAll<HTMLElement>('[data-diffs-header][data-sticky]'),
-  ]
-
-  for (const container of root.querySelectorAll<HTMLElement>(
-    PIERRE_DIFF_CONTAINER_SELECTOR
-  )) {
-    if (container.shadowRoot !== null) {
-      headers.push(
-        ...container.shadowRoot.querySelectorAll<HTMLElement>(
-          '[data-diffs-header][data-sticky]'
-        )
-      )
-    }
-  }
-
-  const height = Math.max(
-    0,
-    ...headers.map((header) => header.getBoundingClientRect().height)
-  )
-
-  return height === 0 ? 0 : height + STICKY_HEADER_SCROLL_GAP_PX
-}
-
-// A hunk already sitting fully within the visible viewport (below any sticky
-// header) should not trigger a scroll — moving the cursor is enough. This keeps
-// `[` / `]` from jerking the page when the next hunk is already on screen.
-export const isLineRangeFullyVisible = (
-  container: HTMLElement,
-  firstLine: HTMLElement,
-  lastLine: HTMLElement
-): boolean => {
-  if (container.clientHeight <= 0) {
-    return false
-  }
-
-  const containerRect = container.getBoundingClientRect()
-  const stickyOffset = stickyHeaderOffsetForDiffRoot(container)
-  const firstRect = firstLine.getBoundingClientRect()
-  const lastRect = lastLine.getBoundingClientRect()
-  const top = Math.min(firstRect.top, lastRect.top)
-  const bottom = Math.max(firstRect.bottom, lastRect.bottom)
-  const visibleTop = containerRect.top + stickyOffset
-
-  return top >= visibleTop && bottom <= containerRect.bottom
-}
-
-// Corrects scrollIntoView when the target row lands underneath the sticky
-// header instead of actually being visible.
-const revealLineBelowStickyHeader = (
-  container: HTMLElement,
-  line: HTMLElement,
-  reservePreviousRow: boolean
-): void => {
-  const stickyOffset = stickyHeaderOffsetForDiffRoot(container)
-  if (stickyOffset === 0) {
-    return
-  }
-
-  const containerTop = container.getBoundingClientRect().top
-  const lineRect = line.getBoundingClientRect()
-  const rowOffset = reservePreviousRow ? lineRect.height : 0
-  const overlap = containerTop + stickyOffset + rowOffset - lineRect.top
-
-  if (overlap > 0) {
-    container.scrollTop = Math.max(0, container.scrollTop - Math.ceil(overlap))
-  }
-}
-
 // Applies the small set of scroll rules the diff view needs: nearest for normal
 // moves, top/bottom at the file edges, then sticky-header correction.
 const scrollLineElementIntoView = (
@@ -462,38 +375,39 @@ const scrollLineElementIntoView = (
   delta: number
 ): void => {
   if (delta === 0) {
-    line.scrollIntoView({ block: 'nearest', inline: 'nearest' })
-    revealLineBelowStickyHeader(container, line, false)
+    scrollElementIntoViewBelowHeader(container, line, { block: 'nearest' })
 
     return
   }
 
   if (targetCount === 1) {
-    line.scrollIntoView({
+    scrollElementIntoViewBelowHeader(container, line, {
       block: delta > 0 ? 'end' : 'start',
-      inline: 'nearest',
+      reservePreviousRow: delta < 0,
     })
-    revealLineBelowStickyHeader(container, line, delta < 0)
 
     return
   }
 
   if (targetIndex === 0) {
-    line.scrollIntoView({ block: 'start', inline: 'nearest' })
-    revealLineBelowStickyHeader(container, line, delta < 0)
+    scrollElementIntoViewBelowHeader(container, line, {
+      block: 'start',
+      reservePreviousRow: delta < 0,
+    })
 
     return
   }
 
   if (targetIndex === targetCount - 1) {
-    line.scrollIntoView({ block: 'end', inline: 'nearest' })
-    revealLineBelowStickyHeader(container, line, false)
+    scrollElementIntoViewBelowHeader(container, line, { block: 'end' })
 
     return
   }
 
-  line.scrollIntoView({ block: 'nearest', inline: 'nearest' })
-  revealLineBelowStickyHeader(container, line, delta < 0)
+  scrollElementIntoViewBelowHeader(container, line, {
+    block: 'nearest',
+    reservePreviousRow: delta < 0,
+  })
 }
 
 // After page scrolling, use the row closest to the viewport center as the new
@@ -680,11 +594,11 @@ export const useReviewTargetNavigation = ({
         return true
       }
 
-      firstLine.scrollIntoView({ block: 'start', inline: 'nearest' })
+      scrollElementIntoViewBelowHeader(node, firstLine, { block: 'start' })
 
       if (
         firstLine === lastLine ||
-        !lineRangeFitsContainer(node, firstLine, lastLine)
+        !lineRangeFitsBelowHeader(node, firstLine, lastLine)
       ) {
         return true
       }

--- a/src/features/diff/scroll/stickyHeaderScroll.test.ts
+++ b/src/features/diff/scroll/stickyHeaderScroll.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, test, vi } from 'vitest'
+import {
+  isLineRangeFullyVisible,
+  lineRangeFitsBelowHeader,
+  scrollElementIntoViewBelowHeader,
+  stickyHeaderOffsetForDiffRoot,
+} from './stickyHeaderScroll'
+
+const rect = (top: number, bottom: number): DOMRect =>
+  ({
+    top,
+    bottom,
+    height: bottom - top,
+    left: 0,
+    right: 0,
+    width: 0,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  }) as DOMRect
+
+const withRect = (
+  element: HTMLElement,
+  top: number,
+  bottom: number
+): HTMLElement => {
+  element.getBoundingClientRect = (): DOMRect => rect(top, bottom)
+
+  return element
+}
+
+const lineWithRect = (top: number, bottom: number): HTMLElement =>
+  withRect(document.createElement('div'), top, bottom)
+
+const containerWithViewport = (top: number, bottom: number): HTMLElement => {
+  const element = document.createElement('div')
+  Object.defineProperty(element, 'clientHeight', {
+    value: bottom - top,
+    configurable: true,
+  })
+
+  return withRect(element, top, bottom)
+}
+
+// Appends a sticky file header of the given height so the container reports a
+// non-zero offset (jsdom has no layout, so rects are mocked).
+const attachStickyHeader = (container: HTMLElement, height: number): void => {
+  const header = document.createElement('div')
+  header.setAttribute('data-diffs-header', 'split')
+  header.setAttribute('data-sticky', '')
+  withRect(header, 0, height)
+  container.appendChild(header)
+}
+
+describe('stickyHeaderOffsetForDiffRoot', () => {
+  test('returns 0 when no sticky header is present', () => {
+    expect(stickyHeaderOffsetForDiffRoot(document.createElement('div'))).toBe(0)
+  })
+
+  test('returns the header height plus a breathing gap', () => {
+    const container = containerWithViewport(0, 500)
+    attachStickyHeader(container, 40)
+
+    expect(stickyHeaderOffsetForDiffRoot(container)).toBe(44)
+  })
+})
+
+describe('isLineRangeFullyVisible', () => {
+  test('true when the whole range sits below the header inside the viewport', () => {
+    const container = containerWithViewport(0, 500)
+
+    expect(
+      isLineRangeFullyVisible(
+        container,
+        lineWithRect(100, 120),
+        lineWithRect(300, 320)
+      )
+    ).toBe(true)
+  })
+
+  test('false when the range extends below the viewport', () => {
+    const container = containerWithViewport(0, 500)
+
+    expect(
+      isLineRangeFullyVisible(
+        container,
+        lineWithRect(400, 420),
+        lineWithRect(560, 580)
+      )
+    ).toBe(false)
+  })
+
+  test('false when the range is hidden under the sticky header', () => {
+    const container = containerWithViewport(0, 500)
+    attachStickyHeader(container, 40)
+
+    // Top row at y=20 is inside the container but under the 44px header band.
+    expect(
+      isLineRangeFullyVisible(
+        container,
+        lineWithRect(20, 40),
+        lineWithRect(200, 220)
+      )
+    ).toBe(false)
+  })
+
+  test('false when the container has no measured height', () => {
+    const container = containerWithViewport(0, 0)
+
+    expect(
+      isLineRangeFullyVisible(
+        container,
+        lineWithRect(10, 20),
+        lineWithRect(30, 40)
+      )
+    ).toBe(false)
+  })
+})
+
+describe('lineRangeFitsBelowHeader', () => {
+  test('true when the range fits within the header-adjusted height', () => {
+    const container = containerWithViewport(0, 500)
+    attachStickyHeader(container, 40)
+
+    // 400px range vs 500 - 44 = 456px available.
+    expect(
+      lineRangeFitsBelowHeader(
+        container,
+        lineWithRect(0, 200),
+        lineWithRect(200, 400)
+      )
+    ).toBe(true)
+  })
+
+  test('false when the header eats enough height that the range no longer fits', () => {
+    const container = containerWithViewport(0, 500)
+    attachStickyHeader(container, 100)
+
+    // 460px range vs 500 - 104 = 396px available.
+    expect(
+      lineRangeFitsBelowHeader(
+        container,
+        lineWithRect(0, 230),
+        lineWithRect(230, 460)
+      )
+    ).toBe(false)
+  })
+})
+
+describe('scrollElementIntoViewBelowHeader', () => {
+  test('scrolls the element into view, defaulting block to nearest', () => {
+    const container = containerWithViewport(0, 500)
+    const element = lineWithRect(100, 120)
+    const scrollSpy = vi.fn()
+    element.scrollIntoView = scrollSpy
+
+    scrollElementIntoViewBelowHeader(container, element)
+
+    expect(scrollSpy).toHaveBeenCalledWith({
+      block: 'nearest',
+      inline: 'nearest',
+    })
+  })
+
+  test('nudges the scroll position when the element lands under the header', () => {
+    const container = containerWithViewport(0, 500)
+    container.scrollTop = 100
+    attachStickyHeader(container, 40)
+    const element = lineWithRect(10, 30)
+    element.scrollIntoView = vi.fn()
+
+    scrollElementIntoViewBelowHeader(container, element, { block: 'start' })
+
+    // overlap = containerTop(0) + offset(44) - lineTop(10) = 34 → scrollTop -= 34.
+    expect(container.scrollTop).toBe(66)
+  })
+
+  test('leaves the scroll position alone when there is no sticky header', () => {
+    const container = containerWithViewport(0, 500)
+    container.scrollTop = 100
+    const element = lineWithRect(10, 30)
+    element.scrollIntoView = vi.fn()
+
+    scrollElementIntoViewBelowHeader(container, element, { block: 'start' })
+
+    expect(container.scrollTop).toBe(100)
+  })
+})

--- a/src/features/diff/scroll/stickyHeaderScroll.ts
+++ b/src/features/diff/scroll/stickyHeaderScroll.ts
@@ -1,0 +1,128 @@
+// Shared, header-aware scroll primitive for the diff viewer. Every navigation
+// and search path routes reveal-a-target scrolling through here so the sticky
+// per-file header is always compensated for — the "always take the file header
+// into account" guarantee (VIM-280). Pierre renders each file inside a
+// `diffs-container` custom element with an open shadow root, and the sticky file
+// header lives inside that shadow tree.
+
+export const PIERRE_DIFF_CONTAINER_SELECTOR = 'diffs-container'
+
+// Small breathing gap so a revealed row never sits flush against the header.
+const STICKY_HEADER_SCROLL_GAP_PX = 4
+
+// Measures the tallest sticky file header covering the top of the scroll body,
+// looking in both the light DOM (tests) and every Pierre shadow root. Returns 0
+// when no sticky header is present (e.g. the file header is disabled).
+export const stickyHeaderOffsetForDiffRoot = (root: HTMLElement): number => {
+  const headers = [
+    ...root.querySelectorAll<HTMLElement>('[data-diffs-header][data-sticky]'),
+  ]
+
+  for (const container of root.querySelectorAll<HTMLElement>(
+    PIERRE_DIFF_CONTAINER_SELECTOR
+  )) {
+    if (container.shadowRoot !== null) {
+      headers.push(
+        ...container.shadowRoot.querySelectorAll<HTMLElement>(
+          '[data-diffs-header][data-sticky]'
+        )
+      )
+    }
+  }
+
+  const height = Math.max(
+    0,
+    ...headers.map((header) => header.getBoundingClientRect().height)
+  )
+
+  return height === 0 ? 0 : height + STICKY_HEADER_SCROLL_GAP_PX
+}
+
+// A range already sitting fully within the visible viewport (below any sticky
+// header) needs no scroll — moving the cursor is enough. Keeps `[` / `]` from
+// jerking the page when the next hunk is already on screen (VIM-272).
+export const isLineRangeFullyVisible = (
+  container: HTMLElement,
+  firstLine: HTMLElement,
+  lastLine: HTMLElement
+): boolean => {
+  if (container.clientHeight <= 0) {
+    return false
+  }
+
+  const containerRect = container.getBoundingClientRect()
+  const stickyOffset = stickyHeaderOffsetForDiffRoot(container)
+  const firstRect = firstLine.getBoundingClientRect()
+  const lastRect = lastLine.getBoundingClientRect()
+  const top = Math.min(firstRect.top, lastRect.top)
+  const bottom = Math.max(firstRect.bottom, lastRect.bottom)
+  const visibleTop = containerRect.top + stickyOffset
+
+  return top >= visibleTop && bottom <= containerRect.bottom
+}
+
+// Whether a line range fits within the header-adjusted visible height, so hunk
+// jumps only try to show the whole range when it can actually clear the header.
+export const lineRangeFitsBelowHeader = (
+  container: HTMLElement,
+  firstLine: HTMLElement,
+  lastLine: HTMLElement
+): boolean => {
+  if (container.clientHeight <= 0) {
+    return true
+  }
+
+  const available =
+    container.clientHeight - stickyHeaderOffsetForDiffRoot(container)
+  const firstRect = firstLine.getBoundingClientRect()
+  const lastRect = lastLine.getBoundingClientRect()
+  const top = Math.min(firstRect.top, lastRect.top)
+  const bottom = Math.max(firstRect.bottom, lastRect.bottom)
+
+  return bottom - top <= available
+}
+
+// Corrects scrollIntoView when the target row lands underneath the sticky
+// header instead of actually being visible.
+const revealLineBelowStickyHeader = (
+  container: HTMLElement,
+  line: HTMLElement,
+  reservePreviousRow: boolean
+): void => {
+  const stickyOffset = stickyHeaderOffsetForDiffRoot(container)
+  if (stickyOffset === 0) {
+    return
+  }
+
+  const containerTop = container.getBoundingClientRect().top
+  const lineRect = line.getBoundingClientRect()
+  const rowOffset = reservePreviousRow ? lineRect.height : 0
+  const overlap = containerTop + stickyOffset + rowOffset - lineRect.top
+
+  if (overlap > 0) {
+    container.scrollTop = Math.max(0, container.scrollTop - Math.ceil(overlap))
+  }
+}
+
+// THE shared entry point: scroll `element` into `container`, then nudge it clear
+// of the sticky file header. `reservePreviousRow` keeps one row visible above
+// the target on upward moves.
+export const scrollElementIntoViewBelowHeader = (
+  container: HTMLElement,
+  element: HTMLElement,
+  options: {
+    block?: ScrollLogicalPosition
+    reservePreviousRow?: boolean
+  } = {}
+): void => {
+  element.scrollIntoView({
+    block: options.block ?? 'nearest',
+    inline: 'nearest',
+  })
+
+  revealLineBelowStickyHeader(
+    container,
+    element,
+    options.reservePreviousRow ?? false
+  )
+}

--- a/src/features/diff/search/diffSearchDom.test.ts
+++ b/src/features/diff/search/diffSearchDom.test.ts
@@ -251,20 +251,36 @@ describe('paintMatches / clearPaint (stubbed registry)', () => {
 })
 
 describe('scrollToMatch', () => {
-  test('scrolls the matched line element into view', () => {
+  test('routes through the header-aware primitive when a container is present', () => {
+    const container = document.createElement('div')
     const el = document.createElement('div')
     const scrollSpy = vi.fn()
     el.scrollIntoView = scrollSpy
     const elements = new Map([['additions:0,0', el]])
 
     scrollToMatch(
-      {
-        key: 'additions:0,0',
-        side: 'additions',
-        order: 0,
-        start: 0,
-        end: 1,
-      },
+      container,
+      { key: 'additions:0,0', side: 'additions', order: 0, start: 0, end: 1 },
+      elements
+    )
+
+    // The shared primitive always passes inline:'nearest'; the old header-blind
+    // path passed only { block: 'nearest' }.
+    expect(scrollSpy).toHaveBeenCalledWith({
+      block: 'nearest',
+      inline: 'nearest',
+    })
+  })
+
+  test('falls back to a plain scroll when no container is available', () => {
+    const el = document.createElement('div')
+    const scrollSpy = vi.fn()
+    el.scrollIntoView = scrollSpy
+    const elements = new Map([['additions:0,0', el]])
+
+    scrollToMatch(
+      null,
+      { key: 'additions:0,0', side: 'additions', order: 0, start: 0, end: 1 },
       elements
     )
 

--- a/src/features/diff/search/diffSearchDom.ts
+++ b/src/features/diff/search/diffSearchDom.ts
@@ -3,6 +3,7 @@ import type {
   DiffSearchMatch,
   DiffSearchSide,
 } from './matchDiffLines'
+import { scrollElementIntoViewBelowHeader } from '../scroll/stickyHeaderScroll'
 
 export const DIFF_SEARCH_HIGHLIGHT = 'vf-diff-search'
 
@@ -192,8 +193,22 @@ export const clearPaint = (): void => {
 }
 
 export const scrollToMatch = (
+  container: HTMLElement | null,
   match: DiffSearchMatch,
   elements: Map<string, HTMLElement>
 ): void => {
-  elements.get(match.key)?.scrollIntoView({ block: 'nearest' })
+  const element = elements.get(match.key)
+  if (element === undefined) {
+    return
+  }
+
+  // No scroll container available (before pierre's first render): fall back to a
+  // plain scroll so the match is at least reachable, without header correction.
+  if (container === null) {
+    element.scrollIntoView({ block: 'nearest' })
+
+    return
+  }
+
+  scrollElementIntoViewBelowHeader(container, element, { block: 'nearest' })
 }

--- a/src/features/workspace/hooks/useDockShortcuts.test.ts
+++ b/src/features/workspace/hooks/useDockShortcuts.test.ts
@@ -282,4 +282,69 @@ describe('useDockShortcuts', () => {
 
     document.body.removeChild(cmEditor)
   })
+
+  test('Cmd+g fires openDock("diff") from within the terminal zone (macOS jump-to-diff)', () => {
+    // macOS terminals drive vim/readline with Ctrl, so Cmd+g never collides — it
+    // must reach the diff dock even when xterm has focus (VIM-277).
+    const props = makeProps({ modKey: '⌘' })
+
+    const terminalZone = document.createElement('div')
+    terminalZone.setAttribute('data-container-id', TERMINAL_CONTAINER_ID)
+    const xtermTextarea = document.createElement('textarea')
+    xtermTextarea.className = 'xterm-helper-textarea'
+    terminalZone.appendChild(xtermTextarea)
+    document.body.appendChild(terminalZone)
+    xtermTextarea.focus()
+
+    renderHook(() => useDockShortcuts(props))
+    const event = fire('g', { metaKey: true })
+
+    expect(props.openDock).toHaveBeenCalledWith('diff')
+    expect(event.preventDefaultSpy).toHaveBeenCalled()
+
+    document.body.removeChild(terminalZone)
+  })
+
+  test('Cmd+e fires openDock("editor") from within the terminal zone (macOS jump-to-editor)', () => {
+    const props = makeProps({ modKey: '⌘' })
+
+    const terminalZone = document.createElement('div')
+    terminalZone.setAttribute('data-container-id', TERMINAL_CONTAINER_ID)
+    const xtermTextarea = document.createElement('textarea')
+    xtermTextarea.className = 'xterm-helper-textarea'
+    terminalZone.appendChild(xtermTextarea)
+    document.body.appendChild(terminalZone)
+    xtermTextarea.focus()
+
+    renderHook(() => useDockShortcuts(props))
+    const event = fire('e', { metaKey: true })
+
+    expect(props.openDock).toHaveBeenCalledWith('editor')
+    expect(event.preventDefaultSpy).toHaveBeenCalled()
+
+    document.body.removeChild(terminalZone)
+  })
+
+  test('Cmd+g does not fire when CodeMirror has focus (find-next preserved)', () => {
+    // CodeMirror binds Cmd/Ctrl+g to find-next; the guard must still hold there
+    // even though it now lets Cmd+g out of the terminal zone (VIM-277).
+    const props = makeProps({ modKey: '⌘' })
+
+    const cmEditor = document.createElement('div')
+    cmEditor.className = 'cm-editor'
+    const cmContent = document.createElement('div')
+    cmContent.setAttribute('contenteditable', 'true')
+    cmContent.className = 'cm-content'
+    cmEditor.appendChild(cmContent)
+    document.body.appendChild(cmEditor)
+    cmContent.focus()
+
+    renderHook(() => useDockShortcuts(props))
+    const event = fire('g', { metaKey: true })
+
+    expect(props.openDock).not.toHaveBeenCalled()
+    expect(event.preventDefaultSpy).not.toHaveBeenCalled()
+
+    document.body.removeChild(cmEditor)
+  })
 })

--- a/src/features/workspace/hooks/useDockShortcuts.ts
+++ b/src/features/workspace/hooks/useDockShortcuts.ts
@@ -72,10 +72,17 @@ export const useDockShortcuts = ({
 
       const key = event.key.toLowerCase()
 
-      // Ctrl+e / Ctrl+g: do not steal vim/readline shortcuts when xterm or
-      // CodeMirror has focus. Ctrl+b is exempt — it only fires when dock is
-      // active (checked below), so it can never originate from either surface.
-      if ((key === 'e' || key === 'g') && (inTerminalZone || inCodeMirror)) {
+      // Ctrl+e / Ctrl+g would clobber vim/readline (both Ctrl-based) in xterm,
+      // and Cmd/Ctrl+g is find-next inside CodeMirror — keep those guarded. But
+      // Cmd+e / Cmd+g don't collide with the terminal (macOS terminals drive
+      // vim/readline with Ctrl), so let them out of the terminal zone to reach
+      // the dock from anywhere. Ctrl+b is exempt — it only fires when the dock
+      // is active (checked below), so it can never originate from either surface.
+      const modifierCollidesWithTerminal = modKeyRef.current === 'Ctrl'
+      if (
+        (key === 'e' || key === 'g') &&
+        (inCodeMirror || (inTerminalZone && modifierCollidesWithTerminal))
+      ) {
         return
       }
 


### PR DESCRIPTION
**Diff Review UX Polish** milestone — the dogfooding findings that don't touch the theme layer (so independent of #647).

## Fixes

### `Cmd+G` / `Cmd+E` reach the dock from the terminal (VIM-277)
The dock shortcut guard dropped `e`/`g` whenever focus was in the terminal or CodeMirror, so once focus landed in the terminal there was no way to `Cmd+G` back to the diff. macOS terminals drive vim/readline with **Ctrl**, so `Cmd+G`/`Cmd+E` never collide there — the guard now only blocks the terminal zone when the active modifier is Ctrl (Linux). CodeMirror stays fully guarded (`Cmd/Ctrl+G` is find-next there). `openDock` already opens a collapsed dock, so this also covers the "open when collapsed" case.

### `[` / `]` don't scroll when the next hunk is already on screen (VIM-272)
Hunk navigation always scrolled the target hunk to the top, even when it was already fully visible. `scrollHunkIntoView` now short-circuits when the hunk range sits fully within the viewport (below any sticky header); the cursor still moves via `activateTarget`.

### Sticky file-header compensation is now intrinsic to all scroll paths (VIM-280)
In-file search (VIM-252) scrolled to a match with a bare `scrollIntoView` and no handle to the scroll body, so scrolling **up** parked the match under the sticky file header. The `[` / `]` hunk-scroll branch had the same gap. Root cause: four independent scroll paths, with header compensation living privately in one of them.

Extracted a shared `src/features/diff/scroll/stickyHeaderScroll.ts` — `scrollElementIntoViewBelowHeader` (scroll + reveal-below-header) plus `stickyHeaderOffsetForDiffRoot` / `isLineRangeFullyVisible` / `lineRangeFitsBelowHeader`. Review-nav (j/k · h/l · `[`/`]`) and search both route through it, and the search hook is threaded the diff scroll container. Any future scroll path gets header-awareness for free.

## Tests
- New `stickyHeaderScroll.test.ts` (11): offset measurement, visibility/fit predicates, reveal-scroll correction.
- `useDockShortcuts` / `useReviewTargetNavigation` / `diffSearchDom` / `useDiffSearch` updated; the behavior-preserving refactor is covered by the existing suites.
- Full gate green: type-check, lint (0 errors), format, `vitest run` (4520 passed).

Closes VIM-272
Closes VIM-277
Closes VIM-280

Deferred: **VIM-276** (theme-change focus loss) rides a later batch, after #647 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
