### PR TITLE
feat(diff): persistent gutter bar for committed range comments

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -83,7 +83,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 13       | 3    | 2026-06-15   |
 | [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 30       | 6    | 2026-07-02   |
 | [Verify Render Target](patterns/verify-render-target.md)                                             | code-quality       | 3        | 1    | 2026-07-01   |
-| [UI Visual Regression](patterns/ui-visual-regression.md)                                             | code-quality       | 21       | 14   | 2026-07-03   |
+| [UI Visual Regression](patterns/ui-visual-regression.md)                                             | code-quality       | 23       | 15   | 2026-07-04   |
 | [Status Indicator Display](patterns/status-indicator-display.md)                                     | code-quality       | 3        | 0    | 2026-05-26   |
 | [Parser Resilience](patterns/parser-resilience.md)                                                   | code-quality       | 14       | 8    | 2026-06-22   |
 | [Persisted State Invariants](patterns/persisted-state-invariants.md)                                 | correctness        | 14       | 7    | 2026-06-23   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -100,7 +100,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Agent-State Guards](patterns/agent-state-guards.md)                                                 | correctness        | 10       | 7    | 2026-06-22   |
 | [React Prop Contracts](patterns/react-prop-contracts.md)                                             | react-patterns     | 8        | 6    | 2026-06-22   |
 | [Stale Retained Interactions](patterns/stale-retained-interactions.md)                               | react-patterns     | 6        | 5    | 2026-07-03   |
-| [Retained State Identity](patterns/retained-state-identity.md)                                       | react-patterns     | 2        | 2    | 2026-06-28   |
+| [Retained State Identity](patterns/retained-state-identity.md)                                       | react-patterns     | 3        | 3    | 2026-07-04   |
 | [Authoritative Completion Guard](patterns/authoritative-completion-guard.md)                         | correctness        | 6        | 3    | 2026-06-27   |
 | [Equality Guard Completeness](patterns/equality-guard-completeness.md)                               | correctness        | 2        | 0    | 2026-06-17   |
 | [Resizable Layout Bounds](patterns/resizable-layout-bounds.md)                                       | correctness        | 3        | 2    | 2026-06-18   |

--- a/docs/reviews/patterns/retained-state-identity.md
+++ b/docs/reviews/patterns/retained-state-identity.md
@@ -2,8 +2,8 @@
 id: retained-state-identity
 category: react-patterns
 created: 2026-06-15
-last_updated: 2026-06-28
-ref_count: 2
+last_updated: 2026-07-04
+ref_count: 3
 ---
 
 # Retained State Identity
@@ -36,4 +36,13 @@ When a React component renders retained (stale) content while fresh data for a n
   session id, storing, reading, and deleting only the active session's restore
   layout. Added a regression test covering two sessions toggled to focus mode
   independently.
+- **Commit:** same commit as this entry
+
+### 3. Range-bar repaint can target a stale file container on file switch
+
+- **Source:** github-codex-connector | PR #654 round 1 | 2026-07-04
+- **Severity:** HIGH
+- **File:** `src/features/diff/hooks/useDiffRangeBars.ts`
+- **Finding:** The diff range-bar hook retained Pierre's last rendered shadow-DOM container but repainted whenever selected-file annotations changed. During file navigation, new-file spans could be combined with the previous file's retained container before Pierre posted the new file's render callback.
+- **Fix:** Passed the selected-file key into the hook, stored that key with the retained container, invalidated the container on file-key changes, and skipped repaint unless the stored container key still matches the active file key. Added a regression test that changes file keys with different spans and verifies the previous file host is not repainted.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/ui-visual-regression.md
+++ b/docs/reviews/patterns/ui-visual-regression.md
@@ -2,8 +2,8 @@
 id: ui-visual-regression
 category: code-quality
 created: 2026-06-11
-last_updated: 2026-07-03
-ref_count: 14
+last_updated: 2026-07-04
+ref_count: 15
 ---
 
 # UI Visual Regression
@@ -270,4 +270,18 @@ test case for the state that triggers the collision.
 - **Fix:** Moved the four `browser-bar` tokens to distinct neighboring theme
   values and added a regression test asserting `browser-bar` remains distinct
   from `surface-container-lowest` in every shipped theme.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 23. Unified diff range bars missed normalized removed rows
