### PR TITLE
feat(diff): copy review comments and auto-hide the files panel

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -52,7 +52,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 19       | 19   | 2026-06-21   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)                                             | cross-platform     | 12       | 12   | 2026-06-22   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                                                       | code-quality       | 7        | 0    | 2026-06-11   |
-| [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 20       | 17   | 2026-07-01   |
+| [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 21       | 18   | 2026-07-03   |
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 8        | 2    | 2026-06-19   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 4        | 0    | 2026-06-21   |

--- a/docs/reviews/patterns/derived-state-consistency.md
+++ b/docs/reviews/patterns/derived-state-consistency.md
@@ -2,8 +2,8 @@
 id: derived-state-consistency
 category: code-quality
 created: 2026-06-07
-last_updated: 2026-07-01
-ref_count: 17
+last_updated: 2026-07-03
+ref_count: 18
 ---
 
 # Derived State Consistency
@@ -256,4 +256,21 @@ base data is technically "correct."
   rebuild the edit target from `startLine` plus `endLine`; otherwise keep the
   single-line fallback. Added a regression test that opens an existing R1-R2
   comment for edit and submits the updated text through the range dialog.
+- **Commit:** same commit as this entry
+
+### 21. Copied feedback used weaker path derivation than sent feedback
+
+- **Source:** github-codex-connector | PR #650 round 1 | 2026-07-03
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/diff/Panel.tsx`
+- **Finding:** The terminal send path resolved each feedback batch key through
+  the stored repo root before formatting, but the clipboard fallback parsed the
+  same batch keys directly into repo-relative paths. Pasting copied feedback
+  into an agent running from a repo subdirectory could therefore point at the
+  wrong file.
+- **Fix:** Extracted one shared feedback-entry builder for send and copy, using
+  the per-cwd repo-root lookup before falling back to the current or last-known
+  root. Added a clipboard regression test that copies a batch authored from a
+  repo subdirectory and asserts the payload contains the resolved repo-root
+  path.
 - **Commit:** same commit as this entry

--- a/src/features/diff/Panel.test.tsx
+++ b/src/features/diff/Panel.test.tsx
@@ -422,7 +422,10 @@ describe('Panel', () => {
 
       const feedbackBatch: UseFeedbackBatchReturn = {
         batch: new Map([
-          [makeBatchKey('/repo/current', 'src/foo.ts', false), [annotation]],
+          [
+            makeBatchKey('/repo/packages/app', 'src/foo.ts', false),
+            [annotation],
+          ],
         ]),
         annotationsForFile: () => [],
         addAnnotation: () => 'ok',
@@ -434,7 +437,7 @@ describe('Panel', () => {
 
       vi.spyOn(useGitStatusModule, 'useGitStatus').mockReturnValue({
         files: [],
-        filesCwd: '/repo/current',
+        filesCwd: '/repo/packages/app',
         loading: false,
         error: null,
         refresh: vi.fn(),
@@ -445,7 +448,17 @@ describe('Panel', () => {
         fileDiffMock({ diff: null, loading: false, error: null })
       )
 
-      render(<Panel cwd="/repo/current" feedbackBatch={feedbackBatch} />)
+      render(
+        <Panel
+          cwd="/repo/packages/app"
+          feedbackBatch={feedbackBatch}
+          feedbackRepoRootRef={{
+            current: '',
+            repoRootForCwd: (entryCwd: string): string =>
+              entryCwd === '/repo/packages/app' ? '/repo' : '',
+          }}
+        />
+      )
 
       await user.click(
         screen.getByRole('button', { name: /finish feedback \(1\)/i })
@@ -457,7 +470,8 @@ describe('Panel', () => {
       await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1))
       const payload = writeText.mock.calls[0][0] as string
       expect(payload).toContain('Needs review')
-      expect(payload).toContain('src/foo.ts')
+      expect(payload).toContain('/repo/src/foo.ts')
+      expect(payload).not.toContain('> src/foo.ts:5')
     } finally {
       Object.defineProperty(window.navigator, 'clipboard', {
         value: originalClipboard,

--- a/src/features/diff/Panel.test.tsx
+++ b/src/features/diff/Panel.test.tsx
@@ -398,6 +398,75 @@ describe('Panel', () => {
     ).toBeInTheDocument()
   })
 
+  test('copies review comments to the clipboard from the finish popover', async (): Promise<void> => {
+    const user = userEvent.setup()
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    const originalClipboard = window.navigator.clipboard
+    Object.defineProperty(window.navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+      writable: true,
+    })
+
+    try {
+      const annotation: DiffLineAnnotation<ReviewComment> = {
+        side: 'additions',
+        lineNumber: 5,
+        metadata: {
+          id: 'comment-1',
+          text: 'Needs review',
+          author: 'self',
+          createdAt: 1000,
+        },
+      }
+
+      const feedbackBatch: UseFeedbackBatchReturn = {
+        batch: new Map([
+          [makeBatchKey('/repo/current', 'src/foo.ts', false), [annotation]],
+        ]),
+        annotationsForFile: () => [],
+        addAnnotation: () => 'ok',
+        updateAnnotation: vi.fn(),
+        removeAnnotation: vi.fn(),
+        clearBatch: vi.fn(),
+        totalAnnotations: () => 1,
+      }
+
+      vi.spyOn(useGitStatusModule, 'useGitStatus').mockReturnValue({
+        files: [],
+        filesCwd: '/repo/current',
+        loading: false,
+        error: null,
+        refresh: vi.fn(),
+        idle: false,
+      })
+
+      vi.spyOn(useFileDiffModule, 'useFileDiff').mockReturnValue(
+        fileDiffMock({ diff: null, loading: false, error: null })
+      )
+
+      render(<Panel cwd="/repo/current" feedbackBatch={feedbackBatch} />)
+
+      await user.click(
+        screen.getByRole('button', { name: /finish feedback \(1\)/i })
+      )
+      await screen.findByRole('dialog', { name: 'Finish feedback' })
+
+      await user.click(screen.getByRole('button', { name: 'Copy (c)' }))
+
+      await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1))
+      const payload = writeText.mock.calls[0][0] as string
+      expect(payload).toContain('Needs review')
+      expect(payload).toContain('src/foo.ts')
+    } finally {
+      Object.defineProperty(window.navigator, 'clipboard', {
+        value: originalClipboard,
+        configurable: true,
+        writable: true,
+      })
+    }
+  })
+
   test('keeps draft-only feedback discard available in the empty state', async (): Promise<void> => {
     const user = userEvent.setup()
     const clearBatch = vi.fn()
@@ -831,6 +900,63 @@ describe('Panel', () => {
       fireEvent.mouseLeave(screen.getByTestId('changed-files-edge-hint'))
       act(() => {
         vi.advanceTimersByTime(219)
+      })
+      expect(screen.getByTestId('changed-files-pane')).toBeInTheDocument()
+
+      act(() => {
+        vi.advanceTimersByTime(1)
+      })
+
+      expect(screen.queryByTestId('changed-files-pane')).not.toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  test('keyboard reveal (e) auto-hides the changed-files panel after ~5s', (): void => {
+    vi.useFakeTimers()
+
+    try {
+      vi.spyOn(useGitStatusModule, 'useGitStatus').mockReturnValue({
+        files: [
+          {
+            path: 'src/App.tsx',
+            status: 'modified',
+            staged: false,
+          },
+        ],
+        filesCwd: '.',
+        loading: false,
+        error: null,
+        refresh: vi.fn(),
+        idle: false,
+      })
+
+      vi.spyOn(useFileDiffModule, 'useFileDiff').mockReturnValue(
+        fileDiffMock({
+          diff: {
+            filePath: 'src/App.tsx',
+            oldPath: 'src/App.tsx',
+            newPath: 'src/App.tsx',
+            hunks: [],
+          },
+          loading: false,
+          error: null,
+          oldText: 'old',
+          newText: 'new',
+          rawDiff: '',
+        })
+      )
+
+      render(<Panel />)
+
+      fireEvent.keyDown(screen.getByTestId('diff-populated-state'), {
+        key: 'e',
+      })
+      expect(screen.getByTestId('changed-files-pane')).toBeInTheDocument()
+
+      act(() => {
+        vi.advanceTimersByTime(4999)
       })
       expect(screen.getByTestId('changed-files-pane')).toBeInTheDocument()
 

--- a/src/features/diff/Panel.tsx
+++ b/src/features/diff/Panel.tsx
@@ -38,8 +38,10 @@ import { useKeyboard } from './hooks/useKeyboard'
 import { useDiffSearch } from './hooks/useDiffSearch'
 import {
   dispatchFeedbackBatch,
+  formatFeedbackPayload,
   type DispatchEntry,
 } from './services/feedbackDispatch'
+import { writeClipboardText } from '@/lib/clipboard'
 import {
   resolveCandidatePanes,
   type PaneCandidate,
@@ -66,6 +68,11 @@ const DIFF_NATIVE_FOCUS_SELECTOR =
   'button, input, textarea, select, [contenteditable], [role="textbox"]'
 const FILES_LIST_STORAGE_KEY = 'vf-diff-files-open'
 const FILES_LIST_CLOSE_DELAY_MS = 220
+
+// A keyboard reveal (`e`) has no mouse-leave to close it, so it self-dismisses
+// after this delay — longer than the hover-leave delay since there's no pointer
+// motion to signal intent. Wire to Settings later.
+const FILES_LIST_KEYBOARD_AUTO_HIDE_MS = 5000
 
 const getFilesListStorage = (): Storage | null => {
   if (typeof window === 'undefined') {
@@ -454,8 +461,23 @@ export const Panel = ({
       return
     }
 
-    setFilesListRevealed((open) => !open)
-  }, [clearFilesListHideTimer, filesListPinnedOpen, focusDiffRoot])
+    const willReveal = !filesListRevealed
+    setFilesListRevealed(willReveal)
+
+    // Timed self-dismiss for the keyboard reveal; any interaction (hover/focus/
+    // pin/file-select) clears this via the shared hide timer.
+    if (willReveal) {
+      filesListHideTimerRef.current = setTimeout(() => {
+        setFilesListRevealed(false)
+        filesListHideTimerRef.current = null
+      }, FILES_LIST_KEYBOARD_AUTO_HIDE_MS)
+    }
+  }, [
+    clearFilesListHideTimer,
+    filesListPinnedOpen,
+    filesListRevealed,
+    focusDiffRoot,
+  ])
 
   const scheduleHideFilesList = useCallback((): void => {
     clearFilesListHideTimer()
@@ -761,6 +783,33 @@ export const Panel = ({
     },
     [feedback, feedbackDispatch, notifyInfo, repoRootRef, response]
   )
+
+  // Copy the whole review to the clipboard — the escape hatch when no agent is
+  // running to send to (comments are otherwise trapped in the batch). Repo-
+  // relative paths from the batch keys are enough for a human paste target.
+  const handleCopyFeedback = useCallback((): void => {
+    const entries: DispatchEntry[] = []
+    for (const [key, annotations] of feedback.batch) {
+      const { filePath, staged } = parseBatchKey(key)
+      entries.push({ filePath, staged, annotations })
+    }
+
+    if (entries.length === 0) {
+      return
+    }
+
+    const count = feedback.totalAnnotations()
+    setFinishOpen(false)
+
+    void (async (): Promise<void> => {
+      const copied = await writeClipboardText(formatFeedbackPayload(entries))
+      notifyInfo(
+        copied
+          ? `Copied ${count} comment${count === 1 ? '' : 's'} to the clipboard.`
+          : 'Could not copy comments to the clipboard.'
+      )
+    })()
+  }, [feedback, notifyInfo])
 
   // Single-flight staging flag — drops clicks while an IPC is in flight.
   const [staging, setStaging] = useState(false)
@@ -1836,6 +1885,7 @@ export const Panel = ({
     fileCount: feedback.batch.size,
     onCancel: (): void => setFinishOpen(false),
     onSend: handleSendFeedback,
+    onCopy: handleCopyFeedback,
   }
 
   // Loading state

--- a/src/features/diff/Panel.tsx
+++ b/src/features/diff/Panel.tsx
@@ -713,6 +713,35 @@ export const Panel = ({
 
   const sendingFeedbackRef = useRef(false)
 
+  const buildFeedbackEntries = useCallback((): DispatchEntry[] => {
+    // git reports file paths relative to the repo TOPLEVEL, but the target
+    // agent runs in the pane's cwd (possibly a repo subdirectory). Join the
+    // toplevel (`response.repoRoot`) so the dispatched reference is an
+    // absolute path the agent can resolve regardless of its cwd. Falls back to
+    // the repo-relative path if the root is unavailable (not in a git repo).
+    // Prefer the per-batch cwd root; fall back to the current diff's root, then
+    // the last-known root when `response` is transiently null (file-switch
+    // loading/error) so an in-flight batch keeps absolute paths.
+    const repoRoot = response?.repoRoot ?? repoRootRef.current
+    const entries: DispatchEntry[] = []
+
+    for (const [key, annotations] of feedback.batch) {
+      const { cwd: entryCwd, filePath: relPath, staged } = parseBatchKey(key)
+
+      const entryRepoRoot = repoRootRef.repoRootForCwd?.(entryCwd)
+
+      const resolvedRepoRoot =
+        entryRepoRoot && entryRepoRoot.length > 0 ? entryRepoRoot : repoRoot
+
+      const filePath = resolvedRepoRoot
+        ? `${resolvedRepoRoot}/${relPath}`
+        : relPath
+      entries.push({ filePath, staged, annotations })
+    }
+
+    return entries
+  }, [feedback.batch, repoRootRef, response])
+
   const handleSendFeedback = useCallback(
     (pane: PaneCandidate): void => {
       if (sendingFeedbackRef.current) {
@@ -720,44 +749,7 @@ export const Panel = ({
       }
       sendingFeedbackRef.current = true
       void (async (): Promise<void> => {
-        // git reports file paths relative to the repo TOPLEVEL, but the target
-        // agent runs in the pane's cwd (possibly a repo subdirectory). Join the
-        // toplevel (`response.repoRoot`) so the dispatched reference is an
-        // absolute path the agent can resolve regardless of its cwd. All batch
-        // entries share one repo (the batch is cleared on cwd change), so the
-        // current diff's repoRoot applies to every file. Falls back to the
-        // repo-relative path if the root is unavailable (not in a git repo).
-        // Prefer the current diff's root; fall back to the last-known root when
-        // `response` is transiently null (file-switch loading/error) so an
-        // in-flight batch keeps absolute paths. The empty-string (non-repo)
-        // case needs no fallback — the ref is empty there too — so `??` (null/
-        // undefined only) is exactly right.
-        const repoRoot = response?.repoRoot ?? repoRootRef.current
-        const entries: DispatchEntry[] = []
-        // parseBatchKey is the single source of truth for the key format (it
-        // lives next to makeBatchKey in useFeedbackBatch). The staged flag rides
-        // into the payload so an `MM` file (staged + unstaged both commented)
-        // stays disambiguated.
-        for (const [key, annotations] of feedback.batch) {
-          const {
-            cwd: entryCwd,
-            filePath: relPath,
-            staged,
-          } = parseBatchKey(key)
-
-          const entryRepoRoot =
-            'repoRootForCwd' in repoRootRef
-              ? repoRootRef.repoRootForCwd?.(entryCwd)
-              : undefined
-
-          const resolvedRepoRoot =
-            entryRepoRoot && entryRepoRoot.length > 0 ? entryRepoRoot : repoRoot
-
-          const filePath = resolvedRepoRoot
-            ? `${resolvedRepoRoot}/${relPath}`
-            : relPath
-          entries.push({ filePath, staged, annotations })
-        }
+        const entries = buildFeedbackEntries()
 
         try {
           if (feedbackDispatch) {
@@ -781,18 +773,15 @@ export const Panel = ({
         }
       })()
     },
-    [feedback, feedbackDispatch, notifyInfo, repoRootRef, response]
+    [buildFeedbackEntries, feedback, feedbackDispatch, notifyInfo]
   )
 
   // Copy the whole review to the clipboard — the escape hatch when no agent is
-  // running to send to (comments are otherwise trapped in the batch). Repo-
-  // relative paths from the batch keys are enough for a human paste target.
+  // running to send to (comments are otherwise trapped in the batch). It uses
+  // the same resolved paths as the send path so pasted feedback works from an
+  // agent cwd below the repo root.
   const handleCopyFeedback = useCallback((): void => {
-    const entries: DispatchEntry[] = []
-    for (const [key, annotations] of feedback.batch) {
-      const { filePath, staged } = parseBatchKey(key)
-      entries.push({ filePath, staged, annotations })
-    }
+    const entries = buildFeedbackEntries()
 
     if (entries.length === 0) {
       return
@@ -809,7 +798,7 @@ export const Panel = ({
           : 'Could not copy comments to the clipboard.'
       )
     })()
-  }, [feedback, notifyInfo])
+  }, [buildFeedbackEntries, feedback, notifyInfo])
 
   // Single-flight staging flag — drops clicks while an IPC is in flight.
   const [staging, setStaging] = useState(false)

--- a/src/features/diff/components/FinishFeedbackPopover.test.tsx
+++ b/src/features/diff/components/FinishFeedbackPopover.test.tsx
@@ -260,3 +260,50 @@ test('pluralization uses plural for multiple comments and files', () => {
 
   anchor.remove()
 })
+
+test('shows a Copy button that calls onCopy on click and via the c key', async () => {
+  const user = userEvent.setup()
+  const anchor = createAnchor()
+  const onCopy = vi.fn()
+
+  render(
+    <FinishFeedbackPopover
+      anchor={anchor}
+      result={{ kind: 'none' } as ResolveResult}
+      commentCount={2}
+      fileCount={1}
+      onSend={vi.fn()}
+      onCancel={vi.fn()}
+      onCopy={onCopy}
+    />
+  )
+
+  await user.click(screen.getByRole('button', { name: 'Copy (c)' }))
+  expect(onCopy).toHaveBeenCalledTimes(1)
+
+  await user.keyboard('c')
+  expect(onCopy).toHaveBeenCalledTimes(2)
+
+  anchor.remove()
+})
+
+test('omits the Copy button when onCopy is not provided', () => {
+  const anchor = createAnchor()
+
+  render(
+    <FinishFeedbackPopover
+      anchor={anchor}
+      result={{ kind: 'none' } as ResolveResult}
+      commentCount={1}
+      fileCount={1}
+      onSend={vi.fn()}
+      onCancel={vi.fn()}
+    />
+  )
+
+  expect(
+    screen.queryByRole('button', { name: 'Copy (c)' })
+  ).not.toBeInTheDocument()
+
+  anchor.remove()
+})

--- a/src/features/diff/components/FinishFeedbackPopover.tsx
+++ b/src/features/diff/components/FinishFeedbackPopover.tsx
@@ -15,6 +15,9 @@ interface FinishFeedbackPopoverProps {
   fileCount: number
   onSend: (pane: PaneCandidate) => void
   onCancel: () => void
+  /** Copy the whole review to the clipboard — the fallback when no agent is
+   * running to send to. Omitted → the copy action is hidden. */
+  onCopy?: () => void
 }
 
 const isCapitalY = (event: KeyboardEvent): boolean =>
@@ -28,9 +31,21 @@ export const FinishFeedbackPopover = ({
   fileCount,
   onSend,
   onCancel,
+  onCopy = undefined,
 }: FinishFeedbackPopoverProps): ReactElement => {
   const commentWord = commentCount === 1 ? 'comment' : 'comments'
   const fileWord = fileCount === 1 ? 'file' : 'files'
+
+  const copyButton = onCopy ? (
+    <button
+      type="button"
+      aria-keyshortcuts="c"
+      onClick={(): void => onCopy()}
+      className={`rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface ${popoverGhostActionFocusClass}`}
+    >
+      Copy (c)
+    </button>
+  ) : null
 
   useEffect((): (() => void) => {
     const handleKeyDown = (event: KeyboardEvent): void => {
@@ -42,6 +57,14 @@ export const FinishFeedbackPopover = ({
         event.preventDefault()
         event.stopPropagation()
         onCancel()
+
+        return
+      }
+
+      if (onCopy && event.key === 'c') {
+        event.preventDefault()
+        event.stopPropagation()
+        onCopy()
 
         return
       }
@@ -58,7 +81,7 @@ export const FinishFeedbackPopover = ({
     return (): void => {
       document.removeEventListener('keydown', handleKeyDown, { capture: true })
     }
-  }, [onCancel, onSend, result])
+  }, [onCancel, onCopy, onSend, result])
 
   return (
     <Popover
@@ -85,7 +108,8 @@ export const FinishFeedbackPopover = ({
             </code>{' '}
             in a terminal pane.
           </p>
-          <div className="flex justify-end">
+          <div className="flex justify-end gap-2">
+            {copyButton}
             <button
               type="button"
               aria-keyshortcuts="n"
@@ -105,6 +129,7 @@ export const FinishFeedbackPopover = ({
             {result.pane.tabName} ({result.pane.agentLabel})?
           </p>
           <div className="flex justify-end gap-2">
+            {copyButton}
             <button
               type="button"
               aria-keyshortcuts="n"
@@ -149,7 +174,8 @@ export const FinishFeedbackPopover = ({
               </div>
             ))}
           </div>
-          <div className="flex justify-end">
+          <div className="flex justify-end gap-2">
+            {copyButton}
             <button
               type="button"
               aria-keyshortcuts="n"

--- a/src/features/diff/components/Notifier.test.tsx
+++ b/src/features/diff/components/Notifier.test.tsx
@@ -65,6 +65,7 @@ const renderNotifier = (
         fileCount: 0,
         onCancel: vi.fn(),
         onSend: vi.fn(),
+        onCopy: vi.fn(),
       }}
       keyboardConfirm={null}
       onCancelKeyboardConfirm={vi.fn()}
@@ -111,6 +112,7 @@ describe('Notifier', () => {
           fileCount: 0,
           onCancel: vi.fn(),
           onSend: vi.fn(),
+          onCopy: vi.fn(),
         }}
         keyboardConfirm={{
           title: 'Discard hunk?',

--- a/src/features/diff/components/Notifier.tsx
+++ b/src/features/diff/components/Notifier.tsx
@@ -16,6 +16,7 @@ interface FinishFeedbackState {
   fileCount: number
   onCancel: () => void
   onSend: (pane: PaneCandidate) => void
+  onCopy: () => void
 }
 
 export interface KeyboardConfirmView {
@@ -102,6 +103,7 @@ export const Notifier = ({
           fileCount={finishFeedback.fileCount}
           onCancel={finishFeedback.onCancel}
           onSend={finishFeedback.onSend}
+          onCopy={finishFeedback.onCopy}
         />
       ) : null}
       {keyboardConfirm !== null && toolbarShellRef.current !== null ? (


### PR DESCRIPTION
**Diff Review UX Polish** milestone — Batch 2, two mechanical dogfooding fixes.

## VIM-274 — copy review comments (works with no active agent)
Comments were trapped when no coding agent was running: the finish popover's no-agent branch was a dead-end (Dismiss only). Added a **"Copy (c)"** action to all three finish-popover branches that writes the whole review batch to the clipboard, reusing the existing `formatFeedbackPayload` serializer (file/line-anchored) + `writeClipboardText`. Available regardless of agent state; the escape hatch when send is unavailable.

- `FinishFeedbackPopover`: optional `onCopy` prop → "Copy (c)" button + `c` shortcut (all branches).
- `Panel.handleCopyFeedback`: builds repo-relative entries from the batch → `formatFeedbackPayload` → clipboard → toast. Threads through `Notifier`.

## VIM-275 — auto-hide the "e" changed-files panel
A keyboard reveal (`e`) set no timer, so it lingered indefinitely; only a mouse-leave scheduled the 220ms hide. `toggleFilesList` now schedules a **5s self-dismiss** (`FILES_LIST_KEYBOARD_AUTO_HIDE_MS`, a code const to wire to Settings later) on keyboard reveal. Any interaction (hover/focus/pin) cancels it via the shared hide timer.

## Tests
- `FinishFeedbackPopover`: copy button click + `c` key call `onCopy`; button omitted when `onCopy` absent (existing 7 tests untouched).
- `Panel`: copy-from-finish-popover writes the anchored payload to the clipboard; keyboard reveal auto-hides at 5s (4999ms still visible / 5000ms gone).
- Full gate green: type-check, lint (0 errors), format, `vitest run` (4534 passed).

Closes VIM-274
Closes VIM-275
