### PR TITLE
feat(diff): persist dispatched review comments in the hunk (VIM-282)

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -99,7 +99,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [String Construction Hygiene](patterns/string-construction-hygiene.md)                               | code-quality       | 2        | 1    | 2026-06-19   |
 | [Agent-State Guards](patterns/agent-state-guards.md)                                                 | correctness        | 10       | 7    | 2026-06-22   |
 | [React Prop Contracts](patterns/react-prop-contracts.md)                                             | react-patterns     | 8        | 6    | 2026-06-22   |
-| [Stale Retained Interactions](patterns/stale-retained-interactions.md)                               | react-patterns     | 8        | 7    | 2026-07-04   |
+| [Stale Retained Interactions](patterns/stale-retained-interactions.md)                               | react-patterns     | 9        | 8    | 2026-07-04   |
 | [Retained State Identity](patterns/retained-state-identity.md)                                       | react-patterns     | 3        | 3    | 2026-07-04   |
 | [Authoritative Completion Guard](patterns/authoritative-completion-guard.md)                         | correctness        | 6        | 3    | 2026-06-27   |
 | [Equality Guard Completeness](patterns/equality-guard-completeness.md)                               | correctness        | 2        | 0    | 2026-06-17   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -52,7 +52,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 19       | 19   | 2026-06-21   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)                                             | cross-platform     | 12       | 12   | 2026-06-22   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                                                       | code-quality       | 7        | 0    | 2026-06-11   |