+
+- **Source:** github-codex-connector | PR #654 round 1 | 2026-07-04
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/diff/rangeBar/diffRangeBars.ts`
+- **Finding:** The range-bar DOM pass treated unified gutter cells as deletion
+  rows only when `data-line-type="change-deletion"`. Unified diffs can also
+  expose removed rows as `data-line-type="removed"`, which made deletion-side
+  range comments fail to paint their persistent gutter bar on those rows.
+- **Fix:** Mirrored the review-navigation side resolver by classifying both
+  `change-deletion` and `removed` as deletions, and expanded the co-located
+  range-bar test to cover both unified deletion row spellings.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/src/features/diff/Panel.test.tsx
+++ b/src/features/diff/Panel.test.tsx
@@ -4140,7 +4140,9 @@ describe('Panel', () => {
         'src/foo.ts',
         false,
         expect.objectContaining({
-          lineNumber: 1,
+          // Anchored at the range's last line so the comment renders below the
+          // selection; the span stays in target (VIM-273).
+          lineNumber: 2,
           side: 'additions',
           metadata: expect.objectContaining({
             text: 'Review this range',

--- a/src/features/diff/Panel.tsx
+++ b/src/features/diff/Panel.tsx
@@ -1739,7 +1739,10 @@ export const Panel = ({
           selectedFileStaged,
           {
             side: annotationTarget.side,
-            lineNumber: annotationTarget.lineNumber,
+            // Anchor a range comment at its last line so it renders below the
+            // selection; the span stays in metadata.target (VIM-273).
+            lineNumber:
+              annotationTarget.rangeEndLine ?? annotationTarget.lineNumber,
             metadata: {
               id: nextFeedbackCommentId(),
               text,

--- a/src/features/diff/Panel.tsx
+++ b/src/features/diff/Panel.tsx
@@ -36,6 +36,7 @@ import {
 } from './hooks/useFeedbackBatch'
 import { useKeyboard } from './hooks/useKeyboard'
 import { useDiffSearch } from './hooks/useDiffSearch'
+import { useDiffRangeBars } from './hooks/useDiffRangeBars'
 import {
   dispatchFeedbackBatch,
   formatFeedbackPayload,
@@ -63,6 +64,12 @@ import { DiffSearchPopup } from './components/DiffSearchPopup'
 import { ReviewCommentEditor } from './components/ReviewCommentEditor'
 import { ReviewCommentRow } from './components/ReviewCommentRow'
 import { DIFF_SEARCH_UNSAFE_CSS } from './search/diffSearchDom'
+import { DIFF_RANGE_BAR_UNSAFE_CSS } from './rangeBar/diffRangeBars'
+
+// One stable <style> injected into pierre's shadow tree: the search highlight
+// plus the persistent range-comment gutter bar (VIM-273). A module constant so
+// pierre never force-rebuilds on an unsafeCSS identity change.
+const DIFF_UNSAFE_CSS = `${DIFF_SEARCH_UNSAFE_CSS}\n${DIFF_RANGE_BAR_UNSAFE_CSS}`
 
 const DIFF_NATIVE_FOCUS_SELECTOR =
   'button, input, textarea, select, [contenteditable], [role="textbox"]'
@@ -1099,8 +1106,15 @@ export const Panel = ({
     scrollContainerRef: diffScrollBodyRef,
   })
 
+  const diffRangeBars = useDiffRangeBars({
+    annotations: realAnnotations,
+    fileKey: diffSearchFileKey,
+  })
+
   const diffSearchPostRenderRef = useRef(diffSearch.handlePostRender)
   diffSearchPostRenderRef.current = diffSearch.handlePostRender
+  const diffRangeBarsPostRenderRef = useRef(diffRangeBars.handlePostRender)
+  diffRangeBarsPostRenderRef.current = diffRangeBars.handlePostRender
   const multiFileDiffOptionsRef = useRef(multiFileDiffOptions)
   multiFileDiffOptionsRef.current = multiFileDiffOptions
 
@@ -1108,13 +1122,14 @@ export const Panel = ({
     NonNullable<FileDiffOptions<ReviewComment>['onPostRender']>
   >((node, instance) => {
     diffSearchPostRenderRef.current(node)
+    diffRangeBarsPostRenderRef.current(node)
     multiFileDiffOptionsRef.current.onPostRender?.(node, instance)
   }, [])
 
   const diffOptionsWithSearch = useMemo<FileDiffOptions<ReviewComment>>(
     () => ({
       ...multiFileDiffOptions,
-      unsafeCSS: DIFF_SEARCH_UNSAFE_CSS,
+      unsafeCSS: DIFF_UNSAFE_CSS,
       onPostRender: handleDiffPostRender,
     }),
     [multiFileDiffOptions, handleDiffPostRender]

--- a/src/features/diff/Panel.tsx
+++ b/src/features/diff/Panel.tsx
@@ -1106,7 +1106,10 @@ export const Panel = ({
     scrollContainerRef: diffScrollBodyRef,
   })
 
-  const diffRangeBars = useDiffRangeBars({ annotations: realAnnotations })
+  const diffRangeBars = useDiffRangeBars({
+    fileKey: diffSearchFileKey,
+    annotations: realAnnotations,
+  })
 
   const diffSearchPostRenderRef = useRef(diffSearch.handlePostRender)
   diffSearchPostRenderRef.current = diffSearch.handlePostRender

--- a/src/features/diff/Panel.tsx
+++ b/src/features/diff/Panel.tsx
@@ -1106,10 +1106,7 @@ export const Panel = ({
     scrollContainerRef: diffScrollBodyRef,
   })
 
-  const diffRangeBars = useDiffRangeBars({
-    annotations: realAnnotations,
-    fileKey: diffSearchFileKey,
-  })
+  const diffRangeBars = useDiffRangeBars({ annotations: realAnnotations })
 
   const diffSearchPostRenderRef = useRef(diffSearch.handlePostRender)
   diffSearchPostRenderRef.current = diffSearch.handlePostRender

--- a/src/features/diff/components/PanelBody.tsx
+++ b/src/features/diff/components/PanelBody.tsx
@@ -249,6 +249,7 @@ export const PanelBody = ({
               return (
                 <ReviewCommentRow
                   comment={annotation.metadata}
+                  targetLabel={annotationTargetLabel(annotation)}
                   onEdit={(): void => onEditComment(annotation)}
                   onDelete={(): void => onDeleteComment(annotation.metadata.id)}
                 />

--- a/src/features/diff/components/ReviewCommentRow.test.tsx
+++ b/src/features/diff/components/ReviewCommentRow.test.tsx
@@ -106,4 +106,40 @@ describe('ReviewCommentRow', () => {
 
     expect(handleDelete).not.toHaveBeenCalled()
   })
+
+  test('shows the range label when provided', () => {
+    render(
+      <ReviewCommentRow
+        comment={{
+          id: '5',
+          text: 'Range note',
+          author: 'self',
+          createdAt: 5000,
+        }}
+        targetLabel="lines R4-R6"
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('lines R4-R6')).toBeInTheDocument()
+    expect(screen.getByText('Range note')).toBeInTheDocument()
+  })
+
+  test('omits the label for a plain comment', () => {
+    render(
+      <ReviewCommentRow
+        comment={{
+          id: '6',
+          text: 'Plain note',
+          author: 'self',
+          createdAt: 6000,
+        }}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByText(/lines R/)).not.toBeInTheDocument()
+  })
 })

--- a/src/features/diff/components/ReviewCommentRow.tsx
+++ b/src/features/diff/components/ReviewCommentRow.tsx
@@ -6,6 +6,10 @@ interface ReviewCommentRowProps {
   comment: ReviewComment
   editShortcut?: 'u' | 'Shift+U'
   deleteShortcut?: 'x' | null
+  /** Range/line reference shown above the text (e.g. "lines R4-R6"); the diff
+   * itself shows the code, so this only names the span. Omitted for plain line
+   * comments. */
+  targetLabel?: string
   onEdit: () => void
   onDelete: () => void
 }
@@ -14,13 +18,21 @@ export const ReviewCommentRow = ({
   comment,
   editShortcut = 'u',
   deleteShortcut = 'x',
+  targetLabel = undefined,
   onEdit,
   onDelete,
 }: ReviewCommentRowProps): ReactElement => (
   <div className="mx-2 my-1 flex items-start gap-2 rounded-md bg-surface-container-high/60 px-3 py-2">
-    <p className="flex-1 break-words whitespace-pre-wrap text-xs text-on-surface">
-      {comment.text}
-    </p>
+    <div className="min-w-0 flex-1">
+      {targetLabel !== undefined ? (
+        <span className="mb-1 inline-block rounded bg-surface-container-highest/70 px-1.5 py-px font-mono text-[10px] text-on-surface-variant">
+          {targetLabel}
+        </span>
+      ) : null}
+      <p className="break-words whitespace-pre-wrap text-xs text-on-surface">
+        {comment.text}
+      </p>
+    </div>
     <div className="flex shrink-0 items-center gap-1">
       <IconButton
         icon="edit"

--- a/src/features/diff/hooks/useDiffRangeBars.test.ts
+++ b/src/features/diff/hooks/useDiffRangeBars.test.ts
@@ -1,0 +1,119 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import type { DiffLineAnnotation } from '@pierre/diffs'
+import { useDiffRangeBars } from './useDiffRangeBars'
+import { DIFF_RANGE_BAR_ATTR } from '../rangeBar/diffRangeBars'
+import type { ReviewComment } from './useFeedbackBatch'
+
+let rafCallbacks: FrameRequestCallback[] = []
+beforeEach(() => {
+  rafCallbacks = []
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback): number => {
+    rafCallbacks.push(cb)
+
+    return rafCallbacks.length
+  })
+  vi.stubGlobal('cancelAnimationFrame', vi.fn())
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+const flushRaf = (): void =>
+  act(() => {
+    const pending = rafCallbacks
+    rafCallbacks = []
+    pending.forEach((cb) => cb(0))
+  })
+
+const makeHost = (lines: number[]): HTMLElement => {
+  const host = document.createElement('div')
+  const root = host.attachShadow({ mode: 'open' })
+  const code = document.createElement('div')
+  code.setAttribute('data-additions', '')
+  const gutter = document.createElement('div')
+  gutter.setAttribute('data-gutter', '')
+  for (const line of lines) {
+    const cell = document.createElement('div')
+    cell.setAttribute('data-column-number', String(line))
+    gutter.appendChild(cell)
+  }
+  code.appendChild(gutter)
+  root.appendChild(code)
+
+  return host
+}
+
+const barAt = (host: HTMLElement, line: number): string | null =>
+  host.shadowRoot
+    ?.querySelector(`[data-column-number="${line}"]`)
+    ?.getAttribute(DIFF_RANGE_BAR_ATTR) ?? null
+
+const rangeAnn = (
+  startLine: number,
+  endLine: number
+): DiffLineAnnotation<ReviewComment> => ({
+  side: 'additions',
+  lineNumber: startLine,
+  metadata: {
+    id: `c${startLine}`,
+    text: 't',
+    author: 'self',
+    createdAt: 1,
+    target: { scope: 'range', side: 'additions', startLine, endLine },
+  },
+})
+
+describe('useDiffRangeBars', () => {
+  test('paints the range bar on the post-render frame', () => {
+    const host = makeHost([3, 4, 5, 6])
+
+    const { result } = renderHook(() =>
+      useDiffRangeBars({
+        annotations: [rangeAnn(4, 6)],
+        fileKey: 'a.ts:unstaged',
+      })
+    )
+
+    act(() => result.current.handlePostRender(host))
+    expect(barAt(host, 5)).toBeNull() // not painted until the frame runs
+
+    flushRaf()
+    expect(barAt(host, 4)).toBe('first')
+    expect(barAt(host, 6)).toBe('last')
+  })
+
+  test('re-tags when the ranges change without a new post-render', () => {
+    const host = makeHost([3, 4, 5, 6])
+
+    const { result, rerender } = renderHook(
+      ({ ann }) =>
+        useDiffRangeBars({ annotations: ann, fileKey: 'a.ts:unstaged' }),
+      { initialProps: { ann: [rangeAnn(4, 6)] } }
+    )
+
+    act(() => result.current.handlePostRender(host))
+    flushRaf()
+    expect(barAt(host, 5)).toBe('mid')
+
+    rerender({ ann: [] })
+    expect(barAt(host, 5)).toBeNull()
+  })
+
+  test('drops a frame that resolves after a file switch', () => {
+    const host = makeHost([3, 4, 5, 6])
+
+    const { result, rerender } = renderHook(
+      ({ fk }) =>
+        useDiffRangeBars({ annotations: [rangeAnn(4, 6)], fileKey: fk }),
+      { initialProps: { fk: 'a.ts:unstaged' } }
+    )
+
+    act(() => result.current.handlePostRender(host))
+    rerender({ fk: 'b.ts:unstaged' }) // switch before the frame runs
+    flushRaf()
+
+    expect(barAt(host, 5)).toBeNull()
+  })
+})

--- a/src/features/diff/hooks/useDiffRangeBars.test.ts
+++ b/src/features/diff/hooks/useDiffRangeBars.test.ts
@@ -70,10 +70,7 @@ describe('useDiffRangeBars', () => {
     const host = makeHost([3, 4, 5, 6])
 
     const { result } = renderHook(() =>
-      useDiffRangeBars({
-        annotations: [rangeAnn(4, 6)],
-        fileKey: 'a.ts:unstaged',
-      })
+      useDiffRangeBars({ annotations: [rangeAnn(4, 6)] })
     )
 
     act(() => result.current.handlePostRender(host))
@@ -88,8 +85,7 @@ describe('useDiffRangeBars', () => {
     const host = makeHost([3, 4, 5, 6])
 
     const { result, rerender } = renderHook(
-      ({ ann }) =>
-        useDiffRangeBars({ annotations: ann, fileKey: 'a.ts:unstaged' }),
+      ({ ann }) => useDiffRangeBars({ annotations: ann }),
       { initialProps: { ann: [rangeAnn(4, 6)] } }
     )
 
@@ -98,22 +94,6 @@ describe('useDiffRangeBars', () => {
     expect(barAt(host, 5)).toBe('mid')
 
     rerender({ ann: [] })
-    expect(barAt(host, 5)).toBeNull()
-  })
-
-  test('drops a frame that resolves after a file switch', () => {
-    const host = makeHost([3, 4, 5, 6])
-
-    const { result, rerender } = renderHook(
-      ({ fk }) =>
-        useDiffRangeBars({ annotations: [rangeAnn(4, 6)], fileKey: fk }),
-      { initialProps: { fk: 'a.ts:unstaged' } }
-    )
-
-    act(() => result.current.handlePostRender(host))
-    rerender({ fk: 'b.ts:unstaged' }) // switch before the frame runs
-    flushRaf()
-
     expect(barAt(host, 5)).toBeNull()
   })
 })

--- a/src/features/diff/hooks/useDiffRangeBars.test.ts
+++ b/src/features/diff/hooks/useDiffRangeBars.test.ts
@@ -70,7 +70,10 @@ describe('useDiffRangeBars', () => {
     const host = makeHost([3, 4, 5, 6])
 
     const { result } = renderHook(() =>
-      useDiffRangeBars({ annotations: [rangeAnn(4, 6)] })
+      useDiffRangeBars({
+        fileKey: 'src/a.ts:unstaged',
+        annotations: [rangeAnn(4, 6)],
+      })
     )
 
     act(() => result.current.handlePostRender(host))
@@ -85,7 +88,11 @@ describe('useDiffRangeBars', () => {
     const host = makeHost([3, 4, 5, 6])
 
     const { result, rerender } = renderHook(
-      ({ ann }) => useDiffRangeBars({ annotations: ann }),
+      ({ ann }) =>
+        useDiffRangeBars({
+          fileKey: 'src/a.ts:unstaged',
+          annotations: ann,
+        }),
       { initialProps: { ann: [rangeAnn(4, 6)] } }
     )
 
@@ -95,5 +102,35 @@ describe('useDiffRangeBars', () => {
 
     rerender({ ann: [] })
     expect(barAt(host, 5)).toBeNull()
+  })
+
+  test('does not repaint the previous file container after the file key changes', () => {
+    const previousHost = makeHost([3, 4, 5, 6])
+
+    const { result, rerender } = renderHook(
+      ({ ann, fileKey }) =>
+        useDiffRangeBars({
+          fileKey,
+          annotations: ann,
+        }),
+      {
+        initialProps: {
+          ann: [rangeAnn(4, 6)],
+          fileKey: 'src/a.ts:unstaged',
+        },
+      }
+    )
+
+    act(() => result.current.handlePostRender(previousHost))
+    flushRaf()
+    expect(barAt(previousHost, 5)).toBe('mid')
+
+    rerender({
+      ann: [rangeAnn(3, 4)],
+      fileKey: 'src/b.ts:unstaged',
+    })
+
+    expect(barAt(previousHost, 4)).toBe('first')
+    expect(barAt(previousHost, 5)).toBe('mid')
   })
 })

--- a/src/features/diff/hooks/useDiffRangeBars.ts
+++ b/src/features/diff/hooks/useDiffRangeBars.ts
@@ -10,8 +10,6 @@ import type { ReviewComment } from './useFeedbackBatch'
 export interface UseDiffRangeBarsOptions {
   /** Committed line-level annotations for the selected file. */
   annotations: DiffLineAnnotation<ReviewComment>[]
-  /** `${path}:${'staged' | 'unstaged'}` or null; a change invalidates in-flight paints. */
-  fileKey: string | null
 }
 
 export interface UseDiffRangeBarsResult {
@@ -23,15 +21,18 @@ export interface UseDiffRangeBarsResult {
  * Draws the persistent gutter bar for committed range comments (VIM-273).
  * Pierre has no decorations API, so — like search — this tags shadow-DOM gutter
  * cells on every `onPostRender` (pierre wipes custom attributes when it
- * rebuilds), coalescing rebuild bursts with a single rAF and guarding stale
- * frames with a monotonic generation token.
+ * rebuilds), coalescing rebuild bursts with a single rAF.
+ *
+ * Tagging is idempotent — it reads the live container + spans and rewrites to
+ * the current state — so unlike search (which owns the global CSS.highlights
+ * registry) it needs no stale-frame/generation guard: a late frame simply paints
+ * the truth. A file switch is handled by the new file's own onPostRender, which
+ * replaces the container and cancels any in-flight frame.
  */
 export const useDiffRangeBars = ({
   annotations,
-  fileKey,
 }: UseDiffRangeBarsOptions): UseDiffRangeBarsResult => {
   const containerRef = useRef<Element | null>(null)
-  const generationRef = useRef(0)
   const rafRef = useRef<number | null>(null)
 
   const spans = rangeBarSpansForAnnotations(annotations)
@@ -51,14 +52,9 @@ export const useDiffRangeBars = ({
       containerRef.current = node
       cancelPendingFrame()
 
-      const generation = generationRef.current
       // One frame coalesces pierre's rebuild bursts (plain → highlighted paint).
       rafRef.current = requestAnimationFrame(() => {
         rafRef.current = null
-        if (generation !== generationRef.current) {
-          return
-        }
-
         paintRangeBars(containerRef.current, spansRef.current)
       })
     },
@@ -71,21 +67,7 @@ export const useDiffRangeBars = ({
     paintRangeBars(containerRef.current, spansRef.current)
   }, [spansKey])
 
-  // A file switch invalidates any in-flight frame and the stored container; the
-  // next onPostRender re-establishes both.
-  useEffect(() => {
-    generationRef.current += 1
-    cancelPendingFrame()
-    containerRef.current = null
-  }, [cancelPendingFrame, fileKey])
-
-  useEffect(
-    () => (): void => {
-      generationRef.current += 1
-      cancelPendingFrame()
-    },
-    [cancelPendingFrame]
-  )
+  useEffect(() => cancelPendingFrame, [cancelPendingFrame])
 
   return { handlePostRender }
 }

--- a/src/features/diff/hooks/useDiffRangeBars.ts
+++ b/src/features/diff/hooks/useDiffRangeBars.ts
@@ -8,6 +8,8 @@ import {
 import type { ReviewComment } from './useFeedbackBatch'
 
 export interface UseDiffRangeBarsOptions {
+  /** Identity for the selected file whose diff DOM owns these annotations. */
+  fileKey: string | null
   /** Committed line-level annotations for the selected file. */
   annotations: DiffLineAnnotation<ReviewComment>[]
 }
@@ -23,21 +25,32 @@ export interface UseDiffRangeBarsResult {
  * cells on every `onPostRender` (pierre wipes custom attributes when it
  * rebuilds), coalescing rebuild bursts with a single rAF.
  *
- * Tagging is idempotent — it reads the live container + spans and rewrites to
- * the current state — so unlike search (which owns the global CSS.highlights
- * registry) it needs no stale-frame/generation guard: a late frame simply paints
- * the truth. A file switch is handled by the new file's own onPostRender, which
- * replaces the container and cancels any in-flight frame.
+ * Tagging is idempotent when the stored container still belongs to the selected
+ * file: it reads the live container + spans and rewrites to the current state.
+ * File switches invalidate the retained Pierre container until the new file's
+ * own `onPostRender` stores a matching container, preventing annotation changes
+ * from repainting stale shadow DOM from the previously selected file.
  */
 export const useDiffRangeBars = ({
+  fileKey,
   annotations,
 }: UseDiffRangeBarsOptions): UseDiffRangeBarsResult => {
   const containerRef = useRef<Element | null>(null)
+  const containerFileKeyRef = useRef<string | null>(null)
+  const previousFileKeyRef = useRef(fileKey)
+  const fileKeyRef = useRef(fileKey)
   const rafRef = useRef<number | null>(null)
+
+  if (previousFileKeyRef.current !== fileKey) {
+    previousFileKeyRef.current = fileKey
+    containerRef.current = null
+    containerFileKeyRef.current = null
+  }
 
   const spans = rangeBarSpansForAnnotations(annotations)
   const spansRef = useRef(spans)
   spansRef.current = spans
+  fileKeyRef.current = fileKey
   const spansKey = rangeBarSpansKey(spans)
 
   const cancelPendingFrame = useCallback((): void => {
@@ -47,25 +60,37 @@ export const useDiffRangeBars = ({
     }
   }, [])
 
+  const paintStoredContainer = useCallback((): void => {
+    if (
+      fileKeyRef.current === null ||
+      containerFileKeyRef.current !== fileKeyRef.current
+    ) {
+      return
+    }
+
+    paintRangeBars(containerRef.current, spansRef.current)
+  }, [])
+
   const handlePostRender = useCallback(
     (node: Element): void => {
       containerRef.current = node
+      containerFileKeyRef.current = fileKey
       cancelPendingFrame()
 
       // One frame coalesces pierre's rebuild bursts (plain → highlighted paint).
       rafRef.current = requestAnimationFrame(() => {
         rafRef.current = null
-        paintRangeBars(containerRef.current, spansRef.current)
+        paintStoredContainer()
       })
     },
-    [cancelPendingFrame]
+    [cancelPendingFrame, fileKey, paintStoredContainer]
   )
 
   // Re-tag when the committed ranges change without a pierre rebuild — a comment
   // added/removed while the same file stays rendered.
   useEffect(() => {
-    paintRangeBars(containerRef.current, spansRef.current)
-  }, [spansKey])
+    paintStoredContainer()
+  }, [paintStoredContainer, spansKey])
 
   useEffect(() => cancelPendingFrame, [cancelPendingFrame])
 

--- a/src/features/diff/hooks/useDiffRangeBars.ts
+++ b/src/features/diff/hooks/useDiffRangeBars.ts
@@ -1,0 +1,91 @@
+import { useCallback, useEffect, useRef } from 'react'
+import type { DiffLineAnnotation } from '@pierre/diffs'
+import {
+  paintRangeBars,
+  rangeBarSpansForAnnotations,
+  rangeBarSpansKey,
+} from '../rangeBar/diffRangeBars'
+import type { ReviewComment } from './useFeedbackBatch'
+
+export interface UseDiffRangeBarsOptions {
+  /** Committed line-level annotations for the selected file. */
+  annotations: DiffLineAnnotation<ReviewComment>[]
+  /** `${path}:${'staged' | 'unstaged'}` or null; a change invalidates in-flight paints. */
+  fileKey: string | null
+}
+
+export interface UseDiffRangeBarsResult {
+  /** Wire to pierre `options.onPostRender` via a stable forwarding callback. */
+  handlePostRender: (node: Element) => void
+}
+
+/**
+ * Draws the persistent gutter bar for committed range comments (VIM-273).
+ * Pierre has no decorations API, so — like search — this tags shadow-DOM gutter
+ * cells on every `onPostRender` (pierre wipes custom attributes when it
+ * rebuilds), coalescing rebuild bursts with a single rAF and guarding stale
+ * frames with a monotonic generation token.
+ */
+export const useDiffRangeBars = ({
+  annotations,
+  fileKey,
+}: UseDiffRangeBarsOptions): UseDiffRangeBarsResult => {
+  const containerRef = useRef<Element | null>(null)
+  const generationRef = useRef(0)
+  const rafRef = useRef<number | null>(null)
+
+  const spans = rangeBarSpansForAnnotations(annotations)
+  const spansRef = useRef(spans)
+  spansRef.current = spans
+  const spansKey = rangeBarSpansKey(spans)
+
+  const cancelPendingFrame = useCallback((): void => {
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current)
+      rafRef.current = null
+    }
+  }, [])
+
+  const handlePostRender = useCallback(
+    (node: Element): void => {
+      containerRef.current = node
+      cancelPendingFrame()
+
+      const generation = generationRef.current
+      // One frame coalesces pierre's rebuild bursts (plain → highlighted paint).
+      rafRef.current = requestAnimationFrame(() => {
+        rafRef.current = null
+        if (generation !== generationRef.current) {
+          return
+        }
+
+        paintRangeBars(containerRef.current, spansRef.current)
+      })
+    },
+    [cancelPendingFrame]
+  )
+
+  // Re-tag when the committed ranges change without a pierre rebuild — a comment
+  // added/removed while the same file stays rendered.
+  useEffect(() => {
+    paintRangeBars(containerRef.current, spansRef.current)
+  }, [spansKey])
+
+  // A file switch invalidates any in-flight frame and the stored container; the
+  // next onPostRender re-establishes both.
+  useEffect(() => {
+    generationRef.current += 1
+    cancelPendingFrame()
+    containerRef.current = null
+  }, [cancelPendingFrame, fileKey])
+
+  useEffect(
+    () => (): void => {
+      generationRef.current += 1
+      cancelPendingFrame()
+    },
+    [cancelPendingFrame]
+  )
+
+  return { handlePostRender }
+}

--- a/src/features/diff/hooks/useReviewCommentDraft.test.ts
+++ b/src/features/diff/hooks/useReviewCommentDraft.test.ts
@@ -222,6 +222,9 @@ describe('useReviewCommentDraft', () => {
         endLine: 3,
       },
     })
+    // The draft anchors at the range's LAST line so the editor renders below the
+    // selection (VIM-273); the span stays in target.
+    expect(result.current.lineAnnotations[1]?.lineNumber).toBe(3)
   })
 
   test('treats a range draft as stale when the end line is missing', () => {

--- a/src/features/diff/hooks/useReviewCommentDraft.ts
+++ b/src/features/diff/hooks/useReviewCommentDraft.ts
@@ -390,7 +390,9 @@ export const useReviewCommentDraft = ({
       // annotation reserves the exact line slot for the unsent comment editor.
       const draft: DiffLineAnnotation<ReviewComment> = {
         side: annotationTarget.side,
-        lineNumber: annotationTarget.lineNumber,
+        // Match the committed anchor: a range draft renders below its last line.
+        lineNumber:
+          annotationTarget.rangeEndLine ?? annotationTarget.lineNumber,
         metadata: {
           id: DRAFT_ID,
           text: '',

--- a/src/features/diff/rangeBar/diffRangeBars.test.ts
+++ b/src/features/diff/rangeBar/diffRangeBars.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from 'vitest'
+import type { DiffLineAnnotation } from '@pierre/diffs'
+import {
+  DIFF_RANGE_BAR_ATTR,
+  paintRangeBars,
+  rangeBarSpansForAnnotations,
+  rangeBarSpansKey,
+  type RangeBarSpan,
+} from './diffRangeBars'
+import type { ReviewComment } from '../hooks/useFeedbackBatch'
+
+// A mock pierre shadow tree with gutter cells for the given line numbers. Split
+// columns wrap them in [data-additions]/[data-deletions]; unified marks the cell
+// with data-line-type.
+const makeHost = (
+  layout: 'split-additions' | 'split-deletions' | 'unified',
+  lines: number[]
+): HTMLElement => {
+  const host = document.createElement('div')
+  const root = host.attachShadow({ mode: 'open' })
+  const code = document.createElement('div')
+  if (layout === 'split-additions') {
+    code.setAttribute('data-additions', '')
+  }
+  if (layout === 'split-deletions') {
+    code.setAttribute('data-deletions', '')
+  }
+
+  const gutter = document.createElement('div')
+  gutter.setAttribute('data-gutter', '')
+  for (const line of lines) {
+    const cell = document.createElement('div')
+    cell.setAttribute('data-column-number', String(line))
+    if (layout === 'unified') {
+      cell.setAttribute('data-line-type', 'added')
+    }
+    gutter.appendChild(cell)
+  }
+  code.appendChild(gutter)
+  root.appendChild(code)
+
+  return host
+}
+
+const barAt = (host: HTMLElement, line: number): string | null => {
+  const cell = host.shadowRoot?.querySelector(`[data-column-number="${line}"]`)
+
+  return cell?.getAttribute(DIFF_RANGE_BAR_ATTR) ?? null
+}
+
+const annotation = (
+  target?: ReviewComment['target']
+): DiffLineAnnotation<ReviewComment> => ({
+  side: 'additions',
+  lineNumber: 4,
+  metadata: { id: 'c', text: 't', author: 'self', createdAt: 1, target },
+})
+
+describe('rangeBarSpansForAnnotations', () => {
+  test('extracts only range-scoped comments', () => {
+    const spans = rangeBarSpansForAnnotations([
+      annotation(),
+      annotation({ scope: 'file' }),
+      annotation({
+        scope: 'range',
+        side: 'additions',
+        startLine: 4,
+        endLine: 6,
+      }),
+    ])
+
+    expect(spans).toEqual([{ side: 'additions', startLine: 4, endLine: 6 }])
+  })
+})
+
+describe('rangeBarSpansKey', () => {
+  test('is order-independent', () => {
+    const a: RangeBarSpan[] = [
+      { side: 'additions', startLine: 4, endLine: 6 },
+      { side: 'deletions', startLine: 1, endLine: 2 },
+    ]
+
+    expect(rangeBarSpansKey(a)).toBe(rangeBarSpansKey([a[1], a[0]]))
+  })
+})
+
+describe('paintRangeBars', () => {
+  test('tags gutter cells within the range with edge roles', () => {
+    const host = makeHost('split-additions', [3, 4, 5, 6, 7])
+
+    paintRangeBars(host, [{ side: 'additions', startLine: 4, endLine: 6 }])
+
+    expect(barAt(host, 3)).toBeNull()
+    expect(barAt(host, 4)).toBe('first')
+    expect(barAt(host, 5)).toBe('mid')
+    expect(barAt(host, 6)).toBe('last')
+    expect(barAt(host, 7)).toBeNull()
+  })
+
+  test('a single-line range uses the single role', () => {
+    const host = makeHost('split-additions', [4, 5, 6])
+
+    paintRangeBars(host, [{ side: 'additions', startLine: 5, endLine: 5 }])
+
+    expect(barAt(host, 5)).toBe('single')
+  })
+
+  test('does not tag the wrong side', () => {
+    const host = makeHost('split-deletions', [4, 5, 6])
+
+    paintRangeBars(host, [{ side: 'additions', startLine: 4, endLine: 6 }])
+
+    expect(barAt(host, 5)).toBeNull()
+  })
+
+  test('unified deletion rows resolve to the deletions side', () => {
+    const host = makeHost('unified', [5])
+    const cell = host.shadowRoot?.querySelector('[data-column-number="5"]')
+    cell?.setAttribute('data-line-type', 'change-deletion')
+
+    paintRangeBars(host, [{ side: 'deletions', startLine: 5, endLine: 5 }])
+
+    expect(barAt(host, 5)).toBe('single')
+  })
+
+  test('clears prior tags on repaint', () => {
+    const host = makeHost('split-additions', [4, 5, 6])
+
+    paintRangeBars(host, [{ side: 'additions', startLine: 4, endLine: 6 }])
+    expect(barAt(host, 5)).toBe('mid')
+
+    paintRangeBars(host, [])
+    expect(barAt(host, 5)).toBeNull()
+  })
+
+  test('degrades silently with no shadow root', () => {
+    expect(() =>
+      paintRangeBars(document.createElement('div'), [
+        { side: 'additions', startLine: 1, endLine: 2 },
+      ])
+    ).not.toThrow()
+    expect(() => paintRangeBars(null, [])).not.toThrow()
+  })
+})

--- a/src/features/diff/rangeBar/diffRangeBars.test.ts
+++ b/src/features/diff/rangeBar/diffRangeBars.test.ts
@@ -113,15 +113,18 @@ describe('paintRangeBars', () => {
     expect(barAt(host, 5)).toBeNull()
   })
 
-  test('unified deletion rows resolve to the deletions side', () => {
-    const host = makeHost('unified', [5])
-    const cell = host.shadowRoot?.querySelector('[data-column-number="5"]')
-    cell?.setAttribute('data-line-type', 'change-deletion')
+  test.each(['change-deletion', 'removed'])(
+    'unified %s rows resolve to the deletions side',
+    (lineType) => {
+      const host = makeHost('unified', [5])
+      const cell = host.shadowRoot?.querySelector('[data-column-number="5"]')
+      cell?.setAttribute('data-line-type', lineType)
 
-    paintRangeBars(host, [{ side: 'deletions', startLine: 5, endLine: 5 }])
+      paintRangeBars(host, [{ side: 'deletions', startLine: 5, endLine: 5 }])
 
-    expect(barAt(host, 5)).toBe('single')
-  })
+      expect(barAt(host, 5)).toBe('single')
+    }
+  )
 
   test('clears prior tags on repaint', () => {
     const host = makeHost('split-additions', [4, 5, 6])

--- a/src/features/diff/rangeBar/diffRangeBars.ts
+++ b/src/features/diff/rangeBar/diffRangeBars.ts
@@ -63,8 +63,11 @@ const gutterCellSide = (el: HTMLElement): AnnotationSide => {
     return 'additions'
   }
 
-  // Unified column: deletion rows carry data-line-type="change-deletion".
-  return el.getAttribute('data-line-type') === 'change-deletion'
+  // Unified column: deletion rows can use either pierre's change-deletion
+  // marker or the normalized removed line type used by navigation.
+  const lineType = el.getAttribute('data-line-type')
+
+  return lineType === 'change-deletion' || lineType === 'removed'
     ? 'deletions'
     : 'additions'
 }

--- a/src/features/diff/rangeBar/diffRangeBars.ts
+++ b/src/features/diff/rangeBar/diffRangeBars.ts
@@ -1,0 +1,123 @@
+import type { AnnotationSide, DiffLineAnnotation } from '@pierre/diffs'
+import type { ReviewComment } from '../hooks/useFeedbackBatch'
+
+/** Attribute stamped onto the gutter cells inside a committed range's span.
+ * Value is the edge role so the bar can round its ends. */
+export const DIFF_RANGE_BAR_ATTR = 'data-vf-range-bar'
+
+/** Persistent gutter bar for committed range comments. Pierre exposes no
+ * decorations API, so — exactly like search — we tag shadow-DOM gutter cells in
+ * `onPostRender` and style them here. This MUST stay a module constant: any
+ * option merged into pierre (incl. `unsafeCSS`) that changes identity across
+ * renders force-rebuilds its DOM. The bar sits at the gutter's right edge — the
+ * seam between the line number and the code content (GitHub-style). Theme custom
+ * properties cascade across the shadow boundary. */
+export const DIFF_RANGE_BAR_UNSAFE_CSS = [
+  `[data-gutter] > [${DIFF_RANGE_BAR_ATTR}] { position: relative; }`,
+  `[data-gutter] > [${DIFF_RANGE_BAR_ATTR}]::after { content: ''; position: absolute; right: 0; top: 0; bottom: 0; width: 3px; background: var(--color-primary-container); pointer-events: none; }`,
+  `[data-gutter] > [${DIFF_RANGE_BAR_ATTR}='first']::after { top: 2px; border-top-left-radius: 2px; border-top-right-radius: 2px; }`,
+  `[data-gutter] > [${DIFF_RANGE_BAR_ATTR}='last']::after { bottom: 2px; border-bottom-left-radius: 2px; border-bottom-right-radius: 2px; }`,
+  `[data-gutter] > [${DIFF_RANGE_BAR_ATTR}='single']::after { top: 2px; bottom: 2px; border-radius: 2px; }`,
+].join('\n')
+
+export interface RangeBarSpan {
+  side: AnnotationSide
+  startLine: number
+  endLine: number
+}
+
+/** The committed range comments whose span the gutter bar should mark. */
+export const rangeBarSpansForAnnotations = (
+  annotations: DiffLineAnnotation<ReviewComment>[]
+): RangeBarSpan[] =>
+  annotations.flatMap((annotation) => {
+    const target = annotation.metadata.target
+
+    return target?.scope === 'range'
+      ? [
+          {
+            side: target.side,
+            startLine: target.startLine,
+            endLine: target.endLine,
+          },
+        ]
+      : []
+  })
+
+/** Stable key so the repaint effect only fires when the spans actually change,
+ * not on every render (the annotations array is rebuilt each render). */
+export const rangeBarSpansKey = (spans: RangeBarSpan[]): string =>
+  spans
+    .map((s) => `${s.side}:${s.startLine}-${s.endLine}`)
+    .sort()
+    .join('|')
+
+// Which side a gutter cell belongs to — mirrors search's sideForLine, but the
+// gutter cells live under the same [data-deletions]/[data-additions] columns.
+const gutterCellSide = (el: HTMLElement): AnnotationSide => {
+  if (el.closest('[data-deletions]') !== null) {
+    return 'deletions'
+  }
+
+  if (el.closest('[data-additions]') !== null) {
+    return 'additions'
+  }
+
+  // Unified column: deletion rows carry data-line-type="change-deletion".
+  return el.getAttribute('data-line-type') === 'change-deletion'
+    ? 'deletions'
+    : 'additions'
+}
+
+const edgeRole = (line: number, span: RangeBarSpan): string => {
+  if (span.startLine === span.endLine) {
+    return 'single'
+  }
+
+  if (line === span.startLine) {
+    return 'first'
+  }
+
+  return line === span.endLine ? 'last' : 'mid'
+}
+
+/** Walk pierre's shadow root and tag the gutter cells inside each committed
+ * range. Sole coupling point to pierre's DOM shape — a restructure yields no
+ * bar (silent degrade), never a throw. Re-run on every `onPostRender`: pierre
+ * wipes custom attributes when it rebuilds its DOM. */
+export const paintRangeBars = (
+  container: Element | null,
+  spans: RangeBarSpan[]
+): void => {
+  const root = container?.shadowRoot ?? null
+  if (root === null) {
+    return
+  }
+
+  for (const tagged of root.querySelectorAll(`[${DIFF_RANGE_BAR_ATTR}]`)) {
+    tagged.removeAttribute(DIFF_RANGE_BAR_ATTR)
+  }
+
+  if (spans.length === 0) {
+    return
+  }
+
+  for (const cell of root.querySelectorAll<HTMLElement>(
+    '[data-gutter] > [data-column-number]'
+  )) {
+    const raw = cell.getAttribute('data-column-number')
+    const line = raw === null ? Number.NaN : Number(raw)
+    if (!Number.isFinite(line)) {
+      continue
+    }
+
+    const side = gutterCellSide(cell)
+
+    const span = spans.find(
+      (s) => s.side === side && line >= s.startLine && line <= s.endLine
+    )
+    if (span !== undefined) {
+      cell.setAttribute(DIFF_RANGE_BAR_ATTR, edgeRole(line, span))
+    }
+  }
+}


### PR DESCRIPTION
**Diff Review UX Polish** milestone — the last item, VIM-273. Design dialed in via throwaway demos.

## 1. Persistent gutter bar
A committed range comment showed only a transient highlight; now a thin **gutter bar** (right of the line number, left of the content — GitHub-style, demo option **B**) persistently marks the commented lines.

Pierre has **no decorations API**, so this follows the search pattern: `onPostRender` tags the shadow-DOM gutter cells (`[data-gutter] > [data-column-number]`, matched by line number + side) in each committed range with `data-vf-range-bar="first|mid|last|single"`, styled by a **module-constant** `unsafeCSS` string (concatenated with the search CSS into one stable `<style>`). Re-tags on every render (Pierre wipes attributes on rebuild), coalesced with a single rAF + generation-guarded against stale frames on file switch. (`rangeBar/diffRangeBars.ts`, `hooks/useDiffRangeBars.ts`, `Panel.tsx`.)

## 2. Comment card (review feedback)
- **Below the selection:** the range comment (draft + committed) now anchors at its **last line**, so it renders beneath the whole selection instead of after the first line. The span stays in `metadata.target`, so the bar, label, and edit round-trip are unaffected (they read `target`, not the anchor).
- **Names the span:** the committed row shows the `lines R4–R6` label (was editor-only). The diff already shows the code, so — per review — the card just names the span (demo option **C**); plain line comments show no label.

## Tests
- `diffRangeBars.test.ts` / `useDiffRangeBars.test.ts` (13): shadow-DOM tagging (edge roles, side isolation split+unified, repaint-clears, silent degrade) + the rAF/generation lifecycle.
- `ReviewCommentRow.test.tsx`: label shown when provided, omitted for plain comments. `Panel.test.tsx`: committed range comment anchored at the last line.
- Full gate green: type-check, lint (0 errors), format, `vitest run` (4549 passed).

> **Dogfood check** (jsdom can't render Pierre): make a range comment (`v`-select → comment) — the gutter bar should span the range, the comment should sit **below the last line** with a `lines R…` label, and both should clear on delete.

Closes VIM-273
