### PR TITLE
feat(terminal): Tighten Ghostty live resize tracking

### DIFF
--- a/electron/ghostty-native-helper.test.ts
+++ b/electron/ghostty-native-helper.test.ts
@@ -153,6 +153,7 @@ describe('ghostty native helper', () => {
         paneId: 'pane-1',
         cwd: '/tmp',
         visible: true,
+        parentHeight: 900,
         bounds: { x: 10, y: 20, width: 300, height: 200 },
       }
     )
@@ -231,6 +232,7 @@ describe('ghostty native helper', () => {
           paneId: 'pane-1',
           cwd: '',
           visible: true,
+          parentHeight: 900,
           bounds: { x: 10, y: 20, width: 300, height: 200 },
         }
       )
@@ -286,6 +288,7 @@ describe('ghostty native helper', () => {
           paneId: 'pane-1',
           cwd: '/tmp',
           visible: true,
+          parentHeight: 900,
           bounds: { x: 10, y: 20, width: 300, height: 200 },
           bottomCornerRadius: 10,
         }
@@ -350,6 +353,7 @@ describe('ghostty native helper', () => {
         paneId: 'pane-1',
         cwd: '/tmp',
         visible: true,
+        parentHeight: 900,
         bounds: { x: 10, y: 20, width: 300, height: 200 },
       }
     )
@@ -407,6 +411,7 @@ describe('ghostty native helper', () => {
         paneId: 'pane-1',
         cwd: '/tmp',
         visible: true,
+        parentHeight: 900,
         bounds: { x: 10, y: 20, width: 300, height: 200 },
       }
     )
@@ -481,6 +486,7 @@ describe('ghostty native helper', () => {
         paneId: 'pane-1',
         cwd: '/tmp',
         visible: true,
+        parentHeight: 900,
         bounds: { x: 10, y: 20, width: 300, height: 200 },
       }
     )
@@ -556,6 +562,7 @@ describe('ghostty native helper', () => {
         paneId: 'pane-1',
         cwd: '/tmp',
         visible: true,
+        parentHeight: 900,
         bounds: { x: 10, y: 20, width: 300, height: 200 },
       }
     )
@@ -618,6 +625,7 @@ describe('ghostty native helper', () => {
         paneId: 'pane-1',
         cwd: '/tmp',
         visible: true,
+        parentHeight: 900,
         bounds: { x: 10, y: 20, width: 300, height: 200 },
       }
     )
@@ -656,6 +664,7 @@ describe('ghostty native helper', () => {
         paneId: 'pane-2',
         cwd: '/tmp',
         visible: true,
+        parentHeight: 900,
         bounds: { x: 10, y: 20, width: 300, height: 200 },
       }
     )

--- a/electron/ghostty-native-helper.ts
+++ b/electron/ghostty-native-helper.ts
@@ -589,6 +589,8 @@ function isGhosttyNativeUpdateRequest(
     (value.backgroundColor === undefined ||
       isHexColor(value.backgroundColor)) &&
     isOptionalFiniteNumber(value.bottomCornerRadius) &&
+    typeof value.parentHeight === 'number' &&
+    Number.isFinite(value.parentHeight) &&
     typeof value.visible === 'boolean'
   )
 }

--- a/electron/ghostty-native-parent.test.ts
+++ b/electron/ghostty-native-parent.test.ts
@@ -155,6 +155,7 @@ describe('ghostty native parent', () => {
           cwd: '/tmp',
           backgroundColor: 'not-a-color',
           visible: true,
+        parentHeight: 900,
           bounds: { x: 10, y: 20, width: 300, height: 200 },
         }
       )
@@ -182,6 +183,7 @@ describe('ghostty native parent', () => {
           paneId: 'pane-1',
           cwd: '/tmp',
           visible: true,
+        parentHeight: 900,
           bounds: { x: 10, y: 20, width: 300, height: 200 },
         }
       )
@@ -232,6 +234,7 @@ describe('ghostty native parent', () => {
         paneId: 'pane-1',
         cwd: '/tmp',
         visible: true,
+        parentHeight: 900,
         bounds: { x: 10, y: 20, width: 300, height: 200 },
       }
     )
@@ -272,11 +275,20 @@ describe('ghostty native parent', () => {
         paneId: 'pane-1',
         cwd: '/tmp',
         visible: true,
+        parentHeight: 900,
         bounds: { x: 10.4, y: 20.5, width: 300.49, height: 200.51 },
       }
     )
 
-    expect(addon.setFrame).toHaveBeenCalledWith(surface, 10, 21, 300, 201, 0)
+    expect(addon.setFrame).toHaveBeenCalledWith(
+      surface,
+      10,
+      21,
+      300,
+      201,
+      0,
+      900
+    )
 
     handlers.get(GHOSTTY_NATIVE_UPDATE)?.(
       { sender: {} },
@@ -285,11 +297,20 @@ describe('ghostty native parent', () => {
         paneId: 'pane-1',
         cwd: '/tmp',
         visible: false,
+        parentHeight: 900,
         bounds: { x: 10.6, y: 20.4, width: 300.51, height: 200.49 },
       }
     )
 
-    expect(addon.setFrame).toHaveBeenLastCalledWith(surface, 11, 20, 0, 0, 0)
+    expect(addon.setFrame).toHaveBeenLastCalledWith(
+      surface,
+      11,
+      20,
+      0,
+      0,
+      0,
+      900
+    )
 
     controller.dispose()
   })
@@ -327,11 +348,91 @@ describe('ghostty native parent', () => {
         cwd: '/tmp',
         backgroundColor: '#fffcf0',
         visible: true,
+        parentHeight: 900,
         bounds: { x: 10, y: 20, width: 300, height: 200 },
       }
     )
 
     expect(addon.setBackgroundColor).toHaveBeenCalledWith(surface, '#fffcf0')
+
+    handlers.get(GHOSTTY_NATIVE_UPDATE)?.(
+      { sender: {} },
+      {
+        sessionId: 'pty-1',
+        paneId: 'pane-1',
+        cwd: '/tmp',
+        backgroundColor: '#fffcf0',
+        visible: true,
+        parentHeight: 900,
+        bounds: { x: 10, y: 20, width: 300, height: 200 },
+      }
+    )
+
+    expect(addon.setBackgroundColor).toHaveBeenCalledTimes(1)
+
+    controller.dispose()
+  })
+
+  test('flushes pending data once when the parented surface is created', () => {
+    const surface = {}
+
+    const addon = {
+      create: vi.fn(() => surface),
+      setFrame: vi.fn(),
+      write: vi.fn(),
+      focus: vi.fn(),
+      destroy: vi.fn(),
+    }
+
+    const sidecar = {
+      invoke: <T>(): Promise<T> => Promise.resolve(undefined as T),
+      onEvent: vi.fn(() => vi.fn()),
+      shutdown: vi.fn(() => Promise.resolve()),
+    } satisfies Sidecar
+
+    const controller = setupGhosttyNativeParent({
+      sidecar,
+      platform: 'darwin',
+      env: { VITE_GHOSTTY_NATIVE_MACOS_PARENT: '1' },
+      addon,
+    })
+    const update = handlers.get(GHOSTTY_NATIVE_UPDATE)
+
+    expect(
+      handlers.get(GHOSTTY_NATIVE_DATA)?.(
+        {},
+        { sessionId: 'pty-1', paneId: 'pane-1', data: 'boot' }
+      )
+    ).toEqual({ enabled: true })
+    expect(addon.write).not.toHaveBeenCalled()
+
+    update?.(
+      { sender: {} },
+      {
+        sessionId: 'pty-1',
+        paneId: 'pane-1',
+        cwd: '/tmp',
+        visible: true,
+        parentHeight: 900,
+        bounds: { x: 10, y: 20, width: 300, height: 200 },
+      }
+    )
+
+    expect(addon.write).toHaveBeenCalledWith(surface, 'boot')
+
+    update?.(
+      { sender: {} },
+      {
+        sessionId: 'pty-1',
+        paneId: 'pane-1',
+        cwd: '/tmp',
+        visible: true,
+        parentHeight: 900,
+        bounds: { x: 10, y: 20, width: 300, height: 200 },
+      }
+    )
+
+    expect(addon.write).toHaveBeenCalledTimes(1)
 
     controller.dispose()
   })