-| [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 21       | 18   | 2026-07-03   |
+| [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 22       | 19   | 2026-07-04   |
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 8        | 2    | 2026-06-19   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 4        | 0    | 2026-06-21   |
@@ -99,7 +99,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [String Construction Hygiene](patterns/string-construction-hygiene.md)                               | code-quality       | 2        | 1    | 2026-06-19   |
 | [Agent-State Guards](patterns/agent-state-guards.md)                                                 | correctness        | 10       | 7    | 2026-06-22   |
 | [React Prop Contracts](patterns/react-prop-contracts.md)                                             | react-patterns     | 8        | 6    | 2026-06-22   |
-| [Stale Retained Interactions](patterns/stale-retained-interactions.md)                               | react-patterns     | 6        | 5    | 2026-07-03   |
+| [Stale Retained Interactions](patterns/stale-retained-interactions.md)                               | react-patterns     | 8        | 7    | 2026-07-04   |
 | [Retained State Identity](patterns/retained-state-identity.md)                                       | react-patterns     | 3        | 3    | 2026-07-04   |
 | [Authoritative Completion Guard](patterns/authoritative-completion-guard.md)                         | correctness        | 6        | 3    | 2026-06-27   |
 | [Equality Guard Completeness](patterns/equality-guard-completeness.md)                               | correctness        | 2        | 0    | 2026-06-17   |

--- a/docs/reviews/patterns/derived-state-consistency.md
+++ b/docs/reviews/patterns/derived-state-consistency.md
@@ -2,8 +2,8 @@
 id: derived-state-consistency
 category: code-quality
 created: 2026-06-07
-last_updated: 2026-07-03
-ref_count: 18
+last_updated: 2026-07-04
+ref_count: 19
 ---
 
 # Derived State Consistency
@@ -273,4 +273,21 @@ base data is technically "correct."
   root. Added a clipboard regression test that copies a batch authored from a
   repo subdirectory and asserts the payload contains the resolved repo-root
   path.
+- **Commit:** same commit as this entry
+
+### 22. Sent review anchors counted as active pending feedback
+
+- **Source:** github-claude + github-codex-connector | PR #655 round 1 | 2026-07-04
+- **Severity:** HIGH
+- **File:** `src/features/diff/hooks/useFeedbackBatch.ts`
+- **Finding:** VIM-282 kept dispatched review comments in the hunk as sent
+  anchors, but the soft-cap and send-completion paths still treated every
+  retained annotation as active pending feedback. A sent 50-comment review could
+  permanently block new comments, and comments added after the send snapshot but
+  before completion could be stamped as sent without ever being included in the
+  terminal payload.
+- **Fix:** Changed the cap to count only pending annotations and made
+  `markDispatched` accept the exact dispatched annotation-id snapshot built by
+  the send path. Added hook regressions for sent anchors freeing capacity and
+  for late comments remaining pending.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/stale-retained-interactions.md
+++ b/docs/reviews/patterns/stale-retained-interactions.md
@@ -3,7 +3,7 @@ id: stale-retained-interactions
 category: react-patterns
 created: 2026-06-15
 last_updated: 2026-07-04
-ref_count: 7
+ref_count: 8
 ---
 
 # Stale Retained Interactions
@@ -89,4 +89,13 @@ When a React component renders retained or stale content while fresh data for a 
 - **Fix:** Made dispatched comment rows read-only by hiding Edit/Delete controls
   whenever `dispatchedAt` is present. Added component coverage proving sent
   anchors expose no edit or delete buttons.
+- **Commit:** same commit as this entry
+
+### 9. Sent review anchors stayed mutable through keyboard shortcuts
+
+- **Source:** github-claude | PR #655 round 2 | 2026-07-04
+- **Severity:** HIGH
+- **File:** `src/features/diff/Panel.tsx`
+- **Finding:** Dispatched review comments were read-only through row controls, but the keyboard edit/delete handlers still operated on the selected annotation without checking `dispatchedAt`. Keyboard users could change the local text for a sent anchor or remove the anchor entirely after feedback had already been delivered.
+- **Fix:** Guarded line-level `u`/`x` handlers with `isPendingReviewAnnotation` and made `Shift+U` select only pending file-level comments. Added panel coverage proving dispatched line and file comments remain visible and do not open edit state or delete through shortcuts.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/stale-retained-interactions.md
+++ b/docs/reviews/patterns/stale-retained-interactions.md
@@ -2,8 +2,8 @@
 id: stale-retained-interactions
 category: react-patterns
 created: 2026-06-15
-last_updated: 2026-07-03
-ref_count: 6
+last_updated: 2026-07-04
+ref_count: 7
 ---
 
 # Stale Retained Interactions
@@ -76,3 +76,17 @@ When a React component renders retained or stale content while fresh data for a 
 - **Finding:** The round-1 file-switch fix reused the full collected-line reset from `close()`. Closing the search popup does not trigger a pierre rerender, so reopening search on the same file recomputed against an empty collection and reported zero matches until an unrelated diff rebuild occurred.
 - **Fix:** Split visible-popup reset from full collected-line invalidation. Manual close now clears query, matches, active index, and paint while preserving the current file's collected line cache; file-key changes still clear the collection. Added hook coverage for close-then-reopen on the same file without another `handlePostRender`.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 8. Sent review anchors kept pending edit/delete controls
+
+- **Source:** github-claude + github-codex-connector | PR #655 round 1 | 2026-07-04
+- **Severity:** HIGH
+- **File:** `src/features/diff/components/ReviewCommentRow.tsx`
+- **Finding:** Dispatched review comments were retained in the diff as "Sent"
+  anchors, but the row still rendered Edit and Delete actions. Editing preserved
+  `dispatchedAt`, so local text changed while Finish/Send ignored it; deleting
+  removed the thread anchor for feedback that had already been delivered.
+- **Fix:** Made dispatched comment rows read-only by hiding Edit/Delete controls
+  whenever `dispatchedAt` is present. Added component coverage proving sent
+  anchors expose no edit or delete buttons.
+- **Commit:** same commit as this entry

--- a/src/features/diff/Panel.test.tsx
+++ b/src/features/diff/Panel.test.tsx
@@ -99,12 +99,7 @@ vi.mock('@pierre/diffs/react', () => ({
     lineAnnotations?: {
       lineNumber: number
       side: string
-      metadata: {
-        id: string
-        text: string
-        author: string
-        createdAt: number
-      }
+      metadata: ReviewComment
     }[]
     renderGutterUtility?: (
       getHovered: () => { lineNumber: number; side: string }
@@ -112,12 +107,7 @@ vi.mock('@pierre/diffs/react', () => ({
     renderAnnotation?: (a: {
       lineNumber: number
       side: string
-      metadata: {
-        id: string
-        text: string
-        author: string
-        createdAt: number
-      }
+      metadata: ReviewComment
     }) => ReactElement
   }): ReactElement => {
     multiFileDiffOptionsSeen.push(options)
@@ -3728,6 +3718,58 @@ describe('Panel', () => {
       ).not.toBeInTheDocument()
     })
 
+    test('keyboard Shift+U leaves dispatched file-level comments read-only', (): void => {
+      const updateAnnotation = vi.fn()
+
+      const feedbackBatch: UseFeedbackBatchReturn = {
+        batch: new Map(),
+        annotationsForFile: () => [
+          {
+            lineNumber: 0,
+            side: 'additions',
+            metadata: {
+              id: 'comment-1',
+              text: 'Sent file comment',
+              author: 'self',
+              createdAt: 1000,
+              dispatchedAt: 2000,
+              target: { scope: 'file' },
+            },
+          },
+        ],
+        addAnnotation: vi.fn(() => 'ok' as const),
+        updateAnnotation,
+        removeAnnotation: vi.fn(),
+        clearBatch: vi.fn(),
+        clearPending: vi.fn(),
+        markDispatched: vi.fn(),
+        totalAnnotations: () => 1,
+        pendingAnnotations: () => 0,
+      }
+
+      render(
+        <Panel
+          cwd="/repo"
+          selectedFile={{ path: 'src/foo.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+          feedbackBatch={feedbackBatch}
+        />
+      )
+
+      setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
+
+      fireEvent.keyDown(screen.getByTestId('multi-file-diff'), {
+        key: 'U',
+        shiftKey: true,
+      })
+
+      expect(
+        screen.queryByRole('dialog', { name: 'Comment on file src/foo.ts' })
+      ).not.toBeInTheDocument()
+      expect(screen.getByText('Sent file comment')).toBeInTheDocument()
+      expect(updateAnnotation).not.toHaveBeenCalled()
+    })
+
     test('hides a file-level draft when another file is selected', async (): Promise<void> => {
       const user = userEvent.setup()
 
@@ -4446,6 +4488,58 @@ describe('Panel', () => {
       fireEvent.keyDown(diff, { key: 'x' })
 
       expect(screen.queryByText('Updated comment')).not.toBeInTheDocument()
+    })
+
+    test('u and x leave a dispatched keyboard-selected line comment read-only', (): void => {
+      const updateAnnotation = vi.fn()
+      const removeAnnotation = vi.fn()
+
+      const feedbackBatch: UseFeedbackBatchReturn = {
+        batch: new Map(),
+        annotationsForFile: () => [
+          {
+            lineNumber: 1,
+            side: 'additions',
+            metadata: {
+              id: 'comment-1',
+              text: 'Sent comment',
+              author: 'self',
+              createdAt: 1000,
+              dispatchedAt: 2000,
+            },
+          },
+        ],
+        addAnnotation: vi.fn(() => 'ok' as const),
+        updateAnnotation,
+        removeAnnotation,
+        clearBatch: vi.fn(),
+        clearPending: vi.fn(),
+        markDispatched: vi.fn(),
+        totalAnnotations: () => 1,
+        pendingAnnotations: () => 0,
+      }
+
+      render(
+        <Panel
+          cwd="/repo"
+          selectedFile={{ path: 'src/foo.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+          feedbackBatch={feedbackBatch}
+        />
+      )
+
+      setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
+
+      const diff = screen.getByTestId('multi-file-diff')
+      fireEvent.keyDown(diff, { key: 'u' })
+      fireEvent.keyDown(diff, { key: 'x' })
+
+      expect(
+        screen.queryByRole('dialog', { name: /Comment on line R1/ })
+      ).not.toBeInTheDocument()
+      expect(screen.getByText('Sent comment')).toBeInTheDocument()
+      expect(updateAnnotation).not.toHaveBeenCalled()
+      expect(removeAnnotation).not.toHaveBeenCalled()
     })
 
     test('exiting a comment editor returns focus to the diff root', async (): Promise<void> => {

--- a/src/features/diff/Panel.test.tsx
+++ b/src/features/diff/Panel.test.tsx
@@ -335,6 +335,7 @@ describe('Panel', () => {
   test('keeps feedback actions available in the empty state', async (): Promise<void> => {
     const user = userEvent.setup()
     const clearBatch = vi.fn()
+    const clearPending = vi.fn()
 
     const annotation: DiffLineAnnotation<ReviewComment> = {
       side: 'additions',
@@ -358,7 +359,10 @@ describe('Panel', () => {
       updateAnnotation: vi.fn(),
       removeAnnotation: vi.fn(),
       clearBatch,
+      clearPending,
+      markDispatched: vi.fn(),
       totalAnnotations: () => 1,
+      pendingAnnotations: () => 1,
     }
 
     vi.spyOn(useGitStatusModule, 'useGitStatus').mockReturnValue({
@@ -389,7 +393,7 @@ describe('Panel', () => {
       screen.getByRole('button', { name: /discard all feedback/i })
     )
 
-    expect(clearBatch).toHaveBeenCalledOnce()
+    expect(clearPending).toHaveBeenCalledOnce()
 
     await user.click(
       screen.getByRole('button', { name: /finish feedback \(1\)/i })
@@ -434,7 +438,10 @@ describe('Panel', () => {
         updateAnnotation: vi.fn(),
         removeAnnotation: vi.fn(),
         clearBatch: vi.fn(),
+        clearPending: vi.fn(),
+        markDispatched: vi.fn(),
         totalAnnotations: () => 1,
+        pendingAnnotations: () => 1,
       }
 
       vi.spyOn(useGitStatusModule, 'useGitStatus').mockReturnValue({
@@ -486,6 +493,7 @@ describe('Panel', () => {
   test('keeps draft-only feedback discard available in the empty state', async (): Promise<void> => {
     const user = userEvent.setup()
     const clearBatch = vi.fn()
+    const clearPending = vi.fn()
     const setDraft = vi.fn()
 
     const feedbackBatch: UseFeedbackBatchReturn = {
@@ -495,7 +503,10 @@ describe('Panel', () => {
       updateAnnotation: vi.fn(),
       removeAnnotation: vi.fn(),
       clearBatch,
+      clearPending,
+      markDispatched: vi.fn(),
       totalAnnotations: () => 0,
+      pendingAnnotations: () => 0,
     }
 
     const feedbackDraft: FeedbackDraftStore = {
@@ -553,7 +564,7 @@ describe('Panel', () => {
       screen.getByRole('button', { name: /discard all feedback/i })
     )
 
-    expect(clearBatch).toHaveBeenCalledOnce()
+    expect(clearPending).toHaveBeenCalledOnce()
   })
 
   test('renders full-width diff with a hover cue when changes exist', (): void => {
@@ -3561,7 +3572,10 @@ describe('Panel', () => {
         updateAnnotation: vi.fn(),
         removeAnnotation: vi.fn(),
         clearBatch: vi.fn(),
+        clearPending: vi.fn(),
+        markDispatched: vi.fn(),
         totalAnnotations: () => 0,
+        pendingAnnotations: () => 0,
       }
 
       render(
@@ -4106,7 +4120,10 @@ describe('Panel', () => {
         updateAnnotation: vi.fn(),
         removeAnnotation: vi.fn(),
         clearBatch: vi.fn(),
+        clearPending: vi.fn(),
+        markDispatched: vi.fn(),
         totalAnnotations: () => 0,
+        pendingAnnotations: () => 0,
       }
 
       render(
@@ -4215,7 +4232,10 @@ describe('Panel', () => {
         updateAnnotation,
         removeAnnotation: vi.fn(),
         clearBatch: vi.fn(),
+        clearPending: vi.fn(),
+        markDispatched: vi.fn(),
         totalAnnotations: () => 1,
+        pendingAnnotations: () => 1,
       }
 
       render(
@@ -4291,7 +4311,10 @@ describe('Panel', () => {
         updateAnnotation,
         removeAnnotation: vi.fn(),
         clearBatch: vi.fn(),
+        clearPending: vi.fn(),
+        markDispatched: vi.fn(),
         totalAnnotations: () => 1,
+        pendingAnnotations: () => 1,
       }
 
       render(
@@ -5608,7 +5631,7 @@ describe('Panel', () => {
       expect(screen.queryByText('Great change!')).not.toBeInTheDocument()
     })
 
-    test('Finish with one running candidate dispatches via writePty and clears the batch', async (): Promise<void> => {
+    test('Finish with one running candidate dispatches via writePty and keeps the sent comment in the hunk', async (): Promise<void> => {
       const user = userEvent.setup()
       const writePty = vi.fn().mockResolvedValue(undefined)
       const focusTerminal = vi.fn()
@@ -5684,6 +5707,10 @@ describe('Panel', () => {
           screen.queryByRole('button', { name: /finish feedback/i })
         ).not.toBeInTheDocument()
       )
+
+      // VIM-282: the dispatched comment stays in the hunk as a thread anchor
+      // instead of being wiped on send.
+      expect(screen.getByText('Great change!')).toBeInTheDocument()
     })
 
     test('preserves the comment draft and shows a notification when the feedback cap is reached', async (): Promise<void> => {
@@ -5699,7 +5726,10 @@ describe('Panel', () => {
           updateAnnotation: vi.fn(),
           removeAnnotation: vi.fn(),
           clearBatch: vi.fn(),
+          clearPending: vi.fn(),
+          markDispatched: vi.fn(),
           totalAnnotations: () => 50,
+          pendingAnnotations: () => 50,
         })
 
       render(

--- a/src/features/diff/Panel.tsx
+++ b/src/features/diff/Panel.tsx
@@ -28,6 +28,7 @@ import {
   FILE_COMMENT_LINE_NUMBER,
   isFileLevelReviewAnnotation,
   isLineLevelReviewAnnotation,
+  isPendingReviewAnnotation,
   useFeedbackBatch,
   parseBatchKey,
   type FeedbackDraftStore,
@@ -736,6 +737,13 @@ export const Panel = ({
     const entries: DispatchEntry[] = []
 
     for (const [key, annotations] of feedback.batch) {
+      // Only dispatch comments that have not been sent yet; already-dispatched
+      // thread anchors stay in the hunk but are never re-sent (VIM-282).
+      const pending = annotations.filter(isPendingReviewAnnotation)
+      if (pending.length === 0) {
+        continue
+      }
+
       const { cwd: entryCwd, filePath: relPath, staged } = parseBatchKey(key)
 
       const entryRepoRoot = repoRootRef.repoRootForCwd?.(entryCwd)
@@ -746,7 +754,7 @@ export const Panel = ({
       const filePath = resolvedRepoRoot
         ? `${resolvedRepoRoot}/${relPath}`
         : relPath
-      entries.push({ filePath, staged, annotations })
+      entries.push({ filePath, staged, annotations: pending })
     }
 
     return entries
@@ -770,7 +778,10 @@ export const Panel = ({
               feedbackDispatch.writePty
             )
           }
-          feedback.clearBatch()
+          // Keep the sent comments in the hunk as thread anchors instead of
+          // wiping them (VIM-282); they are stamped dispatched so they are not
+          // re-sent, counted as pending, or removed by discard.
+          feedback.markDispatched(Date.now())
           setFinishOpen(false)
           const focusTerminal = feedbackDispatch?.focusTerminal
           if (focusTerminal !== undefined) {
@@ -797,7 +808,7 @@ export const Panel = ({
       return
     }
 
-    const count = feedback.totalAnnotations()
+    const count = feedback.pendingAnnotations()
     setFinishOpen(false)
 
     void (async (): Promise<void> => {
@@ -1817,7 +1828,7 @@ export const Panel = ({
     onUpdateFileComment: updateSelectedFileComment,
     onDeleteComment: deleteSelectedComment,
     onFinishReview: (): void => {
-      if (feedback.totalAnnotations() > 0) {
+      if (feedback.pendingAnnotations() > 0) {
         setFinishOpen(true)
       }
     },
@@ -1909,9 +1920,19 @@ export const Panel = ({
     ]
   )
 
-  const feedbackCount = feedback.totalAnnotations()
+  const feedbackCount = feedback.pendingAnnotations()
   const feedbackDraftCount = commentDraftText.trim().length > 0 ? 1 : 0
   const pendingFeedbackCount = feedbackCount + feedbackDraftCount
+
+  // Files with at least one pending comment — the "across N files" the Finish
+  // popover would actually send (VIM-282). Dispatched-only files are excluded.
+  const pendingFileCount = useMemo(
+    (): number =>
+      [...feedback.batch.values()].filter((list) =>
+        list.some(isPendingReviewAnnotation)
+      ).length,
+    [feedback.batch]
+  )
 
   const onFinishFeedback =
     feedbackCount > 0 ? (): void => setFinishOpen(true) : undefined
@@ -1923,7 +1944,7 @@ export const Panel = ({
       diffCwd: cwd,
     }),
     commentCount: feedbackCount,
-    fileCount: feedback.batch.size,
+    fileCount: pendingFileCount,
     onCancel: (): void => setFinishOpen(false),
     onSend: handleSendFeedback,
     onCopy: handleCopyFeedback,
@@ -1979,7 +2000,7 @@ export const Panel = ({
             currentFileIndex: -1,
             totalFiles: 0,
             feedbackCount: pendingFeedbackCount,
-            onDiscardFeedback: feedback.clearBatch,
+            onDiscardFeedback: feedback.clearPending,
             onFinishFeedback,
           }}
           finishFeedback={finishFeedback}
@@ -2047,7 +2068,7 @@ export const Panel = ({
           staging,
           selectedFileName: selectedFilePath ?? undefined,
           feedbackCount: pendingFeedbackCount,
-          onDiscardFeedback: feedback.clearBatch,
+          onDiscardFeedback: feedback.clearPending,
           onFinishFeedback,
           onRefreshActiveFile:
             latestDiffStatus === 'ready' ? acceptLatestDiff : undefined,

--- a/src/features/diff/Panel.tsx
+++ b/src/features/diff/Panel.tsx
@@ -1594,7 +1594,8 @@ export const Panel = ({
     if (
       selectedFilePath === null ||
       reviewTarget === null ||
-      reviewTargetComment === undefined
+      reviewTargetComment === undefined ||
+      !isPendingReviewAnnotation(reviewTargetComment)
     ) {
       notifyInfo('No comment selected.')
 
@@ -1629,8 +1630,18 @@ export const Panel = ({
       return
     }
 
+    const pendingFileComments = fileCommentsForSelectedFile.filter(
+      isPendingReviewAnnotation
+    )
+
+    if (pendingFileComments.length === 0) {
+      notifyInfo('No file comment selected.')
+
+      return
+    }
+
     const fileCommentToEdit =
-      fileCommentsForSelectedFile[fileCommentsForSelectedFile.length - 1]
+      pendingFileComments[pendingFileComments.length - 1]
 
     setFileCommentAnchorPoint(null)
     setAnnotationTarget({
@@ -1654,7 +1665,8 @@ export const Panel = ({
     if (
       selectedFilePath === null ||
       reviewTarget === null ||
-      reviewTargetComment === undefined
+      reviewTargetComment === undefined ||
+      !isPendingReviewAnnotation(reviewTargetComment)
     ) {
       notifyInfo('No comment selected.')
 

--- a/src/features/diff/Panel.tsx
+++ b/src/features/diff/Panel.tsx
@@ -781,7 +781,14 @@ export const Panel = ({
           // Keep the sent comments in the hunk as thread anchors instead of
           // wiping them (VIM-282); they are stamped dispatched so they are not
           // re-sent, counted as pending, or removed by discard.
-          feedback.markDispatched(Date.now())
+          feedback.markDispatched(
+            Date.now(),
+            new Set(
+              entries.flatMap((entry) =>
+                entry.annotations.map((annotation) => annotation.metadata.id)
+              )
+            )
+          )
           setFinishOpen(false)
           const focusTerminal = feedbackDispatch?.focusTerminal
           if (focusTerminal !== undefined) {

--- a/src/features/diff/components/ReviewCommentRow.test.tsx
+++ b/src/features/diff/components/ReviewCommentRow.test.tsx
@@ -162,6 +162,30 @@ describe('ReviewCommentRow', () => {
     expect(screen.getByText(/^Sent\b.*ago$/)).toBeInTheDocument()
   })
 
+  test('dispatched comments are read-only anchors', () => {
+    render(
+      <ReviewCommentRow
+        comment={{
+          id: 'sent-read-only',
+          text: 'Sent note',
+          author: 'self',
+          createdAt: 7000,
+          dispatchedAt: 7100,
+        }}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    )
+
+    expect(
+      screen.queryByRole('button', { name: 'Edit comment' })
+    ).not.toBeInTheDocument()
+
+    expect(
+      screen.queryByRole('button', { name: 'Delete comment' })
+    ).not.toBeInTheDocument()
+  })
+
   test('a pending comment shows no Sent label and keeps edit', () => {
     render(
       <ReviewCommentRow

--- a/src/features/diff/components/ReviewCommentRow.test.tsx
+++ b/src/features/diff/components/ReviewCommentRow.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, test, vi } from 'vitest'
-import { ReviewCommentRow } from './ReviewCommentRow'
+import { formatSentAgo, ReviewCommentRow } from './ReviewCommentRow'
 
 describe('ReviewCommentRow', () => {
   test('renders the comment text', () => {
@@ -143,7 +143,7 @@ describe('ReviewCommentRow', () => {
     expect(screen.queryByText(/lines R/)).not.toBeInTheDocument()
   })
 
-  test('marks a dispatched comment as Sent', () => {
+  test('marks a dispatched comment as Sent with the time elapsed', () => {
     render(
       <ReviewCommentRow
         comment={{
@@ -158,7 +158,8 @@ describe('ReviewCommentRow', () => {
       />
     )
 
-    expect(screen.getByText('Sent')).toBeInTheDocument()
+    // "Sent <n>d ago" — the badge leads with "Sent" and carries an elapsed time.
+    expect(screen.getByText(/^Sent\b.*ago$/)).toBeInTheDocument()
   })
 
   test('a pending comment shows no Sent label and keeps edit', () => {
@@ -175,9 +176,33 @@ describe('ReviewCommentRow', () => {
       />
     )
 
-    expect(screen.queryByText('Sent')).not.toBeInTheDocument()
+    expect(screen.queryByText(/^Sent\b/)).not.toBeInTheDocument()
     expect(
       screen.getByRole('button', { name: 'Edit comment' })
     ).toBeInTheDocument()
+  })
+})
+
+const MINUTE = 60_000
+const HOUR = 60 * MINUTE
+const DAY = 24 * HOUR
+
+describe('formatSentAgo', () => {
+  const base = 1_000_000_000_000
+
+  test('under a minute reads "just now"', () => {
+    expect(formatSentAgo(base, base)).toBe('just now')
+    expect(formatSentAgo(base, base + 59_000)).toBe('just now')
+  })
+
+  test('rounds down to minutes, hours, and days', () => {
+    expect(formatSentAgo(base, base + 5 * MINUTE)).toBe('5m ago')
+    expect(formatSentAgo(base, base + 90 * MINUTE)).toBe('1h ago')
+    expect(formatSentAgo(base, base + 3 * HOUR)).toBe('3h ago')
+    expect(formatSentAgo(base, base + 2 * DAY)).toBe('2d ago')
+  })
+
+  test('a future dispatchedAt (clock skew) reads "just now"', () => {
+    expect(formatSentAgo(base + 5000, base)).toBe('just now')
   })
 })

--- a/src/features/diff/components/ReviewCommentRow.test.tsx
+++ b/src/features/diff/components/ReviewCommentRow.test.tsx
@@ -142,4 +142,42 @@ describe('ReviewCommentRow', () => {
 
     expect(screen.queryByText(/lines R/)).not.toBeInTheDocument()
   })
+
+  test('marks a dispatched comment as Sent', () => {
+    render(
+      <ReviewCommentRow
+        comment={{
+          id: '7',
+          text: 'Sent note',
+          author: 'self',
+          createdAt: 7000,
+          dispatchedAt: 7100,
+        }}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Sent')).toBeInTheDocument()
+  })
+
+  test('a pending comment shows no Sent label and keeps edit', () => {
+    render(
+      <ReviewCommentRow
+        comment={{
+          id: '8',
+          text: 'Pending note',
+          author: 'self',
+          createdAt: 8000,
+        }}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByText('Sent')).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Edit comment' })
+    ).toBeInTheDocument()
+  })
 })

--- a/src/features/diff/components/ReviewCommentRow.tsx
+++ b/src/features/diff/components/ReviewCommentRow.tsx
@@ -53,13 +53,14 @@ export const ReviewCommentRow = ({
   // anchor (VIM-282); label it "Sent <time ago>" so it reads as sent — with how
   // long ago — rather than an unsent draft.
   const { dispatchedAt } = comment
+  const isDispatched = dispatchedAt !== undefined
 
   return (
     <div className="mx-2 my-1 flex items-start gap-2 rounded-md bg-surface-container-high/60 px-3 py-2">
       <div className="min-w-0 flex-1">
-        {dispatchedAt !== undefined || targetLabel !== undefined ? (
+        {isDispatched || targetLabel !== undefined ? (
           <div className="mb-1 flex flex-wrap items-center gap-1">
-            {dispatchedAt !== undefined ? (
+            {isDispatched ? (
               <span className="inline-flex items-center rounded bg-surface-container-highest/70 px-1.5 py-px text-[10px] font-medium text-primary">
                 Sent {formatSentAgo(dispatchedAt, Date.now())}
               </span>
@@ -75,25 +76,27 @@ export const ReviewCommentRow = ({
           {comment.text}
         </p>
       </div>
-      <div className="flex shrink-0 items-center gap-1">
-        <IconButton
-          icon="edit"
-          label="Edit comment"
-          size="sm"
-          shortcut={editShortcut === 'Shift+U' ? ['Shift', 'U'] : 'u'}
-          aria-keyshortcuts={editShortcut}
-          onClick={(): void => onEdit()}
-        />
-        <IconButton
-          icon="delete"
-          label="Delete comment"
-          variant="danger"
-          size="sm"
-          shortcut={deleteShortcut ?? undefined}
-          aria-keyshortcuts={deleteShortcut ?? undefined}
-          onClick={(): void => onDelete()}
-        />
-      </div>
+      {isDispatched ? null : (
+        <div className="flex shrink-0 items-center gap-1">
+          <IconButton
+            icon="edit"
+            label="Edit comment"
+            size="sm"
+            shortcut={editShortcut === 'Shift+U' ? ['Shift', 'U'] : 'u'}
+            aria-keyshortcuts={editShortcut}
+            onClick={(): void => onEdit()}
+          />
+          <IconButton
+            icon="delete"
+            label="Delete comment"
+            variant="danger"
+            size="sm"
+            shortcut={deleteShortcut ?? undefined}
+            aria-keyshortcuts={deleteShortcut ?? undefined}
+            onClick={(): void => onDelete()}
+          />
+        </div>
+      )}
     </div>
   )
 }

--- a/src/features/diff/components/ReviewCommentRow.tsx
+++ b/src/features/diff/components/ReviewCommentRow.tsx
@@ -14,6 +14,33 @@ interface ReviewCommentRowProps {
   onDelete: () => void
 }
 
+const MINUTE_MS = 60_000
+const HOUR_MS = 60 * MINUTE_MS
+const DAY_MS = 24 * HOUR_MS
+
+/**
+ * Compact "time since sent" for the Sent badge: `just now`, `5m ago`, `3h ago`,
+ * `2d ago`. Takes an explicit `now` so it stays pure and testable; the row
+ * passes `Date.now()`.
+ */
+export const formatSentAgo = (dispatchedAt: number, now: number): string => {
+  const delta = now - dispatchedAt
+
+  if (delta < MINUTE_MS) {
+    return 'just now'
+  }
+
+  if (delta < HOUR_MS) {
+    return `${Math.floor(delta / MINUTE_MS)}m ago`
+  }
+
+  if (delta < DAY_MS) {
+    return `${Math.floor(delta / HOUR_MS)}h ago`
+  }
+
+  return `${Math.floor(delta / DAY_MS)}d ago`
+}
+
 export const ReviewCommentRow = ({
   comment,
   editShortcut = 'u',
@@ -23,18 +50,18 @@ export const ReviewCommentRow = ({
   onDelete,
 }: ReviewCommentRowProps): ReactElement => {
   // A dispatched comment was sent to an agent and now persists as a thread
-  // anchor (VIM-282); label it "Sent" so it reads as sent rather than an unsent
-  // draft.
-  const dispatched = comment.dispatchedAt !== undefined
+  // anchor (VIM-282); label it "Sent <time ago>" so it reads as sent — with how
+  // long ago — rather than an unsent draft.
+  const { dispatchedAt } = comment
 
   return (
     <div className="mx-2 my-1 flex items-start gap-2 rounded-md bg-surface-container-high/60 px-3 py-2">
       <div className="min-w-0 flex-1">
-        {dispatched || targetLabel !== undefined ? (
+        {dispatchedAt !== undefined || targetLabel !== undefined ? (
           <div className="mb-1 flex flex-wrap items-center gap-1">
-            {dispatched ? (
+            {dispatchedAt !== undefined ? (
               <span className="inline-flex items-center rounded bg-surface-container-highest/70 px-1.5 py-px text-[10px] font-medium text-primary">
-                Sent
+                Sent {formatSentAgo(dispatchedAt, Date.now())}
               </span>
             ) : null}
             {targetLabel !== undefined ? (

--- a/src/features/diff/components/ReviewCommentRow.tsx
+++ b/src/features/diff/components/ReviewCommentRow.tsx
@@ -21,36 +21,52 @@ export const ReviewCommentRow = ({
   targetLabel = undefined,
   onEdit,
   onDelete,
-}: ReviewCommentRowProps): ReactElement => (
-  <div className="mx-2 my-1 flex items-start gap-2 rounded-md bg-surface-container-high/60 px-3 py-2">
-    <div className="min-w-0 flex-1">
-      {targetLabel !== undefined ? (
-        <span className="mb-1 inline-block rounded bg-surface-container-highest/70 px-1.5 py-px font-mono text-[10px] text-on-surface-variant">
-          {targetLabel}
-        </span>
-      ) : null}
-      <p className="break-words whitespace-pre-wrap text-xs text-on-surface">
-        {comment.text}
-      </p>
+}: ReviewCommentRowProps): ReactElement => {
+  // A dispatched comment was sent to an agent and now persists as a thread
+  // anchor (VIM-282); label it "Sent" so it reads as sent rather than an unsent
+  // draft.
+  const dispatched = comment.dispatchedAt !== undefined
+
+  return (
+    <div className="mx-2 my-1 flex items-start gap-2 rounded-md bg-surface-container-high/60 px-3 py-2">
+      <div className="min-w-0 flex-1">
+        {dispatched || targetLabel !== undefined ? (
+          <div className="mb-1 flex flex-wrap items-center gap-1">
+            {dispatched ? (
+              <span className="inline-flex items-center rounded bg-surface-container-highest/70 px-1.5 py-px text-[10px] font-medium text-primary">
+                Sent
+              </span>
+            ) : null}
+            {targetLabel !== undefined ? (
+              <span className="inline-block rounded bg-surface-container-highest/70 px-1.5 py-px font-mono text-[10px] text-on-surface-variant">
+                {targetLabel}
+              </span>
+            ) : null}
+          </div>
+        ) : null}
+        <p className="break-words whitespace-pre-wrap text-xs text-on-surface">
+          {comment.text}
+        </p>
+      </div>
+      <div className="flex shrink-0 items-center gap-1">
+        <IconButton
+          icon="edit"
+          label="Edit comment"
+          size="sm"
+          shortcut={editShortcut === 'Shift+U' ? ['Shift', 'U'] : 'u'}
+          aria-keyshortcuts={editShortcut}
+          onClick={(): void => onEdit()}
+        />
+        <IconButton
+          icon="delete"
+          label="Delete comment"
+          variant="danger"
+          size="sm"
+          shortcut={deleteShortcut ?? undefined}
+          aria-keyshortcuts={deleteShortcut ?? undefined}
+          onClick={(): void => onDelete()}
+        />
+      </div>
     </div>
-    <div className="flex shrink-0 items-center gap-1">
-      <IconButton
-        icon="edit"
-        label="Edit comment"
-        size="sm"
-        shortcut={editShortcut === 'Shift+U' ? ['Shift', 'U'] : 'u'}
-        aria-keyshortcuts={editShortcut}
-        onClick={(): void => onEdit()}
-      />
-      <IconButton
-        icon="delete"
-        label="Delete comment"
-        variant="danger"
-        size="sm"
-        shortcut={deleteShortcut ?? undefined}
-        aria-keyshortcuts={deleteShortcut ?? undefined}
-        onClick={(): void => onDelete()}
-      />
-    </div>
-  </div>
-)
+  )
+}

--- a/src/features/diff/hooks/useFeedbackBatch.test.ts
+++ b/src/features/diff/hooks/useFeedbackBatch.test.ts
@@ -199,6 +199,138 @@ describe('useFeedbackBatch', () => {
     expect(result.current.batch.size).toBe(0)
   })
 
+  test('markDispatched stamps pending comments and keeps them in the batch', () => {
+    const { result } = renderHook(() => useFeedbackBatch())
+
+    act(() => {
+      result.current.addAnnotation(
+        '/repo',
+        'a.ts',
+        false,
+        makeAnnotation('m-1')
+      )
+
+      result.current.addAnnotation(
+        '/repo',
+        'b.ts',
+        false,
+        makeAnnotation('m-2')
+      )
+    })
+
+    expect(result.current.pendingAnnotations()).toBe(2)
+
+    act(() => {
+      result.current.markDispatched(4242)
+    })
+
+    // Comments persist as thread anchors, but none are pending anymore.
+    expect(result.current.totalAnnotations()).toBe(2)
+    expect(result.current.pendingAnnotations()).toBe(0)
+    expect(
+      result.current.annotationsForFile('/repo', 'a.ts', false)[0].metadata
+        .dispatchedAt
+    ).toBe(4242)
+  })
+
+  test('markDispatched leaves already-dispatched comments untouched', () => {
+    const { result } = renderHook(() => useFeedbackBatch())
+
+    act(() => {
+      result.current.addAnnotation(
+        '/repo',
+        'a.ts',
+        false,
+        makeAnnotation('first')
+      )
+    })
+
+    act(() => {
+      result.current.markDispatched(100)
+    })
+
+    act(() => {
+      result.current.addAnnotation(
+        '/repo',
+        'a.ts',
+        false,
+        makeAnnotation('second')
+      )
+    })
+
+    act(() => {
+      result.current.markDispatched(200)
+    })
+
+    const [first, second] = result.current.annotationsForFile(
+      '/repo',
+      'a.ts',
+      false
+    )
+    expect(first.metadata.dispatchedAt).toBe(100)
+    expect(second.metadata.dispatchedAt).toBe(200)
+  })
+
+  test('clearPending drops pending comments but keeps dispatched thread anchors', () => {
+    const { result } = renderHook(() => useFeedbackBatch())
+
+    act(() => {
+      result.current.addAnnotation(
+        '/repo',
+        'a.ts',
+        false,
+        makeAnnotation('kept')
+      )
+    })
+
+    act(() => {
+      result.current.markDispatched(100)
+    })
+
+    act(() => {
+      result.current.addAnnotation(
+        '/repo',
+        'a.ts',
+        false,
+        makeAnnotation('dropped')
+      )
+    })
+
+    expect(result.current.totalAnnotations()).toBe(2)
+
+    act(() => {
+      result.current.clearPending()
+    })
+
+    const list = result.current.annotationsForFile('/repo', 'a.ts', false)
+    expect(list).toHaveLength(1)
+    expect(list[0].metadata.id).toBe('kept')
+    expect(result.current.pendingAnnotations()).toBe(0)
+  })
+
+  test('clearPending removes the file key when only pending comments existed', () => {
+    const { result } = renderHook(() => useFeedbackBatch())
+    const key = makeBatchKey('/repo', 'a.ts', false)
+
+    act(() => {
+      result.current.addAnnotation(
+        '/repo',
+        'a.ts',
+        false,
+        makeAnnotation('p-1')
+      )
+    })
+
+    expect(result.current.batch.has(key)).toBe(true)
+
+    act(() => {
+      result.current.clearPending()
+    })
+
+    expect(result.current.batch.has(key)).toBe(false)
+    expect(result.current.totalAnnotations()).toBe(0)
+  })
+
   test('clearBatch identity is stable across a re-render (add does not change clearBatch ref)', () => {
     const { result } = renderHook(() => useFeedbackBatch())
 
@@ -509,6 +641,70 @@ describe('useFeedbackBatchStore', () => {
 
     expect(result.current.feedbackDraft.draft).toBeNull()
     expect(result.current.feedbackBatch.totalAnnotations()).toBe(0)
+  })
+
+  test('markDispatched keeps the comment but clears the owner draft', () => {
+    const { result } = renderHook(() =>
+      useFeedbackBatchStore('session-a:p0', '/repo-a')
+    )
+
+    act(() => {
+      result.current.feedbackDraft.setDraft({
+        cwd: '/repo-a',
+        filePath: 'src/a.ts',
+        staged: false,
+        side: 'additions',
+        lineNumber: 7,
+        text: 'draft a',
+      })
+
+      result.current.feedbackBatch.addAnnotation(
+        '/repo-a',
+        'src/a.ts',
+        false,
+        makeAnnotation('owner-a')
+      )
+    })
+
+    act(() => {
+      result.current.feedbackBatch.markDispatched(999)
+    })
+
+    expect(result.current.feedbackDraft.draft).toBeNull()
+    // The dispatched comment stays in the hunk as a thread anchor.
+    expect(result.current.feedbackBatch.totalAnnotations()).toBe(1)
+    expect(result.current.feedbackBatch.pendingAnnotations()).toBe(0)
+  })
+
+  test('a fully dispatched owner drops out of unfinished-review summaries', () => {
+    const { result } = renderHook(() =>
+      useFeedbackBatchStore('session-a:p0', '/repo-a')
+    )
+
+    act(() => {
+      result.current.feedbackBatch.addAnnotation(
+        '/repo-a',
+        'src/a.ts',
+        false,
+        makeAnnotation('owner-a')
+      )
+    })
+
+    expect(result.current.summaries).toHaveLength(1)
+
+    act(() => {
+      result.current.feedbackBatch.markDispatched(1)
+    })
+
+    // The comment still renders in the hunk, but it is no longer "unfinished".
+    expect(result.current.summaries).toEqual([])
+    expect(
+      result.current.feedbackBatch.annotationsForFile(
+        '/repo-a',
+        'src/a.ts',
+        false
+      )
+    ).toHaveLength(1)
   })
 
   test('prunes drafts for closed owners', () => {

--- a/src/features/diff/hooks/useFeedbackBatch.test.ts
+++ b/src/features/diff/hooks/useFeedbackBatch.test.ts
@@ -90,6 +90,42 @@ describe('useFeedbackBatch', () => {
     expect(result.current.totalAnnotations()).toBe(50)
   })
 
+  test('dispatched comments do not count against the pending soft cap', () => {
+    const { result } = renderHook(() => useFeedbackBatch())
+    const dispatchedIds = new Set<string>()
+
+    act(() => {
+      for (let i = 0; i < 50; i++) {
+        const id = `sent-${i}`
+        dispatchedIds.add(id)
+        result.current.addAnnotation(
+          '/repo',
+          `file-${i}.ts`,
+          false,
+          makeAnnotation(id, 'x', i + 1)
+        )
+      }
+    })
+
+    act(() => {
+      result.current.markDispatched(4242, dispatchedIds)
+    })
+
+    let addResult: 'ok' | 'cap-reached' = 'cap-reached'
+    act(() => {
+      addResult = result.current.addAnnotation(
+        '/repo',
+        'next.ts',
+        false,
+        makeAnnotation('next')
+      )
+    })
+
+    expect(addResult).toBe('ok')
+    expect(result.current.totalAnnotations()).toBe(51)
+    expect(result.current.pendingAnnotations()).toBe(1)
+  })
+
   test('updateAnnotation patches text; preserves createdAt, author, side, lineNumber', () => {
     const { result } = renderHook(() => useFeedbackBatch())
 
@@ -221,7 +257,7 @@ describe('useFeedbackBatch', () => {
     expect(result.current.pendingAnnotations()).toBe(2)
 
     act(() => {
-      result.current.markDispatched(4242)
+      result.current.markDispatched(4242, new Set(['m-1', 'm-2']))
     })
 
     // Comments persist as thread anchors, but none are pending anymore.
@@ -246,7 +282,7 @@ describe('useFeedbackBatch', () => {
     })
 
     act(() => {
-      result.current.markDispatched(100)
+      result.current.markDispatched(100, new Set(['first']))
     })
 
     act(() => {
@@ -259,7 +295,7 @@ describe('useFeedbackBatch', () => {
     })
 
     act(() => {
-      result.current.markDispatched(200)
+      result.current.markDispatched(200, new Set(['second']))
     })
 
     const [first, second] = result.current.annotationsForFile(
@@ -269,6 +305,39 @@ describe('useFeedbackBatch', () => {
     )
     expect(first.metadata.dispatchedAt).toBe(100)
     expect(second.metadata.dispatchedAt).toBe(200)
+  })
+
+  test('markDispatched stamps only the dispatched snapshot ids', () => {
+    const { result } = renderHook(() => useFeedbackBatch())
+
+    act(() => {
+      result.current.addAnnotation(
+        '/repo',
+        'a.ts',
+        false,
+        makeAnnotation('sent')
+      )
+
+      result.current.addAnnotation(
+        '/repo',
+        'a.ts',
+        false,
+        makeAnnotation('late')
+      )
+    })
+
+    act(() => {
+      result.current.markDispatched(100, new Set(['sent']))
+    })
+
+    const [sent, late] = result.current.annotationsForFile(
+      '/repo',
+      'a.ts',
+      false
+    )
+    expect(sent.metadata.dispatchedAt).toBe(100)
+    expect(late.metadata.dispatchedAt).toBeUndefined()
+    expect(result.current.pendingAnnotations()).toBe(1)
   })
 
   test('clearPending drops pending comments but keeps dispatched thread anchors', () => {
@@ -284,7 +353,7 @@ describe('useFeedbackBatch', () => {
     })
 
     act(() => {
-      result.current.markDispatched(100)
+      result.current.markDispatched(100, new Set(['kept']))
     })
 
     act(() => {
@@ -667,7 +736,7 @@ describe('useFeedbackBatchStore', () => {
     })
 
     act(() => {
-      result.current.feedbackBatch.markDispatched(999)
+      result.current.feedbackBatch.markDispatched(999, new Set(['owner-a']))
     })
 
     expect(result.current.feedbackDraft.draft).toBeNull()
@@ -693,7 +762,7 @@ describe('useFeedbackBatchStore', () => {
     expect(result.current.summaries).toHaveLength(1)
 
     act(() => {
-      result.current.feedbackBatch.markDispatched(1)
+      result.current.feedbackBatch.markDispatched(1, new Set(['owner-a']))
     })
 
     // The comment still renders in the hunk, but it is no longer "unfinished".

--- a/src/features/diff/hooks/useFeedbackBatch.ts
+++ b/src/features/diff/hooks/useFeedbackBatch.ts
@@ -244,7 +244,10 @@ export interface UseFeedbackBatchReturn {
    * hunk as thread anchors) and clear the open draft. Replaces clearBatch on the
    * send path so submitted comments persist instead of being wiped.
    */
-  markDispatched: (dispatchedAt: number) => void
+  markDispatched: (
+    dispatchedAt: number,
+    dispatchedAnnotationIds: ReadonlySet<string>
+  ) => void
   /**
    * Drop the pending comments and the open draft, leaving already dispatched
    * thread anchors intact. The discard action.
@@ -359,7 +362,7 @@ export const useFeedbackBatchStore = (
       const optimisticBatch =
         optimisticBatchesRef.current.get(ownerKey) ?? EMPTY_BATCH
 
-      if (countAnnotationsInBatch(optimisticBatch) >= SOFT_CAP) {
+      if (countPendingInBatch(optimisticBatch) >= SOFT_CAP) {
         addAnnotationResultRef.current = 'cap-reached'
 
         return addAnnotationResultRef.current
@@ -377,7 +380,7 @@ export const useFeedbackBatchStore = (
       addAnnotationResultRef.current = 'ok'
       setBatchesByOwner((prev) => {
         const currentBatch = prev.get(ownerKey) ?? EMPTY_BATCH
-        if (countAnnotationsInBatch(currentBatch) >= SOFT_CAP) {
+        if (countPendingInBatch(currentBatch) >= SOFT_CAP) {
           addAnnotationResultRef.current = 'cap-reached'
           optimisticBatchesRef.current = prev
 
@@ -513,12 +516,15 @@ export const useFeedbackBatchStore = (
     })
   }, [ownerKey])
 
-  // Send path (VIM-282): stamp every pending comment as dispatched and keep it
-  // in the hunk as a thread anchor, then close the draft. Unchanged file lists
+  // Send path (VIM-282): stamp sent pending comments as dispatched and keep
+  // them in the hunk as thread anchors, then close the draft. Unchanged file lists
   // keep their identity so Pierre does not re-tokenize files with no pending
   // comment.
   const markDispatched = useCallback(
-    (dispatchedAt: number): void => {
+    (
+      dispatchedAt: number,
+      dispatchedAnnotationIds: ReadonlySet<string>
+    ): void => {
       setBatchesByOwner((prev) => {
         const currentBatch = prev.get(ownerKey)
         if (currentBatch === undefined || currentBatch.size === 0) {
@@ -528,7 +534,13 @@ export const useFeedbackBatchStore = (
         let changed = false
         const nextBatch: FeedbackBatch = new Map()
         for (const [key, list] of currentBatch) {
-          if (!list.some(isPendingReviewAnnotation)) {
+          if (
+            !list.some(
+              (annotation) =>
+                isPendingReviewAnnotation(annotation) &&
+                dispatchedAnnotationIds.has(annotation.metadata.id)
+            )
+          ) {
             nextBatch.set(key, list)
 
             continue
@@ -538,7 +550,8 @@ export const useFeedbackBatchStore = (
           nextBatch.set(
             key,
             list.map((annotation) =>
-              isPendingReviewAnnotation(annotation)
+              isPendingReviewAnnotation(annotation) &&
+              dispatchedAnnotationIds.has(annotation.metadata.id)
                 ? {
                     ...annotation,
                     metadata: { ...annotation.metadata, dispatchedAt },

--- a/src/features/diff/hooks/useFeedbackBatch.ts
+++ b/src/features/diff/hooks/useFeedbackBatch.ts
@@ -19,6 +19,14 @@ export interface ReviewComment {
   text: string
   author: 'self'
   createdAt: number
+  /**
+   * When set, the comment has been dispatched to an agent and now stays in the
+   * hunk as a thread anchor (VIM-282) instead of being wiped on send.
+   * Comments with no dispatchedAt are the *pending* review — what Finish/Send
+   * and the discard action act on. A timestamp, not a boolean, so the thread
+   * model can order sends.
+   */
+  dispatchedAt?: number
   target?:
     | { scope: 'file' }
     | {
@@ -89,10 +97,32 @@ export const isLineLevelReviewAnnotation = (
   annotation: DiffLineAnnotation<ReviewComment>
 ): boolean => !isFileLevelReviewAnnotation(annotation)
 
+/**
+ * A comment is *pending* until it is dispatched to an agent. Pending comments
+ * are the review the user is still assembling; dispatched ones stay in the hunk
+ * as thread anchors but are never re-sent, counted as unfinished, or discarded.
+ */
+export const isPendingReviewAnnotation = (
+  annotation: DiffLineAnnotation<ReviewComment>
+): boolean => annotation.metadata.dispatchedAt === undefined
+
 const countAnnotationsInBatch = (batch: FeedbackBatch): number => {
   let count = 0
   for (const list of batch.values()) {
     count += list.length
+  }
+
+  return count
+}
+
+const countPendingInBatch = (batch: FeedbackBatch): number => {
+  let count = 0
+  for (const list of batch.values()) {
+    for (const annotation of list) {
+      if (isPendingReviewAnnotation(annotation)) {
+        count += 1
+      }
+    }
   }
 
   return count
@@ -209,7 +239,20 @@ export interface UseFeedbackBatchReturn {
     id: string
   ) => void
   clearBatch: () => void
+  /**
+   * Mark every pending comment in the owner as dispatched (keeping them in the
+   * hunk as thread anchors) and clear the open draft. Replaces clearBatch on the
+   * send path so submitted comments persist instead of being wiped.
+   */
+  markDispatched: (dispatchedAt: number) => void
+  /**
+   * Drop the pending comments and the open draft, leaving already dispatched
+   * thread anchors intact. The discard action.
+   */
+  clearPending: () => void
   totalAnnotations: () => number
+  /** Count of pending comments (not yet dispatched) — what Finish/Send acts on. */
+  pendingAnnotations: () => number
 }
 
 export interface FeedbackBatchSummary {
@@ -283,6 +326,11 @@ export const useFeedbackBatchStore = (
 
   const totalAnnotations = useCallback(
     (): number => countAnnotationsInBatch(batch),
+    [batch]
+  )
+
+  const pendingAnnotations = useCallback(
+    (): number => countPendingInBatch(batch),
     [batch]
   )
 
@@ -452,6 +500,113 @@ export const useFeedbackBatchStore = (
     })
   }, [ownerKey])
 
+  const clearOwnerDraft = useCallback((): void => {
+    setDraftsByOwner((prev) => {
+      if (!prev.has(ownerKey)) {
+        return prev
+      }
+
+      const next = new Map(prev)
+      next.delete(ownerKey)
+
+      return next
+    })
+  }, [ownerKey])
+
+  // Send path (VIM-282): stamp every pending comment as dispatched and keep it
+  // in the hunk as a thread anchor, then close the draft. Unchanged file lists
+  // keep their identity so Pierre does not re-tokenize files with no pending
+  // comment.
+  const markDispatched = useCallback(
+    (dispatchedAt: number): void => {
+      setBatchesByOwner((prev) => {
+        const currentBatch = prev.get(ownerKey)
+        if (currentBatch === undefined || currentBatch.size === 0) {
+          return prev
+        }
+
+        let changed = false
+        const nextBatch: FeedbackBatch = new Map()
+        for (const [key, list] of currentBatch) {
+          if (!list.some(isPendingReviewAnnotation)) {
+            nextBatch.set(key, list)
+
+            continue
+          }
+
+          changed = true
+          nextBatch.set(
+            key,
+            list.map((annotation) =>
+              isPendingReviewAnnotation(annotation)
+                ? {
+                    ...annotation,
+                    metadata: { ...annotation.metadata, dispatchedAt },
+                  }
+                : annotation
+            )
+          )
+        }
+
+        if (!changed) {
+          return prev
+        }
+
+        const next = new Map(prev).set(ownerKey, nextBatch)
+        optimisticBatchesRef.current = next
+
+        return next
+      })
+
+      clearOwnerDraft()
+    },
+    [clearOwnerDraft, ownerKey]
+  )
+
+  // Discard path (VIM-282): drop pending comments and the draft, but leave
+  // dispatched thread anchors in place.
+  const clearPending = useCallback((): void => {
+    setBatchesByOwner((prev) => {
+      const currentBatch = prev.get(ownerKey)
+      if (currentBatch === undefined || currentBatch.size === 0) {
+        return prev
+      }
+
+      let changed = false
+      const nextBatch: FeedbackBatch = new Map()
+      for (const [key, list] of currentBatch) {
+        const kept = list.filter(
+          (annotation) => !isPendingReviewAnnotation(annotation)
+        )
+        if (kept.length === list.length) {
+          nextBatch.set(key, list)
+
+          continue
+        }
+        changed = true
+        if (kept.length > 0) {
+          nextBatch.set(key, kept)
+        }
+      }
+
+      if (!changed) {
+        return prev
+      }
+
+      const next = new Map(prev)
+      if (nextBatch.size === 0) {
+        next.delete(ownerKey)
+      } else {
+        next.set(ownerKey, nextBatch)
+      }
+      optimisticBatchesRef.current = next
+
+      return next
+    })
+
+    clearOwnerDraft()
+  }, [clearOwnerDraft, ownerKey])
+
   const setDraft = useCallback(
     (nextDraft: FeedbackDraft | null): void => {
       setDraftsByOwner((prev) => {
@@ -481,7 +636,10 @@ export const useFeedbackBatchStore = (
       updateAnnotation,
       removeAnnotation,
       clearBatch,
+      markDispatched,
+      clearPending,
       totalAnnotations,
+      pendingAnnotations,
     }),
     [
       batch,
@@ -490,7 +648,10 @@ export const useFeedbackBatchStore = (
       updateAnnotation,
       removeAnnotation,
       clearBatch,
+      markDispatched,
+      clearPending,
       totalAnnotations,
+      pendingAnnotations,
     ]
   )
 
@@ -543,7 +704,14 @@ export const useFeedbackBatchStore = (
       .map((entryOwnerKey) => {
         const entryBatch = batchesByOwner.get(entryOwnerKey) ?? EMPTY_BATCH
         const entryDraft = draftsByOwner.get(entryOwnerKey) ?? null
-        const fileKeys = new Set(entryBatch.keys())
+
+        // Only files with a pending comment count as unfinished — dispatched
+        // thread anchors are done (VIM-282).
+        const fileKeys = new Set(
+          [...entryBatch.entries()]
+            .filter(([, list]) => list.some(isPendingReviewAnnotation))
+            .map(([entryKey]) => entryKey)
+        )
 
         const draftCount =
           entryDraft !== null && entryDraft.text.trim().length > 0 ? 1 : 0
@@ -557,7 +725,7 @@ export const useFeedbackBatchStore = (
         return {
           ownerKey: entryOwnerKey,
           fileCount: fileKeys.size,
-          commentCount: countAnnotationsInBatch(entryBatch),
+          commentCount: countPendingInBatch(entryBatch),
           draftCount,
         }
       })


### PR DESCRIPTION
## What

First building block of the **Inline Agent Q&A** epic (VIM-284). Review comments now **stay anchored in the hunk after they're sent** instead of being wiped, becoming the thread anchor an agent reply will later attach to.

## Why

`handleSendFeedback` called `clearBatch()` the instant a review was dispatched, so the hunk lost every comment on send. Send and discard were the identical full wipe. A two-way thread needs the user's comment to persist.

## How

A comment gains an optional `dispatchedAt` timestamp:

- **Send** → `markDispatched(Date.now())`: stamps the pending comments and **keeps** them; the draft closes as before.
- **Dispatch payload + all counts** (finish badge, finish/copy guards, popover "N comments across M files", unfinished-review summaries) filter to **pending** (un-stamped), so a dispatched comment is never re-sent or counted as unfinished — but still renders in the hunk.
- **Discard** → `clearPending()`: drops only the pending comments + draft, leaving dispatched thread anchors intact.

Rendering is unchanged — `annotationsForFile` returns everything, so dispatched comments keep showing for free.

## Scope / deferral

Cross-restart durability is **deferred**. This keeps the existing in-memory per-pane store; comments survive dispatch and reopening the file **in-session**, which is what the acceptance criteria require. A durable store (localStorage keyed by cwd+file, or a Rust JSON store) is a clean fast-follow (issue idea for the epic) if threads should survive an app restart.

Visual distinction between a user comment and a future agent reply is intentionally left to **VIM-256**.

## Tests

- `useFeedbackBatch.test.ts`: `markDispatched` stamps + keeps, leaves already-dispatched untouched; `clearPending` drops pending but keeps anchors and removes empty keys; draft clearing; fully-dispatched owners drop out of unfinished-review summaries.
- `Panel.test.tsx`: send now keeps the comment in the DOM (was: cleared); discard calls `clearPending`.
- Full `src/features/diff` suite (593) + workspace (667) + repo-wide type-check green.

Closes VIM-282
Part of VIM-284

🤖 Generated with [Claude Code](https://claude.com/claude-code)