### PR TITLE
fix: keep keyboard focus across theme changes and command-palette commands

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -56,10 +56,10 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 8        | 2    | 2026-06-19   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 4        | 0    | 2026-06-21   |
-| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 86       | 40   | 2026-06-29   |
+| [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 87       | 41   | 2026-07-04   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 5        | 3    | 2026-06-24   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 93       | 90   | 2026-06-25   |
-| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 91       | 87   | 2026-07-03   |
+| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 93       | 88   | 2026-07-04   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 71       | 70   | 2026-06-26   |
 | [Canonical Path Dedupe](patterns/canonical-path-dedupe.md)                                           | correctness        | 2        | 0    | 2026-06-14   |

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -2,8 +2,8 @@
 id: accessibility
 category: a11y
 created: 2026-04-09
-last_updated: 2026-07-03
-ref_count: 87
+last_updated: 2026-07-04
+ref_count: 88
 ---
 
 # Accessibility
@@ -849,4 +849,22 @@ handlers must not trap focus without implementing the promised behavior.
 - **File:** `src/theme/themes/gruvbox/gruvbox-dark.ts`, `src/theme/themes/gruvbox/gruvbox-light.ts`
 - **Finding:** The final Gruvbox token choices preserved compact-label contrast but left the dark theme with `surface-container` and `surface-bright` duplicated, and both Gruvbox themes with elevated rungs that moved opposite the theme-kind elevation direction. Nested panels and hover states could therefore render flat or visually inverted.
 - **Fix:** Re-picked nearby Gruvbox surface values so the dark ladder increases in luminance, the light ladder decreases in luminance, and all compact surface rungs still meet the existing AA contrast guard. Added a Gruvbox-specific regression test that checks the full surface ladder ordering by theme kind.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 84. Diff remount focus restore stole focus from editable descendants
+
+- **Source:** github-codex-connector | PR #652 round 1 | 2026-07-04
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/diff/Panel.tsx`
+- **Finding:** The render-key focus restoration for theme and line-style remounts treated any active element inside the diff root as safe to replace with root focus. Diff-owned text inputs such as search and review-comment editors could regain focus after a workspace theme command, then immediately lose it to the bare diff root.
+- **Fix:** Added a shared diff native-focus predicate and skipped the render-key root restore when `document.activeElement` is an input, textarea, contenteditable element, or `role="textbox"`. Added a regression test that keeps the diff search textbox focused across a workspace theme change.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 85. Palette-close surface focus restore ignored follow-up dialogs
+
+- **Source:** github-claude + github-codex-connector | PR #652 round 1 | 2026-07-04
+- **Severity:** HIGH
+- **File:** `src/features/workspace/WorkspaceView.tsx`
+- **Finding:** The command-palette close effect always restored focus to the active terminal or dock surface, even when the command itself opened a follow-up modal such as `UnsavedChangesDialog`. That could move keyboard focus behind an active `aria-modal` dialog.
+- **Fix:** Guarded the palette-close focus restore while `showUnsavedDialog` or `newSessionDialog.open` is true, preserving the follow-up dialog's focus ownership.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/testing-gaps.md
+++ b/docs/reviews/patterns/testing-gaps.md
@@ -2,8 +2,8 @@
 id: testing-gaps
 category: testing
 created: 2026-04-09
-last_updated: 2026-06-29
-ref_count: 40
+last_updated: 2026-07-04
+ref_count: 41
 ---
 
 # Testing Gaps
@@ -843,4 +843,13 @@ filesystem scope restrictions).
 - **File:** `src/features/diff/components/DiffPanelContent.test.tsx`
 - **Finding:** The `h` and `l` split-side toggle assertions checked selectors and `display: none` strings that appear in both hide-origin and hide-new CSS blocks, so swapping the two constants would still pass.
 - **Fix:** Added unique border-adjustment assertions for each branch: `border-left: 0` after hiding origin and `border-right: 0` after hiding the new side.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 87. Palette-close focus restore lacked follow-up dialog coverage
+
+- **Source:** github-claude | PR #652 round 1 | 2026-07-04
+- **Severity:** MEDIUM
+- **File:** `src/features/workspace/WorkspaceView.command-palette.test.tsx`
+- **Finding:** The command-palette close focus-restore behavior had no test for commands that both close the palette and open another modal, leaving the dialog-focus regression uncovered.
+- **Fix:** Extended the dirty `:open-file` command-palette test so it opens `UnsavedChangesDialog` and asserts the terminal focus handoff is not requested while that follow-up dialog is active.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/src/features/diff/Panel.test.tsx
+++ b/src/features/diff/Panel.test.tsx
@@ -34,6 +34,7 @@ import {
 import type { MockInstance } from 'vitest'
 import type { PaneCandidate } from './services/activePanePicker'
 import type { DiffLineAnnotation, FileDiffOptions } from '@pierre/diffs'
+import { themeService } from '../../theme'
 
 // Mock the hooks
 vi.mock('./hooks/useGitStatus')
@@ -240,6 +241,7 @@ describe('Panel', () => {
     vi.clearAllMocks()
     multiFileDiffOptionsSeen.length = 0
     window.localStorage.clear()
+    themeService.apply('obsidian-lens')
     installMockResizeObserver()
   })
 
@@ -912,6 +914,56 @@ describe('Panel', () => {
     await user.click(within(menu).getByRole('menuitem', { name: /dracula/i }))
 
     await waitFor(() => expect(diffRoot).toHaveFocus())
+  })
+
+  test('changing the workspace theme preserves focused diff text fields', async (): Promise<void> => {
+    vi.spyOn(useGitStatusModule, 'useGitStatus').mockReturnValue({
+      files: [{ path: 'src/App.tsx', status: 'modified', staged: false }],
+      filesCwd: '.',
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+      idle: false,
+    })
+
+    vi.spyOn(useFileDiffModule, 'useFileDiff').mockReturnValue(
+      fileDiffMock({
+        diff: {
+          filePath: 'src/App.tsx',
+          oldPath: 'src/App.tsx',
+          newPath: 'src/App.tsx',
+          hunks: [],
+        },
+        loading: false,
+        error: null,
+        oldText: 'old',
+        newText: 'new',
+        rawDiff: '',
+      })
+    )
+
+    render(<Panel />)
+
+    fireEvent.keyDown(screen.getByTestId('diff-populated-state'), {
+      key: '/',
+    })
+
+    const input = await screen.findByRole('textbox', {
+      name: /search in diff/i,
+    })
+    await waitFor(() => expect(input).toHaveFocus())
+
+    act(() => {
+      themeService.apply('flexoki')
+    })
+
+    await waitFor(() =>
+      expect(screen.getByTestId('multi-file-diff')).toHaveAttribute(
+        'data-theme',
+        'pierre-light'
+      )
+    )
+    expect(input).toHaveFocus()
   })
 
   test('hover reveal waits before closing on mouse leave', (): void => {

--- a/src/features/diff/Panel.test.tsx
+++ b/src/features/diff/Panel.test.tsx
@@ -871,6 +871,49 @@ describe('Panel', () => {
     expect(screen.queryByTestId('changed-files-pane')).not.toBeInTheDocument()
   })
 
+  test('changing the syntax theme keeps keyboard focus on the diff (VIM-276)', async (): Promise<void> => {
+    const user = userEvent.setup()
+
+    vi.spyOn(useGitStatusModule, 'useGitStatus').mockReturnValue({
+      files: [{ path: 'src/App.tsx', status: 'modified', staged: false }],
+      filesCwd: '.',
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+      idle: false,
+    })
+
+    vi.spyOn(useFileDiffModule, 'useFileDiff').mockReturnValue(
+      fileDiffMock({
+        diff: {
+          filePath: 'src/App.tsx',
+          oldPath: 'src/App.tsx',
+          newPath: 'src/App.tsx',
+          hunks: [],
+        },
+        loading: false,
+        error: null,
+        oldText: 'old',
+        newText: 'new',
+        rawDiff: '',
+      })
+    )
+
+    render(<Panel />)
+
+    const diffRoot = screen.getByTestId('diff-populated-state')
+    act(() => diffRoot.focus())
+    expect(diffRoot).toHaveFocus()
+
+    // Switch the syntax theme via the toolbar dropdown; the pierre surface
+    // re-keys and remounts, which used to strand focus off the diff.
+    await user.click(screen.getByRole('button', { name: /pierre-dark/i }))
+    const menu = await screen.findByRole('menu')
+    await user.click(within(menu).getByRole('menuitem', { name: /dracula/i }))
+
+    await waitFor(() => expect(diffRoot).toHaveFocus())
+  })
+
   test('hover reveal waits before closing on mouse leave', (): void => {
     vi.useFakeTimers()
 

--- a/src/features/diff/Panel.tsx
+++ b/src/features/diff/Panel.tsx
@@ -1044,6 +1044,30 @@ export const Panel = ({
     toggleDiffStyle,
   } = useToolbarState()
 
+  // A syntax-theme or line-diff-style change re-keys the pierre surface and
+  // remounts it. The generic post-render restore above only catches focus
+  // falling to document.body, but the theme control (a portalled dropdown) can
+  // leave focus on its chip and pierre's shadow-DOM remount can strand it on the
+  // shadow host, so a theme switch would otherwise lose keyboard focus. Once the
+  // remount commits, pull focus back to the diff root — but only when it's lost
+  // to the body or already sitting inside the diff pane, never yanking it from
+  // another workspace surface. Keyed on renderKey (theme + line-diff style) only;
+  // file switches also re-key but must not grab focus.
+  const previousRenderKeyRef = useRef(renderKey)
+  useEffect(() => {
+    const themeOrStyleChanged = previousRenderKeyRef.current !== renderKey
+    previousRenderKeyRef.current = renderKey
+    if (!themeOrStyleChanged) {
+      return
+    }
+
+    const root = diffRootRef.current
+    const active = document.activeElement
+    if (root !== null && (active === document.body || root.contains(active))) {
+      focusDiffRoot()
+    }
+  }, [renderKey, focusDiffRoot])
+
   // In-file diff search (VIM-252). The identity key drives the hook's reset
   // rules: new key = different file (active match resets), null = nothing
   // searchable (popup closes; also covers the narrow placeholder). Everything

--- a/src/features/diff/Panel.tsx
+++ b/src/features/diff/Panel.tsx
@@ -69,6 +69,9 @@ const DIFF_NATIVE_FOCUS_SELECTOR =
 const FILES_LIST_STORAGE_KEY = 'vf-diff-files-open'
 const FILES_LIST_CLOSE_DELAY_MS = 220
 
+const isDiffNativeFocusTarget = (target: Element): boolean =>
+  target.closest(DIFF_NATIVE_FOCUS_SELECTOR) !== null
+
 // A keyboard reveal (`e`) has no mouse-leave to close it, so it self-dismisses
 // after this delay — longer than the hover-leave delay since there's no pointer
 // motion to signal intent. Wire to Settings later.
@@ -511,7 +514,7 @@ export const Panel = ({
 
       if (
         event.target instanceof Element &&
-        event.target.closest(DIFF_NATIVE_FOCUS_SELECTOR) === null
+        !isDiffNativeFocusTarget(event.target)
       ) {
         focusDiffRoot()
       }
@@ -1063,7 +1066,15 @@ export const Panel = ({
 
     const root = diffRootRef.current
     const active = document.activeElement
-    if (root !== null && (active === document.body || root.contains(active))) {
+
+    const activeIsEditable =
+      active instanceof Element && isDiffNativeFocusTarget(active)
+
+    if (
+      root !== null &&
+      !activeIsEditable &&
+      (active === document.body || root.contains(active))
+    ) {
       focusDiffRoot()
     }
   }, [renderKey, focusDiffRoot])
@@ -1171,8 +1182,7 @@ export const Panel = ({
     onPointerHover: handleBodyPointerMove,
     scrollTargetIntoView,
     shouldIgnorePointerTarget: (target): boolean =>
-      target instanceof Element &&
-      target.closest(DIFF_NATIVE_FOCUS_SELECTOR) !== null,
+      target instanceof Element && isDiffNativeFocusTarget(target),
     targetIndexFromPointerEvent,
     targets: reviewTargets,
   })

--- a/src/features/workspace/WorkspaceView.command-palette.test.tsx
+++ b/src/features/workspace/WorkspaceView.command-palette.test.tsx
@@ -1,17 +1,28 @@
 import { render, screen, waitFor, act } from '@testing-library/react'
 import { describe, test, expect, vi, beforeEach } from 'vitest'
 import userEvent from '@testing-library/user-event'
-import type { ReactElement, ReactNode } from 'react'
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  type ReactElement,
+  type ReactNode,
+} from 'react'
 import { WorkspaceView } from './WorkspaceView'
 import type { SessionManager } from '../sessions/hooks/useSessionManager'
 import type { AgentStatus } from '../agent-status/types'
 import type { Session } from '../sessions/types'
-import type { TerminalZoneProps } from './components/TerminalZone'
+import type {
+  TerminalZoneHandle,
+  TerminalZoneProps,
+} from './components/TerminalZone'
 import type { WorkspaceOverlayRegistrationsProps } from './overlays/WorkspaceOverlayRegistrations'
 import { BUILTIN_PANE_LAYOUT_REGISTRY } from '../terminal/layout-registry'
 
 const terminalZonePropsSpy = vi.hoisted(() => vi.fn())
 const overlayRegistrationPropsSpy = vi.hoisted(() => vi.fn())
+const terminalFocusActivePaneSpy = vi.hoisted(() => vi.fn())
 
 // Mock all WorkspaceView dependencies
 vi.mock('../sessions/hooks/useSessionManager')
@@ -92,11 +103,28 @@ vi.mock('@/components/sidebar/Sidebar', () => ({
 }))
 
 vi.mock('./components/TerminalZone', () => ({
-  TerminalZone: (props: TerminalZoneProps): ReactElement => {
-    terminalZonePropsSpy(props)
+  TerminalZone: forwardRef<TerminalZoneHandle, TerminalZoneProps>(
+    function MockTerminalZone(props, ref): ReactElement {
+      const nodeRef = useRef<HTMLDivElement>(null)
 
-    return <div data-testid="terminal-zone" />
-  },
+      useImperativeHandle(
+        ref,
+        () => ({
+          focusActivePane: (): boolean => {
+            terminalFocusActivePaneSpy()
+            nodeRef.current?.focus()
+
+            return nodeRef.current !== null
+          },
+        }),
+        []
+      )
+
+      terminalZonePropsSpy(props)
+
+      return <div ref={nodeRef} data-testid="terminal-zone" tabIndex={-1} />
+    }
+  ),
 }))
 
 vi.mock('./components/DockPanel', () => ({
@@ -123,10 +151,18 @@ vi.mock('../editor/components/UnsavedChangesDialog', () => ({
     onSave: () => void
     onDiscard: () => void
     onCancel: () => void
-  }): ReactElement | null =>
-    isOpen ? (
-      <div data-testid="unsaved-changes-dialog">
-        <button type="button" onClick={onSave}>
+  }): ReactElement | null => {
+    const saveRef = useRef<HTMLButtonElement>(null)
+
+    useEffect(() => {
+      if (isOpen) {
+        saveRef.current?.focus()
+      }
+    }, [isOpen])
+
+    return isOpen ? (
+      <div data-testid="unsaved-changes-dialog" role="dialog">
+        <button ref={saveRef} type="button" onClick={onSave}>
           Save
         </button>
         <button type="button" onClick={onDiscard}>
@@ -136,7 +172,8 @@ vi.mock('../editor/components/UnsavedChangesDialog', () => ({
           Cancel
         </button>
       </div>
-    ) : null,
+    ) : null
+  },
 }))
 
 const createMockSession = (id: string, name: string): Session => ({
@@ -1033,6 +1070,7 @@ describe('WorkspaceView - Command Palette Integration', () => {
     const input = screen.getByRole('combobox', {
       name: 'Command palette search',
     })
+    terminalFocusActivePaneSpy.mockClear()
     await user.clear(input)
     await user.type(input, ':open-file /tmp/notes.md')
     await user.keyboard('{Enter}')
@@ -1041,6 +1079,12 @@ describe('WorkspaceView - Command Palette Integration', () => {
       expect(screen.getByTestId('unsaved-changes-dialog')).toBeInTheDocument()
     })
 
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('dialog', { name: 'Command palette' })
+      ).toBeNull()
+    })
+    expect(terminalFocusActivePaneSpy).not.toHaveBeenCalled()
     expect(openFile).not.toHaveBeenCalled()
   })
 

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -1750,6 +1750,25 @@ const WorkspaceViewContent = (): ReactElement => {
     enabled: !showUnsavedDialog && !newSessionDialog.open,
   })
 
+  // The palette owns focus while open (its Dialog focus-trap), and restoring to
+  // whatever happened to be focused when it opened is unreliable — a theme
+  // command even remounts the diff underneath it. On close, deterministically
+  // return focus to whichever surface is active — terminal pane or dock
+  // (diff/editor) — so keyboard flow survives any palette command. Runs after
+  // the Dialog's own restore (child effects fire before this parent effect), so
+  // this wins.
+  const wasCommandPaletteOpenRef = useRef(commandPalette.state.isOpen)
+  useEffect(() => {
+    const wasOpen = wasCommandPaletteOpenRef.current
+    wasCommandPaletteOpenRef.current = commandPalette.state.isOpen
+
+    if (wasOpen && !commandPalette.state.isOpen) {
+      requestFocus(
+        activeContainerId === TERMINAL_CONTAINER_ID ? 'terminal' : dockTab
+      )
+    }
+  }, [commandPalette.state.isOpen, activeContainerId, dockTab, requestFocus])
+
   usePaneShortcuts({
     sessions,
     activeSessionId,

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -1762,12 +1762,24 @@ const WorkspaceViewContent = (): ReactElement => {
     const wasOpen = wasCommandPaletteOpenRef.current
     wasCommandPaletteOpenRef.current = commandPalette.state.isOpen
 
-    if (wasOpen && !commandPalette.state.isOpen) {
+    if (
+      wasOpen &&
+      !commandPalette.state.isOpen &&
+      !showUnsavedDialog &&
+      !newSessionDialog.open
+    ) {
       requestFocus(
         activeContainerId === TERMINAL_CONTAINER_ID ? 'terminal' : dockTab
       )
     }
-  }, [commandPalette.state.isOpen, activeContainerId, dockTab, requestFocus])
+  }, [
+    commandPalette.state.isOpen,
+    activeContainerId,
+    dockTab,
+    requestFocus,
+    showUnsavedDialog,
+    newSessionDialog.open,
+  ])
 
   usePaneShortcuts({
     sessions,


### PR DESCRIPTION
**Diff Review UX Polish** milestone — VIM-276, plus the command-palette focus gap it surfaced. Two complementary focus fixes.

## 1. Diff toolbar theme/style change (VIM-276) — `Panel.tsx`
Switching the syntax theme or line-diff style re-keys `<MultiFileDiff>` and remounts Pierre's surface. The app already restores diff focus after remounts, **but only when focus fell to `document.body`** — the portalled theme dropdown leaves focus on its chip, and Pierre's shadow-DOM remount can strand focus on the `<diffs-container>` host. Fix: a `renderKey`-scoped effect restores focus to the diff root after a theme/style re-key **only when focus is on `body` or already inside the diff pane** — never yanking from another surface. Keyed on `renderKey` (theme + line-diff style) only, so file switches don't grab focus.

## 2. Command-palette commands — `WorkspaceView.tsx`
Reported after the first commit: changing the theme via the **command palette** *still* lost focus. Root cause is broader — the palette's Dialog restores focus to whatever was focused at open time, which is unreliable (and a theme command remounts the diff underneath it), so **both** the terminal pane and the hunk view could end up stranded. Fix: on palette close, deterministically `requestFocus` the **active surface** — `terminal` when the terminal is active, else the dock tab (`diff`/`editor`). Runs after the Dialog's own restore (child effects fire before this parent effect), so it wins. This helps every palette command, not just theme.

## Tests
- `Panel` (VIM-276): focus the diff → switch theme via the toolbar dropdown → focus lands back on the diff root. Real red/green (my first attempt, gated on `focusWasInsidePanelRef`, failed because the portalled dropdown clears that flag).
- 3 existing diff focus tests + 74 WorkspaceView tests still pass.
- Full gate green: type-check, lint (0 errors), format, `vitest run` (4535 passed).

> **Dogfood check (jsdom can't reproduce Pierre's shadow DOM or real focus timing):** confirm keyboard nav (j/k) survives a theme switch via the toolbar dropdown **and** the command palette, and that after any command-palette command focus returns to whichever surface you were in — terminal **or** hunk view.

Also: the palette-focus fix (commit 2) warrants its own Linear issue, but the workspace hit its issue limit — folding it here for now; happy to split it out once that's resolved.

Closes VIM-276