@@ -368,11 +469,69 @@ describe('ghostty native parent', () => {
         cwd: '/tmp',
         bottomCornerRadius: 10,
         visible: true,
+        parentHeight: 900,
         bounds: { x: 10, y: 20, width: 300, height: 200 },
       }
     )
 
-    expect(addon.setFrame).toHaveBeenCalledWith(surface, 10, 20, 300, 200, 10)
+    expect(addon.setFrame).toHaveBeenCalledWith(
+      surface,
+      10,
+      20,
+      300,
+      200,
+      10,
+      900
+    )
+
+    controller.dispose()
+  })
+
+  test('forwards same-snapshot parent height to AppKit', () => {
+    const surface = {}
+
+    const addon = {
+      create: vi.fn(() => surface),
+      setFrame: vi.fn(),
+      write: vi.fn(),
+      focus: vi.fn(),
+      destroy: vi.fn(),
+    }
+
+    const sidecar = {
+      invoke: <T>(): Promise<T> => Promise.resolve(undefined as T),
+      onEvent: vi.fn(() => vi.fn()),
+      shutdown: vi.fn(() => Promise.resolve()),
+    } satisfies Sidecar
+
+    const controller = setupGhosttyNativeParent({
+      sidecar,
+      platform: 'darwin',
+      env: { VITE_GHOSTTY_NATIVE_MACOS_PARENT: '1' },
+      addon,
+    })
+
+    handlers.get(GHOSTTY_NATIVE_UPDATE)?.(
+      { sender: {} },
+      {
+        sessionId: 'pty-1',
+        paneId: 'pane-1',
+        cwd: '/tmp',
+        parentHeight: 900.4,
+        visible: true,
+        bounds: { x: 10, y: 20, width: 300, height: 200 },
+      }
+    )
+
+    expect(addon.setFrame).toHaveBeenCalledWith(
+      surface,
+      10,
+      20,
+      300,
+      200,
+      0,
+      900
+    )
 
     controller.dispose()
   })
@@ -409,11 +568,20 @@ describe('ghostty native parent', () => {
         paneId: 'pane-1',
         cwd: '/tmp',
         visible: true,
+        parentHeight: 900,
         bounds: { x: 10, y: 20, width: 0, height: 200 },
       }
     )
 
-    expect(addon.setFrame).toHaveBeenCalledWith(surface, 10, 20, 0, 0, 0)
+    expect(addon.setFrame).toHaveBeenCalledWith(
+      surface,
+      10,
+      20,
+      0,
+      0,
+      0,
+      900
+    )
 
     handlers.get(GHOSTTY_NATIVE_UPDATE)?.(
       { sender: {} },
@@ -422,11 +590,20 @@ describe('ghostty native parent', () => {
         paneId: 'pane-1',
         cwd: '/tmp',
         visible: true,
+        parentHeight: 900,
         bounds: { x: 10, y: 20, width: 300, height: 0 },
       }
     )
 
-    expect(addon.setFrame).toHaveBeenLastCalledWith(surface, 10, 20, 0, 0, 0)
+    expect(addon.setFrame).toHaveBeenLastCalledWith(
+      surface,
+      10,
+      20,
+      0,
+      0,
+      0,
+      900
+    )
 
     controller.dispose()
   })
@@ -463,6 +640,7 @@ describe('ghostty native parent', () => {
         paneId: 'pane-1',
         cwd: '/tmp',
         visible: true,
+        parentHeight: 900,
         bounds: { x: 10, y: 20, width: 300, height: 200 },
         shortcutContext: {
           paneIds: ['pane-1', 'pane-2', 'pane-3'],
@@ -480,6 +658,25 @@ describe('ghostty native parent', () => {
         paneId: 'pane-1',
         cwd: '/tmp',
         visible: true,
+        parentHeight: 900,
+        bounds: { x: 10, y: 20, width: 300, height: 200 },
+        shortcutContext: {
+          paneIds: ['pane-1', 'pane-2', 'pane-3'],
+          activePaneId: 'pane-1',
+        },
+      }
+    )
+
+    expect(addon.setShortcutDigits).toHaveBeenCalledTimes(1)
+
+    handlers.get(GHOSTTY_NATIVE_UPDATE)?.(
+      { sender: {} },
+      {
+        sessionId: 'pty-1',
+        paneId: 'pane-1',
+        cwd: '/tmp',
+        visible: true,
+        parentHeight: 900,
         bounds: { x: 10, y: 20, width: 300, height: 200 },
         shortcutContext: {
           paneIds: ['pane-1', 'pane-2', 'pane-3'],
@@ -541,6 +738,7 @@ describe('ghostty native parent', () => {
         paneId: 'pane-1',
         cwd: '/tmp',
         visible: true,
+        parentHeight: 900,
         bounds: { x: 10, y: 20, width: 300, height: 200 },
       }
     )
@@ -554,7 +752,16 @@ describe('ghostty native parent', () => {
       expect.any(Function),
       expect.any(Function)
     )
-    expect(addon.setFrame).toHaveBeenCalledWith(surface, 10, 20, 300, 200, 0)
+
+    expect(addon.setFrame).toHaveBeenCalledWith(
+      surface,
+      10,
+      20,
+      300,
+      200,
+      0,
+      900
+    )
 
     callbacks.onInput?.('a')
     callbacks.onResize?.(80, 24)
@@ -638,6 +845,7 @@ describe('ghostty native parent', () => {
         paneId: 'pane-1',
         cwd: '/tmp',
         visible: true,
+        parentHeight: 900,
         bounds: { x: 10, y: 20, width: 300, height: 200 },
       }
     )
@@ -713,6 +921,7 @@ describe('ghostty native parent', () => {
         paneId: 'pane-1',
         cwd: '/tmp',
         visible: true,
+        parentHeight: 900,
         bounds: { x: 10, y: 20, width: 300, height: 200 },
       }
     )
@@ -774,6 +983,7 @@ describe('ghostty native parent', () => {
         paneId: 'pane-1',
         cwd: '/tmp',
         visible: true,
+        parentHeight: 900,
         bounds: { x: 10, y: 20, width: 300, height: 200 },
       }
     )
@@ -841,6 +1051,7 @@ describe('ghostty native parent', () => {
         paneId: 'pane-1',
         cwd: '/tmp',
         visible: true,
+        parentHeight: 900,
         bounds: { x: 10, y: 20, width: 300, height: 200 },
       }
     )
@@ -852,6 +1063,7 @@ describe('ghostty native parent', () => {
         paneId: 'pane-2',
         cwd: '/tmp',
         visible: true,
+        parentHeight: 900,
         bounds: { x: 400, y: 20, width: 300, height: 200 },
       }
     )
@@ -864,7 +1076,8 @@ describe('ghostty native parent', () => {
       20,
       300,
       200,
-      0
+      0,
+      900
     )
 
     expect(addon.setFrame).toHaveBeenCalledWith(
@@ -873,7 +1086,8 @@ describe('ghostty native parent', () => {
       20,
       300,
       200,
-      0
+      0,
+      900
     )
 
     callbacks[0]?.onInput('a')

--- a/electron/ghostty-native-parent.test.ts
+++ b/electron/ghostty-native-parent.test.ts
@@ -155,7 +155,7 @@ describe('ghostty native parent', () => {
           cwd: '/tmp',
           backgroundColor: 'not-a-color',
           visible: true,
-        parentHeight: 900,
+          parentHeight: 900,
           bounds: { x: 10, y: 20, width: 300, height: 200 },
         }
       )
@@ -183,7 +183,7 @@ describe('ghostty native parent', () => {
           paneId: 'pane-1',
           cwd: '/tmp',
           visible: true,
-        parentHeight: 900,
+          parentHeight: 900,
           bounds: { x: 10, y: 20, width: 300, height: 200 },
         }
       )
@@ -573,15 +573,7 @@ describe('ghostty native parent', () => {
       }
     )
 
-    expect(addon.setFrame).toHaveBeenCalledWith(
-      surface,
-      10,
-      20,
-      0,
-      0,
-      0,
-      900
-    )
+    expect(addon.setFrame).toHaveBeenCalledWith(surface, 10, 20, 0, 0, 0, 900)
 
     handlers.get(GHOSTTY_NATIVE_UPDATE)?.(
       { sender: {} },

--- a/electron/ghostty-native-parent.ts
+++ b/electron/ghostty-native-parent.ts
@@ -56,7 +56,8 @@ interface GhosttyNativeParentAddon {
     y: number,
     width: number,
     height: number,
-    bottomCornerRadius: number
+    bottomCornerRadius: number,
+    parentHeight: number
   ) => void
   setShortcutDigits?: (surface: unknown, digits: string) => void
   setBackgroundColor?: (surface: unknown, color: string) => void
@@ -78,7 +79,11 @@ interface GhosttyNativeSurfaceState {
   pane: GhosttyNativePaneRequest
   surface: unknown
   pendingData: string[]
+  // Resize updates pass through this same path. Cache values that reapply
+  // Ghostty theme/shortcut state so steady resize only calls setFrame.
+  lastBackgroundColor: string | null
   lastResize: { cols: number; rows: number } | null
+  lastShortcutDigits: string | null
 }
 
 interface GhosttyNativeShortcutInput {
@@ -192,6 +197,8 @@ function isNativePayload<TKind extends keyof GhosttyNativePayloadByKind>(
         (value.backgroundColor === undefined ||
           isHexColor(value.backgroundColor)) &&
         isOptionalFiniteNumber(value.bottomCornerRadius) &&
+        typeof value.parentHeight === 'number' &&
+        Number.isFinite(value.parentHeight) &&
         typeof value.visible === 'boolean' &&
         (value.shortcutContext === undefined ||
           isShortcutContext(value.shortcutContext))
@@ -318,8 +325,13 @@ export class GhosttyNativeParentController {
       bottomCornerRadius: frameVisible
         ? Math.max(0, Math.round(payload.bottomCornerRadius ?? 0))
         : 0,
+      parentHeight: Math.max(0, Math.round(payload.parentHeight)),
     }
-    if (isHexColor(payload.backgroundColor)) {
+    if (
+      isHexColor(payload.backgroundColor) &&
+      state.lastBackgroundColor !== payload.backgroundColor
+    ) {
+      state.lastBackgroundColor = payload.backgroundColor
       addon.setBackgroundColor?.(surface, payload.backgroundColor)
     }
     addon.setFrame(
@@ -328,10 +340,16 @@ export class GhosttyNativeParentController {
       frame.y,
       frame.width,
       frame.height,
-      frame.bottomCornerRadius
+      frame.bottomCornerRadius,
+      frame.parentHeight
     )
-    addon.setShortcutDigits?.(surface, shortcutDigits)
-    this.flushPendingData(addon, state)
+    if (state.lastShortcutDigits !== shortcutDigits) {
+      state.lastShortcutDigits = shortcutDigits
+      addon.setShortcutDigits?.(surface, shortcutDigits)
+    }
+    if (state.pendingData.length > 0) {
+      this.flushPendingData(addon, state)
+    }
 
     return { enabled: true }
   }
@@ -450,7 +468,9 @@ export class GhosttyNativeParentController {
       },
       surface: null,
       pendingData: [],
+      lastBackgroundColor: null,
       lastResize: null,
+      lastShortcutDigits: null,
     }
     this.surfaces.set(key, state)
 

--- a/electron/ghostty-native-shared.ts
+++ b/electron/ghostty-native-shared.ts
@@ -21,6 +21,7 @@ export interface GhosttyNativeUpdateRequest extends GhosttyNativePaneRequest {
   bounds: GhosttyNativeBounds
   backgroundColor?: string
   bottomCornerRadius?: number
+  parentHeight: number
   visible: boolean
   shortcutContext?: GhosttyNativeShortcutContext
 }

--- a/native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift
+++ b/native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift
@@ -252,13 +252,14 @@ private final class EmbeddedGhosttySurface: NSObject {
         y: Double,
         width: Double,
         height: Double,
-        bottomCornerRadius: Double
+        bottomCornerRadius: Double,
+        parentHeight: Double
     ) {
         let safeWidth = max(0, width)
         let safeHeight = max(0, height)
         let safeBottomCornerRadius = max(0, bottomCornerRadius)
-        let parentHeight = parentView.bounds.height
-        let appKitY = parentHeight - y - safeHeight
+        let safeParentHeight = parentHeight.isFinite && parentHeight > 0 ? parentHeight : parentView.bounds.height
+        let appKitY = safeParentHeight - y - safeHeight
 
         container.layer?.cornerRadius = CGFloat(safeBottomCornerRadius)
         container.layer?.maskedCorners = [
@@ -470,7 +471,8 @@ public func vimeflowGhosttySetFrame(
     _ y: Double,
     _ width: Double,
     _ height: Double,
-    _ bottomCornerRadius: Double
+    _ bottomCornerRadius: Double,
+    _ parentHeight: Double
 ) {
     guard let surfacePointer else {
         return
@@ -486,7 +488,8 @@ public func vimeflowGhosttySetFrame(
             y: y,
             width: width,
             height: height,
-            bottomCornerRadius: bottomCornerRadius
+            bottomCornerRadius: bottomCornerRadius,
+            parentHeight: parentHeight
         )
     }
 }

--- a/native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift
+++ b/native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift
@@ -273,6 +273,7 @@ private final class EmbeddedGhosttySurface: NSObject {
             width: safeWidth,
             height: safeHeight
         )
+        updateLiveResizePrediction(frame: container.frame)
         terminalView.frame = container.bounds
         container.isHidden = safeWidth <= 0 || safeHeight <= 0
     }
@@ -342,6 +343,70 @@ private final class EmbeddedGhosttySurface: NSObject {
         shortcutMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown]) { [weak self] event in
             self?.handleKeyDown(event) == true ? nil : event
         }
+    }
+
+    private func updateLiveResizePrediction(frame: NSRect) {
+        guard parentView.inLiveResize else {
+            container.autoresizingMask = []
+
+            return
+        }
+
+        // AppKit moves/resizes the native view between renderer IPC corrections
+        // during live resize; renderer frames still win on the next update.
+        container.autoresizingMask = predictedAutoresizingMask(
+            frame: frame,
+            parentBounds: parentView.bounds
+        )
+    }
+
+    private func predictedAutoresizingMask(
+        frame: NSRect,
+        parentBounds: NSRect
+    ) -> NSView.AutoresizingMask {
+        let tolerance: CGFloat = 1
+        let touchesLeft = abs(frame.minX - parentBounds.minX) <= tolerance
+        let touchesRight = abs(frame.maxX - parentBounds.maxX) <= tolerance
+        let touchesBottom = abs(frame.minY - parentBounds.minY) <= tolerance
+        let touchesTop = abs(frame.maxY - parentBounds.maxY) <= tolerance
+        var mask: NSView.AutoresizingMask = []
+
+        mask.formUnion(axisAutoresizingMask(
+            touchesMin: touchesLeft,
+            touchesMax: touchesRight,
+            size: .width,
+            minMargin: .minXMargin,
+            maxMargin: .maxXMargin
+        ))
+        mask.formUnion(axisAutoresizingMask(
+            touchesMin: touchesBottom,
+            touchesMax: touchesTop,
+            size: .height,
+            minMargin: .minYMargin,
+            maxMargin: .maxYMargin
+        ))
+
+        return mask
+    }
+
+    private func axisAutoresizingMask(
+        touchesMin: Bool,
+        touchesMax: Bool,
+        size: NSView.AutoresizingMask,
+        minMargin: NSView.AutoresizingMask,
+        maxMargin: NSView.AutoresizingMask
+    ) -> NSView.AutoresizingMask {
+        if touchesMin && touchesMax {
+            return [size]
+        }
+        if touchesMin {
+            return [maxMargin]
+        }
+        if touchesMax {
+            return [minMargin]
+        }
+
+        return [minMargin, size, maxMargin]
     }
 
     private func handleMouseDown(_ event: NSEvent) {

--- a/native/ghostty-parent/ghostty_native_parent.cc
+++ b/native/ghostty-parent/ghostty_native_parent.cc
@@ -19,7 +19,11 @@ using RenamePaneCallback = void (*)(void *);
 using CreateFn = void *(*)(void *, InputCallback, ResizeCallback,
                            FocusCallback, ShortcutCallback,
                            RenamePaneCallback, void *);
-using SetFrameFn = void (*)(void *, double, double, double, double, double);
+// JS calls setFrame(surface, x, y, width, height, bottomCornerRadius,
+// parentHeight). The six numeric args map the renderer's top-left native frame
+// plus styling and same-snapshot parent height for Swift's AppKit y-flip.
+using SetFrameFn = void (*)(
+    void *, double, double, double, double, double, double);
 using SetShortcutDigitsFn = void (*)(void *, const char *);
 using SetBackgroundColorFn = void (*)(void *, const char *);
 using WriteFn = void (*)(void *, const unsigned char *, int);
@@ -476,13 +480,13 @@ napi_value Create(napi_env env, napi_callback_info info) {
 }
 
 napi_value SetFrame(napi_env env, napi_callback_info info) {
-  size_t argc = 6;
-  napi_value args[6];
+  size_t argc = 7;
+  napi_value args[7];
   napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
   if (argc < 5) {
     return Throw(env,
                  "setFrame(surface, x, y, width, height[, "
-                 "bottomCornerRadius]) expected");
+                 "bottomCornerRadius, parentHeight]) expected");
   }
 
   SurfaceHandle *surface = GetSurface(env, args[0]);
@@ -495,6 +499,7 @@ napi_value SetFrame(napi_env env, napi_callback_info info) {
   double width = 0;
   double height = 0;
   double bottom_corner_radius = 0;
+  double parent_height = 0;
   napi_get_value_double(env, args[1], &x);
   napi_get_value_double(env, args[2], &y);
   napi_get_value_double(env, args[3], &width);
@@ -502,8 +507,11 @@ napi_value SetFrame(napi_env env, napi_callback_info info) {
   if (argc >= 6) {
     napi_get_value_double(env, args[5], &bottom_corner_radius);
   }
+  if (argc >= 7) {
+    napi_get_value_double(env, args[6], &parent_height);
+  }
   bridge.set_frame(surface->swift_surface, x, y, width, height,
-                   bottom_corner_radius);
+                   bottom_corner_radius, parent_height);
 
   return nullptr;
 }

--- a/src/features/terminal/components/TerminalPane/GhosttyBody.test.tsx
+++ b/src/features/terminal/components/TerminalPane/GhosttyBody.test.tsx
@@ -331,6 +331,95 @@ describe('GhosttyBody', () => {
     })
   })
 
+  test('tracks native frame updates until resize callbacks go quiet', async () => {
+    let resizeCallback: ResizeObserverCallback | null = null
+    let now = 1_000
+    const frameCallbacks: FrameRequestCallback[] = []
+
+    const dateNowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now)
+
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback) => {
+        frameCallbacks.push(callback)
+
+        return frameCallbacks.length
+      })
+
+    vi.stubGlobal(
+      'ResizeObserver',
+      vi.fn().mockImplementation((callback: ResizeObserverCallback) => {
+        resizeCallback = callback
+
+        return {
+          observe: vi.fn(),
+          unobserve: vi.fn(),
+          disconnect: vi.fn(),
+        }
+      })
+    )
+
+    render(
+      <GhosttyBody
+        paneId="pane-1"
+        ptyId="pty-1"
+        cwd="/tmp"
+        active
+        service={createService()}
+      />
+    )
+
+    await waitFor(() => {
+      expect(updateNativeGhostty).toHaveBeenCalledTimes(1)
+    })
+    vi.mocked(updateNativeGhostty).mockClear()
+
+    act(() => {
+      resizeCallback?.([], {} as ResizeObserver)
+      resizeCallback?.([], {} as ResizeObserver)
+      resizeCallback?.([], {} as ResizeObserver)
+    })
+
+    expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      now = 1_016
+      frameCallbacks.shift()?.(0)
+      await Promise.resolve()
+    })
+
+    expect(updateNativeGhostty).toHaveBeenCalledTimes(1)
+    expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(2)
+
+    act(() => {
+      now = 1_060
+      resizeCallback?.([], {} as ResizeObserver)
+    })
+
+    expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(2)
+
+    await act(async () => {
+      now = 1_130
+      frameCallbacks.shift()?.(16)
+      await Promise.resolve()
+    })
+
+    expect(updateNativeGhostty).toHaveBeenCalledTimes(2)
+    expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(3)
+
+    await act(async () => {
+      now = 1_195
+      frameCallbacks.shift()?.(32)
+      await Promise.resolve()
+    })
+
+    expect(updateNativeGhostty).toHaveBeenCalledTimes(3)
+    expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(3)
+
+    dateNowSpy.mockRestore()
+    requestAnimationFrameSpy.mockRestore()
+  })
+
   test('absorbs native destroy failures during unmount cleanup', async () => {
     vi.mocked(destroyNativeGhostty).mockRejectedValueOnce(new Error('disposed'))
 

--- a/src/features/terminal/components/TerminalPane/GhosttyBody.test.tsx
+++ b/src/features/terminal/components/TerminalPane/GhosttyBody.test.tsx
@@ -1,5 +1,5 @@
 // cspell:ignore Ghostty
-import { act, render, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { flexoki, obsidianLens, themeService } from '../../../../theme'
 import type { ITerminalService } from '../../services/terminalService'
@@ -15,6 +15,7 @@ import {
   GhosttyBody,
   nativeGhosttyBoundsFromRect,
   nativeGhosttyCornerRadiusFromCssPixels,
+  nativeGhosttyParentHeightFromViewport,
 } from './GhosttyBody'
 
 const backendListeners = new Map<string, (payload: unknown) => void>()
@@ -291,6 +292,17 @@ describe('GhosttyBody', () => {
     ).toBeCloseTo(9.13242)
   })
 
+  test('converts CSS viewport height to native window points', () => {
+    expect(
+      nativeGhosttyParentHeightFromViewport({
+        innerWidth: 1533,
+        innerHeight: 985,
+        outerWidth: 1400,
+        outerHeight: 900,
+      })
+    ).toBe(900)
+  })
+
   test('falls back to unscaled native frame bounds when viewport metrics are unavailable', () => {
     expect(
       nativeGhosttyBoundsFromRect(rect(10, 20, 300, 200), {
@@ -327,6 +339,53 @@ describe('GhosttyBody', () => {
     await waitFor(() => {
       expect(updateNativeGhostty).toHaveBeenCalledWith(
         expect.objectContaining({ shortcutContext })
+      )
+    })
+  })
+
+  test('sends native frame updates when only shortcut context changes', async () => {
+    const firstShortcutContext = {
+      paneIds: ['pane-1', 'pane-2'],
+      activePaneId: 'pane-1',
+    }
+
+    const nextShortcutContext = {
+      paneIds: ['pane-1', 'pane-2'],
+      activePaneId: 'pane-2',
+    }
+
+    const { rerender } = render(
+      <GhosttyBody
+        paneId="pane-1"
+        ptyId="pty-1"
+        cwd="/tmp"
+        active
+        shortcutContext={firstShortcutContext}
+        service={createService()}
+      />
+    )
+
+    await waitFor(() => {
+      expect(updateNativeGhostty).toHaveBeenCalledWith(
+        expect.objectContaining({ shortcutContext: firstShortcutContext })
+      )
+    })
+    vi.mocked(updateNativeGhostty).mockClear()
+
+    rerender(
+      <GhosttyBody
+        paneId="pane-1"
+        ptyId="pty-1"
+        cwd="/tmp"
+        active
+        shortcutContext={nextShortcutContext}
+        service={createService()}
+      />
+    )
+
+    await waitFor(() => {
+      expect(updateNativeGhostty).toHaveBeenCalledWith(
+        expect.objectContaining({ shortcutContext: nextShortcutContext })
       )
     })
   })
@@ -380,6 +439,7 @@ describe('GhosttyBody', () => {
       resizeCallback?.([], {} as ResizeObserver)
     })
 
+    expect(updateNativeGhostty).toHaveBeenCalledTimes(0)
     expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(1)
 
     await act(async () => {
@@ -388,7 +448,7 @@ describe('GhosttyBody', () => {
       await Promise.resolve()
     })
 
-    expect(updateNativeGhostty).toHaveBeenCalledTimes(1)
+    expect(updateNativeGhostty).toHaveBeenCalledTimes(0)
     expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(2)
 
     act(() => {
@@ -404,7 +464,7 @@ describe('GhosttyBody', () => {
       await Promise.resolve()
     })
 
-    expect(updateNativeGhostty).toHaveBeenCalledTimes(2)
+    expect(updateNativeGhostty).toHaveBeenCalledTimes(0)
     expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(3)
 
     await act(async () => {
@@ -413,11 +473,162 @@ describe('GhosttyBody', () => {
       await Promise.resolve()
     })
 
-    expect(updateNativeGhostty).toHaveBeenCalledTimes(3)
+    expect(updateNativeGhostty).toHaveBeenCalledTimes(0)
     expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(3)
 
     dateNowSpy.mockRestore()
     requestAnimationFrameSpy.mockRestore()
+  })
+
+  test('dedupes resize observer updates by rounded native frame', async () => {
+    let resizeCallback: ResizeObserverCallback | null = null
+
+    vi.stubGlobal(
+      'ResizeObserver',
+      vi.fn().mockImplementation((callback: ResizeObserverCallback) => {
+        resizeCallback = callback
+
+        return {
+          observe: vi.fn(),
+          unobserve: vi.fn(),
+          disconnect: vi.fn(),
+        }
+      })
+    )
+
+    render(
+      <GhosttyBody
+        paneId="pane-1"
+        ptyId="pty-1"
+        cwd="/tmp"
+        active
+        service={createService()}
+      />
+    )
+
+    await waitFor(() => {
+      expect(updateNativeGhostty).toHaveBeenCalledTimes(1)
+    })
+    vi.mocked(updateNativeGhostty).mockClear()
+
+    const node = screen.getByTestId('native-ghostty-pane')
+    node.getBoundingClientRect = vi.fn(() =>
+      rect(10.4, 20.4, 300.4, 200.4)
+    )
+
+    act(() => {
+      resizeCallback?.([], {} as ResizeObserver)
+    })
+
+    expect(updateNativeGhostty).toHaveBeenCalledTimes(1)
+    expect(updateNativeGhostty).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        bounds: { x: 10.4, y: 20.4, width: 300.4, height: 200.4 },
+        parentHeight: window.outerHeight,
+      })
+    )
+
+    node.getBoundingClientRect = vi.fn(() =>
+      rect(10.49, 20.49, 300.49, 200.49)
+    )
+
+    act(() => {
+      resizeCallback?.([], {} as ResizeObserver)
+    })
+
+    expect(updateNativeGhostty).toHaveBeenCalledTimes(1)
+
+    node.getBoundingClientRect = vi.fn(() =>
+      rect(10.6, 20.6, 300.6, 200.6)
+    )
+
+    act(() => {
+      resizeCallback?.([], {} as ResizeObserver)
+    })
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(updateNativeGhostty).toHaveBeenCalledTimes(2)
+    expect(updateNativeGhostty).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        bounds: { x: 10.6, y: 20.6, width: 300.6, height: 200.6 },
+      })
+    )
+  })
+
+  test('coalesces native frame updates while one IPC request is in flight', async () => {
+    let resizeCallback: ResizeObserverCallback | null = null
+    let resolveFirstResize: ((enabled: boolean) => void) | undefined
+
+    vi.stubGlobal(
+      'ResizeObserver',
+      vi.fn().mockImplementation((callback: ResizeObserverCallback) => {
+        resizeCallback = callback
+
+        return {
+          observe: vi.fn(),
+          unobserve: vi.fn(),
+          disconnect: vi.fn(),
+        }
+      })
+    )
+
+    render(
+      <GhosttyBody
+        paneId="pane-1"
+        ptyId="pty-1"
+        cwd="/tmp"
+        active
+        service={createService()}
+      />
+    )
+
+    await waitFor(() => {
+      expect(updateNativeGhostty).toHaveBeenCalledTimes(1)
+    })
+    vi.mocked(updateNativeGhostty).mockClear()
+    vi.mocked(updateNativeGhostty).mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveFirstResize = resolve
+      })
+    )
+
+    const node = screen.getByTestId('native-ghostty-pane')
+    node.getBoundingClientRect = vi.fn(() => rect(10, 20, 300, 200))
+
+    act(() => {
+      resizeCallback?.([], {} as ResizeObserver)
+    })
+
+    expect(updateNativeGhostty).toHaveBeenCalledTimes(1)
+
+    node.getBoundingClientRect = vi.fn(() => rect(15, 20, 300, 200))
+    act(() => {
+      resizeCallback?.([], {} as ResizeObserver)
+    })
+
+    node.getBoundingClientRect = vi.fn(() => rect(25, 20, 300, 200))
+    act(() => {
+      resizeCallback?.([], {} as ResizeObserver)
+    })
+
+    expect(updateNativeGhostty).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      resolveFirstResize?.(true)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(updateNativeGhostty).toHaveBeenCalledTimes(2)
+    expect(updateNativeGhostty).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        bounds: { x: 25, y: 20, width: 300, height: 200 },
+      })
+    )
   })
 
   test('absorbs native destroy failures during unmount cleanup', async () => {

--- a/src/features/terminal/components/TerminalPane/GhosttyBody.test.tsx
+++ b/src/features/terminal/components/TerminalPane/GhosttyBody.test.tsx
@@ -500,9 +500,7 @@ describe('GhosttyBody', () => {
     vi.mocked(updateNativeGhostty).mockClear()
 
     const node = screen.getByTestId('native-ghostty-pane')
-    node.getBoundingClientRect = vi.fn(() =>
-      rect(10.4, 20.4, 300.4, 200.4)
-    )
+    node.getBoundingClientRect = vi.fn(() => rect(10.4, 20.4, 300.4, 200.4))
 
     act(() => {
       resizeCallback?.([], {} as ResizeObserver)
@@ -516,9 +514,7 @@ describe('GhosttyBody', () => {
       })
     )
 
-    node.getBoundingClientRect = vi.fn(() =>
-      rect(10.49, 20.49, 300.49, 200.49)
-    )
+    node.getBoundingClientRect = vi.fn(() => rect(10.49, 20.49, 300.49, 200.49))
 
     act(() => {
       resizeCallback?.([], {} as ResizeObserver)
@@ -526,9 +522,7 @@ describe('GhosttyBody', () => {
 
     expect(updateNativeGhostty).toHaveBeenCalledTimes(1)
 
-    node.getBoundingClientRect = vi.fn(() =>
-      rect(10.6, 20.6, 300.6, 200.6)
-    )
+    node.getBoundingClientRect = vi.fn(() => rect(10.6, 20.6, 300.6, 200.6))
 
     act(() => {
       resizeCallback?.([], {} as ResizeObserver)

--- a/src/features/terminal/components/TerminalPane/GhosttyBody.test.tsx
+++ b/src/features/terminal/components/TerminalPane/GhosttyBody.test.tsx
@@ -15,7 +15,6 @@ import {
   GhosttyBody,
   nativeGhosttyBoundsFromRect,
   nativeGhosttyCornerRadiusFromCssPixels,
-  nativeGhosttyParentHeightFromViewport,
 } from './GhosttyBody'
 
 const backendListeners = new Map<string, (payload: unknown) => void>()
@@ -290,17 +289,6 @@ describe('GhosttyBody', () => {
         outerHeight: 900,
       })
     ).toBeCloseTo(9.13242)
-  })
-
-  test('converts CSS viewport height to native window points', () => {
-    expect(
-      nativeGhosttyParentHeightFromViewport({
-        innerWidth: 1533,
-        innerHeight: 985,
-        outerWidth: 1400,
-        outerHeight: 900,
-      })
-    ).toBe(900)
   })
 
   test('falls back to unscaled native frame bounds when viewport metrics are unavailable', () => {

--- a/src/features/terminal/components/TerminalPane/GhosttyBody.tsx
+++ b/src/features/terminal/components/TerminalPane/GhosttyBody.tsx
@@ -63,6 +63,8 @@ const TERMINAL_INPUT_CONTROL_SEQUENCE_PATTERN =
 
 const AGENT_CWD_HINT_BUFFER_SIZE = 4096
 const OSC7_SEQUENCE_PATTERN = /\u001b\]7;([^\u0007\u001b]*)(?:\u0007|\u001b\\)/g
+// ponytail: rAF resize-tracking loop; revert to one-shot scheduling if manual Ghostty testing shows IPC churn/jitter.
+const NATIVE_RESIZE_TRACKING_QUIET_MS = 120
 
 const stripTerminalInputControlSequences = (data: string): string =>
   data.replace(TERMINAL_INPUT_CONTROL_SEQUENCE_PATTERN, '')
@@ -133,6 +135,7 @@ export const GhosttyBody = ({
   const backgroundColor = theme.terminal.background
   const containerRef = useRef<HTMLDivElement | null>(null)
   const frameIdRef = useRef<number | null>(null)
+  const resizeTrackingUntilRef = useRef(0)
   const submittedInputLineRef = useRef('')
   const agentCwdOutputBufferRef = useRef('')
   const agentCwdHintContextRef = useRef('')
@@ -384,14 +387,25 @@ export const GhosttyBody = ({
   ])
 
   const scheduleNativeFrameUpdate = useCallback((): void => {
+    resizeTrackingUntilRef.current =
+      Date.now() + NATIVE_RESIZE_TRACKING_QUIET_MS
+
     if (frameIdRef.current !== null) {
       return
     }
 
-    frameIdRef.current = window.requestAnimationFrame(() => {
+    const runFrameUpdate = (): void => {
       frameIdRef.current = null
       void updateNativeFrame()
-    })
+
+      if (Date.now() >= resizeTrackingUntilRef.current) {
+        return
+      }
+
+      frameIdRef.current = window.requestAnimationFrame(runFrameUpdate)
+    }
+
+    frameIdRef.current = window.requestAnimationFrame(runFrameUpdate)
   }, [updateNativeFrame])
 
   // Keep the parented NSView aligned; resize events only schedule rAF updates.
@@ -411,6 +425,7 @@ export const GhosttyBody = ({
         window.cancelAnimationFrame(frameIdRef.current)
         frameIdRef.current = null
       }
+      resizeTrackingUntilRef.current = 0
       observer.disconnect()
       window.removeEventListener('resize', scheduleNativeFrameUpdate)
     }

--- a/src/features/terminal/components/TerminalPane/GhosttyBody.tsx
+++ b/src/features/terminal/components/TerminalPane/GhosttyBody.tsx
@@ -2,6 +2,7 @@
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   type ReactElement,
@@ -76,6 +77,11 @@ interface NativeGhosttyViewportMetrics {
   outerHeight: number
 }
 
+interface NativeGhosttyFrameSnapshot {
+  key: string
+  request: Parameters<typeof updateNativeGhostty>[0]
+}
+
 const nativePointScale = (outerSize: number, innerSize: number): number =>
   Number.isFinite(outerSize) &&
   Number.isFinite(innerSize) &&
@@ -107,6 +113,50 @@ export const nativeGhosttyCornerRadiusFromCssPixels = (
   viewport: NativeGhosttyViewportMetrics = window
 ): number => radius * nativePointScale(viewport.outerWidth, viewport.innerWidth)
 
+// AppKit flips y from the parent view height. Send the renderer's same-window
+// snapshot so top-edge live resize cannot mix old pane bounds with a new height.
+export const nativeGhosttyParentHeightFromViewport = (
+  viewport: NativeGhosttyViewportMetrics = window
+): number =>
+  Number.isFinite(viewport.outerHeight) && viewport.outerHeight > 0
+    ? viewport.outerHeight
+    : viewport.innerHeight
+
+// Main rounds native frames before calling AppKit. Dedupe on that rounded shape
+// so tiny DOM float churn does not become repeated native resize IPC.
+const nativeGhosttyFrameKey = ({
+  backgroundColor,
+  bottomCornerRadius,
+  bounds,
+  parentHeight,
+  shortcutContext,
+  visible,
+}: {
+  backgroundColor: string
+  bottomCornerRadius: number
+  bounds: NativeGhosttyBounds
+  parentHeight: number
+  shortcutContext?: NativeGhosttyShortcutContext
+  visible: boolean
+}): string => {
+  const roundedWidth = Math.round(bounds.width)
+  const roundedHeight = Math.round(bounds.height)
+  const frameVisible = visible && roundedWidth > 0 && roundedHeight > 0
+
+  return [
+    Math.round(bounds.x),
+    Math.round(bounds.y),
+    frameVisible ? roundedWidth : 0,
+    frameVisible ? roundedHeight : 0,
+    Math.round(parentHeight),
+    frameVisible ? Math.max(0, Math.round(bottomCornerRadius)) : 0,
+    frameVisible ? '1' : '0',
+    backgroundColor,
+    shortcutContext?.activePaneId ?? '',
+    ...(shortcutContext?.paneIds ?? []),
+  ].join(':')
+}
+
 const shouldPreserveOsc7FileUrlHost = (currentCwd?: string): boolean =>
   Boolean(
     currentCwd &&
@@ -135,6 +185,12 @@ export const GhosttyBody = ({
   const backgroundColor = theme.terminal.background
   const containerRef = useRef<HTMLDivElement | null>(null)
   const frameIdRef = useRef<number | null>(null)
+  const inFlightNativeFrameRef = useRef<Promise<void> | null>(null)
+  const lastSentNativeFrameKeyRef = useRef<string | null>(null)
+
+  const queuedNativeFrameSnapshotRef = useRef<NativeGhosttyFrameSnapshot | null>(
+    null
+  )
   const resizeTrackingUntilRef = useRef(0)
   const submittedInputLineRef = useRef('')
   const agentCwdOutputBufferRef = useRef('')
@@ -349,39 +405,107 @@ export const GhosttyBody = ({
     [handleNativeOutput, sendOutputToNative]
   )
 
-  const updateNativeFrame = useCallback(async (): Promise<void> => {
+  // One place for native-frame IPC error handling; callers queue snapshots and
+  // do not need to care whether native Ghostty is disabled or unavailable.
+  const sendNativeFrameSnapshot = useCallback(
+    async (snapshot: NativeGhosttyFrameSnapshot): Promise<void> => {
+      try {
+        const enabled = await updateNativeGhostty(snapshot.request)
+
+        if (!enabled) {
+          onUnavailable?.()
+        }
+      } catch {
+        onUnavailable?.()
+      }
+    },
+    [onUnavailable]
+  )
+
+  // Keep only one IPC in flight. Resize can fire faster than native can apply
+  // frames, so newer snapshots replace the queued one instead of stacking calls.
+  const flushQueuedNativeFrame = useCallback((): void => {
+    if (inFlightNativeFrameRef.current !== null) {
+      return
+    }
+
+    const snapshot = queuedNativeFrameSnapshotRef.current
+    if (!snapshot) {
+      return
+    }
+
+    queuedNativeFrameSnapshotRef.current = null
+    lastSentNativeFrameKeyRef.current = snapshot.key
+
+    const inFlight = sendNativeFrameSnapshot(snapshot)
+    inFlightNativeFrameRef.current = inFlight
+
+    void (async (): Promise<void> => {
+      await inFlight
+      if (inFlightNativeFrameRef.current === inFlight) {
+        inFlightNativeFrameRef.current = null
+      }
+      flushQueuedNativeFrame()
+    })()
+  }, [sendNativeFrameSnapshot])
+
+  const updateNativeFrame = useCallback((): void => {
     const node = containerRef.current
     if (!node) {
       return
     }
 
-    const bounds = nativeGhosttyBoundsFromRect(node.getBoundingClientRect())
+    const viewport = {
+      innerWidth: window.innerWidth,
+      innerHeight: window.innerHeight,
+      outerWidth: window.outerWidth,
+      outerHeight: window.outerHeight,
+    }
+
+    const bounds = nativeGhosttyBoundsFromRect(
+      node.getBoundingClientRect(),
+      viewport
+    )
 
     const nativeBottomCornerRadius =
-      nativeGhosttyCornerRadiusFromCssPixels(bottomCornerRadius)
+      nativeGhosttyCornerRadiusFromCssPixels(bottomCornerRadius, viewport)
+    const parentHeight = nativeGhosttyParentHeightFromViewport(viewport)
+    const visible = true
 
-    try {
-      const enabled = await updateNativeGhostty({
+    const snapshot = {
+      key: nativeGhosttyFrameKey({
+        backgroundColor,
+        bottomCornerRadius: nativeBottomCornerRadius,
+        bounds,
+        parentHeight,
+        shortcutContext,
+        visible,
+      }),
+      request: {
         ...paneRef,
         cwd,
         bounds,
         backgroundColor,
         bottomCornerRadius: nativeBottomCornerRadius,
-        visible: true,
+        parentHeight,
+        visible,
         ...(shortcutContext ? { shortcutContext } : {}),
-      })
-
-      if (!enabled) {
-        onUnavailable?.()
-      }
-    } catch {
-      onUnavailable?.()
+      },
     }
+
+    if (lastSentNativeFrameKeyRef.current === snapshot.key) {
+      queuedNativeFrameSnapshotRef.current = null
+
+      return
+    }
+
+    queuedNativeFrameSnapshotRef.current = snapshot
+    flushQueuedNativeFrame()
   }, [
     backgroundColor,
     bottomCornerRadius,
     cwd,
-    onUnavailable,
+    flushQueuedNativeFrame,
     paneRef,
     shortcutContext,
   ])
@@ -396,7 +520,7 @@ export const GhosttyBody = ({
 
     const runFrameUpdate = (): void => {
       frameIdRef.current = null
-      void updateNativeFrame()
+      updateNativeFrame()
 
       if (Date.now() >= resizeTrackingUntilRef.current) {
         return
@@ -408,17 +532,27 @@ export const GhosttyBody = ({
     frameIdRef.current = window.requestAnimationFrame(runFrameUpdate)
   }, [updateNativeFrame])
 
-  // Keep the parented NSView aligned; resize events only schedule rAF updates.
-  useEffect(() => {
+  const syncAndTrackNativeFrame = useCallback((): void => {
+    updateNativeFrame()
+    scheduleNativeFrameUpdate()
+  }, [scheduleNativeFrameUpdate, updateNativeFrame])
+
+  // Keep the parented NSView aligned with the React pane:
+  // 1. ResizeObserver/window resize sends one frame update immediately.
+  // 2. The same signal extends a short "keep sampling" deadline.
+  // 3. One rAF loop samples again until resize has been quiet long enough.
+  // 4. Cleanup cancels that loop, drops the queued frame, and unregisters both
+  //    the observer and window listener.
+  useLayoutEffect(() => {
     const node = containerRef.current
     if (!node) {
       return
     }
 
-    void updateNativeFrame()
-    const observer = new ResizeObserver(scheduleNativeFrameUpdate)
+    updateNativeFrame()
+    const observer = new ResizeObserver(syncAndTrackNativeFrame)
     observer.observe(node)
-    window.addEventListener('resize', scheduleNativeFrameUpdate)
+    window.addEventListener('resize', syncAndTrackNativeFrame)
 
     return (): void => {
       if (frameIdRef.current !== null) {
@@ -426,10 +560,11 @@ export const GhosttyBody = ({
         frameIdRef.current = null
       }
       resizeTrackingUntilRef.current = 0
+      queuedNativeFrameSnapshotRef.current = null
       observer.disconnect()
-      window.removeEventListener('resize', scheduleNativeFrameUpdate)
+      window.removeEventListener('resize', syncAndTrackNativeFrame)
     }
-  }, [scheduleNativeFrameUpdate, updateNativeFrame])
+  }, [syncAndTrackNativeFrame, updateNativeFrame])
 
   // Focus follows the active pane, but focus no longer owns surface lifetime.
   useEffect(() => {

--- a/src/features/terminal/components/TerminalPane/GhosttyBody.tsx
+++ b/src/features/terminal/components/TerminalPane/GhosttyBody.tsx
@@ -113,15 +113,6 @@ export const nativeGhosttyCornerRadiusFromCssPixels = (
   viewport: NativeGhosttyViewportMetrics = window
 ): number => radius * nativePointScale(viewport.outerWidth, viewport.innerWidth)
 
-// AppKit flips y from the parent view height. Send the renderer's same-window
-// snapshot so top-edge live resize cannot mix old pane bounds with a new height.
-export const nativeGhosttyParentHeightFromViewport = (
-  viewport: NativeGhosttyViewportMetrics = window
-): number =>
-  Number.isFinite(viewport.outerHeight) && viewport.outerHeight > 0
-    ? viewport.outerHeight
-    : viewport.innerHeight
-
 // Main rounds native frames before calling AppKit. Dedupe on that rounded shape
 // so tiny DOM float churn does not become repeated native resize IPC.
 const nativeGhosttyFrameKey = ({
@@ -405,23 +396,6 @@ export const GhosttyBody = ({
     [handleNativeOutput, sendOutputToNative]
   )
 
-  // One place for native-frame IPC error handling; callers queue snapshots and
-  // do not need to care whether native Ghostty is disabled or unavailable.
-  const sendNativeFrameSnapshot = useCallback(
-    async (snapshot: NativeGhosttyFrameSnapshot): Promise<void> => {
-      try {
-        const enabled = await updateNativeGhostty(snapshot.request)
-
-        if (!enabled) {
-          onUnavailable?.()
-        }
-      } catch {
-        onUnavailable?.()
-      }
-    },
-    [onUnavailable]
-  )
-
   // Keep only one IPC in flight. Resize can fire faster than native can apply
   // frames, so newer snapshots replace the queued one instead of stacking calls.
   const flushQueuedNativeFrame = useCallback((): void => {
@@ -437,7 +411,17 @@ export const GhosttyBody = ({
     queuedNativeFrameSnapshotRef.current = null
     lastSentNativeFrameKeyRef.current = snapshot.key
 
-    const inFlight = sendNativeFrameSnapshot(snapshot)
+    const inFlight = (async (): Promise<void> => {
+      try {
+        const enabled = await updateNativeGhostty(snapshot.request)
+
+        if (!enabled) {
+          onUnavailable?.()
+        }
+      } catch {
+        onUnavailable?.()
+      }
+    })()
     inFlightNativeFrameRef.current = inFlight
 
     void (async (): Promise<void> => {
@@ -447,7 +431,7 @@ export const GhosttyBody = ({
       }
       flushQueuedNativeFrame()
     })()
-  }, [sendNativeFrameSnapshot])
+  }, [onUnavailable])
 
   const updateNativeFrame = useCallback((): void => {
     const node = containerRef.current
@@ -469,7 +453,14 @@ export const GhosttyBody = ({
 
     const nativeBottomCornerRadius =
       nativeGhosttyCornerRadiusFromCssPixels(bottomCornerRadius, viewport)
-    const parentHeight = nativeGhosttyParentHeightFromViewport(viewport)
+
+    // AppKit flips y from the parent view height. Send the renderer's
+    // same-window snapshot so top-edge live resize cannot mix old pane bounds
+    // with a new height.
+    const parentHeight =
+      Number.isFinite(viewport.outerHeight) && viewport.outerHeight > 0
+        ? viewport.outerHeight
+        : viewport.innerHeight
     const visible = true
 
     const snapshot = {
@@ -532,11 +523,6 @@ export const GhosttyBody = ({
     frameIdRef.current = window.requestAnimationFrame(runFrameUpdate)
   }, [updateNativeFrame])
 
-  const syncAndTrackNativeFrame = useCallback((): void => {
-    updateNativeFrame()
-    scheduleNativeFrameUpdate()
-  }, [scheduleNativeFrameUpdate, updateNativeFrame])
-
   // Keep the parented NSView aligned with the React pane:
   // 1. ResizeObserver/window resize sends one frame update immediately.
   // 2. The same signal extends a short "keep sampling" deadline.
@@ -547,6 +533,11 @@ export const GhosttyBody = ({
     const node = containerRef.current
     if (!node) {
       return
+    }
+
+    const syncAndTrackNativeFrame = (): void => {
+      updateNativeFrame()
+      scheduleNativeFrameUpdate()
     }
 
     updateNativeFrame()
@@ -564,7 +555,7 @@ export const GhosttyBody = ({
       observer.disconnect()
       window.removeEventListener('resize', syncAndTrackNativeFrame)
     }
-  }, [syncAndTrackNativeFrame, updateNativeFrame])
+  }, [scheduleNativeFrameUpdate, updateNativeFrame])
 
   // Focus follows the active pane, but focus no longer owns surface lifetime.
   useEffect(() => {

--- a/src/features/terminal/components/TerminalPane/GhosttyBody.tsx
+++ b/src/features/terminal/components/TerminalPane/GhosttyBody.tsx
@@ -179,9 +179,8 @@ export const GhosttyBody = ({
   const inFlightNativeFrameRef = useRef<Promise<void> | null>(null)
   const lastSentNativeFrameKeyRef = useRef<string | null>(null)
 
-  const queuedNativeFrameSnapshotRef = useRef<NativeGhosttyFrameSnapshot | null>(
-    null
-  )
+  const queuedNativeFrameSnapshotRef =
+    useRef<NativeGhosttyFrameSnapshot | null>(null)
   const resizeTrackingUntilRef = useRef(0)
   const submittedInputLineRef = useRef('')
   const agentCwdOutputBufferRef = useRef('')
@@ -451,8 +450,10 @@ export const GhosttyBody = ({
       viewport
     )
 
-    const nativeBottomCornerRadius =
-      nativeGhosttyCornerRadiusFromCssPixels(bottomCornerRadius, viewport)
+    const nativeBottomCornerRadius = nativeGhosttyCornerRadiusFromCssPixels(
+      bottomCornerRadius,
+      viewport
+    )
 
     // AppKit flips y from the parent view height. Send the renderer's
     // same-window snapshot so top-edge live resize cannot mix old pane bounds

--- a/src/features/terminal/nativeGhosttyClient.ts
+++ b/src/features/terminal/nativeGhosttyClient.ts
@@ -23,6 +23,7 @@ export interface NativeGhosttyUpdateRequest extends NativeGhosttyPaneRef {
   bounds: NativeGhosttyBounds
   backgroundColor: string
   bottomCornerRadius?: number
+  parentHeight: number
   visible: boolean
   shortcutContext?: NativeGhosttyShortcutContext
 }


### PR DESCRIPTION
## Summary
- keep Ghostty native frame updates in a short resize-tracking loop with rounded-frame dedupe and one-in-flight IPC coalescing
- pass same-snapshot parent height through the native parent bridge so AppKit y-flip uses renderer-consistent coordinates
- cache parent-side theme/shortcut work during resize and add AppKit live-resize prediction for the native container

## Validation
- `npx eslint --max-warnings=0 --no-warn-ignored src/features/terminal/components/TerminalPane/GhosttyBody.tsx src/features/terminal/components/TerminalPane/GhosttyBody.test.tsx electron/ghostty-native-parent.ts electron/ghostty-native-parent.test.ts electron/ghostty-native-helper.ts electron/ghostty-native-helper.test.ts electron/ghostty-native-shared.ts src/features/terminal/nativeGhosttyClient.ts`
- `npx vitest run src/features/terminal/components/TerminalPane/GhosttyBody.test.tsx electron/ghostty-native-parent.test.ts electron/ghostty-native-helper.test.ts`
- `npm run type-check:generated`
- `npm run ghostty:native-parent:build`
- `git diff --check`

Manual verification: live-resize prediction was tested locally and kept because it improved fast pane drag/resize responsiveness.
