### PR TITLE
Add Ghostty burner secondary pane

### DIFF
--- a/docs/exploration/2026-07-04-ghostty-burner-side-pane/HANDOFF.md
+++ b/docs/exploration/2026-07-04-ghostty-burner-side-pane/HANDOFF.md
@@ -159,6 +159,12 @@ Source inspection of `libghostty-spm` 1.2.7 (rev `2b0e1b9d`), independently re-v
 - **The fallback (two `TerminalView`s in one `EmbeddedGhosttySurface`) is confirmed viable**, with one hard rule: each `TerminalView` needs its **own `TerminalController`** — `onWakeup`/`shouldProcessWakeup` are single-slot closures, so a shared controller silences the earlier view. `EmbeddedGhosttySurface` already creates a per-surface controller (`GhosttyElectronBridge.swift:201`), so the burner just adds a second controller + view + session.
 - Recommended spike order: Swift-only second `TerminalView` in `GhosttyNativeMacosSmoke` first, then bridge/N-API/IPC per the change plan in the technical note.
 
+## Implementation Status
+
+- **Milestone 1: Swift-only smoke is complete.** `ghostty-native-macos-smoke` can show, hide, remove, and resize a second native `TerminalView` inside one container. The smoke keeps the child role generic as `secondary`, even though the first product use is the burner.
+- **Milestone 2: Native bridge API is in progress.** `GhosttyElectronBridge` now owns an optional secondary child inside `EmbeddedGhosttySurface`, with a separate `TerminalController`, `InMemoryTerminalSession`, input callback, resize callback, focus callback, and AppKit divider. The C++ addon exposes `addSecondary`, `setSecondaryVisible`, `writeSecondary`, `focusSecondary`, and `removeSecondary`; the native-parent smoke checks those exports.
+- **Next: Electron and renderer wiring.** Add child-aware IPC and renderer calls so product code can attach the burner PTY to the secondary native child. This must preserve hide-vs-remove semantics and route burner input/resize/output by the burner PTY id, never by the primary pane session id.
+
 ## Open Questions
 
 - Should opening burner focus the burner immediately or keep focus in primary until user clicks it?
@@ -195,4 +201,3 @@ Constraints:
 
 Deliver a concise visual spec with states, spacing, labels, and interaction notes.
 ```
-

--- a/docs/exploration/2026-07-04-ghostty-burner-side-pane/HANDOFF.md
+++ b/docs/exploration/2026-07-04-ghostty-burner-side-pane/HANDOFF.md
@@ -1,0 +1,198 @@
+# Ghostty Burner Nested Pane Handoff
+
+## Current Decision
+
+The burner terminal should not consume Vimeflow split-layout slots.
+
+The old burner popup cannot reliably work above native Ghostty, but turning the burner into a normal Vimeflow pane would break user layouts. A user with six panes could accidentally create six more burner panes, which defeats the point of a temporary per-pane shell.
+
+The target model is:
+
+```text
+Vimeflow TerminalPane
+└─ AppKit EmbeddedGhosttySurface
+   ├─ primary shell
+   └─ optional burner shell, max 1
+```
+
+The burner is nested inside the host terminal pane. It is not a global Vimeflow pane, not a React popup, and not another BrowserWindow overlay.
+
+## Architecture Question
+
+There are two possible native implementations:
+
+### Preferred If Exposed: One Ghostty Instance With Two Ghostty Panes
+
+```text
+EmbeddedGhosttySurface
+└─ one Ghostty terminal/surface/controller
+   ├─ primary Ghostty pane
+   └─ burner Ghostty pane
+```
+
+This is cleaner because Ghostty would own focus, layout, and terminal-pane rendering internally. Vimeflow would send higher-level commands:
+
+- `openBurner`
+- `writePrimary`
+- `writeBurner`
+- `focusPrimary`
+- `focusBurner`
+- `closeBurner`
+
+Blocker: our current `GhosttyTerminal` usage exposes one `TerminalView` with one `InMemoryTerminalSession`. We have not found a split-pane API exposed through the current Swift package/bridge.
+
+### Fallback If No Ghostty Split API: One AppKit Wrapper With Two TerminalViews
+
+```text
+EmbeddedGhosttySurface
+├─ primary TerminalView + primary InMemoryTerminalSession
+└─ optional burner TerminalView + burner InMemoryTerminalSession
+```
+
+This still keeps the burner nested inside the pane and above React, but Vimeflow/AppKit owns the tiny two-child layout. Keep this deliberately small:
+
+- max two terminal children total
+- primary plus optional burner only
+- right split by default
+- bottom split only for narrow host panes
+- no recursive pane tree
+- no arbitrary layout engine
+
+## Why Existing Paths Are Rejected
+
+- **React popup:** hidden under Ghostty native `NSView`.
+- **Native BrowserWindow overlay with xterm:** repeats focus/shutdown/z-order complexity and still gives us a second terminal UI path.
+- **Normal Vimeflow split pane:** pollutes the user's layout and scales badly when every pane can have a burner.
+- **tmux/zellij inside the user's PTY:** mutates user shell state and does not integrate with Vimeflow lifecycle, cwd sync, headers, or status.
+
+## Current Code To Read
+
+- `src/features/terminal/hooks/useBurnerTerminals.ts`
+  - owns existing ephemeral PTY lifecycle, cwd align, foreground cue, and hide-vs-kill behavior.
+- `src/features/terminal/components/BurnerTerminalPopup/index.tsx`
+  - old popup presentation to retire for Ghostty.
+- `src/features/terminal/components/TerminalPane/GhosttyBody.tsx`
+  - React-to-native bounds, output forwarding, native frame lifecycle.
+- `src/features/terminal/nativeGhosttyClient.ts`
+  - renderer API shape for native Ghostty update/data/focus/destroy.
+- `electron/ghostty-native-parent.ts`
+  - one native surface per `sessionId:paneId`, PTY input/resize/focus routing.
+- `native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift`
+  - `EmbeddedGhosttySurface`, currently one `TerminalView` and one `InMemoryTerminalSession`.
+- `native/ghostty-parent/ghostty_native_parent.cc`
+  - C/N-API bridge. Will need child routing if we add burner inside the surface.
+
+## Next Experiment
+
+1. Inspect `libghostty-spm`/`GhosttyTerminal` source for any real host-controlled split-pane API.
+2. If such API exists, spike one `EmbeddedGhosttySurface` with primary plus burner internal Ghostty panes.
+3. If not, spike the fallback: two `TerminalView`s inside one `EmbeddedGhosttySurface`.
+4. Keep current burner PTY lifecycle, but stop rendering `BurnerTerminalPopup` in native Ghostty mode.
+5. Add routing IDs for terminal child:
+
+```ts
+type GhosttyChild = 'primary' | 'burner'
+```
+
+Then route:
+
+- native input -> `write_pty` for the matching PTY id
+- native resize -> `resize_pty` for the matching PTY id
+- app output -> primary or burner `receive`
+- focus events -> active child state
+
+## Minimal API Shape To Spike
+
+Renderer to Electron:
+
+```ts
+interface NativeGhosttyPaneRef {
+  sessionId: string
+  paneId: string
+}
+
+interface NativeGhosttyBurnerAttachRequest extends NativeGhosttyPaneRef {
+  burnerSessionId: string
+  cwd: string
+  placement: 'right' | 'bottom'
+}
+```
+
+Native bridge concepts:
+
+```swift
+enum GhosttyChild {
+    case primary
+    case burner
+}
+```
+
+Do not add arbitrary child counts or layout trees in the spike.
+
+## UI State Needed
+
+Host header:
+
+- small `BURNER` cue when burner exists
+- running foreground cue when burner has active command
+- no layout-slot count changes
+
+Nested burner header/chrome:
+
+- compact `BURNER` identity
+- linked host pane title or cwd
+- sync cwd action
+- close/hide action
+
+Terminal area:
+
+- primary remains dominant
+- burner is visibly secondary
+- nested divider must be native/AppKit, not React over the Ghostty pixels
+
+## Resolved 2026-07-03: No Ghostty Split API — Fallback Is the Path
+
+Source inspection of `libghostty-spm` 1.2.7 (rev `2b0e1b9d`), independently re-verified with `codex exec`. Full findings, change map, and risks: [`ghostty-split-api-technical-note.html`](./ghostty-split-api-technical-note.html) (bilingual EN/中文).
+
+- **No host-controllable split API exists.** `TerminalSurfaceContext.split` is only a surface-creation hint (`GHOSTTY_SURFACE_CONTEXT_SPLIT`, key-binding routing). Ghostty's real split machinery (SplitTree etc.) lives in the app runtime layer, which the package compiles out (`-Dapp-runtime=none`). The "Preferred If Exposed" option is dead, not pending.
+- **Recompiling cannot restore it** (verified against upstream ghostty v1.2.3). The full embedded C API's split surface is action-request plumbing only: `ghostty_surface_split()` just fires `.new_split` back out to the host's action callback (`src/apprt/embedded.zig:1843`); the actual split engine (`SplitTree.swift`, surface arrangement) is Swift application source under `macos/` — not library code behind any build flag. Hosting two views is the same role Ghostty.app itself plays, so the fallback is architecturally faithful, not a workaround.
+- **The fallback (two `TerminalView`s in one `EmbeddedGhosttySurface`) is confirmed viable**, with one hard rule: each `TerminalView` needs its **own `TerminalController`** — `onWakeup`/`shouldProcessWakeup` are single-slot closures, so a shared controller silences the earlier view. `EmbeddedGhosttySurface` already creates a per-surface controller (`GhosttyElectronBridge.swift:201`), so the burner just adds a second controller + view + session.
+- Recommended spike order: Swift-only second `TerminalView` in `GhosttyNativeMacosSmoke` first, then bridge/N-API/IPC per the change plan in the technical note.
+
+## Open Questions
+
+- Should opening burner focus the burner immediately or keep focus in primary until user clicks it?
+- Should close kill the burner PTY, or should close hide and a separate action kill?
+- Should placement be automatic only, or user-toggleable right/bottom?
+
+## Updated Claude Design Prompt
+
+```text
+Design Vimeflow's Ghostty burner terminal as a nested per-pane terminal, not a React popup and not a Vimeflow layout pane.
+
+Architecture:
+- Each Vimeflow TerminalPane owns one native AppKit EmbeddedGhosttySurface.
+- That surface contains the primary terminal and, optionally, one burner terminal.
+- The burner is an ephemeral shell linked to the host pane.
+- It must not consume the user's global Vimeflow split layout slots.
+- It must visually feel temporary and secondary while still being a real terminal.
+
+Please design:
+1. Host pane header when a burner exists, is focused, is running, or is idle.
+2. The nested burner strip/header/chrome inside the terminal pane.
+3. Right-side vs bottom nested placement behavior.
+4. Cwd sync, close/hide, and foreground-running cues.
+5. Narrow pane behavior.
+
+Constraints:
+- Max one burner per host pane.
+- No modal popup.
+- No BrowserWindow overlay.
+- No global Vimeflow pane insertion.
+- No arbitrary nested layout tree.
+- Keep the main pane header compact.
+- Use existing Vimeflow theme tokens and shell accent.
+
+Deliver a concise visual spec with states, spacing, labels, and interaction notes.
+```
+

--- a/docs/exploration/2026-07-04-ghostty-burner-side-pane/README.md
+++ b/docs/exploration/2026-07-04-ghostty-burner-side-pane/README.md
@@ -1,0 +1,144 @@
+# Ghostty Burner Side Pane Spike
+
+> Update: the follow-up discussion rejected consuming Vimeflow split-layout slots.
+> The current direction is a nested per-pane burner inside the native Ghostty
+> surface. See `HANDOFF.md`.
+
+## Why This Exists
+
+The old burner terminal is a React dialog containing the xterm `Body`. That cannot reliably sit above the native Ghostty `NSView`, and making it another overlay terminal repeats the native layering problem we just paid down.
+
+The current Ghostty bridge gives Vimeflow one native Ghostty surface per React shell pane:
+
+- `GhosttyBody` measures the React pane and sends bounds to Electron.
+- `electron/ghostty-native-parent.ts` keys native surfaces by `sessionId:paneId`.
+- `GhosttyElectronBridge.swift` creates one `TerminalView` plus one `InMemoryTerminalSession` per surface.
+- PTY input/output still belongs to Vimeflow's backend; Ghostty only renders and captures terminal input.
+
+The initial reliable fallback was a Vimeflow pane, not a floating popup. That
+was later rejected because it changes the user's chosen layout.
+
+## External Check
+
+Ghostty the app supports native windows, tabs, and splits, but that is app-level UI. The Swift package we use exposes `TerminalView`, `TerminalController`, `TerminalSurfaceOptions`, and `InMemoryTerminalSession`; it does not expose a host-side "spawn split inside this terminal view" API in our current bridge. Sources checked:
+
+- Ghostty feature docs: https://ghostty.org/docs/features
+- GhosttyKit Swift package page: https://swiftpackageregistry.com/Lakr233/libghostty-spm
+- libghostty roadmap notes: https://mitchellh.com/writing/libghostty-is-coming
+
+## Options
+
+### Option A: Vimeflow Side Pane, Rejected For Current Direction
+
+Clicking the burner button creates or reveals a normal shell pane in the same Vimeflow session. The pane uses the existing Ghostty native renderer because it is just another `TerminalPane`.
+
+Implementation shape:
+
+- Reuse `useBurnerTerminals` lifecycle rules: ephemeral PTY, no agent bridge, cwd alignment, foreground cue, hide does not kill until we decide otherwise.
+- Add a small pane marker, likely `pane.burnerHostPaneId?: string`, instead of a new renderer kind. It is still a shell pane.
+- Add a session helper such as `openBurnerSidePane(target)` that:
+  - spawns an ephemeral PTY at the target cwd,
+  - appends a shell pane with the burner marker and restore data,
+  - places it in the next slot, preferring a vertical side slot,
+  - activates the burner pane or keeps focus on host depending on design.
+- Header displays a compact `BURNER` chip and linked host info.
+- Existing `SplitView` and native Ghostty surface creation do the layout and rendering.
+
+Why this is the shortest good path:
+
+- No new native split API.
+- No overlay terminal.
+- No second terminal renderer.
+- Works with xterm fallback because it still uses `TerminalPane`.
+
+### Option B: Native Overlay Terminal Window, Not Recommended
+
+Render the burner terminal in the native overlay/menu `BrowserWindow`.
+
+Rejected for v1:
+
+- It is another terminal-over-terminal overlay.
+- Focus, shortcuts, resize, and shutdown are harder than a pane.
+- It keeps the UI split between React overlay rules and native Ghostty layer rules.
+
+### Option C: True Ghostty Internal Split, Blocked
+
+Ask Ghostty/libghostty to split inside one native surface.
+
+Blocked for v1:
+
+- Our bridge has no command for this.
+- The current Swift package usage is one `TerminalView` per `InMemoryTerminalSession`.
+- This would require upstream/package API discovery or a new native wrapper model.
+
+### Option D: tmux/zellij Inside The Pane, Not Product UI
+
+Run a terminal multiplexer inside the host PTY.
+
+Rejected for product UX:
+
+- It changes user shell state.
+- It does not integrate with Vimeflow pane headers, status, cwd sync, or lifecycle.
+- It is a user workaround, not our burner feature.
+
+## Recommended Interaction
+
+The burner button should become "open side burner".
+
+When closed:
+
+- Header action shows the existing terminal icon.
+- Tooltip/copy: "Open side burner".
+
+When side burner exists:
+
+- Host header shows a small live cue: `BURNER x1`.
+- Burner pane header shows `BURNER`, host pane title, cwd sync state, close/hide action.
+- Status bar counts it as a burner, not as an agent pane.
+
+When user clicks burner again:
+
+- If side burner exists and is hidden by layout: reveal it.
+- If visible: focus it.
+- Killing should remain explicit through close for now.
+
+## HTML Demo
+
+Open:
+
+```sh
+open docs/exploration/2026-07-04-ghostty-burner-side-pane/index.html
+```
+
+The demo compares the three viable presentation directions and defaults to the recommended side-pane model.
+
+## Claude Design Prompt Draft
+
+Use this if we choose Option A:
+
+```text
+Design the Vimeflow Ghostty burner terminal as an in-canvas side pane, not a floating dialog.
+
+Context:
+- Vimeflow owns the multi-pane layout in React.
+- Ghostty renders one native terminal surface per Vimeflow shell pane.
+- The burner is an ephemeral shell linked to a host pane. It should feel temporary, fast, and lower-commitment than an agent pane, but it must still be a real pane so it appears above/inside the Ghostty-native canvas correctly.
+- Existing visual language: compact terminal pane headers, monospace labels, theme tokens, no heavy borders, tonal depth, shell accent for burner state.
+
+Please design:
+1. The host pane header when a burner side pane is available/running.
+2. The burner side pane header.
+3. The split layout behavior when the burner opens from a single pane and when it opens from an existing split layout.
+4. The close/hide affordance and cwd sync cue.
+5. Empty, running, and exited burner states.
+
+Constraints:
+- No modal popup.
+- No React overlay terminal.
+- No separate AppKit menu UI.
+- Keep the top header compact.
+- Prefer a right-side vertical burner pane unless the current layout makes a bottom pane clearly better.
+- Make the burner visually distinct but not as important as an agent pane.
+
+Deliver a concise visual spec with spacing, labels, state changes, and interaction notes.
+```

--- a/docs/exploration/2026-07-04-ghostty-burner-side-pane/ghostty-split-api-technical-note.html
+++ b/docs/exploration/2026-07-04-ghostty-burner-side-pane/ghostty-split-api-technical-note.html
@@ -1,315 +1,834 @@
 <!doctype html>
 <html lang="en">
-<head>
-<meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Ghostty Split API Exploration — Burner Nested Pane | Ghostty 分屏 API 探索 —— Burner 嵌套窗格</title>
-<style>
-  :root {
-    --base: #1e1e2e;
-    --mantle: #181825;
-    --crust: #11111b;
-    --surface0: #313244;
-    --surface1: #45475a;
-    --text: #cdd6f4;
-    --subtext: #a6adc8;
-    --overlay: #6c7086;
-    --green: #a6e3a1;
-    --red: #f38ba8;
-    --yellow: #f9e2af;
-    --peach: #fab387;
-    --blue: #89b4fa;
-    --mauve: #cba6f7;
-    --teal: #94e2d5;
-    --mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
-  }
-  * { box-sizing: border-box; }
-  body {
-    margin: 0;
-    background: var(--base);
-    color: var(--text);
-    font: 15px/1.65 Inter, -apple-system, 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', sans-serif;
-    padding: 0 0 80px;
-  }
-  main { max-width: 980px; margin: 0 auto; padding: 0 28px; }
-  h1, h2, h3 { font-family: Manrope, Inter, -apple-system, 'PingFang SC', sans-serif; line-height: 1.3; }
-  h1 { font-size: 26px; margin: 8px 0 4px; }
-  h2 { font-size: 20px; margin: 44px 0 12px; color: var(--mauve); }
-  h3 { font-size: 16px; margin: 26px 0 8px; color: var(--blue); }
-  p { margin: 10px 0; }
-  code, .mono { font-family: var(--mono); font-size: 0.86em; }
-  code { background: var(--surface0); padding: 1px 6px; border-radius: 5px; color: var(--teal); white-space: nowrap; }
-  pre {
-    background: var(--crust); border-radius: 10px; padding: 14px 18px;
-    overflow-x: auto; font-family: var(--mono); font-size: 12.5px; line-height: 1.6;
-    color: var(--subtext);
-  }
-  pre code { background: none; padding: 0; color: inherit; white-space: pre; }
-  a { color: var(--blue); }
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>
+      Ghostty Split API Exploration — Burner Nested Pane | Ghostty 分屏 API 探索
+      —— Burner 嵌套窗格
+    </title>
+    <style>
+      :root {
+        --base: #1e1e2e;
+        --mantle: #181825;
+        --crust: #11111b;
+        --surface0: #313244;
+        --surface1: #45475a;
+        --text: #cdd6f4;
+        --subtext: #a6adc8;
+        --overlay: #6c7086;
+        --green: #a6e3a1;
+        --red: #f38ba8;
+        --yellow: #f9e2af;
+        --peach: #fab387;
+        --blue: #89b4fa;
+        --mauve: #cba6f7;
+        --teal: #94e2d5;
+        --mono:
+          'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--base);
+        color: var(--text);
+        font:
+          15px/1.65 Inter,
+          -apple-system,
+          'PingFang SC',
+          'Hiragino Sans GB',
+          'Microsoft YaHei',
+          sans-serif;
+        padding: 0 0 80px;
+      }
+      main {
+        max-width: 980px;
+        margin: 0 auto;
+        padding: 0 28px;
+      }
+      h1,
+      h2,
+      h3 {
+        font-family:
+          Manrope,
+          Inter,
+          -apple-system,
+          'PingFang SC',
+          sans-serif;
+        line-height: 1.3;
+      }
+      h1 {
+        font-size: 26px;
+        margin: 8px 0 4px;
+      }
+      h2 {
+        font-size: 20px;
+        margin: 44px 0 12px;
+        color: var(--mauve);
+      }
+      h3 {
+        font-size: 16px;
+        margin: 26px 0 8px;
+        color: var(--blue);
+      }
+      p {
+        margin: 10px 0;
+      }
+      code,
+      .mono {
+        font-family: var(--mono);
+        font-size: 0.86em;
+      }
+      code {
+        background: var(--surface0);
+        padding: 1px 6px;
+        border-radius: 5px;
+        color: var(--teal);
+        white-space: nowrap;
+      }
+      pre {
+        background: var(--crust);
+        border-radius: 10px;
+        padding: 14px 18px;
+        overflow-x: auto;
+        font-family: var(--mono);
+        font-size: 12.5px;
+        line-height: 1.6;
+        color: var(--subtext);
+      }
+      pre code {
+        background: none;
+        padding: 0;
+        color: inherit;
+        white-space: pre;
+      }
+      a {
+        color: var(--blue);
+      }
 
-  /* language toggle */
-  .langbar {
-    position: sticky; top: 0; z-index: 10;
-    background: color-mix(in srgb, var(--mantle) 88%, transparent);
-    backdrop-filter: blur(10px);
-    padding: 10px 28px; display: flex; gap: 8px; align-items: center;
-    justify-content: flex-end; margin-bottom: 28px;
-  }
-  .langbar span.hint { margin-right: auto; color: var(--overlay); font-size: 12px; }
-  .langbar button {
-    background: var(--surface0); color: var(--subtext); border: 0; border-radius: 8px;
-    padding: 5px 14px; font: 13px Inter, 'PingFang SC', sans-serif; cursor: pointer;
-  }
-  .langbar button.active { background: var(--mauve); color: var(--crust); font-weight: 600; }
-  body[data-lang="en"] .zh { display: none; }
-  body[data-lang="zh"] .en { display: none; }
-  body[data-lang="both"] .zh { color: var(--subtext); }
-  body[data-lang="both"] td .zh, body[data-lang="both"] li .zh { display: block; margin-top: 2px; }
+      /* language toggle */
+      .langbar {
+        position: sticky;
+        top: 0;
+        z-index: 10;
+        background: color-mix(in srgb, var(--mantle) 88%, transparent);
+        backdrop-filter: blur(10px);
+        padding: 10px 28px;
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        justify-content: flex-end;
+        margin-bottom: 28px;
+      }
+      .langbar span.hint {
+        margin-right: auto;
+        color: var(--overlay);
+        font-size: 12px;
+      }
+      .langbar button {
+        background: var(--surface0);
+        color: var(--subtext);
+        border: 0;
+        border-radius: 8px;
+        padding: 5px 14px;
+        font:
+          13px Inter,
+          'PingFang SC',
+          sans-serif;
+        cursor: pointer;
+      }
+      .langbar button.active {
+        background: var(--mauve);
+        color: var(--crust);
+        font-weight: 600;
+      }
+      body[data-lang='en'] .zh {
+        display: none;
+      }
+      body[data-lang='zh'] .en {
+        display: none;
+      }
+      body[data-lang='both'] .zh {
+        color: var(--subtext);
+      }
+      body[data-lang='both'] td .zh,
+      body[data-lang='both'] li .zh {
+        display: block;
+        margin-top: 2px;
+      }
 
-  .meta { color: var(--overlay); font-size: 13px; margin-bottom: 22px; }
-  .meta code { color: var(--subtext); }
+      .meta {
+        color: var(--overlay);
+        font-size: 13px;
+        margin-bottom: 22px;
+      }
+      .meta code {
+        color: var(--subtext);
+      }
 
-  .verdict {
-    display: grid; grid-template-columns: 1fr 1fr; gap: 14px; margin: 24px 0;
-  }
-  .verdict .card {
-    border-radius: 12px; padding: 16px 18px; background: var(--mantle);
-  }
-  .verdict .card.no { box-shadow: inset 3px 0 0 var(--red); }
-  .verdict .card.yes { box-shadow: inset 3px 0 0 var(--green); }
-  .verdict .card b.line { display: block; font-size: 15px; margin-bottom: 6px; }
-  .verdict .no b.line { color: var(--red); }
-  .verdict .yes b.line { color: var(--green); }
-  .verdict .card p { font-size: 13.5px; color: var(--subtext); margin: 4px 0 0; }
+      .verdict {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 14px;
+        margin: 24px 0;
+      }
+      .verdict .card {
+        border-radius: 12px;
+        padding: 16px 18px;
+        background: var(--mantle);
+      }
+      .verdict .card.no {
+        box-shadow: inset 3px 0 0 var(--red);
+      }
+      .verdict .card.yes {
+        box-shadow: inset 3px 0 0 var(--green);
+      }
+      .verdict .card b.line {
+        display: block;
+        font-size: 15px;
+        margin-bottom: 6px;
+      }
+      .verdict .no b.line {
+        color: var(--red);
+      }
+      .verdict .yes b.line {
+        color: var(--green);
+      }
+      .verdict .card p {
+        font-size: 13.5px;
+        color: var(--subtext);
+        margin: 4px 0 0;
+      }
 
-  .badge {
-    display: inline-block; border-radius: 20px; padding: 2px 12px; font-size: 12px;
-    font-weight: 600; vertical-align: 2px; margin-left: 8px;
-  }
-  .badge.ok { background: color-mix(in srgb, var(--green) 18%, transparent); color: var(--green); }
-  .badge.warn { background: color-mix(in srgb, var(--yellow) 18%, transparent); color: var(--yellow); }
+      .badge {
+        display: inline-block;
+        border-radius: 20px;
+        padding: 2px 12px;
+        font-size: 12px;
+        font-weight: 600;
+        vertical-align: 2px;
+        margin-left: 8px;
+      }
+      .badge.ok {
+        background: color-mix(in srgb, var(--green) 18%, transparent);
+        color: var(--green);
+      }
+      .badge.warn {
+        background: color-mix(in srgb, var(--yellow) 18%, transparent);
+        color: var(--yellow);
+      }
 
-  table { border-collapse: collapse; width: 100%; margin: 14px 0; font-size: 13.5px; }
-  th { text-align: left; color: var(--peach); font-weight: 600; padding: 8px 12px; background: var(--mantle); }
-  td { padding: 9px 12px; vertical-align: top; border-top: 1px solid var(--surface0); color: var(--subtext); }
-  td:first-child, th:first-child { border-radius: 0; }
-  tr td b { color: var(--text); }
-  td code { white-space: normal; word-break: break-all; }
+      table {
+        border-collapse: collapse;
+        width: 100%;
+        margin: 14px 0;
+        font-size: 13.5px;
+      }
+      th {
+        text-align: left;
+        color: var(--peach);
+        font-weight: 600;
+        padding: 8px 12px;
+        background: var(--mantle);
+      }
+      td {
+        padding: 9px 12px;
+        vertical-align: top;
+        border-top: 1px solid var(--surface0);
+        color: var(--subtext);
+      }
+      td:first-child,
+      th:first-child {
+        border-radius: 0;
+      }
+      tr td b {
+        color: var(--text);
+      }
+      td code {
+        white-space: normal;
+        word-break: break-all;
+      }
 
-  .callout {
-    border-radius: 10px; background: var(--mantle); padding: 14px 18px; margin: 16px 0;
-    font-size: 14px;
-  }
-  .callout.good { box-shadow: inset 3px 0 0 var(--green); }
-  .callout.warn { box-shadow: inset 3px 0 0 var(--yellow); }
-  .callout.info { box-shadow: inset 3px 0 0 var(--blue); }
-  .callout b:first-child { display: block; margin-bottom: 4px; }
+      .callout {
+        border-radius: 10px;
+        background: var(--mantle);
+        padding: 14px 18px;
+        margin: 16px 0;
+        font-size: 14px;
+      }
+      .callout.good {
+        box-shadow: inset 3px 0 0 var(--green);
+      }
+      .callout.warn {
+        box-shadow: inset 3px 0 0 var(--yellow);
+      }
+      .callout.info {
+        box-shadow: inset 3px 0 0 var(--blue);
+      }
+      .callout b:first-child {
+        display: block;
+        margin-bottom: 4px;
+      }
 
-  .sev { font-family: var(--mono); font-size: 11px; font-weight: 700; border-radius: 6px; padding: 1px 8px; white-space: nowrap; }
-  .sev.high { background: color-mix(in srgb, var(--red) 20%, transparent); color: var(--red); }
-  .sev.med { background: color-mix(in srgb, var(--yellow) 20%, transparent); color: var(--yellow); }
-  .sev.low { background: color-mix(in srgb, var(--blue) 20%, transparent); color: var(--blue); }
+      .sev {
+        font-family: var(--mono);
+        font-size: 11px;
+        font-weight: 700;
+        border-radius: 6px;
+        padding: 1px 8px;
+        white-space: nowrap;
+      }
+      .sev.high {
+        background: color-mix(in srgb, var(--red) 20%, transparent);
+        color: var(--red);
+      }
+      .sev.med {
+        background: color-mix(in srgb, var(--yellow) 20%, transparent);
+        color: var(--yellow);
+      }
+      .sev.low {
+        background: color-mix(in srgb, var(--blue) 20%, transparent);
+        color: var(--blue);
+      }
 
-  ol.plan { padding-left: 20px; }
-  ol.plan > li { margin: 10px 0; color: var(--subtext); }
-  ol.plan > li b { color: var(--text); }
-  ol.plan code { font-size: 0.82em; }
+      ol.plan {
+        padding-left: 20px;
+      }
+      ol.plan > li {
+        margin: 10px 0;
+        color: var(--subtext);
+      }
+      ol.plan > li b {
+        color: var(--text);
+      }
+      ol.plan code {
+        font-size: 0.82em;
+      }
 
-  footer { margin-top: 56px; color: var(--overlay); font-size: 12.5px; border-top: 1px solid var(--surface0); padding-top: 16px; }
-</style>
-</head>
-<body data-lang="both">
-<div class="langbar">
-  <span class="hint mono">docs/exploration/2026-07-04-ghostty-burner-side-pane</span>
-  <button data-set="en">EN</button>
-  <button data-set="zh">中文</button>
-  <button data-set="both" class="active">EN + 中文</button>
-</div>
-<main>
-  <h1>
-    <span class="en">Ghostty Split API Exploration — Burner as a Nested Native Pane</span>
-    <span class="zh">Ghostty 分屏 API 探索 —— Burner 作为嵌套原生窗格</span>
-  </h1>
-  <p class="meta">
-    2026-07-03 ·
-    <span class="en">Package under test:</span><span class="zh">被检包：</span>
-    <code>Lakr233/libghostty-spm 1.2.7</code> (rev <code>2b0e1b9d</code>,
-    <span class="en">pinned by</span><span class="zh">锁定于</span> <code>native/ghostty-helper/Package.resolved</code>) ·
-    <span class="en">Method: 3 parallel source-reading agents + independent <code>codex exec</code> re-verification</span>
-    <span class="zh">方法：3 个并行源码阅读 agent + 独立 <code>codex exec</code> 复核</span>
-  </p>
-
-  <div class="verdict">
-    <div class="card no">
-      <b class="line">
-        <span class="en">✗ Option A is dead: no host-controllable split API</span>
-        <span class="zh">✗ 方案 A 不可行：不存在宿主可控的分屏 API</span>
-      </b>
-      <p>
-        <span class="en">libghostty-spm is strictly a single-surface, single-view embedding API. Ghostty's real split logic (SplitTree, surface tree, tabs) lives in the app shell that this package explicitly strips out (<code>-Dapp-runtime=none</code>).</span>
-        <span class="zh">libghostty-spm 严格上只是单 surface、单 view 的嵌入 API。Ghostty 真正的分屏逻辑（SplitTree、surface 树、标签页）位于其 App 外壳层，而该包在构建时显式剥离了这一层（<code>-Dapp-runtime=none</code>）。</span>
-      </p>
+      footer {
+        margin-top: 56px;
+        color: var(--overlay);
+        font-size: 12.5px;
+        border-top: 1px solid var(--surface0);
+        padding-top: 16px;
+      }
+    </style>
+  </head>
+  <body data-lang="both">
+    <div class="langbar">
+      <span class="hint mono"
+        >docs/exploration/2026-07-04-ghostty-burner-side-pane</span
+      >
+      <button data-set="en">EN</button>
+      <button data-set="zh">中文</button>
+      <button data-set="both" class="active">EN + 中文</button>
     </div>
-    <div class="card yes">
-      <b class="line">
-        <span class="en">✓ Option B is viable: two TerminalViews, host-owned layout</span>
-        <span class="zh">✓ 方案 B 可行：两个 TerminalView，布局由宿主管理</span>
-      </b>
-      <p>
-        <span class="en">Two independent <code>TerminalView</code> + <code>InMemoryTerminalSession</code> pairs can safely coexist inside one <code>EmbeddedGhosttySurface</code> NSView — provided each gets its <b>own <code>TerminalController</code></b>. Confirmed by codex.</span>
-        <span class="zh">两个相互独立的 <code>TerminalView</code> + <code>InMemoryTerminalSession</code> 可以安全共存于同一个 <code>EmbeddedGhosttySurface</code> NSView 内 —— 前提是每个 view 拥有<b>各自独立的 <code>TerminalController</code></b>。已由 codex 复核确认。</span>
+    <main>
+      <h1>
+        <span class="en"
+          >Ghostty Split API Exploration — Burner as a Nested Native Pane</span
+        >
+        <span class="zh">Ghostty 分屏 API 探索 —— Burner 作为嵌套原生窗格</span>
+      </h1>
+      <p class="meta">
+        2026-07-03 ·
+        <span class="en">Package under test:</span
+        ><span class="zh">被检包：</span>
+        <code>Lakr233/libghostty-spm 1.2.7</code> (rev <code>2b0e1b9d</code>,
+        <span class="en">pinned by</span><span class="zh">锁定于</span>
+        <code>native/ghostty-helper/Package.resolved</code>) ·
+        <span class="en"
+          >Method: 3 parallel source-reading agents + independent
+          <code>codex exec</code> re-verification</span
+        >
+        <span class="zh"
+          >方法：3 个并行源码阅读 agent + 独立
+          <code>codex exec</code> 复核</span
+        >
       </p>
-    </div>
-  </div>
 
-  <h2><span class="en">1 · Question 1 — Does the package expose a split-pane API?</span><span class="zh">1 · 问题一 —— 该包是否暴露分屏 API？</span></h2>
-  <p>
-    <span class="en">Verdict: <b>no — single-surface only</b>. The only split-related public symbol in the entire package is <code>TerminalSurfaceContext.split</code>, and it is not a layout API:</span>
-    <span class="zh">结论：<b>否 —— 仅支持单 surface</b>。整个包中唯一与 split 相关的公开符号是 <code>TerminalSurfaceContext.split</code>，且它并不是布局 API：</span>
-  </p>
-  <table>
-    <tr>
-      <th><span class="en">Symbol</span><span class="zh">符号</span></th>
-      <th><span class="en">File</span><span class="zh">文件</span></th>
-      <th><span class="en">Finding</span><span class="zh">结论</span></th>
-    </tr>
-    <tr>
-      <td><b><code>TerminalSurfaceContext.split</code></b></td>
-      <td><code>Surface/TerminalSurfaceContext.swift:8</code></td>
-      <td>
-        <span class="en">Maps to <code>GHOSTTY_SURFACE_CONTEXT_SPLIT</code> — a <b>creation-time hint</b> to the C engine about how the surface was spawned (affects key-binding routing). It does <b>not</b> make Ghostty own a split layout; the host still creates one surface per view and controls all geometry.</span>
-        <span class="zh">映射到 <code>GHOSTTY_SURFACE_CONTEXT_SPLIT</code> —— 仅是创建时传给 C 引擎的<b>提示</b>，说明该 surface 的来源（影响按键绑定路由）。它<b>不会</b>让 Ghostty 接管分屏布局；宿主仍然是每个 view 创建一个 surface，并掌控全部几何布局。</span>
-      </td>
-    </tr>
-    <tr>
-      <td><b><code>TerminalView</code> / <code>AppTerminalView</code></b></td>
-      <td><code>Platform/AppKit/AppTerminalView.swift</code></td>
-      <td>
-        <span class="en">NSView subclass, one <code>CAMetalLayer</code> per instance, surface bound 1:1 to the NSView. No split, pane, or layout API.</span>
-        <span class="zh">NSView 子类，每实例一个 <code>CAMetalLayer</code>，surface 与 NSView 一一绑定。没有任何 split／pane／布局 API。</span>
-      </td>
-    </tr>
-    <tr>
-      <td><b><code>TerminalController</code></b></td>
-      <td><code>Controller/TerminalController.swift</code></td>
-      <td>
-        <span class="en">Owns <code>ghostty_app_t</code>, config, theme, surface creation. No split API. Has a <code>.shared</code> singleton (line 46) <i>and</i> a public designated init.</span>
-        <span class="zh">持有 <code>ghostty_app_t</code>、配置、主题和 surface 创建。没有分屏 API。既提供 <code>.shared</code> 单例（第 46 行），<i>也</i>提供公开的指定构造器。</span>
-      </td>
-    </tr>
-    <tr>
-      <td><b><code>TerminalSurface</code></b> / <b><code>InMemoryTerminalSession</code></b></td>
-      <td><code>Surface/TerminalSurface.swift</code>, <code>InMemory/…</code></td>
-      <td>
-        <span class="en">One surface = one terminal grid; one session per surface, holding a single <code>ghostty_surface_t</code>. No sub-surface / child-surface / multiplexing API.</span>
-        <span class="zh">一个 surface = 一个终端网格；每个 surface 一个 session，仅持有一个 <code>ghostty_surface_t</code>。没有子 surface 或多路复用 API。</span>
-      </td>
-    </tr>
-  </table>
-  <div class="callout info">
-    <b><span class="en">Why the split machinery is absent — and why recompiling can't restore it</span><span class="zh">为什么分屏机制不存在 —— 以及为什么重新编译也无法恢复</span></b>
-    <span class="en">Upstream Ghostty implements splits (SplitTree, SurfaceView arrangement, dividers, focus traversal) in its macOS <i>application</i> layer — Swift source under <code>macos/</code> in the ghostty repo. That code is not behind <code>-Dapp-runtime</code>; it is not part of the Zig library at any flag setting. What <code>-Dapp-runtime=none</code> strips is the action-callback plumbing and the platform app shells — <b>the layout engine was never in the library on any platform</b>. (<code>-Dapp-runtime=gtk</code> builds a Linux GTK <i>application</i> with its own splits — not an embeddable library.)</span>
-    <span class="zh">上游 Ghostty 的分屏（SplitTree、SurfaceView 排布、分隔线、焦点遍历）实现在其 macOS <i>应用程序</i>层 —— 即 ghostty 仓库 <code>macos/</code> 目录下的 Swift 源码。这些代码不受 <code>-Dapp-runtime</code> 控制；无论编译开关如何设置，它都不属于 Zig 库。<code>-Dapp-runtime=none</code> 剔除的只是 action 回调管线和各平台 App 外壳 —— <b>布局引擎在任何平台上都从未存在于库中</b>。（<code>-Dapp-runtime=gtk</code> 编出来的是带自身分屏实现的 Linux GTK <i>应用程序</i>，并非可嵌入的库。）</span>
-  </div>
+      <div class="verdict">
+        <div class="card no">
+          <b class="line">
+            <span class="en"
+              >✗ Option A is dead: no host-controllable split API</span
+            >
+            <span class="zh">✗ 方案 A 不可行：不存在宿主可控的分屏 API</span>
+          </b>
+          <p>
+            <span class="en"
+              >libghostty-spm is strictly a single-surface, single-view
+              embedding API. Ghostty's real split logic (SplitTree, surface
+              tree, tabs) lives in the app shell that this package explicitly
+              strips out (<code>-Dapp-runtime=none</code>).</span
+            >
+            <span class="zh"
+              >libghostty-spm 严格上只是单 surface、单 view 的嵌入 API。Ghostty
+              真正的分屏逻辑（SplitTree、surface 树、标签页）位于其 App
+              外壳层，而该包在构建时显式剥离了这一层（<code>-Dapp-runtime=none</code>）。</span
+            >
+          </p>
+        </div>
+        <div class="card yes">
+          <b class="line">
+            <span class="en"
+              >✓ Option B is viable: two TerminalViews, host-owned layout</span
+            >
+            <span class="zh"
+              >✓ 方案 B 可行：两个 TerminalView，布局由宿主管理</span
+            >
+          </b>
+          <p>
+            <span class="en"
+              >Two independent <code>TerminalView</code> +
+              <code>InMemoryTerminalSession</code> pairs can safely coexist
+              inside one <code>EmbeddedGhosttySurface</code> NSView — provided
+              each gets its <b>own <code>TerminalController</code></b
+              >. Confirmed by codex.</span
+            >
+            <span class="zh"
+              >两个相互独立的 <code>TerminalView</code> +
+              <code>InMemoryTerminalSession</code> 可以安全共存于同一个
+              <code>EmbeddedGhosttySurface</code> NSView 内 —— 前提是每个 view
+              拥有<b>各自独立的 <code>TerminalController</code></b
+              >。已由 codex 复核确认。</span
+            >
+          </p>
+        </div>
+      </div>
 
-  <h3><span class="en">Addendum (2026-07-03) — even the full C API only <i>requests</i> splits from the host</span><span class="zh">补充（2026-07-03）—— 即使完整 C API 也只是向宿主<i>请求</i>分屏</span></h3>
-  <p>
-    <span class="en">Verified against upstream Ghostty v1.2.3 (the untrimmed embedded API that real Ghostty.app itself links). Everything split-related in <code>include/ghostty.h</code> is an <i>action</i>: the enums <code>GHOSTTY_ACTION_NEW_SPLIT</code> / <code>GOTO_SPLIT</code> / <code>RESIZE_SPLIT</code> / <code>EQUALIZE_SPLITS</code> / <code>TOGGLE_SPLIT_ZOOM</code>, plus four functions such as <code>ghostty_surface_split()</code>. In the core, that function is pure request plumbing:</span>
-    <span class="zh">已对照上游 Ghostty v1.2.3（真正的 Ghostty.app 所链接的未裁剪嵌入 API）验证。<code>include/ghostty.h</code> 中所有与分屏相关的内容都是<i>动作（action）</i>：枚举 <code>GHOSTTY_ACTION_NEW_SPLIT</code> / <code>GOTO_SPLIT</code> / <code>RESIZE_SPLIT</code> / <code>EQUALIZE_SPLITS</code> / <code>TOGGLE_SPLIT_ZOOM</code>，以及 <code>ghostty_surface_split()</code> 等四个函数。在核心实现中，该函数纯粹是请求转发：</span>
-  </p>
-  <pre><code>// upstream src/apprt/embedded.zig:1843 (v1.2.3)
+      <h2>
+        <span class="en"
+          >1 · Question 1 — Does the package expose a split-pane API?</span
+        ><span class="zh">1 · 问题一 —— 该包是否暴露分屏 API？</span>
+      </h2>
+      <p>
+        <span class="en"
+          >Verdict: <b>no — single-surface only</b>. The only split-related
+          public symbol in the entire package is
+          <code>TerminalSurfaceContext.split</code>, and it is not a layout
+          API:</span
+        >
+        <span class="zh"
+          >结论：<b>否 —— 仅支持单 surface</b>。整个包中唯一与 split
+          相关的公开符号是
+          <code>TerminalSurfaceContext.split</code>，且它并不是布局 API：</span
+        >
+      </p>
+      <table>
+        <tr>
+          <th><span class="en">Symbol</span><span class="zh">符号</span></th>
+          <th><span class="en">File</span><span class="zh">文件</span></th>
+          <th><span class="en">Finding</span><span class="zh">结论</span></th>
+        </tr>
+        <tr>
+          <td>
+            <b><code>TerminalSurfaceContext.split</code></b>
+          </td>
+          <td><code>Surface/TerminalSurfaceContext.swift:8</code></td>
+          <td>
+            <span class="en"
+              >Maps to <code>GHOSTTY_SURFACE_CONTEXT_SPLIT</code> — a
+              <b>creation-time hint</b> to the C engine about how the surface
+              was spawned (affects key-binding routing). It does <b>not</b> make
+              Ghostty own a split layout; the host still creates one surface per
+              view and controls all geometry.</span
+            >
+            <span class="zh"
+              >映射到 <code>GHOSTTY_SURFACE_CONTEXT_SPLIT</code> ——
+              仅是创建时传给 C 引擎的<b>提示</b>，说明该 surface
+              的来源（影响按键绑定路由）。它<b>不会</b>让 Ghostty
+              接管分屏布局；宿主仍然是每个 view 创建一个
+              surface，并掌控全部几何布局。</span
+            >
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <b><code>TerminalView</code> / <code>AppTerminalView</code></b>
+          </td>
+          <td><code>Platform/AppKit/AppTerminalView.swift</code></td>
+          <td>
+            <span class="en"
+              >NSView subclass, one <code>CAMetalLayer</code> per instance,
+              surface bound 1:1 to the NSView. No split, pane, or layout
+              API.</span
+            >
+            <span class="zh"
+              >NSView 子类，每实例一个 <code>CAMetalLayer</code>，surface 与
+              NSView 一一绑定。没有任何 split／pane／布局 API。</span
+            >
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <b><code>TerminalController</code></b>
+          </td>
+          <td><code>Controller/TerminalController.swift</code></td>
+          <td>
+            <span class="en"
+              >Owns <code>ghostty_app_t</code>, config, theme, surface creation.
+              No split API. Has a <code>.shared</code> singleton (line 46)
+              <i>and</i> a public designated init.</span
+            >
+            <span class="zh"
+              >持有 <code>ghostty_app_t</code>、配置、主题和 surface
+              创建。没有分屏 API。既提供 <code>.shared</code> 单例（第 46
+              行），<i>也</i>提供公开的指定构造器。</span
+            >
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <b><code>TerminalSurface</code></b> /
+            <b><code>InMemoryTerminalSession</code></b>
+          </td>
+          <td>
+            <code>Surface/TerminalSurface.swift</code>, <code>InMemory/…</code>
+          </td>
+          <td>
+            <span class="en"
+              >One surface = one terminal grid; one session per surface, holding
+              a single <code>ghostty_surface_t</code>. No sub-surface /
+              child-surface / multiplexing API.</span
+            >
+            <span class="zh"
+              >一个 surface = 一个终端网格；每个 surface 一个
+              session，仅持有一个 <code>ghostty_surface_t</code>。没有子 surface
+              或多路复用 API。</span
+            >
+          </td>
+        </tr>
+      </table>
+      <div class="callout info">
+        <b
+          ><span class="en"
+            >Why the split machinery is absent — and why recompiling can't
+            restore it</span
+          ><span class="zh"
+            >为什么分屏机制不存在 —— 以及为什么重新编译也无法恢复</span
+          ></b
+        >
+        <span class="en"
+          >Upstream Ghostty implements splits (SplitTree, SurfaceView
+          arrangement, dividers, focus traversal) in its macOS
+          <i>application</i> layer — Swift source under <code>macos/</code> in
+          the ghostty repo. That code is not behind <code>-Dapp-runtime</code>;
+          it is not part of the Zig library at any flag setting. What
+          <code>-Dapp-runtime=none</code> strips is the action-callback plumbing
+          and the platform app shells —
+          <b>the layout engine was never in the library on any platform</b>.
+          (<code>-Dapp-runtime=gtk</code> builds a Linux GTK
+          <i>application</i> with its own splits — not an embeddable
+          library.)</span
+        >
+        <span class="zh"
+          >上游 Ghostty 的分屏（SplitTree、SurfaceView
+          排布、分隔线、焦点遍历）实现在其 macOS <i>应用程序</i>层 —— 即 ghostty
+          仓库 <code>macos/</code> 目录下的 Swift 源码。这些代码不受
+          <code>-Dapp-runtime</code> 控制；无论编译开关如何设置，它都不属于 Zig
+          库。<code>-Dapp-runtime=none</code> 剔除的只是 action 回调管线和各平台
+          App 外壳 —— <b>布局引擎在任何平台上都从未存在于库中</b>。（<code
+            >-Dapp-runtime=gtk</code
+          >
+          编出来的是带自身分屏实现的 Linux GTK
+          <i>应用程序</i>，并非可嵌入的库。）</span
+        >
+      </div>
+
+      <h3>
+        <span class="en"
+          >Addendum (2026-07-03) — even the full C API only
+          <i>requests</i> splits from the host</span
+        ><span class="zh"
+          >补充（2026-07-03）—— 即使完整 C API 也只是向宿主<i>请求</i>分屏</span
+        >
+      </h3>
+      <p>
+        <span class="en"
+          >Verified against upstream Ghostty v1.2.3 (the untrimmed embedded API
+          that real Ghostty.app itself links). Everything split-related in
+          <code>include/ghostty.h</code> is an <i>action</i>: the enums
+          <code>GHOSTTY_ACTION_NEW_SPLIT</code> / <code>GOTO_SPLIT</code> /
+          <code>RESIZE_SPLIT</code> / <code>EQUALIZE_SPLITS</code> /
+          <code>TOGGLE_SPLIT_ZOOM</code>, plus four functions such as
+          <code>ghostty_surface_split()</code>. In the core, that function is
+          pure request plumbing:</span
+        >
+        <span class="zh"
+          >已对照上游 Ghostty v1.2.3（真正的 Ghostty.app 所链接的未裁剪嵌入
+          API）验证。<code>include/ghostty.h</code>
+          中所有与分屏相关的内容都是<i>动作（action）</i>：枚举
+          <code>GHOSTTY_ACTION_NEW_SPLIT</code> / <code>GOTO_SPLIT</code> /
+          <code>RESIZE_SPLIT</code> / <code>EQUALIZE_SPLITS</code> /
+          <code>TOGGLE_SPLIT_ZOOM</code>，以及
+          <code>ghostty_surface_split()</code>
+          等四个函数。在核心实现中，该函数纯粹是请求转发：</span
+        >
+      </p>
+      <pre><code>// upstream src/apprt/embedded.zig:1843 (v1.2.3)
 export fn ghostty_surface_split(ptr: *Surface, direction: apprt.action.SplitDirection) void {
     _ = ptr.app.performAction(.{ .surface = &amp;ptr.core_surface }, .new_split, direction) catch ...
 }
 // fires the .new_split action BACK OUT to the host's action callback.
 // The core never lays out two surfaces: one surface = one view = one Metal layer.</code></pre>
-  <div class="callout good">
-    <b><span class="en">Option B is not a workaround — it <i>is</i> the Ghostty architecture</span><span class="zh">方案 B 不是权宜之计 —— 它<i>就是</i> Ghostty 的架构</span></b>
-    <span class="en">Real Ghostty.app is itself a host that arranges multiple single-surface views and answers <code>.new_split</code> requests (in <code>SplitTree.swift</code>). Two <code>TerminalView</code>s under an AppKit-owned divider put vimeflow in exactly the role Ghostty.app plays — with the split tree deliberately capped at two children.</span>
-    <span class="zh">真正的 Ghostty.app 本身就是一个“排布多个单 surface view、并响应 <code>.new_split</code> 请求”的宿主（实现在 <code>SplitTree.swift</code>）。在 AppKit 分隔线下承载两个 <code>TerminalView</code>，vimeflow 扮演的正是 Ghostty.app 的角色 —— 只是把分屏树刻意封顶为两个子节点。</span>
-  </div>
+      <div class="callout good">
+        <b
+          ><span class="en"
+            >Option B is not a workaround — it <i>is</i> the Ghostty
+            architecture</span
+          ><span class="zh"
+            >方案 B 不是权宜之计 —— 它<i>就是</i> Ghostty 的架构</span
+          ></b
+        >
+        <span class="en"
+          >Real Ghostty.app is itself a host that arranges multiple
+          single-surface views and answers <code>.new_split</code> requests (in
+          <code>SplitTree.swift</code>). Two <code>TerminalView</code>s under an
+          AppKit-owned divider put vimeflow in exactly the role Ghostty.app
+          plays — with the split tree deliberately capped at two children.</span
+        >
+        <span class="zh"
+          >真正的 Ghostty.app 本身就是一个“排布多个单 surface view、并响应
+          <code>.new_split</code> 请求”的宿主（实现在
+          <code>SplitTree.swift</code>）。在 AppKit 分隔线下承载两个
+          <code>TerminalView</code>，vimeflow 扮演的正是 Ghostty.app 的角色 ——
+          只是把分屏树刻意封顶为两个子节点。</span
+        >
+      </div>
 
-  <h2><span class="en">2 · Question 2 — Can two TerminalViews coexist in one surface host?</span><span class="zh">2 · 问题二 —— 两个 TerminalView 能否共存于同一宿主？</span></h2>
-  <p>
-    <span class="en">Yes, with one blocking constraint and two non-issues:</span>
-    <span class="zh">可以，但有一个硬性约束，另外两点无碍：</span>
-  </p>
-  <table>
-    <tr>
-      <th><span class="en">Constraint</span><span class="zh">约束</span></th>
-      <th><span class="en">Evidence</span><span class="zh">证据</span></th>
-      <th><span class="en">Impact</span><span class="zh">影响</span></th>
-    </tr>
-    <tr>
-      <td>
-        <b><span class="en">One <code>TerminalController</code> per view</span><span class="zh">每个 view 必须有独立 <code>TerminalController</code></span></b>
-        <span class="sev high">BLOCKING</span>
-      </td>
-      <td>
-        <code>TerminalController.swift:59-60</code>, <code>TerminalSurfaceCoordinator.swift:138</code>
-      </td>
-      <td>
-        <span class="en"><code>onWakeup</code> / <code>shouldProcessWakeup</code> are <b>single-slot closures</b>; each coordinator's <code>rebuildIfReady()</code> unconditionally overwrites them. Two views sharing one controller ⇒ only the last-attached view gets render ticks — the other goes dark.</span>
-        <span class="zh"><code>onWakeup</code> / <code>shouldProcessWakeup</code> 是<b>单槽位闭包</b>；每个 coordinator 的 <code>rebuildIfReady()</code> 会无条件覆盖它们。两个 view 共享一个 controller ⇒ 只有最后挂载的 view 能收到渲染 tick —— 另一个会“黑掉”。</span>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <b><span class="en">Avoid <code>TerminalController.shared</code></span><span class="zh">不要使用 <code>TerminalController.shared</code></span></b>
-        <span class="sev med">HAZARD</span>
-      </td>
-      <td><code>TerminalController.swift:46</code></td>
-      <td>
-        <span class="en">Convenience singleton; naive use triggers the constraint above. The designated init is public — just construct fresh instances.</span>
-        <span class="zh">便利单例；随手使用即触发上面的约束。指定构造器是公开的 —— 直接为每个 view 新建实例即可。</span>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <b><span class="en">Process-global init &amp; rendering</span><span class="zh">进程级初始化与渲染</span></b>
-        <span class="sev low">SAFE</span>
-      </td>
-      <td><code>TerminalController.swift:300</code>, <code>AppTerminalView.swift:13</code></td>
-      <td>
-        <span class="en"><code>ghostty_init</code> is guarded one-shot (idempotent). Each controller creates its own <code>ghostty_app_t</code>; callbacks route via per-app/per-surface userdata, so nothing cross-routes. Each view owns its own <code>CAMetalLayer</code>; the tick pump is a per-coordinator main-queue schedule — no shared display link.</span>
-        <span class="zh"><code>ghostty_init</code> 有一次性守卫（幂等）。每个 controller 创建独立的 <code>ghostty_app_t</code>；回调经由 per-app / per-surface 的 userdata 路由，不会串线。每个 view 拥有独立 <code>CAMetalLayer</code>；tick 泵为各自 coordinator 的主队列调度 —— 没有共享 display link。</span>
-      </td>
-    </tr>
-  </table>
-  <div class="callout good">
-    <b><span class="en">Vimeflow already follows the required pattern</span><span class="zh">Vimeflow 现有代码已符合该模式</span></b>
-    <span class="en"><code>EmbeddedGhosttySurface</code> creates a per-surface controller today — <code>private lazy var controller = TerminalController()</code> (<code>GhosttyElectronBridge.swift:201</code>). Adding the burner means adding a <i>second</i> controller + view + session inside the same container, not restructuring anything.</span>
-    <span class="zh"><code>EmbeddedGhosttySurface</code> 目前就是按 surface 创建独立 controller —— <code>private lazy var controller = TerminalController()</code>（<code>GhosttyElectronBridge.swift:201</code>）。加入 burner 只是在同一容器里再加<i>第二套</i> controller + view + session，无需重构。</span>
-  </div>
+      <h2>
+        <span class="en"
+          >2 · Question 2 — Can two TerminalViews coexist in one surface
+          host?</span
+        ><span class="zh"
+          >2 · 问题二 —— 两个 TerminalView 能否共存于同一宿主？</span
+        >
+      </h2>
+      <p>
+        <span class="en"
+          >Yes, with one blocking constraint and two non-issues:</span
+        >
+        <span class="zh">可以，但有一个硬性约束，另外两点无碍：</span>
+      </p>
+      <table>
+        <tr>
+          <th>
+            <span class="en">Constraint</span><span class="zh">约束</span>
+          </th>
+          <th><span class="en">Evidence</span><span class="zh">证据</span></th>
+          <th><span class="en">Impact</span><span class="zh">影响</span></th>
+        </tr>
+        <tr>
+          <td>
+            <b
+              ><span class="en"
+                >One <code>TerminalController</code> per view</span
+              ><span class="zh"
+                >每个 view 必须有独立 <code>TerminalController</code></span
+              ></b
+            >
+            <span class="sev high">BLOCKING</span>
+          </td>
+          <td>
+            <code>TerminalController.swift:59-60</code>,
+            <code>TerminalSurfaceCoordinator.swift:138</code>
+          </td>
+          <td>
+            <span class="en"
+              ><code>onWakeup</code> / <code>shouldProcessWakeup</code> are
+              <b>single-slot closures</b>; each coordinator's
+              <code>rebuildIfReady()</code> unconditionally overwrites them. Two
+              views sharing one controller ⇒ only the last-attached view gets
+              render ticks — the other goes dark.</span
+            >
+            <span class="zh"
+              ><code>onWakeup</code> /
+              <code>shouldProcessWakeup</code> 是<b>单槽位闭包</b>；每个
+              coordinator 的
+              <code>rebuildIfReady()</code> 会无条件覆盖它们。两个 view 共享一个
+              controller ⇒ 只有最后挂载的 view 能收到渲染 tick ——
+              另一个会“黑掉”。</span
+            >
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <b
+              ><span class="en"
+                >Avoid <code>TerminalController.shared</code></span
+              ><span class="zh"
+                >不要使用 <code>TerminalController.shared</code></span
+              ></b
+            >
+            <span class="sev med">HAZARD</span>
+          </td>
+          <td><code>TerminalController.swift:46</code></td>
+          <td>
+            <span class="en"
+              >Convenience singleton; naive use triggers the constraint above.
+              The designated init is public — just construct fresh
+              instances.</span
+            >
+            <span class="zh"
+              >便利单例；随手使用即触发上面的约束。指定构造器是公开的 ——
+              直接为每个 view 新建实例即可。</span
+            >
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <b
+              ><span class="en">Process-global init &amp; rendering</span
+              ><span class="zh">进程级初始化与渲染</span></b
+            >
+            <span class="sev low">SAFE</span>
+          </td>
+          <td>
+            <code>TerminalController.swift:300</code>,
+            <code>AppTerminalView.swift:13</code>
+          </td>
+          <td>
+            <span class="en"
+              ><code>ghostty_init</code> is guarded one-shot (idempotent). Each
+              controller creates its own <code>ghostty_app_t</code>; callbacks
+              route via per-app/per-surface userdata, so nothing cross-routes.
+              Each view owns its own <code>CAMetalLayer</code>; the tick pump is
+              a per-coordinator main-queue schedule — no shared display
+              link.</span
+            >
+            <span class="zh"
+              ><code>ghostty_init</code> 有一次性守卫（幂等）。每个 controller
+              创建独立的 <code>ghostty_app_t</code>；回调经由 per-app /
+              per-surface 的 userdata 路由，不会串线。每个 view 拥有独立
+              <code>CAMetalLayer</code>；tick 泵为各自 coordinator 的主队列调度
+              —— 没有共享 display link。</span
+            >
+          </td>
+        </tr>
+      </table>
+      <div class="callout good">
+        <b
+          ><span class="en">Vimeflow already follows the required pattern</span
+          ><span class="zh">Vimeflow 现有代码已符合该模式</span></b
+        >
+        <span class="en"
+          ><code>EmbeddedGhosttySurface</code> creates a per-surface controller
+          today —
+          <code>private lazy var controller = TerminalController()</code>
+          (<code>GhosttyElectronBridge.swift:201</code>). Adding the burner
+          means adding a <i>second</i> controller + view + session inside the
+          same container, not restructuring anything.</span
+        >
+        <span class="zh"
+          ><code>EmbeddedGhosttySurface</code> 目前就是按 surface 创建独立
+          controller ——
+          <code>private lazy var controller = TerminalController()</code
+          >（<code>GhosttyElectronBridge.swift:201</code>）。加入 burner
+          只是在同一容器里再加<i>第二套</i> controller + view +
+          session，无需重构。</span
+        >
+      </div>
 
-  <h2><span class="en">3 · Codex re-verification</span><span class="zh">3 · Codex 复核</span><span class="badge ok">agrees = true</span></h2>
-  <p>
-    <span class="en">An independent <code>codex exec</code> pass over the same pinned source confirmed all three core claims: (1) no library-owned split-pane API; (2) two independent TerminalViews are safe with separate controllers; (3) sharing one controller silences the earlier view via the single-slot wakeup closures. Two refinements surfaced:</span>
-    <span class="zh">对同一锁定版本源码的独立 <code>codex exec</code> 复核确认了全部三条核心结论：（1）库不提供自有的分屏 API；（2）两个独立 TerminalView 在各自 controller 下是安全的；（3）共享 controller 会因单槽位 wakeup 闭包导致先挂载的 view 失效。复核补充了两点修正：</span>
-  </p>
-  <ul>
-    <li>
-      <span class="en"><b>Tick pump precision</b> — <code>startDisplayLink()</code> schedules a per-coordinator main-queue tick; MSDisplayLink is imported but never shared. Whether ticking is per-coordinator MSDisplayLink or raw <code>DispatchQueue.main.async</code> does not change the verdict: nothing is shared across views.</span>
-      <span class="zh"><b>tick 泵表述精度</b> —— <code>startDisplayLink()</code> 为各自 coordinator 调度主队列 tick；MSDisplayLink 虽被引入但从不共享。无论 tick 实现是 per-coordinator 的 MSDisplayLink 还是裸 <code>DispatchQueue.main.async</code>，结论不变：view 之间不存在共享。</span>
-    </li>
-    <li>
-      <span class="en"><b><code>retainedBridges</code> array</b> (<code>TerminalController+Config.swift:64</code>) — one controller <i>can</i> fan out config updates to multiple surfaces. This does not lift the single-slot wakeup constraint (the render trigger is still one closure), so the per-view-controller rule stands.</span>
-      <span class="zh"><b><code>retainedBridges</code> 数组</b>（<code>TerminalController+Config.swift:64</code>）—— 单个 controller <i>确实</i>能向多个 surface 广播配置更新。但这并不解除单槽位 wakeup 约束（渲染触发仍是一个闭包），因此“每 view 一个 controller”的规则依然成立。</span>
-    </li>
-  </ul>
+      <h2>
+        <span class="en">3 · Codex re-verification</span
+        ><span class="zh">3 · Codex 复核</span
+        ><span class="badge ok">agrees = true</span>
+      </h2>
+      <p>
+        <span class="en"
+          >An independent <code>codex exec</code> pass over the same pinned
+          source confirmed all three core claims: (1) no library-owned
+          split-pane API; (2) two independent TerminalViews are safe with
+          separate controllers; (3) sharing one controller silences the earlier
+          view via the single-slot wakeup closures. Two refinements
+          surfaced:</span
+        >
+        <span class="zh"
+          >对同一锁定版本源码的独立
+          <code>codex exec</code>
+          复核确认了全部三条核心结论：（1）库不提供自有的分屏 API；（2）两个独立
+          TerminalView 在各自 controller 下是安全的；（3）共享 controller
+          会因单槽位 wakeup 闭包导致先挂载的 view
+          失效。复核补充了两点修正：</span
+        >
+      </p>
+      <ul>
+        <li>
+          <span class="en"
+            ><b>Tick pump precision</b> —
+            <code>startDisplayLink()</code> schedules a per-coordinator
+            main-queue tick; MSDisplayLink is imported but never shared. Whether
+            ticking is per-coordinator MSDisplayLink or raw
+            <code>DispatchQueue.main.async</code> does not change the verdict:
+            nothing is shared across views.</span
+          >
+          <span class="zh"
+            ><b>tick 泵表述精度</b> —— <code>startDisplayLink()</code> 为各自
+            coordinator 调度主队列 tick；MSDisplayLink 虽被引入但从不共享。无论
+            tick 实现是 per-coordinator 的 MSDisplayLink 还是裸
+            <code>DispatchQueue.main.async</code>，结论不变：view
+            之间不存在共享。</span
+          >
+        </li>
+        <li>
+          <span class="en"
+            ><b><code>retainedBridges</code> array</b>
+            (<code>TerminalController+Config.swift:64</code>) — one controller
+            <i>can</i> fan out config updates to multiple surfaces. This does
+            not lift the single-slot wakeup constraint (the render trigger is
+            still one closure), so the per-view-controller rule stands.</span
+          >
+          <span class="zh"
+            ><b><code>retainedBridges</code> 数组</b
+            >（<code>TerminalController+Config.swift:64</code>）—— 单个
+            controller <i>确实</i>能向多个 surface
+            广播配置更新。但这并不解除单槽位 wakeup
+            约束（渲染触发仍是一个闭包），因此“每 view 一个
+            controller”的规则依然成立。</span
+          >
+        </li>
+      </ul>
 
-  <h3><span class="en">Round 2 (2026-07-03) — risks &amp; spike order</span><span class="zh">第二轮（2026-07-03）—— 风险与 spike 顺序</span></h3>
-  <p>
-    <span class="en">A second <code>codex exec</code> pass reviewed §5 and §6 against the actual code (via the markdown mirror of this note). Verdicts: R2/R4/R6 <b>confirmed</b>; R1/R3/R5 <b>incomplete</b> — corrections folded into §5 (resize shares the PTY-identity path; the digit guard is at Swift:475-480 and context-menu/rename attribution needs child identity; the renderer's pending-buffer drain is owned by the mounted Body). Codex also surfaced <b>four missing HIGH risks</b> (now in §5, marked <i>codex round 2</i>) and a revised spike order (§6).</span>
-    <span class="zh">第二轮 <code>codex exec</code> 依据本笔记的 markdown 镜像，对照实际代码复核了 §5 与 §6。判定：R2/R4/R6 <b>确认</b>；R1/R3/R5 <b>不完整</b> —— 修正已并入 §5（resize 与击键共用同一 PTY 身份路径；数字键守卫实际在 Swift:475-480，右键菜单/重命名归属需要携带子终端身份；渲染进程的待发缓冲排空由挂载的 Body 持有）。codex 还发现了 <b>4 个遗漏的高危风险</b>（已列入 §5，标注 <i>codex round 2</i>），并给出修订后的 spike 顺序（§6）。</span>
-  </p>
+      <h3>
+        <span class="en">Round 2 (2026-07-03) — risks &amp; spike order</span
+        ><span class="zh">第二轮（2026-07-03）—— 风险与 spike 顺序</span>
+      </h3>
+      <p>
+        <span class="en"
+          >A second <code>codex exec</code> pass reviewed §5 and §6 against the
+          actual code (via the markdown mirror of this note). Verdicts: R2/R4/R6
+          <b>confirmed</b>; R1/R3/R5 <b>incomplete</b> — corrections folded into
+          §5 (resize shares the PTY-identity path; the digit guard is at
+          Swift:475-480 and context-menu/rename attribution needs child
+          identity; the renderer's pending-buffer drain is owned by the mounted
+          Body). Codex also surfaced <b>four missing HIGH risks</b> (now in §5,
+          marked <i>codex round 2</i>) and a revised spike order (§6).</span
+        >
+        <span class="zh"
+          >第二轮 <code>codex exec</code> 依据本笔记的 markdown
+          镜像，对照实际代码复核了 §5 与 §6。判定：R2/R4/R6
+          <b>确认</b>；R1/R3/R5 <b>不完整</b> —— 修正已并入 §5（resize
+          与击键共用同一 PTY 身份路径；数字键守卫实际在
+          Swift:475-480，右键菜单/重命名归属需要携带子终端身份；渲染进程的待发缓冲排空由挂载的
+          Body 持有）。codex 还发现了 <b>4 个遗漏的高危风险</b>（已列入 §5，标注
+          <i>codex round 2</i>），并给出修订后的 spike 顺序（§6）。</span
+        >
+      </p>
 
-  <h2><span class="en">4 · What needs to change (Option B change map)</span><span class="zh">4 · 需要改什么（方案 B 变更图）</span></h2>
-  <p>
-    <span class="en">The pipeline today, and the identity fields flowing through it:</span>
-    <span class="zh">现有管线及贯穿其中的标识字段：</span>
-  </p>
-  <pre><code>GhosttyBody.tsx ──▶ nativeGhosttyClient.ts ──▶ preload.ts ──▶ ghostty-native-parent.ts
+      <h2>
+        <span class="en">4 · What needs to change (Option B change map)</span
+        ><span class="zh">4 · 需要改什么（方案 B 变更图）</span>
+      </h2>
+      <p>
+        <span class="en"
+          >The pipeline today, and the identity fields flowing through it:</span
+        >
+        <span class="zh">现有管线及贯穿其中的标识字段：</span>
+      </p>
+      <pre><code>GhosttyBody.tsx ──▶ nativeGhosttyClient.ts ──▶ preload.ts ──▶ ghostty-native-parent.ts
                                                                     │  surfaces: Map&lt;`${sessionId}:${paneId}`&gt;
                                                                     ▼
                                               ghostty_native_parent.cc (N-API, tsfn callbacks)
@@ -321,234 +840,757 @@ sessionId = ptyId  (NOT the layout session id — GhosttyBody.tsx:193)
 burner adds:  childId: 'primary' | 'burner'   +   burnerPtyId
 paneKey stays `${sessionId}:${paneId}` — the burner shares its parent's surface state entry.</code></pre>
 
-  <h3><span class="en">Ordered minimal change plan (native-first)</span><span class="zh">最小变更计划（自原生层向上，按序）</span></h3>
-  <ol class="plan">
-    <li>
-      <b>Swift · <code>GhosttyElectronBridge.swift</code></b> —
-      <span class="en"><code>EmbeddedGhosttySurface</code> gains optional <code>burnerTerminalView</code> / <code>burnerSession</code> / <code>burnerCallbacks</code> (each with its <b>own <code>TerminalController</code></b>); <code>enum BurnerPlacement { right, bottom }</code>; a <code>layoutChildren()</code> that splits <code>container.bounds</code> by ratio (called from <code>setFrame</code>); new <code>@_cdecl</code> exports <code>vimeflow_ghostty_add_burner_child</code> / <code>remove_burner_child</code> / <code>write_burner</code> / <code>focus_burner</code>; fix <code>shortcutMonitor.handleKeyDown</code> (line 441) to match firstResponder against <i>either</i> terminal view.</span>
-      <span class="zh"><code>EmbeddedGhosttySurface</code> 增加可选的 <code>burnerTerminalView</code> / <code>burnerSession</code> / <code>burnerCallbacks</code>（各自持有<b>独立 <code>TerminalController</code></b>）；新增 <code>enum BurnerPlacement { right, bottom }</code>；新增 <code>layoutChildren()</code> 按比例切分 <code>container.bounds</code>（由 <code>setFrame</code> 调用）；新增 <code>@_cdecl</code> 导出 <code>vimeflow_ghostty_add_burner_child</code> / <code>remove_burner_child</code> / <code>write_burner</code> / <code>focus_burner</code>；修正 <code>shortcutMonitor.handleKeyDown</code>（441 行），使 firstResponder 判定同时匹配两个终端 view。</span>
-    </li>
-    <li>
-      <b>N-API · <code>ghostty_native_parent.cc</code></b> —
-      <span class="en">load the four new dylib symbols in <code>EnsureBridge()</code>; add a <code>BurnerContext</code> struct with its own threadsafe functions (input/resize/focus) separate from the primary <code>SurfaceHandle</code> for independent teardown; add <code>AddBurnerChild</code> / <code>RemoveBurnerChild</code> / <code>WriteBurner</code> / <code>FocusBurner</code>; extend <code>ReleaseSurfaceCallbacks</code> to drain burner tsfns.</span>
-      <span class="zh">在 <code>EnsureBridge()</code> 中加载四个新 dylib 符号；新增 <code>BurnerContext</code> 结构体，持有独立的 threadsafe function（input/resize/focus），与主 <code>SurfaceHandle</code> 分离以便独立销毁；新增 <code>AddBurnerChild</code> / <code>RemoveBurnerChild</code> / <code>WriteBurner</code> / <code>FocusBurner</code>；扩展 <code>ReleaseSurfaceCallbacks</code> 以清空 burner 的 tsfn。</span>
-    </li>
-    <li>
-      <b>Channels · <code>electron/ghostty-native-channels.ts</code></b> —
-      <span class="en">add <code>GHOSTTY_NATIVE_ADD_BURNER</code> / <code>GHOSTTY_NATIVE_REMOVE_BURNER</code>. Write/focus/destroy reuse existing channels with a <code>childId</code> field.</span>
-      <span class="zh">新增 <code>GHOSTTY_NATIVE_ADD_BURNER</code> / <code>GHOSTTY_NATIVE_REMOVE_BURNER</code>。write/focus/destroy 复用现有通道，仅增加 <code>childId</code> 字段。</span>
-    </li>
-    <li>
-      <b>Types · <code>electron/ghostty-native-shared.ts</code></b> —
-      <span class="en"><code>childId?: 'primary' | 'burner'</code> on <code>GhosttyNativePaneRequest</code> (flows into update/data requests); new <code>GhosttyNativeAddBurnerRequest { burnerPtyId, placement, ratio }</code>; the main-process <code>paneKey</code> must <b>not</b> include <code>childId</code>.</span>
-      <span class="zh">在 <code>GhosttyNativePaneRequest</code> 上加 <code>childId?: 'primary' | 'burner'</code>（自动传导到 update/data 请求）；新增 <code>GhosttyNativeAddBurnerRequest { burnerPtyId, placement, ratio }</code>；主进程 <code>paneKey</code> <b>不得</b>包含 <code>childId</code>。</span>
-    </li>
-    <li>
-      <b>Main · <code>electron/ghostty-native-parent.ts</code></b> —
-      <span class="en"><code>GhosttyNativeSurfaceState</code> gains <code>burnerPtyId</code>; new IPC handlers for add/remove; <code>sendData</code>/<code>focus</code> branch on <code>childId</code>; the burner's <code>onInput</code>/<code>onResize</code> callbacks route <code>write_pty</code>/<code>resize_pty</code> with <b><code>burnerPtyId</code></b>; <code>destroySurface</code> also removes the burner child.</span>
-      <span class="zh"><code>GhosttyNativeSurfaceState</code> 增加 <code>burnerPtyId</code>；新增 add/remove 两个 IPC handler；<code>sendData</code>/<code>focus</code> 按 <code>childId</code> 分支；burner 的 <code>onInput</code>/<code>onResize</code> 回调必须用 <b><code>burnerPtyId</code></b> 调用 <code>write_pty</code>/<code>resize_pty</code>；<code>destroySurface</code> 同时移除 burner 子终端。</span>
-    </li>
-    <li>
-      <b>Preload · <code>electron/preload.ts</code></b> —
-      <span class="en">expose <code>addBurnerChild</code> / <code>removeBurnerChild</code> invokes on the existing <code>ghosttyNativeBridge</code>.</span>
-      <span class="zh">在现有 <code>ghosttyNativeBridge</code> 上暴露 <code>addBurnerChild</code> / <code>removeBurnerChild</code> 两个 invoke。</span>
-    </li>
-    <li>
-      <b>Renderer client · <code>src/features/terminal/nativeGhosttyClient.ts</code></b> —
-      <span class="en"><code>childId</code> on <code>NativeGhosttyPaneRef</code>; <code>NativeGhosttyAddBurnerRequest</code>; helper functions following the existing enabled/disabled-sentinel pattern.</span>
-      <span class="zh"><code>NativeGhosttyPaneRef</code> 加 <code>childId</code>；新增 <code>NativeGhosttyAddBurnerRequest</code>；按现有 enabled/disabled 哨兵模式补充 helper 函数。</span>
-    </li>
-    <li>
-      <b>React · <code>GhosttyBody.tsx</code> + <code>useBurnerTerminals.ts</code></b> —
-      <span class="en"><code>childId</code> prop threaded into <code>paneRef</code> and the <code>ghostty-native-input</code>/<code>-focus</code> event filters (lines 574–634); the hook's <code>renderNode</code> popup block (lines 537–575) is replaced by native attach/detach calls from <code>show()</code>/<code>hide()</code> — every input the native attach needs (<code>burnerPtyId</code>, visibility, cwd callbacks) is already computed in that scope.</span>
-      <span class="zh"><code>childId</code> prop 传入 <code>paneRef</code> 及 <code>ghostty-native-input</code>/<code>-focus</code> 事件过滤（574–634 行）；hook 中 <code>renderNode</code> 弹窗代码块（537–575 行）改为在 <code>show()</code>/<code>hide()</code> 中调用原生 attach/detach —— 原生挂载所需的全部输入（<code>burnerPtyId</code>、可见性、cwd 回调）在该作用域内均已就绪。</span>
-    </li>
-  </ol>
+      <h3>
+        <span class="en">Ordered minimal change plan (native-first)</span
+        ><span class="zh">最小变更计划（自原生层向上，按序）</span>
+      </h3>
+      <ol class="plan">
+        <li>
+          <b>Swift · <code>GhosttyElectronBridge.swift</code></b> —
+          <span class="en"
+            ><code>EmbeddedGhosttySurface</code> gains optional
+            <code>burnerTerminalView</code> / <code>burnerSession</code> /
+            <code>burnerCallbacks</code> (each with its
+            <b>own <code>TerminalController</code></b
+            >); <code>enum BurnerPlacement { right, bottom }</code>; a
+            <code>layoutChildren()</code> that splits
+            <code>container.bounds</code> by ratio (called from
+            <code>setFrame</code>); new <code>@_cdecl</code> exports
+            <code>vimeflow_ghostty_add_burner_child</code> /
+            <code>remove_burner_child</code> / <code>write_burner</code> /
+            <code>focus_burner</code>; fix
+            <code>shortcutMonitor.handleKeyDown</code> (line 441) to match
+            firstResponder against <i>either</i> terminal view.</span
+          >
+          <span class="zh"
+            ><code>EmbeddedGhosttySurface</code> 增加可选的
+            <code>burnerTerminalView</code> / <code>burnerSession</code> /
+            <code>burnerCallbacks</code>（各自持有<b
+              >独立 <code>TerminalController</code></b
+            >）；新增 <code>enum BurnerPlacement { right, bottom }</code>；新增
+            <code>layoutChildren()</code> 按比例切分
+            <code>container.bounds</code>（由 <code>setFrame</code> 调用）；新增
+            <code>@_cdecl</code> 导出
+            <code>vimeflow_ghostty_add_burner_child</code> /
+            <code>remove_burner_child</code> / <code>write_burner</code> /
+            <code>focus_burner</code>；修正
+            <code>shortcutMonitor.handleKeyDown</code>（441 行），使
+            firstResponder 判定同时匹配两个终端 view。</span
+          >
+        </li>
+        <li>
+          <b>N-API · <code>ghostty_native_parent.cc</code></b> —
+          <span class="en"
+            >load the four new dylib symbols in <code>EnsureBridge()</code>; add
+            a <code>BurnerContext</code> struct with its own threadsafe
+            functions (input/resize/focus) separate from the primary
+            <code>SurfaceHandle</code> for independent teardown; add
+            <code>AddBurnerChild</code> / <code>RemoveBurnerChild</code> /
+            <code>WriteBurner</code> / <code>FocusBurner</code>; extend
+            <code>ReleaseSurfaceCallbacks</code> to drain burner tsfns.</span
+          >
+          <span class="zh"
+            >在 <code>EnsureBridge()</code> 中加载四个新 dylib 符号；新增
+            <code>BurnerContext</code> 结构体，持有独立的 threadsafe
+            function（input/resize/focus），与主
+            <code>SurfaceHandle</code> 分离以便独立销毁；新增
+            <code>AddBurnerChild</code> / <code>RemoveBurnerChild</code> /
+            <code>WriteBurner</code> / <code>FocusBurner</code>；扩展
+            <code>ReleaseSurfaceCallbacks</code> 以清空 burner 的 tsfn。</span
+          >
+        </li>
+        <li>
+          <b>Channels · <code>electron/ghostty-native-channels.ts</code></b> —
+          <span class="en"
+            >add <code>GHOSTTY_NATIVE_ADD_BURNER</code> /
+            <code>GHOSTTY_NATIVE_REMOVE_BURNER</code>. Write/focus/destroy reuse
+            existing channels with a <code>childId</code> field.</span
+          >
+          <span class="zh"
+            >新增 <code>GHOSTTY_NATIVE_ADD_BURNER</code> /
+            <code>GHOSTTY_NATIVE_REMOVE_BURNER</code>。write/focus/destroy
+            复用现有通道，仅增加 <code>childId</code> 字段。</span
+          >
+        </li>
+        <li>
+          <b>Types · <code>electron/ghostty-native-shared.ts</code></b> —
+          <span class="en"
+            ><code>childId?: 'primary' | 'burner'</code> on
+            <code>GhosttyNativePaneRequest</code> (flows into update/data
+            requests); new
+            <code
+              >GhosttyNativeAddBurnerRequest { burnerPtyId, placement, ratio
+              }</code
+            >; the main-process <code>paneKey</code> must <b>not</b> include
+            <code>childId</code>.</span
+          >
+          <span class="zh"
+            >在 <code>GhosttyNativePaneRequest</code> 上加
+            <code>childId?: 'primary' | 'burner'</code>（自动传导到 update/data
+            请求）；新增
+            <code
+              >GhosttyNativeAddBurnerRequest { burnerPtyId, placement, ratio
+              }</code
+            >；主进程 <code>paneKey</code> <b>不得</b>包含
+            <code>childId</code>。</span
+          >
+        </li>
+        <li>
+          <b>Main · <code>electron/ghostty-native-parent.ts</code></b> —
+          <span class="en"
+            ><code>GhosttyNativeSurfaceState</code> gains
+            <code>burnerPtyId</code>; new IPC handlers for add/remove;
+            <code>sendData</code>/<code>focus</code> branch on
+            <code>childId</code>; the burner's <code>onInput</code>/<code
+              >onResize</code
+            >
+            callbacks route <code>write_pty</code>/<code>resize_pty</code> with
+            <b><code>burnerPtyId</code></b
+            >; <code>destroySurface</code> also removes the burner child.</span
+          >
+          <span class="zh"
+            ><code>GhosttyNativeSurfaceState</code> 增加
+            <code>burnerPtyId</code>；新增 add/remove 两个 IPC
+            handler；<code>sendData</code>/<code>focus</code> 按
+            <code>childId</code> 分支；burner 的 <code>onInput</code>/<code
+              >onResize</code
+            >
+            回调必须用 <b><code>burnerPtyId</code></b> 调用
+            <code>write_pty</code>/<code>resize_pty</code>；<code
+              >destroySurface</code
+            >
+            同时移除 burner 子终端。</span
+          >
+        </li>
+        <li>
+          <b>Preload · <code>electron/preload.ts</code></b> —
+          <span class="en"
+            >expose <code>addBurnerChild</code> /
+            <code>removeBurnerChild</code> invokes on the existing
+            <code>ghosttyNativeBridge</code>.</span
+          >
+          <span class="zh"
+            >在现有 <code>ghosttyNativeBridge</code> 上暴露
+            <code>addBurnerChild</code> / <code>removeBurnerChild</code> 两个
+            invoke。</span
+          >
+        </li>
+        <li>
+          <b
+            >Renderer client ·
+            <code>src/features/terminal/nativeGhosttyClient.ts</code></b
+          >
+          —
+          <span class="en"
+            ><code>childId</code> on <code>NativeGhosttyPaneRef</code>;
+            <code>NativeGhosttyAddBurnerRequest</code>; helper functions
+            following the existing enabled/disabled-sentinel pattern.</span
+          >
+          <span class="zh"
+            ><code>NativeGhosttyPaneRef</code> 加 <code>childId</code>；新增
+            <code>NativeGhosttyAddBurnerRequest</code>；按现有 enabled/disabled
+            哨兵模式补充 helper 函数。</span
+          >
+        </li>
+        <li>
+          <b
+            >React · <code>GhosttyBody.tsx</code> +
+            <code>useBurnerTerminals.ts</code></b
+          >
+          —
+          <span class="en"
+            ><code>childId</code> prop threaded into <code>paneRef</code> and
+            the <code>ghostty-native-input</code>/<code>-focus</code> event
+            filters (lines 574–634); the hook's <code>renderNode</code> popup
+            block (lines 537–575) is replaced by native attach/detach calls from
+            <code>show()</code>/<code>hide()</code> — every input the native
+            attach needs (<code>burnerPtyId</code>, visibility, cwd callbacks)
+            is already computed in that scope.</span
+          >
+          <span class="zh"
+            ><code>childId</code> prop 传入 <code>paneRef</code> 及
+            <code>ghostty-native-input</code>/<code>-focus</code>
+            事件过滤（574–634 行）；hook 中
+            <code>renderNode</code> 弹窗代码块（537–575 行）改为在
+            <code>show()</code>/<code>hide()</code> 中调用原生 attach/detach ——
+            原生挂载所需的全部输入（<code>burnerPtyId</code>、可见性、cwd
+            回调）在该作用域内均已就绪。</span
+          >
+        </li>
+      </ol>
 
-  <h3><span class="en">Burner lifecycle: keep vs retire</span><span class="zh">Burner 生命周期：保留 vs 淘汰</span></h3>
-  <table>
-    <tr>
-      <th><span class="en">Keep (presentation-agnostic — survives unchanged)</span><span class="zh">保留（与呈现方式无关 —— 原样保留）</span></th>
-      <th><span class="en">Retire (popup-only)</span><span class="zh">淘汰（仅服务于弹窗）</span></th>
-    </tr>
-    <tr>
-      <td>
-        <span class="en">The entire <code>useBurnerTerminals</code> PTY state machine: ephemeral spawn (<code>{ ephemeral: true }</code>), <code>paneKey</code> keying, show/toggle/hide intents, cwd align (VIM-81, <code>CLEAR_LINE + cd</code> with the foreground-active guard), OSC 7 <code>currentCwd</code> tracking, foreground cue (VIM-71), self-exit (VIM-62), live-pane reconcile/kill, boot reap via <code>killEphemeralPtys()</code>, the <code>Mod+; `</code> chord, and the <code>runningByPane</code>/<code>activeByPane</code> header signals.</span>
-        <span class="zh"><code>useBurnerTerminals</code> 的整套 PTY 状态机：临时 spawn（<code>{ ephemeral: true }</code>）、<code>paneKey</code> 键控、show/toggle/hide 意图、cwd 对齐（VIM-81，带前台命令守卫的 <code>CLEAR_LINE + cd</code>）、OSC 7 <code>currentCwd</code> 跟踪、前台命令提示（VIM-71）、自退出（VIM-62）、live-pane 对账/清理、启动时 <code>killEphemeralPtys()</code> 回收、<code>Mod+; `</code> 和弦快捷键，以及 <code>runningByPane</code>/<code>activeByPane</code> 头部信号。</span>
-      </td>
-      <td>
-        <span class="en"><code>BurnerTerminalPopup/index.tsx</code> in full (overlay, backdrop, focus trap, focus restore, 760×600 panel); the hook's <code>renderNode</code> block + its return-type field; the <code>{burnerTerminalNode}</code> render site (<code>WorkspaceView.tsx:3031</code>); re-evaluate the <code>burnerTerminalOpen</code> occlusion registration (<code>WorkspaceView.tsx:2541-2545</code>) — a native nested child is not a floating DOM overlay.</span>
-        <span class="zh">整个 <code>BurnerTerminalPopup/index.tsx</code>（浮层、backdrop、焦点陷阱、焦点恢复、760×600 面板）；hook 的 <code>renderNode</code> 代码块及其返回类型字段；<code>{burnerTerminalNode}</code> 渲染位点（<code>WorkspaceView.tsx:3031</code>）；重新评估 <code>burnerTerminalOpen</code> 遮挡注册（<code>WorkspaceView.tsx:2541-2545</code>）—— 原生嵌套子终端不再是浮动 DOM 覆盖层。</span>
-      </td>
-    </tr>
-  </table>
+      <h3>
+        <span class="en">Burner lifecycle: keep vs retire</span
+        ><span class="zh">Burner 生命周期：保留 vs 淘汰</span>
+      </h3>
+      <table>
+        <tr>
+          <th>
+            <span class="en"
+              >Keep (presentation-agnostic — survives unchanged)</span
+            ><span class="zh">保留（与呈现方式无关 —— 原样保留）</span>
+          </th>
+          <th>
+            <span class="en">Retire (popup-only)</span
+            ><span class="zh">淘汰（仅服务于弹窗）</span>
+          </th>
+        </tr>
+        <tr>
+          <td>
+            <span class="en"
+              >The entire <code>useBurnerTerminals</code> PTY state machine:
+              ephemeral spawn (<code>{ ephemeral: true }</code>),
+              <code>paneKey</code> keying, show/toggle/hide intents, cwd align
+              (VIM-81, <code>CLEAR_LINE + cd</code> with the foreground-active
+              guard), OSC 7 <code>currentCwd</code> tracking, foreground cue
+              (VIM-71), self-exit (VIM-62), live-pane reconcile/kill, boot reap
+              via <code>killEphemeralPtys()</code>, the
+              <code>Mod+; `</code> chord, and the
+              <code>runningByPane</code>/<code>activeByPane</code> header
+              signals.</span
+            >
+            <span class="zh"
+              ><code>useBurnerTerminals</code> 的整套 PTY 状态机：临时
+              spawn（<code>{ ephemeral: true }</code>）、<code>paneKey</code>
+              键控、show/toggle/hide 意图、cwd 对齐（VIM-81，带前台命令守卫的
+              <code>CLEAR_LINE + cd</code>）、OSC 7
+              <code>currentCwd</code>
+              跟踪、前台命令提示（VIM-71）、自退出（VIM-62）、live-pane
+              对账/清理、启动时 <code>killEphemeralPtys()</code> 回收、<code
+                >Mod+; `</code
+              >
+              和弦快捷键，以及 <code>runningByPane</code>/<code
+                >activeByPane</code
+              >
+              头部信号。</span
+            >
+          </td>
+          <td>
+            <span class="en"
+              ><code>BurnerTerminalPopup/index.tsx</code> in full (overlay,
+              backdrop, focus trap, focus restore, 760×600 panel); the hook's
+              <code>renderNode</code> block + its return-type field; the
+              <code>{burnerTerminalNode}</code> render site
+              (<code>WorkspaceView.tsx:3031</code>); re-evaluate the
+              <code>burnerTerminalOpen</code> occlusion registration
+              (<code>WorkspaceView.tsx:2541-2545</code>) — a native nested child
+              is not a floating DOM overlay.</span
+            >
+            <span class="zh"
+              >整个
+              <code>BurnerTerminalPopup/index.tsx</code
+              >（浮层、backdrop、焦点陷阱、焦点恢复、760×600 面板）；hook 的
+              <code>renderNode</code> 代码块及其返回类型字段；<code
+                >{burnerTerminalNode}</code
+              >
+              渲染位点（<code>WorkspaceView.tsx:3031</code>）；重新评估
+              <code>burnerTerminalOpen</code>
+              遮挡注册（<code>WorkspaceView.tsx:2541-2545</code>）——
+              原生嵌套子终端不再是浮动 DOM 覆盖层。</span
+            >
+          </td>
+        </tr>
+      </table>
 
-  <h2><span class="en">5 · Risks, ranked</span><span class="zh">5 · 风险（按严重度排序）</span></h2>
-  <table>
-    <tr>
-      <th></th>
-      <th><span class="en">Risk</span><span class="zh">风险</span></th>
-      <th><span class="en">Mitigation</span><span class="zh">缓解</span></th>
-    </tr>
-    <tr>
-      <td><span class="sev high">HIGH</span></td>
-      <td>
-        <span class="en"><b>PTY identity mis-routing.</b> The burner's <code>onInput</code> must call <code>write_pty</code> with <code>burnerPtyId</code>, never <code>state.pane.sessionId</code> — otherwise burner keystrokes are injected into the primary (agent) PTY. <i>Codex round 2:</i> <code>resize_pty</code> shares the same identity path (ghostty-native-parent.ts:518-525) — route <b>both</b> write and resize through the burner context.</span>
-        <span class="zh"><b>PTY 身份串线。</b>burner 的 <code>onInput</code> 必须以 <code>burnerPtyId</code> 调用 <code>write_pty</code>，绝不能用 <code>state.pane.sessionId</code> —— 否则 burner 击键会注入主（agent）PTY。<i>codex 第二轮：</i><code>resize_pty</code> 走同一身份路径（ghostty-native-parent.ts:518-525）—— write 与 resize <b>都</b>必须经由 burner 上下文路由。</span>
-      </td>
-      <td>
-        <span class="en">Separate callback context (<code>BurnerContext</code>) end-to-end; an integration test that types into the burner and asserts the primary PTY saw nothing.</span>
-        <span class="zh">全链路使用独立回调上下文（<code>BurnerContext</code>）；集成测试：向 burner 输入并断言主 PTY 未收到任何数据。</span>
-      </td>
-    </tr>
-    <tr>
-      <td><span class="sev high">HIGH</span></td>
-      <td>
-        <span class="en"><b>Teardown ordering.</b> <code>GhosttyBody</code> unmount cleanup calls destroy unconditionally (line 691). A burner destroy with a missing/misrouted <code>childId</code> must map to <code>removeBurnerChild</code>, never <code>destroySurface</code> — or the still-live primary dies with it.</span>
-        <span class="zh"><b>销毁顺序。</b><code>GhosttyBody</code> 卸载清理会无条件调用 destroy（691 行）。burner 的 destroy 若 <code>childId</code> 缺失或误路由，必须落到 <code>removeBurnerChild</code>，绝不能是 <code>destroySurface</code> —— 否则仍存活的主终端会被连带销毁。</span>
-      </td>
-      <td>
-        <span class="en">Main-process branch on <code>childId</code> with a default-deny: absent childId on a surface that has a burner never tears down the whole surface implicitly.</span>
-        <span class="zh">主进程按 <code>childId</code> 分支并默认保守：对持有 burner 的 surface，缺省 childId 的请求绝不隐式整体销毁。</span>
-      </td>
-    </tr>
-    <tr>
-      <td><span class="sev high">HIGH</span></td>
-      <td>
-        <span class="en"><b>Shortcut/focus gating.</b> The window-level <code>shortcutMonitor</code> checks firstResponder against the primary view only (Swift:441-453; digits guard :475-480). With the burner focused, Cmd+digit pane-switching is silently swallowed and key routing can drop events. <i>Codex round 2:</i> the context menu is also primary-only (Swift:425-438), and Electron emits rename with <code>state.pane</code> (ghostty-native-parent.ts:574-577) — rename/context callbacks must carry child identity.</span>
-        <span class="zh"><b>快捷键/焦点判定。</b>窗口级 <code>shortcutMonitor</code> 仅将 firstResponder 与主 view 比对（Swift:441-453，数字守卫 :475-480）。当 burner 获得焦点时，Cmd+数字 切换窗格会被静默吞掉，按键路由也可能丢事件。<i>codex 第二轮：</i>右键菜单同样只识别主 view（Swift:425-438），且 Electron 发出 rename 时使用 <code>state.pane</code>（ghostty-native-parent.ts:574-577）—— rename/右键回调必须携带子终端身份。</span>
-      </td>
-      <td>
-        <span class="en">Extend every firstResponder check to “descendant of primary <i>or</i> burner view”; same for the context-menu monitor (rename would otherwise mis-attribute to the host pane).</span>
-        <span class="zh">所有 firstResponder 判定扩展为“主 view <i>或</i> burner view 的后代”；右键菜单监视器同理（否则重命名会误归属到宿主窗格）。</span>
-      </td>
-    </tr>
-    <tr>
-      <td><span class="sev high">HIGH</span></td>
-      <td>
-        <span class="en"><b>Burner output has no subscriber.</b> Native output forwarding is owned by the mounted <code>GhosttyBody</code> (GhosttyBody.tsx:637-657) — a role the popup Body currently plays for the burner (useBurnerTerminals.ts:537-574). Retiring the popup without a replacement leaves burner PTY output going nowhere. <i>(codex round 2)</i></span>
-        <span class="zh"><b>burner 输出无订阅者。</b>原生输出转发由挂载的 <code>GhosttyBody</code> 持有（GhosttyBody.tsx:637-657）—— 目前弹窗中的 Body 为 burner 扮演该角色（useBurnerTerminals.ts:537-574）。若移除弹窗而不加替代，burner 的 PTY 输出将无处可去。<i>（codex 第二轮）</i></span>
-      </td>
-      <td>
-        <span class="en">Add a forwarder owned by <code>useBurnerTerminals</code> on native attach — <code>service.onData(burnerPtyId)</code> → <code>sendNativeGhosttyData(childId: 'burner')</code> — and drain the <code>registerPending</code> buffer into it.</span>
-        <span class="zh">在原生挂载时由 <code>useBurnerTerminals</code> 持有转发器 —— <code>service.onData(burnerPtyId)</code> → <code>sendNativeGhosttyData(childId: 'burner')</code> —— 并把 <code>registerPending</code> 缓冲排空到该通道。</span>
-      </td>
-    </tr>
-    <tr>
-      <td><span class="sev high">HIGH</span></td>
-      <td>
-        <span class="en"><b>Hide must not become destructive.</b> Today <code>hide()</code> keeps the popup Body mounted (<code>display:none</code>), so the shell and scrollback survive. In the library, surface state is freed on coordinator teardown (TerminalSurfaceCoordinator.swift:311-323) — implementing native hide as remove/destroy kills scrollback. <i>(codex round 2)</i></span>
-        <span class="zh"><b>hide 不能变成销毁。</b>目前 <code>hide()</code> 保持弹窗 Body 挂载（<code>display:none</code>），shell 与回滚缓冲得以存活。而库中 surface 状态会在 coordinator 销毁时释放（TerminalSurfaceCoordinator.swift:311-323）—— 若把原生 hide 实现为 remove/destroy，回滚缓冲会丢失。<i>（codex 第二轮）</i></span>
-      </td>
-      <td>
-        <span class="en">Implement hide as AppKit <code>isHidden</code> on the burner view (view + session stay alive); reserve <code>removeBurnerChild</code> for kill.</span>
-        <span class="zh">hide 实现为对 burner view 设置 AppKit <code>isHidden</code>（view 与 session 均存活）；<code>removeBurnerChild</code> 仅用于 kill。</span>
-      </td>
-    </tr>
-    <tr>
-      <td><span class="sev high">HIGH</span></td>
-      <td>
-        <span class="en"><b>Callback-context use-after-free.</b> Swift's <code>CallbackBox</code> holds the raw C++ context pointer (GhosttyElectronBridge.swift:75-82) and invokes it on input/resize (:101-119); C++ casts it back in the trampolines (ghostty_native_parent.cc:177-184). Freeing the <code>BurnerContext</code> before the Swift child is destroyed is a UAF, not just a leak. <i>(codex round 2)</i></span>
-        <span class="zh"><b>回调上下文悬垂指针（UAF）。</b>Swift 的 <code>CallbackBox</code> 持有裸 C++ 上下文指针（GhosttyElectronBridge.swift:75-82）并在 input/resize 时调用（:101-119）；C++ 在跳板函数中将其转回（ghostty_native_parent.cc:177-184）。若在 Swift 子终端销毁前释放 <code>BurnerContext</code>，就是 use-after-free，而不只是泄漏。<i>（codex 第二轮）</i></span>
-      </td>
-      <td>
-        <span class="en"><code>RemoveBurnerChild</code> destroys the Swift child first, then releases tsfns/context; mirror the primary's atomic <code>released</code> flag.</span>
-        <span class="zh"><code>RemoveBurnerChild</code> 先销毁 Swift 子终端，再释放 tsfn/上下文；沿用主 surface 的原子 <code>released</code> 标志。</span>
-      </td>
-    </tr>
-    <tr>
-      <td><span class="sev high">HIGH</span></td>
-      <td>
-        <span class="en"><b>Child frames in the wrong coordinate space.</b> <code>setFrame</code> y-flips renderer coordinates via <code>parentHeight</code> for the container (GhosttyElectronBridge.swift:261-275); the primary then fills <code>container.bounds</code> (:277). Child sub-rects must be computed in the container's <i>local</i> bounds — a second parent-height y-flip misplaces the burner. <i>(codex round 2)</i></span>
-        <span class="zh"><b>子 view 坐标系用错。</b><code>setFrame</code> 用 <code>parentHeight</code> 对渲染进程坐标做 y 翻转来定位容器（GhosttyElectronBridge.swift:261-275）；主终端随后填满 <code>container.bounds</code>（:277）。子矩形必须在容器的<i>局部</i> bounds 中计算 —— 再做一次 parentHeight y 翻转会把 burner 放错位置。<i>（codex 第二轮）</i></span>
-      </td>
-      <td>
-        <span class="en"><code>layoutChildren()</code> computes sub-rects purely from <code>container.bounds</code> — no <code>parentHeight</code> involvement.</span>
-        <span class="zh"><code>layoutChildren()</code> 只基于 <code>container.bounds</code> 计算子矩形 —— 不涉及 <code>parentHeight</code>。</span>
-      </td>
-    </tr>
-    <tr>
-      <td><span class="sev med">MED</span></td>
-      <td>
-        <span class="en"><b>Split-geometry divergence.</b> Two renderer-driven <code>update</code> paths plus the 120 ms resize quiet window (<code>NATIVE_RESIZE_TRACKING_QUIET_MS</code>) can briefly disagree, leaving a gap or overlap; overlapping sibling NSViews also break hit-testing (top view steals clicks).</span>
-        <span class="zh"><b>切分几何不一致。</b>两条渲染进程驱动的 <code>update</code> 路径叠加 120ms 缩放静默窗口（<code>NATIVE_RESIZE_TRACKING_QUIET_MS</code>）可能短暂不一致，产生缝隙或重叠；同级 NSView 重叠还会破坏点击测试（顶层 view 抢走点击）。</span>
-      </td>
-      <td>
-        <span class="en"><b>Let Swift own the split</b>: one bounds source (the existing per-pane <code>update</code>), <code>layoutChildren()</code> computes both integer-rounded sub-rects. This also satisfies the handoff's “nested divider must be native/AppKit” requirement.</span>
-        <span class="zh"><b>让 Swift 拥有切分权</b>：单一 bounds 来源（现有的按窗格 <code>update</code>），由 <code>layoutChildren()</code> 计算两个整数取整的子矩形。这同时满足 handoff 中“嵌套分隔线必须是原生/AppKit”的要求。</span>
-      </td>
-    </tr>
-    <tr>
-      <td><span class="sev med">MED</span></td>
-      <td>
-        <span class="en"><b>Pending-data race.</b> Main buffers PTY output in <code>pendingData</code> when no surface exists yet (ghostty-native-parent.ts:370-377); the burner needs the same buffering between its PTY spawn and <code>addBurnerChild</code> arrival, or early output is lost.</span>
-        <span class="zh"><b>待发数据竞态。</b>surface 尚未创建时主进程会把 PTY 输出缓存在 <code>pendingData</code>（ghostty-native-parent.ts:370-377）；burner 在其 PTY 启动与 <code>addBurnerChild</code> 到达之间同样需要该缓存，否则早期输出会丢失。</span>
-      </td>
-      <td>
-        <span class="en">Extend the pending-data tail per childId. <i>Codex round 2:</i> the renderer's <code>registerPending</code> buffer drains only when a mounted Body calls <code>onPaneReady</code> (usePtyBufferDrain.ts:60-78) — with the popup gone, the burner needs a new drain owner (see the output-subscriber risk below).</span>
-        <span class="zh">按 childId 扩展 pending-data 缓存。<i>codex 第二轮：</i>渲染进程的 <code>registerPending</code> 缓冲只有在挂载的 Body 调用 <code>onPaneReady</code> 时才会排空（usePtyBufferDrain.ts:60-78）—— 弹窗移除后，burner 需要新的排空持有者（见下方“输出无订阅者”风险）。</span>
-      </td>
-    </tr>
-    <tr>
-      <td><span class="sev low">LOW</span></td>
-      <td>
-        <span class="en"><b>tsfn lifecycle leak.</b> If <code>BurnerContext</code> holds its own threadsafe functions, the primary <code>SurfaceHandle</code>'s finalizer must also release them.</span>
-        <span class="zh"><b>tsfn 生命周期泄漏。</b>若 <code>BurnerContext</code> 持有独立 threadsafe function，主 <code>SurfaceHandle</code> 的 finalizer 必须一并释放它们。</span>
-      </td>
-      <td>
-        <span class="en">Drain burner tsfns in both <code>RemoveBurnerChild</code> and <code>ReleaseSurfaceCallbacks</code>/<code>FinalizeSurface</code>.</span>
-        <span class="zh">在 <code>RemoveBurnerChild</code> 与 <code>ReleaseSurfaceCallbacks</code>/<code>FinalizeSurface</code> 两处都清空 burner 的 tsfn。</span>
-      </td>
-    </tr>
-  </table>
+      <h2>
+        <span class="en">5 · Risks, ranked</span
+        ><span class="zh">5 · 风险（按严重度排序）</span>
+      </h2>
+      <table>
+        <tr>
+          <th></th>
+          <th><span class="en">Risk</span><span class="zh">风险</span></th>
+          <th>
+            <span class="en">Mitigation</span><span class="zh">缓解</span>
+          </th>
+        </tr>
+        <tr>
+          <td><span class="sev high">HIGH</span></td>
+          <td>
+            <span class="en"
+              ><b>PTY identity mis-routing.</b> The burner's
+              <code>onInput</code> must call <code>write_pty</code> with
+              <code>burnerPtyId</code>, never
+              <code>state.pane.sessionId</code> — otherwise burner keystrokes
+              are injected into the primary (agent) PTY. <i>Codex round 2:</i>
+              <code>resize_pty</code> shares the same identity path
+              (ghostty-native-parent.ts:518-525) — route <b>both</b> write and
+              resize through the burner context.</span
+            >
+            <span class="zh"
+              ><b>PTY 身份串线。</b>burner 的 <code>onInput</code> 必须以
+              <code>burnerPtyId</code> 调用 <code>write_pty</code>，绝不能用
+              <code>state.pane.sessionId</code> —— 否则 burner
+              击键会注入主（agent）PTY。<i>codex 第二轮：</i
+              ><code>resize_pty</code>
+              走同一身份路径（ghostty-native-parent.ts:518-525）—— write 与
+              resize <b>都</b>必须经由 burner 上下文路由。</span
+            >
+          </td>
+          <td>
+            <span class="en"
+              >Separate callback context (<code>BurnerContext</code>)
+              end-to-end; an integration test that types into the burner and
+              asserts the primary PTY saw nothing.</span
+            >
+            <span class="zh"
+              >全链路使用独立回调上下文（<code>BurnerContext</code>）；集成测试：向
+              burner 输入并断言主 PTY 未收到任何数据。</span
+            >
+          </td>
+        </tr>
+        <tr>
+          <td><span class="sev high">HIGH</span></td>
+          <td>
+            <span class="en"
+              ><b>Teardown ordering.</b> <code>GhosttyBody</code> unmount
+              cleanup calls destroy unconditionally (line 691). A burner destroy
+              with a missing/misrouted <code>childId</code> must map to
+              <code>removeBurnerChild</code>, never
+              <code>destroySurface</code> — or the still-live primary dies with
+              it.</span
+            >
+            <span class="zh"
+              ><b>销毁顺序。</b><code>GhosttyBody</code> 卸载清理会无条件调用
+              destroy（691 行）。burner 的 destroy 若
+              <code>childId</code> 缺失或误路由，必须落到
+              <code>removeBurnerChild</code>，绝不能是
+              <code>destroySurface</code> ——
+              否则仍存活的主终端会被连带销毁。</span
+            >
+          </td>
+          <td>
+            <span class="en"
+              >Main-process branch on <code>childId</code> with a default-deny:
+              absent childId on a surface that has a burner never tears down the
+              whole surface implicitly.</span
+            >
+            <span class="zh"
+              >主进程按 <code>childId</code> 分支并默认保守：对持有 burner 的
+              surface，缺省 childId 的请求绝不隐式整体销毁。</span
+            >
+          </td>
+        </tr>
+        <tr>
+          <td><span class="sev high">HIGH</span></td>
+          <td>
+            <span class="en"
+              ><b>Shortcut/focus gating.</b> The window-level
+              <code>shortcutMonitor</code> checks firstResponder against the
+              primary view only (Swift:441-453; digits guard :475-480). With the
+              burner focused, Cmd+digit pane-switching is silently swallowed and
+              key routing can drop events. <i>Codex round 2:</i> the context
+              menu is also primary-only (Swift:425-438), and Electron emits
+              rename with
+              <code>state.pane</code> (ghostty-native-parent.ts:574-577) —
+              rename/context callbacks must carry child identity.</span
+            >
+            <span class="zh"
+              ><b>快捷键/焦点判定。</b>窗口级 <code>shortcutMonitor</code> 仅将
+              firstResponder 与主 view 比对（Swift:441-453，数字守卫
+              :475-480）。当 burner 获得焦点时，Cmd+数字
+              切换窗格会被静默吞掉，按键路由也可能丢事件。<i>codex 第二轮：</i
+              >右键菜单同样只识别主 view（Swift:425-438），且 Electron 发出
+              rename 时使用
+              <code>state.pane</code>（ghostty-native-parent.ts:574-577）——
+              rename/右键回调必须携带子终端身份。</span
+            >
+          </td>
+          <td>
+            <span class="en"
+              >Extend every firstResponder check to “descendant of primary
+              <i>or</i> burner view”; same for the context-menu monitor (rename
+              would otherwise mis-attribute to the host pane).</span
+            >
+            <span class="zh"
+              >所有 firstResponder 判定扩展为“主 view <i>或</i> burner view
+              的后代”；右键菜单监视器同理（否则重命名会误归属到宿主窗格）。</span
+            >
+          </td>
+        </tr>
+        <tr>
+          <td><span class="sev high">HIGH</span></td>
+          <td>
+            <span class="en"
+              ><b>Burner output has no subscriber.</b> Native output forwarding
+              is owned by the mounted
+              <code>GhosttyBody</code> (GhosttyBody.tsx:637-657) — a role the
+              popup Body currently plays for the burner
+              (useBurnerTerminals.ts:537-574). Retiring the popup without a
+              replacement leaves burner PTY output going nowhere.
+              <i>(codex round 2)</i></span
+            >
+            <span class="zh"
+              ><b>burner 输出无订阅者。</b>原生输出转发由挂载的
+              <code>GhosttyBody</code> 持有（GhosttyBody.tsx:637-657）——
+              目前弹窗中的 Body 为 burner
+              扮演该角色（useBurnerTerminals.ts:537-574）。若移除弹窗而不加替代，burner
+              的 PTY 输出将无处可去。<i>（codex 第二轮）</i></span
+            >
+          </td>
+          <td>
+            <span class="en"
+              >Add a forwarder owned by <code>useBurnerTerminals</code> on
+              native attach — <code>service.onData(burnerPtyId)</code> →
+              <code>sendNativeGhosttyData(childId: 'burner')</code> — and drain
+              the <code>registerPending</code> buffer into it.</span
+            >
+            <span class="zh"
+              >在原生挂载时由 <code>useBurnerTerminals</code> 持有转发器 ——
+              <code>service.onData(burnerPtyId)</code> →
+              <code>sendNativeGhosttyData(childId: 'burner')</code> —— 并把
+              <code>registerPending</code> 缓冲排空到该通道。</span
+            >
+          </td>
+        </tr>
+        <tr>
+          <td><span class="sev high">HIGH</span></td>
+          <td>
+            <span class="en"
+              ><b>Hide must not become destructive.</b> Today
+              <code>hide()</code> keeps the popup Body mounted
+              (<code>display:none</code>), so the shell and scrollback survive.
+              In the library, surface state is freed on coordinator teardown
+              (TerminalSurfaceCoordinator.swift:311-323) — implementing native
+              hide as remove/destroy kills scrollback.
+              <i>(codex round 2)</i></span
+            >
+            <span class="zh"
+              ><b>hide 不能变成销毁。</b>目前 <code>hide()</code> 保持弹窗 Body
+              挂载（<code>display:none</code>），shell
+              与回滚缓冲得以存活。而库中 surface 状态会在 coordinator
+              销毁时释放（TerminalSurfaceCoordinator.swift:311-323）—— 若把原生
+              hide 实现为 remove/destroy，回滚缓冲会丢失。<i
+                >（codex 第二轮）</i
+              ></span
+            >
+          </td>
+          <td>
+            <span class="en"
+              >Implement hide as AppKit <code>isHidden</code> on the burner view
+              (view + session stay alive); reserve
+              <code>removeBurnerChild</code> for kill.</span
+            >
+            <span class="zh"
+              >hide 实现为对 burner view 设置 AppKit <code>isHidden</code>（view
+              与 session 均存活）；<code>removeBurnerChild</code> 仅用于
+              kill。</span
+            >
+          </td>
+        </tr>
+        <tr>
+          <td><span class="sev high">HIGH</span></td>
+          <td>
+            <span class="en"
+              ><b>Callback-context use-after-free.</b> Swift's
+              <code>CallbackBox</code> holds the raw C++ context pointer
+              (GhosttyElectronBridge.swift:75-82) and invokes it on input/resize
+              (:101-119); C++ casts it back in the trampolines
+              (ghostty_native_parent.cc:177-184). Freeing the
+              <code>BurnerContext</code> before the Swift child is destroyed is
+              a UAF, not just a leak. <i>(codex round 2)</i></span
+            >
+            <span class="zh"
+              ><b>回调上下文悬垂指针（UAF）。</b>Swift 的
+              <code>CallbackBox</code> 持有裸 C++
+              上下文指针（GhosttyElectronBridge.swift:75-82）并在 input/resize
+              时调用（:101-119）；C++
+              在跳板函数中将其转回（ghostty_native_parent.cc:177-184）。若在
+              Swift 子终端销毁前释放 <code>BurnerContext</code>，就是
+              use-after-free，而不只是泄漏。<i>（codex 第二轮）</i></span
+            >
+          </td>
+          <td>
+            <span class="en"
+              ><code>RemoveBurnerChild</code> destroys the Swift child first,
+              then releases tsfns/context; mirror the primary's atomic
+              <code>released</code> flag.</span
+            >
+            <span class="zh"
+              ><code>RemoveBurnerChild</code> 先销毁 Swift 子终端，再释放
+              tsfn/上下文；沿用主 surface 的原子
+              <code>released</code> 标志。</span
+            >
+          </td>
+        </tr>
+        <tr>
+          <td><span class="sev high">HIGH</span></td>
+          <td>
+            <span class="en"
+              ><b>Child frames in the wrong coordinate space.</b>
+              <code>setFrame</code> y-flips renderer coordinates via
+              <code>parentHeight</code> for the container
+              (GhosttyElectronBridge.swift:261-275); the primary then fills
+              <code>container.bounds</code> (:277). Child sub-rects must be
+              computed in the container's <i>local</i> bounds — a second
+              parent-height y-flip misplaces the burner.
+              <i>(codex round 2)</i></span
+            >
+            <span class="zh"
+              ><b>子 view 坐标系用错。</b><code>setFrame</code> 用
+              <code>parentHeight</code> 对渲染进程坐标做 y
+              翻转来定位容器（GhosttyElectronBridge.swift:261-275）；主终端随后填满
+              <code>container.bounds</code>（:277）。子矩形必须在容器的<i
+                >局部</i
+              >
+              bounds 中计算 —— 再做一次 parentHeight y 翻转会把 burner
+              放错位置。<i>（codex 第二轮）</i></span
+            >
+          </td>
+          <td>
+            <span class="en"
+              ><code>layoutChildren()</code> computes sub-rects purely from
+              <code>container.bounds</code> — no
+              <code>parentHeight</code> involvement.</span
+            >
+            <span class="zh"
+              ><code>layoutChildren()</code> 只基于
+              <code>container.bounds</code> 计算子矩形 —— 不涉及
+              <code>parentHeight</code>。</span
+            >
+          </td>
+        </tr>
+        <tr>
+          <td><span class="sev med">MED</span></td>
+          <td>
+            <span class="en"
+              ><b>Split-geometry divergence.</b> Two renderer-driven
+              <code>update</code> paths plus the 120 ms resize quiet window
+              (<code>NATIVE_RESIZE_TRACKING_QUIET_MS</code>) can briefly
+              disagree, leaving a gap or overlap; overlapping sibling NSViews
+              also break hit-testing (top view steals clicks).</span
+            >
+            <span class="zh"
+              ><b>切分几何不一致。</b>两条渲染进程驱动的
+              <code>update</code> 路径叠加 120ms
+              缩放静默窗口（<code>NATIVE_RESIZE_TRACKING_QUIET_MS</code>）可能短暂不一致，产生缝隙或重叠；同级
+              NSView 重叠还会破坏点击测试（顶层 view 抢走点击）。</span
+            >
+          </td>
+          <td>
+            <span class="en"
+              ><b>Let Swift own the split</b>: one bounds source (the existing
+              per-pane <code>update</code>),
+              <code>layoutChildren()</code> computes both integer-rounded
+              sub-rects. This also satisfies the handoff's “nested divider must
+              be native/AppKit” requirement.</span
+            >
+            <span class="zh"
+              ><b>让 Swift 拥有切分权</b>：单一 bounds 来源（现有的按窗格
+              <code>update</code>），由
+              <code>layoutChildren()</code> 计算两个整数取整的子矩形。这同时满足
+              handoff 中“嵌套分隔线必须是原生/AppKit”的要求。</span
+            >
+          </td>
+        </tr>
+        <tr>
+          <td><span class="sev med">MED</span></td>
+          <td>
+            <span class="en"
+              ><b>Pending-data race.</b> Main buffers PTY output in
+              <code>pendingData</code> when no surface exists yet
+              (ghostty-native-parent.ts:370-377); the burner needs the same
+              buffering between its PTY spawn and
+              <code>addBurnerChild</code> arrival, or early output is
+              lost.</span
+            >
+            <span class="zh"
+              ><b>待发数据竞态。</b>surface 尚未创建时主进程会把 PTY 输出缓存在
+              <code>pendingData</code
+              >（ghostty-native-parent.ts:370-377）；burner 在其 PTY 启动与
+              <code>addBurnerChild</code>
+              到达之间同样需要该缓存，否则早期输出会丢失。</span
+            >
+          </td>
+          <td>
+            <span class="en"
+              >Extend the pending-data tail per childId.
+              <i>Codex round 2:</i> the renderer's
+              <code>registerPending</code> buffer drains only when a mounted
+              Body calls <code>onPaneReady</code> (usePtyBufferDrain.ts:60-78) —
+              with the popup gone, the burner needs a new drain owner (see the
+              output-subscriber risk below).</span
+            >
+            <span class="zh"
+              >按 childId 扩展 pending-data 缓存。<i>codex 第二轮：</i
+              >渲染进程的 <code>registerPending</code> 缓冲只有在挂载的 Body
+              调用
+              <code>onPaneReady</code>
+              时才会排空（usePtyBufferDrain.ts:60-78）—— 弹窗移除后，burner
+              需要新的排空持有者（见下方“输出无订阅者”风险）。</span
+            >
+          </td>
+        </tr>
+        <tr>
+          <td><span class="sev low">LOW</span></td>
+          <td>
+            <span class="en"
+              ><b>tsfn lifecycle leak.</b> If <code>BurnerContext</code> holds
+              its own threadsafe functions, the primary
+              <code>SurfaceHandle</code>'s finalizer must also release
+              them.</span
+            >
+            <span class="zh"
+              ><b>tsfn 生命周期泄漏。</b>若 <code>BurnerContext</code> 持有独立
+              threadsafe function，主 <code>SurfaceHandle</code> 的 finalizer
+              必须一并释放它们。</span
+            >
+          </td>
+          <td>
+            <span class="en"
+              >Drain burner tsfns in both <code>RemoveBurnerChild</code> and
+              <code>ReleaseSurfaceCallbacks</code
+              >/<code>FinalizeSurface</code>.</span
+            >
+            <span class="zh"
+              >在 <code>RemoveBurnerChild</code> 与
+              <code>ReleaseSurfaceCallbacks</code>/<code>FinalizeSurface</code>
+              两处都清空 burner 的 tsfn。</span
+            >
+          </td>
+        </tr>
+      </table>
 
-  <h2><span class="en">6 · Recommendation &amp; spike order</span><span class="zh">6 · 建议与 spike 顺序</span></h2>
-  <p>
-    <span class="en"><b>Proceed with HANDOFF Option B</b> — two <code>TerminalView</code>s inside one <code>EmbeddedGhosttySurface</code>, AppKit-owned two-child layout, max one burner, right split by default, bottom for narrow panes. Option A is not a maybe, and recompiling cannot revive it: the layout engine was never in the library (see the §1 addendum). The only path to “Ghostty-owned splits” is vendoring Ghostty.app's Swift shell (<code>SplitTree.swift</code> and its surface/controller machinery) — thousands of app-coupled lines, tracked against a fast-moving app repo, to obtain a recursive layout engine the spike constraints explicitly forbid.</span>
-    <span class="zh"><b>按 HANDOFF 方案 B 推进</b> —— 单个 <code>EmbeddedGhosttySurface</code> 内两个 <code>TerminalView</code>，由 AppKit 管理双子布局，最多一个 burner，默认右分屏，窄窗格用下分屏。方案 A 不是“或许可行”，重新编译也无法复活它：布局引擎从未存在于库中（见 §1 补充）。要获得“Ghostty 自有分屏”，唯一途径是把 Ghostty.app 的 Swift 外壳（<code>SplitTree.swift</code> 及其 surface/controller 机制）整体搬入 —— 数千行与 App 深度耦合的代码、还需持续跟进快速迭代的上游应用仓库，换来的却是 spike 约束明确禁止的递归布局引擎。</span>
-  </p>
-  <ol class="plan">
-    <li>
-      <span class="en"><b>Swift-only spike first</b>: extend <code>GhosttyNativeMacosSmoke</code> (today it proves exactly one <code>TerminalView</code> — GhosttyNativeMacosSmoke.swift:121-135) to exercise <b>add/remove of a second view with its own controller</b>, plus hide-vs-remove semantics — proves rendering, focus, input isolation, and scrollback survival before touching any IPC. <i>(order refined by codex round 2)</i></span>
-      <span class="zh"><b>先做纯 Swift spike</b>：扩展 <code>GhosttyNativeMacosSmoke</code>（目前只验证一个 <code>TerminalView</code> —— GhosttyNativeMacosSmoke.swift:121-135），实测<b>第二个 view（独立 controller）的添加/移除</b>及 hide 与 remove 的语义差异 —— 在不动任何 IPC 的前提下验证渲染、焦点、输入隔离与回滚缓冲存活。<i>（顺序经 codex 第二轮修订）</i></span>
-    </li>
-    <li>
-      <span class="en"><b>C++ N-API next, with its smoke</b>: new symbols/contexts/finalizers in <code>ghostty_native_parent.cc</code>, updating <code>scripts/smoke-ghostty-native-parent.js</code> (it currently checks only create/setFrame/write/focus/destroy) <b>before</b> any Electron work. The build/codesign pipeline already exists (<code>scripts/build-ghostty-native-parent.js</code>).</span>
-      <span class="zh"><b>随后是 C++ N-API 及其冒烟测试</b>：在 <code>ghostty_native_parent.cc</code> 中新增符号/上下文/finalizer，并更新 <code>scripts/smoke-ghostty-native-parent.js</code>（目前只检查 create/setFrame/write/focus/destroy），<b>先于</b>任何 Electron 侧改动。构建/签名管线已就绪（<code>scripts/build-ghostty-native-parent.js</code>）。</span>
-    </li>
-    <li>
-      <span class="en">Then Electron main (childId routing, burner output forwarding, pending-buffer tests) → preload/native client → React hook swap — keeping the <code>useBurnerTerminals</code> PTY lifecycle untouched and replacing only the presentation layer. No Rust bindings regen unless Rust command/types change.</span>
-      <span class="zh">再推进 Electron 主进程（childId 路由、burner 输出转发、待发缓冲测试）→ preload/渲染端 client → React hook 替换 —— 完整保留 <code>useBurnerTerminals</code> 的 PTY 生命周期，仅替换呈现层。除非 Rust 命令/类型变更，无需重新生成 Rust bindings。</span>
-    </li>
-    <li>
-      <span class="en">Open questions from the handoff that are now <i>design</i> (not feasibility) questions: focus-on-open policy, close-vs-hide semantics, and user-toggleable placement.</span>
-      <span class="zh">handoff 中剩余的开放问题现在均属<i>设计</i>问题而非可行性问题：打开时是否夺焦、close 与 hide 的语义、以及 placement 是否允许用户切换。</span>
-    </li>
-  </ol>
+      <h2>
+        <span class="en">6 · Recommendation &amp; spike order</span
+        ><span class="zh">6 · 建议与 spike 顺序</span>
+      </h2>
+      <p>
+        <span class="en"
+          ><b>Proceed with HANDOFF Option B</b> — two <code>TerminalView</code>s
+          inside one <code>EmbeddedGhosttySurface</code>, AppKit-owned two-child
+          layout, max one burner, right split by default, bottom for narrow
+          panes. Option A is not a maybe, and recompiling cannot revive it: the
+          layout engine was never in the library (see the §1 addendum). The only
+          path to “Ghostty-owned splits” is vendoring Ghostty.app's Swift shell
+          (<code>SplitTree.swift</code> and its surface/controller machinery) —
+          thousands of app-coupled lines, tracked against a fast-moving app
+          repo, to obtain a recursive layout engine the spike constraints
+          explicitly forbid.</span
+        >
+        <span class="zh"
+          ><b>按 HANDOFF 方案 B 推进</b> —— 单个
+          <code>EmbeddedGhosttySurface</code> 内两个
+          <code>TerminalView</code>，由 AppKit 管理双子布局，最多一个
+          burner，默认右分屏，窄窗格用下分屏。方案 A
+          不是“或许可行”，重新编译也无法复活它：布局引擎从未存在于库中（见 §1
+          补充）。要获得“Ghostty 自有分屏”，唯一途径是把 Ghostty.app 的 Swift
+          外壳（<code>SplitTree.swift</code> 及其 surface/controller
+          机制）整体搬入 —— 数千行与 App
+          深度耦合的代码、还需持续跟进快速迭代的上游应用仓库，换来的却是 spike
+          约束明确禁止的递归布局引擎。</span
+        >
+      </p>
+      <ol class="plan">
+        <li>
+          <span class="en"
+            ><b>Swift-only spike first</b>: extend
+            <code>GhosttyNativeMacosSmoke</code> (today it proves exactly one
+            <code>TerminalView</code> — GhosttyNativeMacosSmoke.swift:121-135)
+            to exercise
+            <b>add/remove of a second view with its own controller</b>, plus
+            hide-vs-remove semantics — proves rendering, focus, input isolation,
+            and scrollback survival before touching any IPC.
+            <i>(order refined by codex round 2)</i></span
+          >
+          <span class="zh"
+            ><b>先做纯 Swift spike</b>：扩展
+            <code>GhosttyNativeMacosSmoke</code>（目前只验证一个
+            <code>TerminalView</code> ——
+            GhosttyNativeMacosSmoke.swift:121-135），实测<b
+              >第二个 view（独立 controller）的添加/移除</b
+            >及 hide 与 remove 的语义差异 —— 在不动任何 IPC
+            的前提下验证渲染、焦点、输入隔离与回滚缓冲存活。<i
+              >（顺序经 codex 第二轮修订）</i
+            ></span
+          >
+        </li>
+        <li>
+          <span class="en"
+            ><b>C++ N-API next, with its smoke</b>: new
+            symbols/contexts/finalizers in
+            <code>ghostty_native_parent.cc</code>, updating
+            <code>scripts/smoke-ghostty-native-parent.js</code> (it currently
+            checks only create/setFrame/write/focus/destroy) <b>before</b> any
+            Electron work. The build/codesign pipeline already exists
+            (<code>scripts/build-ghostty-native-parent.js</code>).</span
+          >
+          <span class="zh"
+            ><b>随后是 C++ N-API 及其冒烟测试</b>：在
+            <code>ghostty_native_parent.cc</code>
+            中新增符号/上下文/finalizer，并更新
+            <code>scripts/smoke-ghostty-native-parent.js</code>（目前只检查
+            create/setFrame/write/focus/destroy），<b>先于</b>任何 Electron
+            侧改动。构建/签名管线已就绪（<code>scripts/build-ghostty-native-parent.js</code>）。</span
+          >
+        </li>
+        <li>
+          <span class="en"
+            >Then Electron main (childId routing, burner output forwarding,
+            pending-buffer tests) → preload/native client → React hook swap —
+            keeping the <code>useBurnerTerminals</code> PTY lifecycle untouched
+            and replacing only the presentation layer. No Rust bindings regen
+            unless Rust command/types change.</span
+          >
+          <span class="zh"
+            >再推进 Electron 主进程（childId 路由、burner
+            输出转发、待发缓冲测试）→ preload/渲染端 client → React hook 替换 ——
+            完整保留 <code>useBurnerTerminals</code> 的 PTY
+            生命周期，仅替换呈现层。除非 Rust 命令/类型变更，无需重新生成 Rust
+            bindings。</span
+          >
+        </li>
+        <li>
+          <span class="en"
+            >Open questions from the handoff that are now <i>design</i> (not
+            feasibility) questions: focus-on-open policy, close-vs-hide
+            semantics, and user-toggleable placement.</span
+          >
+          <span class="zh"
+            >handoff
+            中剩余的开放问题现在均属<i>设计</i>问题而非可行性问题：打开时是否夺焦、close
+            与 hide 的语义、以及 placement 是否允许用户切换。</span
+          >
+        </li>
+      </ol>
 
-  <footer>
-    <span class="en">
-      Evidence base: libghostty-spm 1.2.7 source at rev <code>2b0e1b9d</code> (materialized from the SwiftPM repo cache);
-      upstream ghostty v1.2.3 <code>include/ghostty.h</code> + <code>src/apprt/embedded.zig</code> (recompile addendum);
-      vimeflow worktree <code>ghostty-burner-pane-spike</code> files — <code>GhosttyElectronBridge.swift</code>, <code>ghostty_native_parent.cc</code>, <code>ghostty-native-parent.ts</code>, <code>nativeGhosttyClient.ts</code>, <code>GhosttyBody.tsx</code>, <code>useBurnerTerminals.ts</code>, <code>BurnerTerminalPopup/index.tsx</code>.
-      Produced by a 4-agent exploration workflow (3 source readers + 1 codex verifier), 2026-07-03. Companion to <code>HANDOFF.md</code> in this directory.
-    </span>
-    <span class="zh">
-      证据基础：libghostty-spm 1.2.7 源码（rev <code>2b0e1b9d</code>，自 SwiftPM 仓库缓存物化）；
-      上游 ghostty v1.2.3 <code>include/ghostty.h</code> + <code>src/apprt/embedded.zig</code>（重编译补充论证）；
-      vimeflow worktree <code>ghostty-burner-pane-spike</code> 中的 <code>GhosttyElectronBridge.swift</code>、<code>ghostty_native_parent.cc</code>、<code>ghostty-native-parent.ts</code>、<code>nativeGhosttyClient.ts</code>、<code>GhosttyBody.tsx</code>、<code>useBurnerTerminals.ts</code>、<code>BurnerTerminalPopup/index.tsx</code>。
-      由 4-agent 探索工作流（3 个源码阅读 agent + 1 个 codex 复核 agent）产出，2026-07-03。与本目录 <code>HANDOFF.md</code> 配套阅读。
-    </span>
-  </footer>
-</main>
-<script>
-  const buttons = document.querySelectorAll('.langbar button')
-  buttons.forEach((btn) => {
-    btn.addEventListener('click', () => {
-      document.body.dataset.lang = btn.dataset.set
-      buttons.forEach((b) => b.classList.toggle('active', b === btn))
-    })
-  })
-</script>
-</body>
+      <footer>
+        <span class="en">
+          Evidence base: libghostty-spm 1.2.7 source at rev
+          <code>2b0e1b9d</code> (materialized from the SwiftPM repo cache);
+          upstream ghostty v1.2.3 <code>include/ghostty.h</code> +
+          <code>src/apprt/embedded.zig</code> (recompile addendum); vimeflow
+          worktree <code>ghostty-burner-pane-spike</code> files —
+          <code>GhosttyElectronBridge.swift</code>,
+          <code>ghostty_native_parent.cc</code>,
+          <code>ghostty-native-parent.ts</code>,
+          <code>nativeGhosttyClient.ts</code>, <code>GhosttyBody.tsx</code>,
+          <code>useBurnerTerminals.ts</code>,
+          <code>BurnerTerminalPopup/index.tsx</code>. Produced by a 4-agent
+          exploration workflow (3 source readers + 1 codex verifier),
+          2026-07-03. Companion to <code>HANDOFF.md</code> in this directory.
+        </span>
+        <span class="zh">
+          证据基础：libghostty-spm 1.2.7 源码（rev <code>2b0e1b9d</code>，自
+          SwiftPM 仓库缓存物化）； 上游 ghostty v1.2.3
+          <code>include/ghostty.h</code> +
+          <code>src/apprt/embedded.zig</code>（重编译补充论证）； vimeflow
+          worktree <code>ghostty-burner-pane-spike</code> 中的
+          <code>GhosttyElectronBridge.swift</code
+          >、<code>ghostty_native_parent.cc</code>、<code>ghostty-native-parent.ts</code>、<code>nativeGhosttyClient.ts</code>、<code>GhosttyBody.tsx</code>、<code>useBurnerTerminals.ts</code>、<code>BurnerTerminalPopup/index.tsx</code>。
+          由 4-agent 探索工作流（3 个源码阅读 agent + 1 个 codex 复核
+          agent）产出，2026-07-03。与本目录 <code>HANDOFF.md</code> 配套阅读。
+        </span>
+      </footer>
+    </main>
+    <script>
+      const buttons = document.querySelectorAll('.langbar button')
+      buttons.forEach((btn) => {
+        btn.addEventListener('click', () => {
+          document.body.dataset.lang = btn.dataset.set
+          buttons.forEach((b) => b.classList.toggle('active', b === btn))
+        })
+      })
+    </script>
+  </body>
 </html>

--- a/docs/exploration/2026-07-04-ghostty-burner-side-pane/ghostty-split-api-technical-note.html
+++ b/docs/exploration/2026-07-04-ghostty-burner-side-pane/ghostty-split-api-technical-note.html
@@ -1,0 +1,554 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Ghostty Split API Exploration — Burner Nested Pane | Ghostty 分屏 API 探索 —— Burner 嵌套窗格</title>
+<style>
+  :root {
+    --base: #1e1e2e;
+    --mantle: #181825;
+    --crust: #11111b;
+    --surface0: #313244;
+    --surface1: #45475a;
+    --text: #cdd6f4;
+    --subtext: #a6adc8;
+    --overlay: #6c7086;
+    --green: #a6e3a1;
+    --red: #f38ba8;
+    --yellow: #f9e2af;
+    --peach: #fab387;
+    --blue: #89b4fa;
+    --mauve: #cba6f7;
+    --teal: #94e2d5;
+    --mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--base);
+    color: var(--text);
+    font: 15px/1.65 Inter, -apple-system, 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', sans-serif;
+    padding: 0 0 80px;
+  }
+  main { max-width: 980px; margin: 0 auto; padding: 0 28px; }
+  h1, h2, h3 { font-family: Manrope, Inter, -apple-system, 'PingFang SC', sans-serif; line-height: 1.3; }
+  h1 { font-size: 26px; margin: 8px 0 4px; }
+  h2 { font-size: 20px; margin: 44px 0 12px; color: var(--mauve); }
+  h3 { font-size: 16px; margin: 26px 0 8px; color: var(--blue); }
+  p { margin: 10px 0; }
+  code, .mono { font-family: var(--mono); font-size: 0.86em; }
+  code { background: var(--surface0); padding: 1px 6px; border-radius: 5px; color: var(--teal); white-space: nowrap; }
+  pre {
+    background: var(--crust); border-radius: 10px; padding: 14px 18px;
+    overflow-x: auto; font-family: var(--mono); font-size: 12.5px; line-height: 1.6;
+    color: var(--subtext);
+  }
+  pre code { background: none; padding: 0; color: inherit; white-space: pre; }
+  a { color: var(--blue); }
+
+  /* language toggle */
+  .langbar {
+    position: sticky; top: 0; z-index: 10;
+    background: color-mix(in srgb, var(--mantle) 88%, transparent);
+    backdrop-filter: blur(10px);
+    padding: 10px 28px; display: flex; gap: 8px; align-items: center;
+    justify-content: flex-end; margin-bottom: 28px;
+  }
+  .langbar span.hint { margin-right: auto; color: var(--overlay); font-size: 12px; }
+  .langbar button {
+    background: var(--surface0); color: var(--subtext); border: 0; border-radius: 8px;
+    padding: 5px 14px; font: 13px Inter, 'PingFang SC', sans-serif; cursor: pointer;
+  }
+  .langbar button.active { background: var(--mauve); color: var(--crust); font-weight: 600; }
+  body[data-lang="en"] .zh { display: none; }
+  body[data-lang="zh"] .en { display: none; }
+  body[data-lang="both"] .zh { color: var(--subtext); }
+  body[data-lang="both"] td .zh, body[data-lang="both"] li .zh { display: block; margin-top: 2px; }
+
+  .meta { color: var(--overlay); font-size: 13px; margin-bottom: 22px; }
+  .meta code { color: var(--subtext); }
+
+  .verdict {
+    display: grid; grid-template-columns: 1fr 1fr; gap: 14px; margin: 24px 0;
+  }
+  .verdict .card {
+    border-radius: 12px; padding: 16px 18px; background: var(--mantle);
+  }
+  .verdict .card.no { box-shadow: inset 3px 0 0 var(--red); }
+  .verdict .card.yes { box-shadow: inset 3px 0 0 var(--green); }
+  .verdict .card b.line { display: block; font-size: 15px; margin-bottom: 6px; }
+  .verdict .no b.line { color: var(--red); }
+  .verdict .yes b.line { color: var(--green); }
+  .verdict .card p { font-size: 13.5px; color: var(--subtext); margin: 4px 0 0; }
+
+  .badge {
+    display: inline-block; border-radius: 20px; padding: 2px 12px; font-size: 12px;
+    font-weight: 600; vertical-align: 2px; margin-left: 8px;
+  }
+  .badge.ok { background: color-mix(in srgb, var(--green) 18%, transparent); color: var(--green); }
+  .badge.warn { background: color-mix(in srgb, var(--yellow) 18%, transparent); color: var(--yellow); }
+
+  table { border-collapse: collapse; width: 100%; margin: 14px 0; font-size: 13.5px; }
+  th { text-align: left; color: var(--peach); font-weight: 600; padding: 8px 12px; background: var(--mantle); }
+  td { padding: 9px 12px; vertical-align: top; border-top: 1px solid var(--surface0); color: var(--subtext); }
+  td:first-child, th:first-child { border-radius: 0; }
+  tr td b { color: var(--text); }
+  td code { white-space: normal; word-break: break-all; }
+
+  .callout {
+    border-radius: 10px; background: var(--mantle); padding: 14px 18px; margin: 16px 0;
+    font-size: 14px;
+  }
+  .callout.good { box-shadow: inset 3px 0 0 var(--green); }
+  .callout.warn { box-shadow: inset 3px 0 0 var(--yellow); }
+  .callout.info { box-shadow: inset 3px 0 0 var(--blue); }
+  .callout b:first-child { display: block; margin-bottom: 4px; }
+
+  .sev { font-family: var(--mono); font-size: 11px; font-weight: 700; border-radius: 6px; padding: 1px 8px; white-space: nowrap; }
+  .sev.high { background: color-mix(in srgb, var(--red) 20%, transparent); color: var(--red); }
+  .sev.med { background: color-mix(in srgb, var(--yellow) 20%, transparent); color: var(--yellow); }
+  .sev.low { background: color-mix(in srgb, var(--blue) 20%, transparent); color: var(--blue); }
+
+  ol.plan { padding-left: 20px; }
+  ol.plan > li { margin: 10px 0; color: var(--subtext); }
+  ol.plan > li b { color: var(--text); }
+  ol.plan code { font-size: 0.82em; }
+
+  footer { margin-top: 56px; color: var(--overlay); font-size: 12.5px; border-top: 1px solid var(--surface0); padding-top: 16px; }
+</style>
+</head>
+<body data-lang="both">
+<div class="langbar">
+  <span class="hint mono">docs/exploration/2026-07-04-ghostty-burner-side-pane</span>
+  <button data-set="en">EN</button>
+  <button data-set="zh">中文</button>
+  <button data-set="both" class="active">EN + 中文</button>
+</div>
+<main>
+  <h1>
+    <span class="en">Ghostty Split API Exploration — Burner as a Nested Native Pane</span>
+    <span class="zh">Ghostty 分屏 API 探索 —— Burner 作为嵌套原生窗格</span>
+  </h1>
+  <p class="meta">
+    2026-07-03 ·
+    <span class="en">Package under test:</span><span class="zh">被检包：</span>
+    <code>Lakr233/libghostty-spm 1.2.7</code> (rev <code>2b0e1b9d</code>,
+    <span class="en">pinned by</span><span class="zh">锁定于</span> <code>native/ghostty-helper/Package.resolved</code>) ·
+    <span class="en">Method: 3 parallel source-reading agents + independent <code>codex exec</code> re-verification</span>
+    <span class="zh">方法：3 个并行源码阅读 agent + 独立 <code>codex exec</code> 复核</span>
+  </p>
+
+  <div class="verdict">
+    <div class="card no">
+      <b class="line">
+        <span class="en">✗ Option A is dead: no host-controllable split API</span>
+        <span class="zh">✗ 方案 A 不可行：不存在宿主可控的分屏 API</span>
+      </b>
+      <p>
+        <span class="en">libghostty-spm is strictly a single-surface, single-view embedding API. Ghostty's real split logic (SplitTree, surface tree, tabs) lives in the app shell that this package explicitly strips out (<code>-Dapp-runtime=none</code>).</span>
+        <span class="zh">libghostty-spm 严格上只是单 surface、单 view 的嵌入 API。Ghostty 真正的分屏逻辑（SplitTree、surface 树、标签页）位于其 App 外壳层，而该包在构建时显式剥离了这一层（<code>-Dapp-runtime=none</code>）。</span>
+      </p>
+    </div>
+    <div class="card yes">
+      <b class="line">
+        <span class="en">✓ Option B is viable: two TerminalViews, host-owned layout</span>
+        <span class="zh">✓ 方案 B 可行：两个 TerminalView，布局由宿主管理</span>
+      </b>
+      <p>
+        <span class="en">Two independent <code>TerminalView</code> + <code>InMemoryTerminalSession</code> pairs can safely coexist inside one <code>EmbeddedGhosttySurface</code> NSView — provided each gets its <b>own <code>TerminalController</code></b>. Confirmed by codex.</span>
+        <span class="zh">两个相互独立的 <code>TerminalView</code> + <code>InMemoryTerminalSession</code> 可以安全共存于同一个 <code>EmbeddedGhosttySurface</code> NSView 内 —— 前提是每个 view 拥有<b>各自独立的 <code>TerminalController</code></b>。已由 codex 复核确认。</span>
+      </p>
+    </div>
+  </div>
+
+  <h2><span class="en">1 · Question 1 — Does the package expose a split-pane API?</span><span class="zh">1 · 问题一 —— 该包是否暴露分屏 API？</span></h2>
+  <p>
+    <span class="en">Verdict: <b>no — single-surface only</b>. The only split-related public symbol in the entire package is <code>TerminalSurfaceContext.split</code>, and it is not a layout API:</span>
+    <span class="zh">结论：<b>否 —— 仅支持单 surface</b>。整个包中唯一与 split 相关的公开符号是 <code>TerminalSurfaceContext.split</code>，且它并不是布局 API：</span>
+  </p>
+  <table>
+    <tr>
+      <th><span class="en">Symbol</span><span class="zh">符号</span></th>
+      <th><span class="en">File</span><span class="zh">文件</span></th>
+      <th><span class="en">Finding</span><span class="zh">结论</span></th>
+    </tr>
+    <tr>
+      <td><b><code>TerminalSurfaceContext.split</code></b></td>
+      <td><code>Surface/TerminalSurfaceContext.swift:8</code></td>
+      <td>
+        <span class="en">Maps to <code>GHOSTTY_SURFACE_CONTEXT_SPLIT</code> — a <b>creation-time hint</b> to the C engine about how the surface was spawned (affects key-binding routing). It does <b>not</b> make Ghostty own a split layout; the host still creates one surface per view and controls all geometry.</span>
+        <span class="zh">映射到 <code>GHOSTTY_SURFACE_CONTEXT_SPLIT</code> —— 仅是创建时传给 C 引擎的<b>提示</b>，说明该 surface 的来源（影响按键绑定路由）。它<b>不会</b>让 Ghostty 接管分屏布局；宿主仍然是每个 view 创建一个 surface，并掌控全部几何布局。</span>
+      </td>
+    </tr>
+    <tr>
+      <td><b><code>TerminalView</code> / <code>AppTerminalView</code></b></td>
+      <td><code>Platform/AppKit/AppTerminalView.swift</code></td>
+      <td>
+        <span class="en">NSView subclass, one <code>CAMetalLayer</code> per instance, surface bound 1:1 to the NSView. No split, pane, or layout API.</span>
+        <span class="zh">NSView 子类，每实例一个 <code>CAMetalLayer</code>，surface 与 NSView 一一绑定。没有任何 split／pane／布局 API。</span>
+      </td>
+    </tr>
+    <tr>
+      <td><b><code>TerminalController</code></b></td>
+      <td><code>Controller/TerminalController.swift</code></td>
+      <td>
+        <span class="en">Owns <code>ghostty_app_t</code>, config, theme, surface creation. No split API. Has a <code>.shared</code> singleton (line 46) <i>and</i> a public designated init.</span>
+        <span class="zh">持有 <code>ghostty_app_t</code>、配置、主题和 surface 创建。没有分屏 API。既提供 <code>.shared</code> 单例（第 46 行），<i>也</i>提供公开的指定构造器。</span>
+      </td>
+    </tr>
+    <tr>
+      <td><b><code>TerminalSurface</code></b> / <b><code>InMemoryTerminalSession</code></b></td>
+      <td><code>Surface/TerminalSurface.swift</code>, <code>InMemory/…</code></td>
+      <td>
+        <span class="en">One surface = one terminal grid; one session per surface, holding a single <code>ghostty_surface_t</code>. No sub-surface / child-surface / multiplexing API.</span>
+        <span class="zh">一个 surface = 一个终端网格；每个 surface 一个 session，仅持有一个 <code>ghostty_surface_t</code>。没有子 surface 或多路复用 API。</span>
+      </td>
+    </tr>
+  </table>
+  <div class="callout info">
+    <b><span class="en">Why the split machinery is absent — and why recompiling can't restore it</span><span class="zh">为什么分屏机制不存在 —— 以及为什么重新编译也无法恢复</span></b>
+    <span class="en">Upstream Ghostty implements splits (SplitTree, SurfaceView arrangement, dividers, focus traversal) in its macOS <i>application</i> layer — Swift source under <code>macos/</code> in the ghostty repo. That code is not behind <code>-Dapp-runtime</code>; it is not part of the Zig library at any flag setting. What <code>-Dapp-runtime=none</code> strips is the action-callback plumbing and the platform app shells — <b>the layout engine was never in the library on any platform</b>. (<code>-Dapp-runtime=gtk</code> builds a Linux GTK <i>application</i> with its own splits — not an embeddable library.)</span>
+    <span class="zh">上游 Ghostty 的分屏（SplitTree、SurfaceView 排布、分隔线、焦点遍历）实现在其 macOS <i>应用程序</i>层 —— 即 ghostty 仓库 <code>macos/</code> 目录下的 Swift 源码。这些代码不受 <code>-Dapp-runtime</code> 控制；无论编译开关如何设置，它都不属于 Zig 库。<code>-Dapp-runtime=none</code> 剔除的只是 action 回调管线和各平台 App 外壳 —— <b>布局引擎在任何平台上都从未存在于库中</b>。（<code>-Dapp-runtime=gtk</code> 编出来的是带自身分屏实现的 Linux GTK <i>应用程序</i>，并非可嵌入的库。）</span>
+  </div>
+
+  <h3><span class="en">Addendum (2026-07-03) — even the full C API only <i>requests</i> splits from the host</span><span class="zh">补充（2026-07-03）—— 即使完整 C API 也只是向宿主<i>请求</i>分屏</span></h3>
+  <p>
+    <span class="en">Verified against upstream Ghostty v1.2.3 (the untrimmed embedded API that real Ghostty.app itself links). Everything split-related in <code>include/ghostty.h</code> is an <i>action</i>: the enums <code>GHOSTTY_ACTION_NEW_SPLIT</code> / <code>GOTO_SPLIT</code> / <code>RESIZE_SPLIT</code> / <code>EQUALIZE_SPLITS</code> / <code>TOGGLE_SPLIT_ZOOM</code>, plus four functions such as <code>ghostty_surface_split()</code>. In the core, that function is pure request plumbing:</span>
+    <span class="zh">已对照上游 Ghostty v1.2.3（真正的 Ghostty.app 所链接的未裁剪嵌入 API）验证。<code>include/ghostty.h</code> 中所有与分屏相关的内容都是<i>动作（action）</i>：枚举 <code>GHOSTTY_ACTION_NEW_SPLIT</code> / <code>GOTO_SPLIT</code> / <code>RESIZE_SPLIT</code> / <code>EQUALIZE_SPLITS</code> / <code>TOGGLE_SPLIT_ZOOM</code>，以及 <code>ghostty_surface_split()</code> 等四个函数。在核心实现中，该函数纯粹是请求转发：</span>
+  </p>
+  <pre><code>// upstream src/apprt/embedded.zig:1843 (v1.2.3)
+export fn ghostty_surface_split(ptr: *Surface, direction: apprt.action.SplitDirection) void {
+    _ = ptr.app.performAction(.{ .surface = &amp;ptr.core_surface }, .new_split, direction) catch ...
+}
+// fires the .new_split action BACK OUT to the host's action callback.
+// The core never lays out two surfaces: one surface = one view = one Metal layer.</code></pre>
+  <div class="callout good">
+    <b><span class="en">Option B is not a workaround — it <i>is</i> the Ghostty architecture</span><span class="zh">方案 B 不是权宜之计 —— 它<i>就是</i> Ghostty 的架构</span></b>
+    <span class="en">Real Ghostty.app is itself a host that arranges multiple single-surface views and answers <code>.new_split</code> requests (in <code>SplitTree.swift</code>). Two <code>TerminalView</code>s under an AppKit-owned divider put vimeflow in exactly the role Ghostty.app plays — with the split tree deliberately capped at two children.</span>
+    <span class="zh">真正的 Ghostty.app 本身就是一个“排布多个单 surface view、并响应 <code>.new_split</code> 请求”的宿主（实现在 <code>SplitTree.swift</code>）。在 AppKit 分隔线下承载两个 <code>TerminalView</code>，vimeflow 扮演的正是 Ghostty.app 的角色 —— 只是把分屏树刻意封顶为两个子节点。</span>
+  </div>
+
+  <h2><span class="en">2 · Question 2 — Can two TerminalViews coexist in one surface host?</span><span class="zh">2 · 问题二 —— 两个 TerminalView 能否共存于同一宿主？</span></h2>
+  <p>
+    <span class="en">Yes, with one blocking constraint and two non-issues:</span>
+    <span class="zh">可以，但有一个硬性约束，另外两点无碍：</span>
+  </p>
+  <table>
+    <tr>
+      <th><span class="en">Constraint</span><span class="zh">约束</span></th>
+      <th><span class="en">Evidence</span><span class="zh">证据</span></th>
+      <th><span class="en">Impact</span><span class="zh">影响</span></th>
+    </tr>
+    <tr>
+      <td>
+        <b><span class="en">One <code>TerminalController</code> per view</span><span class="zh">每个 view 必须有独立 <code>TerminalController</code></span></b>
+        <span class="sev high">BLOCKING</span>
+      </td>
+      <td>
+        <code>TerminalController.swift:59-60</code>, <code>TerminalSurfaceCoordinator.swift:138</code>
+      </td>
+      <td>
+        <span class="en"><code>onWakeup</code> / <code>shouldProcessWakeup</code> are <b>single-slot closures</b>; each coordinator's <code>rebuildIfReady()</code> unconditionally overwrites them. Two views sharing one controller ⇒ only the last-attached view gets render ticks — the other goes dark.</span>
+        <span class="zh"><code>onWakeup</code> / <code>shouldProcessWakeup</code> 是<b>单槽位闭包</b>；每个 coordinator 的 <code>rebuildIfReady()</code> 会无条件覆盖它们。两个 view 共享一个 controller ⇒ 只有最后挂载的 view 能收到渲染 tick —— 另一个会“黑掉”。</span>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <b><span class="en">Avoid <code>TerminalController.shared</code></span><span class="zh">不要使用 <code>TerminalController.shared</code></span></b>
+        <span class="sev med">HAZARD</span>
+      </td>
+      <td><code>TerminalController.swift:46</code></td>
+      <td>
+        <span class="en">Convenience singleton; naive use triggers the constraint above. The designated init is public — just construct fresh instances.</span>
+        <span class="zh">便利单例；随手使用即触发上面的约束。指定构造器是公开的 —— 直接为每个 view 新建实例即可。</span>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <b><span class="en">Process-global init &amp; rendering</span><span class="zh">进程级初始化与渲染</span></b>
+        <span class="sev low">SAFE</span>
+      </td>
+      <td><code>TerminalController.swift:300</code>, <code>AppTerminalView.swift:13</code></td>
+      <td>
+        <span class="en"><code>ghostty_init</code> is guarded one-shot (idempotent). Each controller creates its own <code>ghostty_app_t</code>; callbacks route via per-app/per-surface userdata, so nothing cross-routes. Each view owns its own <code>CAMetalLayer</code>; the tick pump is a per-coordinator main-queue schedule — no shared display link.</span>
+        <span class="zh"><code>ghostty_init</code> 有一次性守卫（幂等）。每个 controller 创建独立的 <code>ghostty_app_t</code>；回调经由 per-app / per-surface 的 userdata 路由，不会串线。每个 view 拥有独立 <code>CAMetalLayer</code>；tick 泵为各自 coordinator 的主队列调度 —— 没有共享 display link。</span>
+      </td>
+    </tr>
+  </table>
+  <div class="callout good">
+    <b><span class="en">Vimeflow already follows the required pattern</span><span class="zh">Vimeflow 现有代码已符合该模式</span></b>
+    <span class="en"><code>EmbeddedGhosttySurface</code> creates a per-surface controller today — <code>private lazy var controller = TerminalController()</code> (<code>GhosttyElectronBridge.swift:201</code>). Adding the burner means adding a <i>second</i> controller + view + session inside the same container, not restructuring anything.</span>
+    <span class="zh"><code>EmbeddedGhosttySurface</code> 目前就是按 surface 创建独立 controller —— <code>private lazy var controller = TerminalController()</code>（<code>GhosttyElectronBridge.swift:201</code>）。加入 burner 只是在同一容器里再加<i>第二套</i> controller + view + session，无需重构。</span>
+  </div>
+
+  <h2><span class="en">3 · Codex re-verification</span><span class="zh">3 · Codex 复核</span><span class="badge ok">agrees = true</span></h2>
+  <p>
+    <span class="en">An independent <code>codex exec</code> pass over the same pinned source confirmed all three core claims: (1) no library-owned split-pane API; (2) two independent TerminalViews are safe with separate controllers; (3) sharing one controller silences the earlier view via the single-slot wakeup closures. Two refinements surfaced:</span>
+    <span class="zh">对同一锁定版本源码的独立 <code>codex exec</code> 复核确认了全部三条核心结论：（1）库不提供自有的分屏 API；（2）两个独立 TerminalView 在各自 controller 下是安全的；（3）共享 controller 会因单槽位 wakeup 闭包导致先挂载的 view 失效。复核补充了两点修正：</span>
+  </p>
+  <ul>
+    <li>
+      <span class="en"><b>Tick pump precision</b> — <code>startDisplayLink()</code> schedules a per-coordinator main-queue tick; MSDisplayLink is imported but never shared. Whether ticking is per-coordinator MSDisplayLink or raw <code>DispatchQueue.main.async</code> does not change the verdict: nothing is shared across views.</span>
+      <span class="zh"><b>tick 泵表述精度</b> —— <code>startDisplayLink()</code> 为各自 coordinator 调度主队列 tick；MSDisplayLink 虽被引入但从不共享。无论 tick 实现是 per-coordinator 的 MSDisplayLink 还是裸 <code>DispatchQueue.main.async</code>，结论不变：view 之间不存在共享。</span>
+    </li>
+    <li>
+      <span class="en"><b><code>retainedBridges</code> array</b> (<code>TerminalController+Config.swift:64</code>) — one controller <i>can</i> fan out config updates to multiple surfaces. This does not lift the single-slot wakeup constraint (the render trigger is still one closure), so the per-view-controller rule stands.</span>
+      <span class="zh"><b><code>retainedBridges</code> 数组</b>（<code>TerminalController+Config.swift:64</code>）—— 单个 controller <i>确实</i>能向多个 surface 广播配置更新。但这并不解除单槽位 wakeup 约束（渲染触发仍是一个闭包），因此“每 view 一个 controller”的规则依然成立。</span>
+    </li>
+  </ul>
+
+  <h3><span class="en">Round 2 (2026-07-03) — risks &amp; spike order</span><span class="zh">第二轮（2026-07-03）—— 风险与 spike 顺序</span></h3>
+  <p>
+    <span class="en">A second <code>codex exec</code> pass reviewed §5 and §6 against the actual code (via the markdown mirror of this note). Verdicts: R2/R4/R6 <b>confirmed</b>; R1/R3/R5 <b>incomplete</b> — corrections folded into §5 (resize shares the PTY-identity path; the digit guard is at Swift:475-480 and context-menu/rename attribution needs child identity; the renderer's pending-buffer drain is owned by the mounted Body). Codex also surfaced <b>four missing HIGH risks</b> (now in §5, marked <i>codex round 2</i>) and a revised spike order (§6).</span>
+    <span class="zh">第二轮 <code>codex exec</code> 依据本笔记的 markdown 镜像，对照实际代码复核了 §5 与 §6。判定：R2/R4/R6 <b>确认</b>；R1/R3/R5 <b>不完整</b> —— 修正已并入 §5（resize 与击键共用同一 PTY 身份路径；数字键守卫实际在 Swift:475-480，右键菜单/重命名归属需要携带子终端身份；渲染进程的待发缓冲排空由挂载的 Body 持有）。codex 还发现了 <b>4 个遗漏的高危风险</b>（已列入 §5，标注 <i>codex round 2</i>），并给出修订后的 spike 顺序（§6）。</span>
+  </p>
+
+  <h2><span class="en">4 · What needs to change (Option B change map)</span><span class="zh">4 · 需要改什么（方案 B 变更图）</span></h2>
+  <p>
+    <span class="en">The pipeline today, and the identity fields flowing through it:</span>
+    <span class="zh">现有管线及贯穿其中的标识字段：</span>
+  </p>
+  <pre><code>GhosttyBody.tsx ──▶ nativeGhosttyClient.ts ──▶ preload.ts ──▶ ghostty-native-parent.ts
+                                                                    │  surfaces: Map&lt;`${sessionId}:${paneId}`&gt;
+                                                                    ▼
+                                              ghostty_native_parent.cc (N-API, tsfn callbacks)
+                                                                    ▼
+                                              GhosttyElectronBridge.swift · EmbeddedGhosttySurface
+                                                 └─ container NSView ─ TerminalView + InMemoryTerminalSession
+
+sessionId = ptyId  (NOT the layout session id — GhosttyBody.tsx:193)
+burner adds:  childId: 'primary' | 'burner'   +   burnerPtyId
+paneKey stays `${sessionId}:${paneId}` — the burner shares its parent's surface state entry.</code></pre>
+
+  <h3><span class="en">Ordered minimal change plan (native-first)</span><span class="zh">最小变更计划（自原生层向上，按序）</span></h3>
+  <ol class="plan">
+    <li>
+      <b>Swift · <code>GhosttyElectronBridge.swift</code></b> —
+      <span class="en"><code>EmbeddedGhosttySurface</code> gains optional <code>burnerTerminalView</code> / <code>burnerSession</code> / <code>burnerCallbacks</code> (each with its <b>own <code>TerminalController</code></b>); <code>enum BurnerPlacement { right, bottom }</code>; a <code>layoutChildren()</code> that splits <code>container.bounds</code> by ratio (called from <code>setFrame</code>); new <code>@_cdecl</code> exports <code>vimeflow_ghostty_add_burner_child</code> / <code>remove_burner_child</code> / <code>write_burner</code> / <code>focus_burner</code>; fix <code>shortcutMonitor.handleKeyDown</code> (line 441) to match firstResponder against <i>either</i> terminal view.</span>
+      <span class="zh"><code>EmbeddedGhosttySurface</code> 增加可选的 <code>burnerTerminalView</code> / <code>burnerSession</code> / <code>burnerCallbacks</code>（各自持有<b>独立 <code>TerminalController</code></b>）；新增 <code>enum BurnerPlacement { right, bottom }</code>；新增 <code>layoutChildren()</code> 按比例切分 <code>container.bounds</code>（由 <code>setFrame</code> 调用）；新增 <code>@_cdecl</code> 导出 <code>vimeflow_ghostty_add_burner_child</code> / <code>remove_burner_child</code> / <code>write_burner</code> / <code>focus_burner</code>；修正 <code>shortcutMonitor.handleKeyDown</code>（441 行），使 firstResponder 判定同时匹配两个终端 view。</span>
+    </li>
+    <li>
+      <b>N-API · <code>ghostty_native_parent.cc</code></b> —
+      <span class="en">load the four new dylib symbols in <code>EnsureBridge()</code>; add a <code>BurnerContext</code> struct with its own threadsafe functions (input/resize/focus) separate from the primary <code>SurfaceHandle</code> for independent teardown; add <code>AddBurnerChild</code> / <code>RemoveBurnerChild</code> / <code>WriteBurner</code> / <code>FocusBurner</code>; extend <code>ReleaseSurfaceCallbacks</code> to drain burner tsfns.</span>
+      <span class="zh">在 <code>EnsureBridge()</code> 中加载四个新 dylib 符号；新增 <code>BurnerContext</code> 结构体，持有独立的 threadsafe function（input/resize/focus），与主 <code>SurfaceHandle</code> 分离以便独立销毁；新增 <code>AddBurnerChild</code> / <code>RemoveBurnerChild</code> / <code>WriteBurner</code> / <code>FocusBurner</code>；扩展 <code>ReleaseSurfaceCallbacks</code> 以清空 burner 的 tsfn。</span>
+    </li>
+    <li>
+      <b>Channels · <code>electron/ghostty-native-channels.ts</code></b> —
+      <span class="en">add <code>GHOSTTY_NATIVE_ADD_BURNER</code> / <code>GHOSTTY_NATIVE_REMOVE_BURNER</code>. Write/focus/destroy reuse existing channels with a <code>childId</code> field.</span>
+      <span class="zh">新增 <code>GHOSTTY_NATIVE_ADD_BURNER</code> / <code>GHOSTTY_NATIVE_REMOVE_BURNER</code>。write/focus/destroy 复用现有通道，仅增加 <code>childId</code> 字段。</span>
+    </li>
+    <li>
+      <b>Types · <code>electron/ghostty-native-shared.ts</code></b> —
+      <span class="en"><code>childId?: 'primary' | 'burner'</code> on <code>GhosttyNativePaneRequest</code> (flows into update/data requests); new <code>GhosttyNativeAddBurnerRequest { burnerPtyId, placement, ratio }</code>; the main-process <code>paneKey</code> must <b>not</b> include <code>childId</code>.</span>
+      <span class="zh">在 <code>GhosttyNativePaneRequest</code> 上加 <code>childId?: 'primary' | 'burner'</code>（自动传导到 update/data 请求）；新增 <code>GhosttyNativeAddBurnerRequest { burnerPtyId, placement, ratio }</code>；主进程 <code>paneKey</code> <b>不得</b>包含 <code>childId</code>。</span>
+    </li>
+    <li>
+      <b>Main · <code>electron/ghostty-native-parent.ts</code></b> —
+      <span class="en"><code>GhosttyNativeSurfaceState</code> gains <code>burnerPtyId</code>; new IPC handlers for add/remove; <code>sendData</code>/<code>focus</code> branch on <code>childId</code>; the burner's <code>onInput</code>/<code>onResize</code> callbacks route <code>write_pty</code>/<code>resize_pty</code> with <b><code>burnerPtyId</code></b>; <code>destroySurface</code> also removes the burner child.</span>
+      <span class="zh"><code>GhosttyNativeSurfaceState</code> 增加 <code>burnerPtyId</code>；新增 add/remove 两个 IPC handler；<code>sendData</code>/<code>focus</code> 按 <code>childId</code> 分支；burner 的 <code>onInput</code>/<code>onResize</code> 回调必须用 <b><code>burnerPtyId</code></b> 调用 <code>write_pty</code>/<code>resize_pty</code>；<code>destroySurface</code> 同时移除 burner 子终端。</span>
+    </li>
+    <li>
+      <b>Preload · <code>electron/preload.ts</code></b> —
+      <span class="en">expose <code>addBurnerChild</code> / <code>removeBurnerChild</code> invokes on the existing <code>ghosttyNativeBridge</code>.</span>
+      <span class="zh">在现有 <code>ghosttyNativeBridge</code> 上暴露 <code>addBurnerChild</code> / <code>removeBurnerChild</code> 两个 invoke。</span>
+    </li>
+    <li>
+      <b>Renderer client · <code>src/features/terminal/nativeGhosttyClient.ts</code></b> —
+      <span class="en"><code>childId</code> on <code>NativeGhosttyPaneRef</code>; <code>NativeGhosttyAddBurnerRequest</code>; helper functions following the existing enabled/disabled-sentinel pattern.</span>
+      <span class="zh"><code>NativeGhosttyPaneRef</code> 加 <code>childId</code>；新增 <code>NativeGhosttyAddBurnerRequest</code>；按现有 enabled/disabled 哨兵模式补充 helper 函数。</span>
+    </li>
+    <li>
+      <b>React · <code>GhosttyBody.tsx</code> + <code>useBurnerTerminals.ts</code></b> —
+      <span class="en"><code>childId</code> prop threaded into <code>paneRef</code> and the <code>ghostty-native-input</code>/<code>-focus</code> event filters (lines 574–634); the hook's <code>renderNode</code> popup block (lines 537–575) is replaced by native attach/detach calls from <code>show()</code>/<code>hide()</code> — every input the native attach needs (<code>burnerPtyId</code>, visibility, cwd callbacks) is already computed in that scope.</span>
+      <span class="zh"><code>childId</code> prop 传入 <code>paneRef</code> 及 <code>ghostty-native-input</code>/<code>-focus</code> 事件过滤（574–634 行）；hook 中 <code>renderNode</code> 弹窗代码块（537–575 行）改为在 <code>show()</code>/<code>hide()</code> 中调用原生 attach/detach —— 原生挂载所需的全部输入（<code>burnerPtyId</code>、可见性、cwd 回调）在该作用域内均已就绪。</span>
+    </li>
+  </ol>
+
+  <h3><span class="en">Burner lifecycle: keep vs retire</span><span class="zh">Burner 生命周期：保留 vs 淘汰</span></h3>
+  <table>
+    <tr>
+      <th><span class="en">Keep (presentation-agnostic — survives unchanged)</span><span class="zh">保留（与呈现方式无关 —— 原样保留）</span></th>
+      <th><span class="en">Retire (popup-only)</span><span class="zh">淘汰（仅服务于弹窗）</span></th>
+    </tr>
+    <tr>
+      <td>
+        <span class="en">The entire <code>useBurnerTerminals</code> PTY state machine: ephemeral spawn (<code>{ ephemeral: true }</code>), <code>paneKey</code> keying, show/toggle/hide intents, cwd align (VIM-81, <code>CLEAR_LINE + cd</code> with the foreground-active guard), OSC 7 <code>currentCwd</code> tracking, foreground cue (VIM-71), self-exit (VIM-62), live-pane reconcile/kill, boot reap via <code>killEphemeralPtys()</code>, the <code>Mod+; `</code> chord, and the <code>runningByPane</code>/<code>activeByPane</code> header signals.</span>
+        <span class="zh"><code>useBurnerTerminals</code> 的整套 PTY 状态机：临时 spawn（<code>{ ephemeral: true }</code>）、<code>paneKey</code> 键控、show/toggle/hide 意图、cwd 对齐（VIM-81，带前台命令守卫的 <code>CLEAR_LINE + cd</code>）、OSC 7 <code>currentCwd</code> 跟踪、前台命令提示（VIM-71）、自退出（VIM-62）、live-pane 对账/清理、启动时 <code>killEphemeralPtys()</code> 回收、<code>Mod+; `</code> 和弦快捷键，以及 <code>runningByPane</code>/<code>activeByPane</code> 头部信号。</span>
+      </td>
+      <td>
+        <span class="en"><code>BurnerTerminalPopup/index.tsx</code> in full (overlay, backdrop, focus trap, focus restore, 760×600 panel); the hook's <code>renderNode</code> block + its return-type field; the <code>{burnerTerminalNode}</code> render site (<code>WorkspaceView.tsx:3031</code>); re-evaluate the <code>burnerTerminalOpen</code> occlusion registration (<code>WorkspaceView.tsx:2541-2545</code>) — a native nested child is not a floating DOM overlay.</span>
+        <span class="zh">整个 <code>BurnerTerminalPopup/index.tsx</code>（浮层、backdrop、焦点陷阱、焦点恢复、760×600 面板）；hook 的 <code>renderNode</code> 代码块及其返回类型字段；<code>{burnerTerminalNode}</code> 渲染位点（<code>WorkspaceView.tsx:3031</code>）；重新评估 <code>burnerTerminalOpen</code> 遮挡注册（<code>WorkspaceView.tsx:2541-2545</code>）—— 原生嵌套子终端不再是浮动 DOM 覆盖层。</span>
+      </td>
+    </tr>
+  </table>
+
+  <h2><span class="en">5 · Risks, ranked</span><span class="zh">5 · 风险（按严重度排序）</span></h2>
+  <table>
+    <tr>
+      <th></th>
+      <th><span class="en">Risk</span><span class="zh">风险</span></th>
+      <th><span class="en">Mitigation</span><span class="zh">缓解</span></th>
+    </tr>
+    <tr>
+      <td><span class="sev high">HIGH</span></td>
+      <td>
+        <span class="en"><b>PTY identity mis-routing.</b> The burner's <code>onInput</code> must call <code>write_pty</code> with <code>burnerPtyId</code>, never <code>state.pane.sessionId</code> — otherwise burner keystrokes are injected into the primary (agent) PTY. <i>Codex round 2:</i> <code>resize_pty</code> shares the same identity path (ghostty-native-parent.ts:518-525) — route <b>both</b> write and resize through the burner context.</span>
+        <span class="zh"><b>PTY 身份串线。</b>burner 的 <code>onInput</code> 必须以 <code>burnerPtyId</code> 调用 <code>write_pty</code>，绝不能用 <code>state.pane.sessionId</code> —— 否则 burner 击键会注入主（agent）PTY。<i>codex 第二轮：</i><code>resize_pty</code> 走同一身份路径（ghostty-native-parent.ts:518-525）—— write 与 resize <b>都</b>必须经由 burner 上下文路由。</span>
+      </td>
+      <td>
+        <span class="en">Separate callback context (<code>BurnerContext</code>) end-to-end; an integration test that types into the burner and asserts the primary PTY saw nothing.</span>
+        <span class="zh">全链路使用独立回调上下文（<code>BurnerContext</code>）；集成测试：向 burner 输入并断言主 PTY 未收到任何数据。</span>
+      </td>
+    </tr>
+    <tr>
+      <td><span class="sev high">HIGH</span></td>
+      <td>
+        <span class="en"><b>Teardown ordering.</b> <code>GhosttyBody</code> unmount cleanup calls destroy unconditionally (line 691). A burner destroy with a missing/misrouted <code>childId</code> must map to <code>removeBurnerChild</code>, never <code>destroySurface</code> — or the still-live primary dies with it.</span>
+        <span class="zh"><b>销毁顺序。</b><code>GhosttyBody</code> 卸载清理会无条件调用 destroy（691 行）。burner 的 destroy 若 <code>childId</code> 缺失或误路由，必须落到 <code>removeBurnerChild</code>，绝不能是 <code>destroySurface</code> —— 否则仍存活的主终端会被连带销毁。</span>
+      </td>
+      <td>
+        <span class="en">Main-process branch on <code>childId</code> with a default-deny: absent childId on a surface that has a burner never tears down the whole surface implicitly.</span>
+        <span class="zh">主进程按 <code>childId</code> 分支并默认保守：对持有 burner 的 surface，缺省 childId 的请求绝不隐式整体销毁。</span>
+      </td>
+    </tr>
+    <tr>
+      <td><span class="sev high">HIGH</span></td>
+      <td>
+        <span class="en"><b>Shortcut/focus gating.</b> The window-level <code>shortcutMonitor</code> checks firstResponder against the primary view only (Swift:441-453; digits guard :475-480). With the burner focused, Cmd+digit pane-switching is silently swallowed and key routing can drop events. <i>Codex round 2:</i> the context menu is also primary-only (Swift:425-438), and Electron emits rename with <code>state.pane</code> (ghostty-native-parent.ts:574-577) — rename/context callbacks must carry child identity.</span>
+        <span class="zh"><b>快捷键/焦点判定。</b>窗口级 <code>shortcutMonitor</code> 仅将 firstResponder 与主 view 比对（Swift:441-453，数字守卫 :475-480）。当 burner 获得焦点时，Cmd+数字 切换窗格会被静默吞掉，按键路由也可能丢事件。<i>codex 第二轮：</i>右键菜单同样只识别主 view（Swift:425-438），且 Electron 发出 rename 时使用 <code>state.pane</code>（ghostty-native-parent.ts:574-577）—— rename/右键回调必须携带子终端身份。</span>
+      </td>
+      <td>
+        <span class="en">Extend every firstResponder check to “descendant of primary <i>or</i> burner view”; same for the context-menu monitor (rename would otherwise mis-attribute to the host pane).</span>
+        <span class="zh">所有 firstResponder 判定扩展为“主 view <i>或</i> burner view 的后代”；右键菜单监视器同理（否则重命名会误归属到宿主窗格）。</span>
+      </td>
+    </tr>
+    <tr>
+      <td><span class="sev high">HIGH</span></td>
+      <td>
+        <span class="en"><b>Burner output has no subscriber.</b> Native output forwarding is owned by the mounted <code>GhosttyBody</code> (GhosttyBody.tsx:637-657) — a role the popup Body currently plays for the burner (useBurnerTerminals.ts:537-574). Retiring the popup without a replacement leaves burner PTY output going nowhere. <i>(codex round 2)</i></span>
+        <span class="zh"><b>burner 输出无订阅者。</b>原生输出转发由挂载的 <code>GhosttyBody</code> 持有（GhosttyBody.tsx:637-657）—— 目前弹窗中的 Body 为 burner 扮演该角色（useBurnerTerminals.ts:537-574）。若移除弹窗而不加替代，burner 的 PTY 输出将无处可去。<i>（codex 第二轮）</i></span>
+      </td>
+      <td>
+        <span class="en">Add a forwarder owned by <code>useBurnerTerminals</code> on native attach — <code>service.onData(burnerPtyId)</code> → <code>sendNativeGhosttyData(childId: 'burner')</code> — and drain the <code>registerPending</code> buffer into it.</span>
+        <span class="zh">在原生挂载时由 <code>useBurnerTerminals</code> 持有转发器 —— <code>service.onData(burnerPtyId)</code> → <code>sendNativeGhosttyData(childId: 'burner')</code> —— 并把 <code>registerPending</code> 缓冲排空到该通道。</span>
+      </td>
+    </tr>
+    <tr>
+      <td><span class="sev high">HIGH</span></td>
+      <td>
+        <span class="en"><b>Hide must not become destructive.</b> Today <code>hide()</code> keeps the popup Body mounted (<code>display:none</code>), so the shell and scrollback survive. In the library, surface state is freed on coordinator teardown (TerminalSurfaceCoordinator.swift:311-323) — implementing native hide as remove/destroy kills scrollback. <i>(codex round 2)</i></span>
+        <span class="zh"><b>hide 不能变成销毁。</b>目前 <code>hide()</code> 保持弹窗 Body 挂载（<code>display:none</code>），shell 与回滚缓冲得以存活。而库中 surface 状态会在 coordinator 销毁时释放（TerminalSurfaceCoordinator.swift:311-323）—— 若把原生 hide 实现为 remove/destroy，回滚缓冲会丢失。<i>（codex 第二轮）</i></span>
+      </td>
+      <td>
+        <span class="en">Implement hide as AppKit <code>isHidden</code> on the burner view (view + session stay alive); reserve <code>removeBurnerChild</code> for kill.</span>
+        <span class="zh">hide 实现为对 burner view 设置 AppKit <code>isHidden</code>（view 与 session 均存活）；<code>removeBurnerChild</code> 仅用于 kill。</span>
+      </td>
+    </tr>
+    <tr>
+      <td><span class="sev high">HIGH</span></td>
+      <td>
+        <span class="en"><b>Callback-context use-after-free.</b> Swift's <code>CallbackBox</code> holds the raw C++ context pointer (GhosttyElectronBridge.swift:75-82) and invokes it on input/resize (:101-119); C++ casts it back in the trampolines (ghostty_native_parent.cc:177-184). Freeing the <code>BurnerContext</code> before the Swift child is destroyed is a UAF, not just a leak. <i>(codex round 2)</i></span>
+        <span class="zh"><b>回调上下文悬垂指针（UAF）。</b>Swift 的 <code>CallbackBox</code> 持有裸 C++ 上下文指针（GhosttyElectronBridge.swift:75-82）并在 input/resize 时调用（:101-119）；C++ 在跳板函数中将其转回（ghostty_native_parent.cc:177-184）。若在 Swift 子终端销毁前释放 <code>BurnerContext</code>，就是 use-after-free，而不只是泄漏。<i>（codex 第二轮）</i></span>
+      </td>
+      <td>
+        <span class="en"><code>RemoveBurnerChild</code> destroys the Swift child first, then releases tsfns/context; mirror the primary's atomic <code>released</code> flag.</span>
+        <span class="zh"><code>RemoveBurnerChild</code> 先销毁 Swift 子终端，再释放 tsfn/上下文；沿用主 surface 的原子 <code>released</code> 标志。</span>
+      </td>
+    </tr>
+    <tr>
+      <td><span class="sev high">HIGH</span></td>
+      <td>
+        <span class="en"><b>Child frames in the wrong coordinate space.</b> <code>setFrame</code> y-flips renderer coordinates via <code>parentHeight</code> for the container (GhosttyElectronBridge.swift:261-275); the primary then fills <code>container.bounds</code> (:277). Child sub-rects must be computed in the container's <i>local</i> bounds — a second parent-height y-flip misplaces the burner. <i>(codex round 2)</i></span>
+        <span class="zh"><b>子 view 坐标系用错。</b><code>setFrame</code> 用 <code>parentHeight</code> 对渲染进程坐标做 y 翻转来定位容器（GhosttyElectronBridge.swift:261-275）；主终端随后填满 <code>container.bounds</code>（:277）。子矩形必须在容器的<i>局部</i> bounds 中计算 —— 再做一次 parentHeight y 翻转会把 burner 放错位置。<i>（codex 第二轮）</i></span>
+      </td>
+      <td>
+        <span class="en"><code>layoutChildren()</code> computes sub-rects purely from <code>container.bounds</code> — no <code>parentHeight</code> involvement.</span>
+        <span class="zh"><code>layoutChildren()</code> 只基于 <code>container.bounds</code> 计算子矩形 —— 不涉及 <code>parentHeight</code>。</span>
+      </td>
+    </tr>
+    <tr>
+      <td><span class="sev med">MED</span></td>
+      <td>
+        <span class="en"><b>Split-geometry divergence.</b> Two renderer-driven <code>update</code> paths plus the 120 ms resize quiet window (<code>NATIVE_RESIZE_TRACKING_QUIET_MS</code>) can briefly disagree, leaving a gap or overlap; overlapping sibling NSViews also break hit-testing (top view steals clicks).</span>
+        <span class="zh"><b>切分几何不一致。</b>两条渲染进程驱动的 <code>update</code> 路径叠加 120ms 缩放静默窗口（<code>NATIVE_RESIZE_TRACKING_QUIET_MS</code>）可能短暂不一致，产生缝隙或重叠；同级 NSView 重叠还会破坏点击测试（顶层 view 抢走点击）。</span>
+      </td>
+      <td>
+        <span class="en"><b>Let Swift own the split</b>: one bounds source (the existing per-pane <code>update</code>), <code>layoutChildren()</code> computes both integer-rounded sub-rects. This also satisfies the handoff's “nested divider must be native/AppKit” requirement.</span>
+        <span class="zh"><b>让 Swift 拥有切分权</b>：单一 bounds 来源（现有的按窗格 <code>update</code>），由 <code>layoutChildren()</code> 计算两个整数取整的子矩形。这同时满足 handoff 中“嵌套分隔线必须是原生/AppKit”的要求。</span>
+      </td>
+    </tr>
+    <tr>
+      <td><span class="sev med">MED</span></td>
+      <td>
+        <span class="en"><b>Pending-data race.</b> Main buffers PTY output in <code>pendingData</code> when no surface exists yet (ghostty-native-parent.ts:370-377); the burner needs the same buffering between its PTY spawn and <code>addBurnerChild</code> arrival, or early output is lost.</span>
+        <span class="zh"><b>待发数据竞态。</b>surface 尚未创建时主进程会把 PTY 输出缓存在 <code>pendingData</code>（ghostty-native-parent.ts:370-377）；burner 在其 PTY 启动与 <code>addBurnerChild</code> 到达之间同样需要该缓存，否则早期输出会丢失。</span>
+      </td>
+      <td>
+        <span class="en">Extend the pending-data tail per childId. <i>Codex round 2:</i> the renderer's <code>registerPending</code> buffer drains only when a mounted Body calls <code>onPaneReady</code> (usePtyBufferDrain.ts:60-78) — with the popup gone, the burner needs a new drain owner (see the output-subscriber risk below).</span>
+        <span class="zh">按 childId 扩展 pending-data 缓存。<i>codex 第二轮：</i>渲染进程的 <code>registerPending</code> 缓冲只有在挂载的 Body 调用 <code>onPaneReady</code> 时才会排空（usePtyBufferDrain.ts:60-78）—— 弹窗移除后，burner 需要新的排空持有者（见下方“输出无订阅者”风险）。</span>
+      </td>
+    </tr>
+    <tr>
+      <td><span class="sev low">LOW</span></td>
+      <td>
+        <span class="en"><b>tsfn lifecycle leak.</b> If <code>BurnerContext</code> holds its own threadsafe functions, the primary <code>SurfaceHandle</code>'s finalizer must also release them.</span>
+        <span class="zh"><b>tsfn 生命周期泄漏。</b>若 <code>BurnerContext</code> 持有独立 threadsafe function，主 <code>SurfaceHandle</code> 的 finalizer 必须一并释放它们。</span>
+      </td>
+      <td>
+        <span class="en">Drain burner tsfns in both <code>RemoveBurnerChild</code> and <code>ReleaseSurfaceCallbacks</code>/<code>FinalizeSurface</code>.</span>
+        <span class="zh">在 <code>RemoveBurnerChild</code> 与 <code>ReleaseSurfaceCallbacks</code>/<code>FinalizeSurface</code> 两处都清空 burner 的 tsfn。</span>
+      </td>
+    </tr>
+  </table>
+
+  <h2><span class="en">6 · Recommendation &amp; spike order</span><span class="zh">6 · 建议与 spike 顺序</span></h2>
+  <p>
+    <span class="en"><b>Proceed with HANDOFF Option B</b> — two <code>TerminalView</code>s inside one <code>EmbeddedGhosttySurface</code>, AppKit-owned two-child layout, max one burner, right split by default, bottom for narrow panes. Option A is not a maybe, and recompiling cannot revive it: the layout engine was never in the library (see the §1 addendum). The only path to “Ghostty-owned splits” is vendoring Ghostty.app's Swift shell (<code>SplitTree.swift</code> and its surface/controller machinery) — thousands of app-coupled lines, tracked against a fast-moving app repo, to obtain a recursive layout engine the spike constraints explicitly forbid.</span>
+    <span class="zh"><b>按 HANDOFF 方案 B 推进</b> —— 单个 <code>EmbeddedGhosttySurface</code> 内两个 <code>TerminalView</code>，由 AppKit 管理双子布局，最多一个 burner，默认右分屏，窄窗格用下分屏。方案 A 不是“或许可行”，重新编译也无法复活它：布局引擎从未存在于库中（见 §1 补充）。要获得“Ghostty 自有分屏”，唯一途径是把 Ghostty.app 的 Swift 外壳（<code>SplitTree.swift</code> 及其 surface/controller 机制）整体搬入 —— 数千行与 App 深度耦合的代码、还需持续跟进快速迭代的上游应用仓库，换来的却是 spike 约束明确禁止的递归布局引擎。</span>
+  </p>
+  <ol class="plan">
+    <li>
+      <span class="en"><b>Swift-only spike first</b>: extend <code>GhosttyNativeMacosSmoke</code> (today it proves exactly one <code>TerminalView</code> — GhosttyNativeMacosSmoke.swift:121-135) to exercise <b>add/remove of a second view with its own controller</b>, plus hide-vs-remove semantics — proves rendering, focus, input isolation, and scrollback survival before touching any IPC. <i>(order refined by codex round 2)</i></span>
+      <span class="zh"><b>先做纯 Swift spike</b>：扩展 <code>GhosttyNativeMacosSmoke</code>（目前只验证一个 <code>TerminalView</code> —— GhosttyNativeMacosSmoke.swift:121-135），实测<b>第二个 view（独立 controller）的添加/移除</b>及 hide 与 remove 的语义差异 —— 在不动任何 IPC 的前提下验证渲染、焦点、输入隔离与回滚缓冲存活。<i>（顺序经 codex 第二轮修订）</i></span>
+    </li>
+    <li>
+      <span class="en"><b>C++ N-API next, with its smoke</b>: new symbols/contexts/finalizers in <code>ghostty_native_parent.cc</code>, updating <code>scripts/smoke-ghostty-native-parent.js</code> (it currently checks only create/setFrame/write/focus/destroy) <b>before</b> any Electron work. The build/codesign pipeline already exists (<code>scripts/build-ghostty-native-parent.js</code>).</span>
+      <span class="zh"><b>随后是 C++ N-API 及其冒烟测试</b>：在 <code>ghostty_native_parent.cc</code> 中新增符号/上下文/finalizer，并更新 <code>scripts/smoke-ghostty-native-parent.js</code>（目前只检查 create/setFrame/write/focus/destroy），<b>先于</b>任何 Electron 侧改动。构建/签名管线已就绪（<code>scripts/build-ghostty-native-parent.js</code>）。</span>
+    </li>
+    <li>
+      <span class="en">Then Electron main (childId routing, burner output forwarding, pending-buffer tests) → preload/native client → React hook swap — keeping the <code>useBurnerTerminals</code> PTY lifecycle untouched and replacing only the presentation layer. No Rust bindings regen unless Rust command/types change.</span>
+      <span class="zh">再推进 Electron 主进程（childId 路由、burner 输出转发、待发缓冲测试）→ preload/渲染端 client → React hook 替换 —— 完整保留 <code>useBurnerTerminals</code> 的 PTY 生命周期，仅替换呈现层。除非 Rust 命令/类型变更，无需重新生成 Rust bindings。</span>
+    </li>
+    <li>
+      <span class="en">Open questions from the handoff that are now <i>design</i> (not feasibility) questions: focus-on-open policy, close-vs-hide semantics, and user-toggleable placement.</span>
+      <span class="zh">handoff 中剩余的开放问题现在均属<i>设计</i>问题而非可行性问题：打开时是否夺焦、close 与 hide 的语义、以及 placement 是否允许用户切换。</span>
+    </li>
+  </ol>
+
+  <footer>
+    <span class="en">
+      Evidence base: libghostty-spm 1.2.7 source at rev <code>2b0e1b9d</code> (materialized from the SwiftPM repo cache);
+      upstream ghostty v1.2.3 <code>include/ghostty.h</code> + <code>src/apprt/embedded.zig</code> (recompile addendum);
+      vimeflow worktree <code>ghostty-burner-pane-spike</code> files — <code>GhosttyElectronBridge.swift</code>, <code>ghostty_native_parent.cc</code>, <code>ghostty-native-parent.ts</code>, <code>nativeGhosttyClient.ts</code>, <code>GhosttyBody.tsx</code>, <code>useBurnerTerminals.ts</code>, <code>BurnerTerminalPopup/index.tsx</code>.
+      Produced by a 4-agent exploration workflow (3 source readers + 1 codex verifier), 2026-07-03. Companion to <code>HANDOFF.md</code> in this directory.
+    </span>
+    <span class="zh">
+      证据基础：libghostty-spm 1.2.7 源码（rev <code>2b0e1b9d</code>，自 SwiftPM 仓库缓存物化）；
+      上游 ghostty v1.2.3 <code>include/ghostty.h</code> + <code>src/apprt/embedded.zig</code>（重编译补充论证）；
+      vimeflow worktree <code>ghostty-burner-pane-spike</code> 中的 <code>GhosttyElectronBridge.swift</code>、<code>ghostty_native_parent.cc</code>、<code>ghostty-native-parent.ts</code>、<code>nativeGhosttyClient.ts</code>、<code>GhosttyBody.tsx</code>、<code>useBurnerTerminals.ts</code>、<code>BurnerTerminalPopup/index.tsx</code>。
+      由 4-agent 探索工作流（3 个源码阅读 agent + 1 个 codex 复核 agent）产出，2026-07-03。与本目录 <code>HANDOFF.md</code> 配套阅读。
+    </span>
+  </footer>
+</main>
+<script>
+  const buttons = document.querySelectorAll('.langbar button')
+  buttons.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      document.body.dataset.lang = btn.dataset.set
+      buttons.forEach((b) => b.classList.toggle('active', b === btn))
+    })
+  })
+</script>
+</body>
+</html>

--- a/docs/exploration/2026-07-04-ghostty-burner-side-pane/ghostty-split-api-technical-note.md
+++ b/docs/exploration/2026-07-04-ghostty-burner-side-pane/ghostty-split-api-technical-note.md
@@ -13,7 +13,7 @@ The only split-related public symbol is `TerminalSurfaceContext.split` (`Sources
 
 ## Addendum — Recompiling doesn't help (verified upstream v1.2.3)
 
-Everything split-related in the **full** `include/ghostty.h` (the untrimmed API real Ghostty.app links) is an *action*: `GHOSTTY_ACTION_NEW_SPLIT` / `GOTO_SPLIT` / `RESIZE_SPLIT` / `EQUALIZE_SPLITS` / `TOGGLE_SPLIT_ZOOM` plus four functions like `ghostty_surface_split()`. In the core:
+Everything split-related in the **full** `include/ghostty.h` (the untrimmed API real Ghostty.app links) is an _action_: `GHOSTTY_ACTION_NEW_SPLIT` / `GOTO_SPLIT` / `RESIZE_SPLIT` / `EQUALIZE_SPLITS` / `TOGGLE_SPLIT_ZOOM` plus four functions like `ghostty_surface_split()`. In the core:
 
 ```zig
 // upstream src/apprt/embedded.zig:1843 (v1.2.3)
@@ -26,11 +26,11 @@ It fires `.new_split` **back out to the host's action callback**. The core never
 
 ## Q2 — Two-TerminalView coexistence constraints
 
-| Constraint | Evidence | Impact |
-|---|---|---|
+| Constraint                                       | Evidence                                                                 | Impact                                                                                                                                                       |
+| ------------------------------------------------ | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **One `TerminalController` per view** (BLOCKING) | `TerminalController.swift:59-60`, `TerminalSurfaceCoordinator.swift:138` | `onWakeup`/`shouldProcessWakeup` are single-slot closures; `rebuildIfReady()` overwrites them — a shared controller silences the earlier view's render loop. |
-| Avoid `TerminalController.shared` | `TerminalController.swift:46` | Convenience singleton; naive use triggers the constraint above. |
-| Process-global init/rendering (SAFE) | `TerminalController.swift:300`, `AppTerminalView.swift:13` | `ghostty_init` one-shot guarded; per-controller `ghostty_app_t`; per-view `CAMetalLayer`; per-coordinator main-queue tick, no shared display link. |
+| Avoid `TerminalController.shared`                | `TerminalController.swift:46`                                            | Convenience singleton; naive use triggers the constraint above.                                                                                              |
+| Process-global init/rendering (SAFE)             | `TerminalController.swift:300`, `AppTerminalView.swift:13`               | `ghostty_init` one-shot guarded; per-controller `ghostty_app_t`; per-view `CAMetalLayer`; per-coordinator main-queue tick, no shared display link.           |
 
 Vimeflow already follows the pattern: `EmbeddedGhosttySurface` uses `private lazy var controller = TerminalController()` (`GhosttyElectronBridge.swift:201`).
 
@@ -59,7 +59,7 @@ Ordered minimal plan (native-first):
 7. **`src/features/terminal/nativeGhosttyClient.ts`** — `childId` on `NativeGhosttyPaneRef`; `NativeGhosttyAddBurnerRequest`; helpers per the existing enabled/disabled-sentinel pattern.
 8. **React `GhosttyBody.tsx` + `useBurnerTerminals.ts`** — `childId` prop threaded into `paneRef` and the `ghostty-native-input`/`-focus` event filters (lines 574-634); the hook's `renderNode` popup block (lines 537-575) replaced by native attach/detach calls from `show()`/`hide()`.
 
-Keep: the entire `useBurnerTerminals` PTY state machine (ephemeral spawn, `paneKey`, show/toggle/hide, cwd align VIM-81, OSC 7 tracking, foreground cue VIM-71, self-exit VIM-62, reconcile/kill, boot reap, `Mod+; \`` chord, header signals). Retire: `BurnerTerminalPopup/index.tsx` in full; the hook's `renderNode` block; `{burnerTerminalNode}` at `WorkspaceView.tsx:3031`; re-evaluate the `burnerTerminalOpen` occlusion registration (`WorkspaceView.tsx:2541-2545`).
+Keep: the entire `useBurnerTerminals` PTY state machine (ephemeral spawn, `paneKey`, show/toggle/hide, cwd align VIM-81, OSC 7 tracking, foreground cue VIM-71, self-exit VIM-62, reconcile/kill, boot reap, `Mod+; \`` chord, header signals). Retire: the full `BurnerTerminalPopup/index.tsx`; the hook renderNode block; the burnerTerminalNode slot at WorkspaceView.tsx:3031; re-evaluate the `burnerTerminalOpen` occlusion registration (`WorkspaceView.tsx:2541-2545`).
 
 ## Risks, ranked (verified by codex round 2)
 
@@ -75,7 +75,7 @@ Added by codex round 2:
 - **R7 (HIGH) — Burner output has no subscriber.** Native output forwarding is owned by the mounted `GhosttyBody` (`GhosttyBody.tsx:637-657`) — a role the popup Body currently plays for the burner (`useBurnerTerminals.ts:537-574`). Retiring the popup without a replacement leaves burner PTY output going nowhere. Mitigation: a forwarder owned by `useBurnerTerminals` on native attach — `service.onData(burnerPtyId)` → `sendNativeGhosttyData(childId: 'burner')` — draining the `registerPending` buffer into it.
 - **R8 (HIGH) — Hide must not become destructive.** Today `hide()` keeps the popup Body mounted (`display:none`), so shell + scrollback survive. The library frees surface state on coordinator teardown (`TerminalSurfaceCoordinator.swift:311-323`, though `AppTerminalView` survives plain window detach — `AppTerminalView+Lifecycle.swift:52-67`, `:96-99`). Implementing native hide as remove/destroy kills scrollback. Mitigation: hide = AppKit `isHidden` on the burner view (view + session alive); `removeBurnerChild` reserved for kill.
 - **R9 (HIGH) — Callback-context use-after-free.** Swift's `CallbackBox` holds the raw C++ context pointer (`GhosttyElectronBridge.swift:75-82`) and invokes it on input/resize (`:101-119`); C++ casts it back in the trampolines (`ghostty_native_parent.cc:177-184`). Freeing the `BurnerContext` before the Swift child is destroyed is a UAF, not just a leak. Mitigation: `RemoveBurnerChild` destroys the Swift child first, then releases tsfns/context; mirror the primary's atomic `released` flag.
-- **R10 (HIGH) — Child frames in the wrong coordinate space.** `setFrame` y-flips renderer coordinates via `parentHeight` for the container (`GhosttyElectronBridge.swift:261-275`); the primary then fills `container.bounds` (`:277`). Child sub-rects must be computed in the container's *local* bounds — a second parent-height y-flip misplaces the burner. Mitigation: `layoutChildren()` computes sub-rects purely from `container.bounds`.
+- **R10 (HIGH) — Child frames in the wrong coordinate space.** `setFrame` y-flips renderer coordinates via `parentHeight` for the container (`GhosttyElectronBridge.swift:261-275`); the primary then fills `container.bounds` (`:277`). Child sub-rects must be computed in the container's _local_ bounds — a second parent-height y-flip misplaces the burner. Mitigation: `layoutChildren()` computes sub-rects purely from `container.bounds`.
 
 ## Spike order (revised per codex round 2)
 

--- a/docs/exploration/2026-07-04-ghostty-burner-side-pane/ghostty-split-api-technical-note.md
+++ b/docs/exploration/2026-07-04-ghostty-burner-side-pane/ghostty-split-api-technical-note.md
@@ -1,0 +1,85 @@
+# Ghostty Split API Exploration — Burner as a Nested Native Pane
+
+2026-07-03 · Package under test: `Lakr233/libghostty-spm` **1.2.7** (rev `2b0e1b9d`, pinned by `native/ghostty-helper/Package.resolved`, source materialized at `/tmp/libghostty-spm-src`) · Markdown mirror of `ghostty-split-api-technical-note.html` (bilingual); this file is the review handoff for codex.
+
+## Verdict
+
+- **Option A (Ghostty-internal split) is dead.** libghostty-spm exposes no host-controllable split API, and recompiling cannot restore one — the split layout engine was never in the library (see Addendum).
+- **Option B (two TerminalViews, host-owned layout) is viable.** Two independent `TerminalView` + `InMemoryTerminalSession` pairs coexist safely inside one `EmbeddedGhosttySurface` NSView — provided **each gets its own `TerminalController`**.
+
+## Q1 — No split API in the package
+
+The only split-related public symbol is `TerminalSurfaceContext.split` (`Sources/GhosttyTerminal/Surface/TerminalSurfaceContext.swift:8`) → `GHOSTTY_SURFACE_CONTEXT_SPLIT`, a **creation-time hint** to the VT engine (key-binding routing). It does not make Ghostty own a split layout. `TerminalView`/`AppTerminalView`, `TerminalController`, `TerminalSurface`, `InMemoryTerminalSession`, `TerminalViewState`, `TerminalSurfaceView` — none expose pane/layout APIs. The package builds upstream Ghostty with `zig build -Dapp-runtime=none` (`Script/build-ghostty.sh:62-64`).
+
+## Addendum — Recompiling doesn't help (verified upstream v1.2.3)
+
+Everything split-related in the **full** `include/ghostty.h` (the untrimmed API real Ghostty.app links) is an *action*: `GHOSTTY_ACTION_NEW_SPLIT` / `GOTO_SPLIT` / `RESIZE_SPLIT` / `EQUALIZE_SPLITS` / `TOGGLE_SPLIT_ZOOM` plus four functions like `ghostty_surface_split()`. In the core:
+
+```zig
+// upstream src/apprt/embedded.zig:1843 (v1.2.3)
+export fn ghostty_surface_split(ptr: *Surface, direction: apprt.action.SplitDirection) void {
+    _ = ptr.app.performAction(.{ .surface = &ptr.core_surface }, .new_split, direction) catch ...
+}
+```
+
+It fires `.new_split` **back out to the host's action callback**. The core never lays out two surfaces (one surface = one view = one Metal layer). The actual split engine (`SplitTree.swift`, surface arrangement, dividers, focus traversal) is Swift **application source** under `macos/` in the ghostty repo — not library code behind any build flag. **Option B is not a workaround; it is the same role Ghostty.app itself plays**, with the split tree capped at two children.
+
+## Q2 — Two-TerminalView coexistence constraints
+
+| Constraint | Evidence | Impact |
+|---|---|---|
+| **One `TerminalController` per view** (BLOCKING) | `TerminalController.swift:59-60`, `TerminalSurfaceCoordinator.swift:138` | `onWakeup`/`shouldProcessWakeup` are single-slot closures; `rebuildIfReady()` overwrites them — a shared controller silences the earlier view's render loop. |
+| Avoid `TerminalController.shared` | `TerminalController.swift:46` | Convenience singleton; naive use triggers the constraint above. |
+| Process-global init/rendering (SAFE) | `TerminalController.swift:300`, `AppTerminalView.swift:13` | `ghostty_init` one-shot guarded; per-controller `ghostty_app_t`; per-view `CAMetalLayer`; per-coordinator main-queue tick, no shared display link. |
+
+Vimeflow already follows the pattern: `EmbeddedGhosttySurface` uses `private lazy var controller = TerminalController()` (`GhosttyElectronBridge.swift:201`).
+
+## Codex verification — round 1 (split-API verdict)
+
+`agrees = true`. Two refinements: (1) tick pump is per-coordinator (MSDisplayLink imported but never shared); (2) `retainedBridges` (`TerminalController+Config.swift:64`) lets one controller fan out config updates to multiple surfaces — does not lift the single-slot wakeup constraint.
+
+## Codex verification — round 2 (risks + spike order)
+
+Adversarial pass over the Risks and Spike order sections against the actual code. Verdicts: R2/R4/R6 **confirmed**; R1/R3/R5 **incomplete** — corrections folded into the risk list below. Codex surfaced **four missing HIGH risks** (R7–R10 below) and a refined spike order (folded into "Spike order").
+
+## Change map (Option B)
+
+Pipeline: `GhosttyBody.tsx` → `nativeGhosttyClient.ts` → `preload.ts` → `electron/ghostty-native-parent.ts` (surfaces keyed `` `${sessionId}:${paneId}` ``) → `native/ghostty-parent/ghostty_native_parent.cc` (N-API, tsfns) → `GhosttyElectronBridge.swift` (`EmbeddedGhosttySurface`: container NSView + TerminalView + InMemoryTerminalSession).
+
+Identity: `sessionId` = ptyId (NOT the layout session id — `GhosttyBody.tsx:193`). Burner adds `childId: 'primary' | 'burner'` + `burnerPtyId`. The main-process paneKey must **not** include `childId` (burner shares its parent's surface state entry).
+
+Ordered minimal plan (native-first):
+
+1. **Swift `GhosttyElectronBridge.swift`** — optional `burnerTerminalView`/`burnerSession`/`burnerCallbacks` (own `TerminalController` each); `enum BurnerPlacement { right, bottom }`; `layoutChildren()` splitting `container.bounds` by ratio, called from `setFrame`; new `@_cdecl` exports `vimeflow_ghostty_add_burner_child` / `remove_burner_child` / `write_burner` / `focus_burner`; fix `shortcutMonitor.handleKeyDown` (line 441) to match firstResponder against either view.
+2. **N-API `ghostty_native_parent.cc`** — load the 4 new dylib symbols in `EnsureBridge()`; `BurnerContext` struct with its own tsfns (input/resize/focus), separate from the primary `SurfaceHandle` for independent teardown; `AddBurnerChild`/`RemoveBurnerChild`/`WriteBurner`/`FocusBurner`; extend `ReleaseSurfaceCallbacks` to drain burner tsfns.
+3. **`electron/ghostty-native-channels.ts`** — add `GHOSTTY_NATIVE_ADD_BURNER` / `GHOSTTY_NATIVE_REMOVE_BURNER`; write/focus/destroy reuse existing channels with a `childId` field.
+4. **`electron/ghostty-native-shared.ts`** — `childId?: 'primary' | 'burner'` on `GhosttyNativePaneRequest`; new `GhosttyNativeAddBurnerRequest { burnerPtyId, placement, ratio }`.
+5. **`electron/ghostty-native-parent.ts`** — `GhosttyNativeSurfaceState.burnerPtyId`; add/remove IPC handlers; `sendData`/`focus` branch on `childId`; burner `onInput`/`onResize` route `write_pty`/`resize_pty` with **`burnerPtyId`**; `destroySurface` also removes the burner child.
+6. **`electron/preload.ts`** — expose `addBurnerChild`/`removeBurnerChild` invokes.
+7. **`src/features/terminal/nativeGhosttyClient.ts`** — `childId` on `NativeGhosttyPaneRef`; `NativeGhosttyAddBurnerRequest`; helpers per the existing enabled/disabled-sentinel pattern.
+8. **React `GhosttyBody.tsx` + `useBurnerTerminals.ts`** — `childId` prop threaded into `paneRef` and the `ghostty-native-input`/`-focus` event filters (lines 574-634); the hook's `renderNode` popup block (lines 537-575) replaced by native attach/detach calls from `show()`/`hide()`.
+
+Keep: the entire `useBurnerTerminals` PTY state machine (ephemeral spawn, `paneKey`, show/toggle/hide, cwd align VIM-81, OSC 7 tracking, foreground cue VIM-71, self-exit VIM-62, reconcile/kill, boot reap, `Mod+; \`` chord, header signals). Retire: `BurnerTerminalPopup/index.tsx` in full; the hook's `renderNode` block; `{burnerTerminalNode}` at `WorkspaceView.tsx:3031`; re-evaluate the `burnerTerminalOpen` occlusion registration (`WorkspaceView.tsx:2541-2545`).
+
+## Risks, ranked (verified by codex round 2)
+
+- **R1 (HIGH) — PTY identity mis-routing.** The burner's `onInput` must call `write_pty` with `burnerPtyId`, never `state.pane.sessionId` — otherwise burner keystrokes are injected into the primary (agent) PTY. Codex round 2: `resize_pty` shares the same identity path (`electron/ghostty-native-parent.ts:518-525`) — route **both** write and resize through the burner context. Mitigation: separate callback context (`BurnerContext`) end-to-end; integration test typing into the burner asserting the primary PTY saw nothing.
+- **R2 (HIGH) — Teardown ordering.** `GhosttyBody` unmount cleanup calls destroy unconditionally (line 691). A burner destroy with missing/misrouted `childId` must map to `removeBurnerChild`, never `destroySurface` — or the still-live primary dies. Mitigation: main-process branch on `childId` with default-deny for surfaces that have a burner.
+- **R3 (HIGH) — Shortcut/focus gating.** The window-level `shortcutMonitor` checks firstResponder against the primary view only (Swift:441-453; digits guard :475-480 — corrected by codex round 2). With the burner focused, Cmd+digit pane-switching is silently swallowed; key routing can drop events. The context menu is also primary-only (Swift:425-438), and Electron emits rename with `state.pane` (`ghostty-native-parent.ts:574-577`) — rename/context callbacks must carry child identity. Mitigation: extend every firstResponder check to "descendant of primary or burner view"; same for the context-menu monitor.
+- **R4 (MED) — Split-geometry divergence.** Two renderer-driven `update` paths plus the 120 ms resize quiet window (`NATIVE_RESIZE_TRACKING_QUIET_MS`, `GhosttyBody.tsx:68`) can briefly disagree → gap/overlap; overlapping sibling NSViews break hit-testing. Mitigation: **let Swift own the split** — one bounds source (the existing per-pane `update`), `layoutChildren()` computes both integer-rounded sub-rects; also satisfies the "nested divider must be native/AppKit" requirement.
+- **R5 (MED) — Pending-data race.** Main buffers PTY output in `pendingData` when no surface exists yet (`ghostty-native-parent.ts:367-377`, flush at `:643-655`); the burner needs equivalent buffering between its PTY spawn and `addBurnerChild` arrival. Codex round 2: the renderer's `registerPending` buffer drains only when a mounted Body calls `onPaneReady` (`usePtyBufferDrain.ts:60-78`, `BurnerTerminalPopup/index.tsx:365-374`) — with the popup gone, the burner needs a new drain owner (see R7).
+- **R6 (LOW) — tsfn lifecycle leak.** If `BurnerContext` holds its own tsfns, the primary `SurfaceHandle` finalizer must also release them (release sites today: `ReleaseSurfaceCallbacks` `ghostty_native_parent.cc:378-418`, explicit destroy `:590-599`, finalizer `:363-375`). Mitigation: drain burner tsfns in both `RemoveBurnerChild` and `ReleaseSurfaceCallbacks`/`FinalizeSurface`.
+
+Added by codex round 2:
+
+- **R7 (HIGH) — Burner output has no subscriber.** Native output forwarding is owned by the mounted `GhosttyBody` (`GhosttyBody.tsx:637-657`) — a role the popup Body currently plays for the burner (`useBurnerTerminals.ts:537-574`). Retiring the popup without a replacement leaves burner PTY output going nowhere. Mitigation: a forwarder owned by `useBurnerTerminals` on native attach — `service.onData(burnerPtyId)` → `sendNativeGhosttyData(childId: 'burner')` — draining the `registerPending` buffer into it.
+- **R8 (HIGH) — Hide must not become destructive.** Today `hide()` keeps the popup Body mounted (`display:none`), so shell + scrollback survive. The library frees surface state on coordinator teardown (`TerminalSurfaceCoordinator.swift:311-323`, though `AppTerminalView` survives plain window detach — `AppTerminalView+Lifecycle.swift:52-67`, `:96-99`). Implementing native hide as remove/destroy kills scrollback. Mitigation: hide = AppKit `isHidden` on the burner view (view + session alive); `removeBurnerChild` reserved for kill.
+- **R9 (HIGH) — Callback-context use-after-free.** Swift's `CallbackBox` holds the raw C++ context pointer (`GhosttyElectronBridge.swift:75-82`) and invokes it on input/resize (`:101-119`); C++ casts it back in the trampolines (`ghostty_native_parent.cc:177-184`). Freeing the `BurnerContext` before the Swift child is destroyed is a UAF, not just a leak. Mitigation: `RemoveBurnerChild` destroys the Swift child first, then releases tsfns/context; mirror the primary's atomic `released` flag.
+- **R10 (HIGH) — Child frames in the wrong coordinate space.** `setFrame` y-flips renderer coordinates via `parentHeight` for the container (`GhosttyElectronBridge.swift:261-275`); the primary then fills `container.bounds` (`:277`). Child sub-rects must be computed in the container's *local* bounds — a second parent-height y-flip misplaces the burner. Mitigation: `layoutChildren()` computes sub-rects purely from `container.bounds`.
+
+## Spike order (revised per codex round 2)
+
+1. **Swift-only spike first**: extend `GhosttyNativeMacosSmoke` (today it proves exactly one `TerminalView` — `GhosttyNativeMacosSmoke.swift:121-135`) to exercise **add/remove of a second view with its own controller**, plus hide-vs-remove semantics — proves rendering, focus, input isolation, and scrollback survival before touching any IPC.
+2. **C++ N-API next, with its smoke**: new symbols/contexts/finalizers in `ghostty_native_parent.cc` (exports today are only the old five — `:604-619`), updating `scripts/smoke-ghostty-native-parent.js` (currently checks only create/setFrame/write/focus/destroy — `:14-28`) **before** any Electron work. Build/codesign pipeline already exists (`scripts/build-ghostty-native-parent.js:43-88`).
+3. Then Electron main (childId routing, burner output forwarding, pending-buffer tests) → preload/native client → React hook swap — keeping the `useBurnerTerminals` PTY lifecycle untouched, replacing only the presentation layer. No Rust bindings regen unless Rust command/types change.
+4. Remaining open questions are design, not feasibility: focus-on-open policy, close-vs-hide semantics, user-toggleable placement.

--- a/docs/exploration/2026-07-04-ghostty-burner-side-pane/index.html
+++ b/docs/exploration/2026-07-04-ghostty-burner-side-pane/index.html
@@ -19,8 +19,13 @@
         --green: #85c88a;
         --danger: #f28b82;
         font-family:
-          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
-          "Segoe UI", sans-serif;
+          Inter,
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          'Segoe UI',
+          sans-serif;
       }
 
       * {
@@ -76,7 +81,10 @@
         background: color-mix(in srgb, var(--shell) 16%, transparent);
         color: #ffd990;
         font:
-          700 11px/1 ui-monospace, "SFMono-Regular", Menlo, Consolas,
+          700 11px/1 ui-monospace,
+          'SFMono-Regular',
+          Menlo,
+          Consolas,
           monospace;
         letter-spacing: 0.06em;
       }
@@ -95,12 +103,15 @@
         background: var(--surface-2);
         color: var(--text);
         font:
-          600 12px/1 ui-monospace, "SFMono-Regular", Menlo, Consolas,
+          600 12px/1 ui-monospace,
+          'SFMono-Regular',
+          Menlo,
+          Consolas,
           monospace;
         cursor: pointer;
       }
 
-      button[data-active="true"] {
+      button[data-active='true'] {
         background: color-mix(in srgb, var(--shell) 28%, var(--surface-2));
         color: #ffe1a3;
       }
@@ -221,7 +232,10 @@
         background: var(--surface-2);
         border-bottom: 1px solid var(--line);
         font:
-          600 11px/1 ui-monospace, "SFMono-Regular", Menlo, Consolas,
+          600 11px/1 ui-monospace,
+          'SFMono-Regular',
+          Menlo,
+          Consolas,
           monospace;
       }
 
@@ -247,7 +261,10 @@
       .micro {
         color: var(--muted);
         font:
-          600 10px/1 ui-monospace, "SFMono-Regular", Menlo, Consolas,
+          600 10px/1 ui-monospace,
+          'SFMono-Regular',
+          Menlo,
+          Consolas,
           monospace;
         letter-spacing: 0.04em;
       }
@@ -258,7 +275,10 @@
         background: color-mix(in srgb, var(--shell) 16%, transparent);
         color: #ffd990;
         font:
-          700 10px/1 ui-monospace, "SFMono-Regular", Menlo, Consolas,
+          700 10px/1 ui-monospace,
+          'SFMono-Regular',
+          Menlo,
+          Consolas,
           monospace;
         letter-spacing: 0.06em;
       }
@@ -269,7 +289,10 @@
         background: #1b1b1b;
         color: #f5f2e9;
         font:
-          700 13px/1.45 ui-monospace, "SFMono-Regular", Menlo, Consolas,
+          700 13px/1.45 ui-monospace,
+          'SFMono-Regular',
+          Menlo,
+          Consolas,
           monospace;
       }
 
@@ -431,7 +454,9 @@
           <h2>Mechanism</h2>
           <div class="note">
             <span class="marker">1</span>
-            <span>Clicking burner creates or reveals a Vimeflow shell pane.</span>
+            <span
+              >Clicking burner creates or reveals a Vimeflow shell pane.</span
+            >
           </div>
           <div class="note">
             <span class="marker">2</span>
@@ -482,21 +507,20 @@
     </main>
 
     <script>
-      const buttons = [...document.querySelectorAll("button[data-mode]")]
-      const grid = document.getElementById("paneGrid")
-      const burner = document.getElementById("burnerPane")
+      const buttons = [...document.querySelectorAll('button[data-mode]')]
+      const grid = document.getElementById('paneGrid')
+      const burner = document.getElementById('burnerPane')
 
       buttons.forEach((button) => {
-        button.addEventListener("click", () => {
+        button.addEventListener('click', () => {
           const mode = button.dataset.mode
           buttons.forEach((item) => {
-            item.dataset.active = item === button ? "true" : "false"
+            item.dataset.active = item === button ? 'true' : 'false'
           })
           grid.className = `pane-grid ${mode}`
-          burner.hidden = mode === "host-only"
+          burner.hidden = mode === 'host-only'
         })
       })
     </script>
   </body>
 </html>
-

--- a/docs/exploration/2026-07-04-ghostty-burner-side-pane/index.html
+++ b/docs/exploration/2026-07-04-ghostty-burner-side-pane/index.html
@@ -1,0 +1,502 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Ghostty Burner Side Pane Options</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #10101b;
+        --surface: #171725;
+        --surface-2: #242037;
+        --surface-3: #312a45;
+        --text: #ebe8f6;
+        --muted: #a59dbb;
+        --line: rgba(224, 216, 255, 0.12);
+        --shell: #d6a348;
+        --blue: #79addc;
+        --green: #85c88a;
+        --danger: #f28b82;
+        font-family:
+          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+          "Segoe UI", sans-serif;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: var(--bg);
+        color: var(--text);
+      }
+
+      main {
+        width: min(1180px, calc(100vw - 32px));
+        margin: 0 auto;
+        padding: 28px 0 40px;
+      }
+
+      header.page {
+        display: flex;
+        align-items: end;
+        justify-content: space-between;
+        gap: 24px;
+        margin-bottom: 20px;
+      }
+
+      h1,
+      h2,
+      p {
+        margin: 0;
+      }
+
+      h1 {
+        font-size: 22px;
+        letter-spacing: 0;
+      }
+
+      .lede {
+        max-width: 760px;
+        margin-top: 8px;
+        color: var(--muted);
+        font-size: 14px;
+        line-height: 1.55;
+      }
+
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+        border-radius: 8px;
+        padding: 5px 8px;
+        background: color-mix(in srgb, var(--shell) 16%, transparent);
+        color: #ffd990;
+        font:
+          700 11px/1 ui-monospace, "SFMono-Regular", Menlo, Consolas,
+          monospace;
+        letter-spacing: 0.06em;
+      }
+
+      .toolbar {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin: 18px 0;
+      }
+
+      button {
+        border: 0;
+        border-radius: 8px;
+        padding: 8px 10px;
+        background: var(--surface-2);
+        color: var(--text);
+        font:
+          600 12px/1 ui-monospace, "SFMono-Regular", Menlo, Consolas,
+          monospace;
+        cursor: pointer;
+      }
+
+      button[data-active="true"] {
+        background: color-mix(in srgb, var(--shell) 28%, var(--surface-2));
+        color: #ffe1a3;
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: 1fr 330px;
+        gap: 14px;
+        align-items: start;
+      }
+
+      .canvas,
+      .notes,
+      .option-card {
+        background: var(--surface);
+        border-radius: 12px;
+      }
+
+      .canvas {
+        overflow: hidden;
+        min-height: 620px;
+        border: 1px solid var(--line);
+      }
+
+      .appbar {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        height: 34px;
+        padding: 0 12px;
+        background: #131322;
+        border-bottom: 1px solid var(--line);
+      }
+
+      .dot {
+        width: 11px;
+        height: 11px;
+        border-radius: 999px;
+      }
+
+      .dot.red {
+        background: #ff6b6b;
+      }
+
+      .dot.yellow {
+        background: #ffd166;
+      }
+
+      .dot.green {
+        background: #87d37c;
+      }
+
+      .workspace {
+        display: grid;
+        grid-template-columns: 180px 1fr;
+        min-height: 586px;
+      }
+
+      .sidebar {
+        padding: 12px;
+        background: #151526;
+        border-right: 1px solid var(--line);
+      }
+
+      .session {
+        margin-top: 12px;
+        border-radius: 8px;
+        padding: 10px;
+        background: var(--surface-2);
+      }
+
+      .stage {
+        padding: 14px;
+      }
+
+      .pane-grid {
+        display: grid;
+        height: 550px;
+        gap: 8px;
+      }
+
+      .pane-grid.side {
+        grid-template-columns: minmax(0, 1.45fr) minmax(260px, 0.8fr);
+      }
+
+      .pane-grid.bottom {
+        grid-template-rows: minmax(0, 1.25fr) minmax(180px, 0.65fr);
+      }
+
+      .pane-grid.host-only {
+        grid-template-columns: 1fr;
+      }
+
+      .pane {
+        display: flex;
+        min-width: 0;
+        min-height: 0;
+        flex-direction: column;
+        overflow: hidden;
+        border-radius: 10px;
+        background: #0f0f18;
+      }
+
+      .pane.host {
+        outline: 1px solid color-mix(in srgb, var(--blue) 22%, transparent);
+      }
+
+      .pane.burner {
+        outline: 1px solid color-mix(in srgb, var(--shell) 35%, transparent);
+      }
+
+      .pane-head {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        min-height: 34px;
+        padding: 6px 8px;
+        background: var(--surface-2);
+        border-bottom: 1px solid var(--line);
+        font:
+          600 11px/1 ui-monospace, "SFMono-Regular", Menlo, Consolas,
+          monospace;
+      }
+
+      .glyph {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 22px;
+        height: 22px;
+        border-radius: 7px;
+        background: color-mix(in srgb, var(--shell) 18%, transparent);
+        color: var(--shell);
+      }
+
+      .title {
+        min-width: 0;
+        flex: 1;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .micro {
+        color: var(--muted);
+        font:
+          600 10px/1 ui-monospace, "SFMono-Regular", Menlo, Consolas,
+          monospace;
+        letter-spacing: 0.04em;
+      }
+
+      .chip {
+        border-radius: 7px;
+        padding: 4px 6px;
+        background: color-mix(in srgb, var(--shell) 16%, transparent);
+        color: #ffd990;
+        font:
+          700 10px/1 ui-monospace, "SFMono-Regular", Menlo, Consolas,
+          monospace;
+        letter-spacing: 0.06em;
+      }
+
+      .term {
+        flex: 1;
+        padding: 14px;
+        background: #1b1b1b;
+        color: #f5f2e9;
+        font:
+          700 13px/1.45 ui-monospace, "SFMono-Regular", Menlo, Consolas,
+          monospace;
+      }
+
+      .prompt {
+        display: inline;
+        background: #ffd69c;
+        color: #17110b;
+        padding: 1px 4px;
+      }
+
+      .burner .term {
+        background: #191715;
+      }
+
+      .ghost {
+        color: #9f9a8e;
+      }
+
+      .notes {
+        padding: 14px;
+        border: 1px solid var(--line);
+      }
+
+      .notes h2 {
+        margin-bottom: 10px;
+        font-size: 14px;
+      }
+
+      .note {
+        display: grid;
+        grid-template-columns: 18px 1fr;
+        gap: 8px;
+        margin: 10px 0;
+        color: var(--muted);
+        font-size: 13px;
+        line-height: 1.45;
+      }
+
+      .marker {
+        color: var(--green);
+        font-weight: 800;
+      }
+
+      .options {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 12px;
+        margin-top: 14px;
+      }
+
+      .option-card {
+        padding: 14px;
+        border: 1px solid var(--line);
+      }
+
+      .option-card h2 {
+        margin-bottom: 8px;
+        font-size: 14px;
+      }
+
+      .option-card p {
+        color: var(--muted);
+        font-size: 13px;
+        line-height: 1.45;
+      }
+
+      @media (max-width: 900px) {
+        .grid,
+        .options,
+        .workspace {
+          grid-template-columns: 1fr;
+        }
+
+        .pane-grid.side {
+          grid-template-columns: 1fr;
+          grid-template-rows: minmax(320px, 1fr) minmax(220px, 0.6fr);
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header class="page">
+        <div>
+          <h1>Ghostty Burner Side Pane Options</h1>
+          <p class="lede">
+            The burner should stop being a floating terminal dialog. The safest
+            route is to make it a normal Vimeflow shell pane rendered by the
+            existing native Ghostty surface path.
+          </p>
+        </div>
+        <span class="badge">RECOMMENDED: SIDE PANE</span>
+      </header>
+
+      <nav class="toolbar" aria-label="Demo mode">
+        <button type="button" data-mode="side" data-active="true">
+          right side pane
+        </button>
+        <button type="button" data-mode="bottom">bottom side pane</button>
+        <button type="button" data-mode="host-only">host only</button>
+      </nav>
+
+      <section class="grid">
+        <div class="canvas" aria-label="Workspace mockup">
+          <div class="appbar">
+            <span class="dot red"></span>
+            <span class="dot yellow"></span>
+            <span class="dot green"></span>
+            <span class="micro">vimeflow ghostty canvas</span>
+          </div>
+          <div class="workspace">
+            <aside class="sidebar">
+              <span class="micro">SESSIONS</span>
+              <div class="session">
+                <strong>vimeflow</strong>
+                <p class="micro" style="margin-top: 8px">running · 2 panes</p>
+              </div>
+            </aside>
+            <section class="stage">
+              <div id="paneGrid" class="pane-grid side">
+                <article class="pane host">
+                  <div class="pane-head">
+                    <span class="glyph">$</span>
+                    <span class="title">vimeflow</span>
+                    <span class="chip">BURNER x1</span>
+                    <span class="micro">CMD 1</span>
+                  </div>
+                  <div class="term">
+                    <span class="prompt">winoooops</span>
+                    <span class="prompt">~/vimeflow</span>
+                    <span class="prompt">feature/vim-267</span>
+                    <br />
+                    <span class="ghost">main Ghostty pane stays primary</span>
+                  </div>
+                </article>
+
+                <article id="burnerPane" class="pane burner">
+                  <div class="pane-head">
+                    <span class="glyph">$</span>
+                    <span class="chip">BURNER</span>
+                    <span class="title">linked to vimeflow</span>
+                    <span class="micro">sync cwd</span>
+                  </div>
+                  <div class="term">
+                    <span class="prompt">burner</span>
+                    <span class="prompt">~/vimeflow</span>
+                    <br />
+                    <span class="ghost">
+                      ephemeral shell, no agent bridge, rendered by Ghostty
+                    </span>
+                  </div>
+                </article>
+              </div>
+            </section>
+          </div>
+        </div>
+
+        <aside class="notes">
+          <h2>Mechanism</h2>
+          <div class="note">
+            <span class="marker">1</span>
+            <span>Clicking burner creates or reveals a Vimeflow shell pane.</span>
+          </div>
+          <div class="note">
+            <span class="marker">2</span>
+            <span>
+              The pane uses an ephemeral PTY and disables the agent bridge.
+            </span>
+          </div>
+          <div class="note">
+            <span class="marker">3</span>
+            <span>
+              Ghostty gets no special split command; it just renders another
+              native surface for another React pane.
+            </span>
+          </div>
+          <div class="note">
+            <span class="marker">4</span>
+            <span>
+              The host header gets a small burner cue. The burner header gets
+              the temporary identity and cwd sync control.
+            </span>
+          </div>
+        </aside>
+      </section>
+
+      <section class="options">
+        <article class="option-card">
+          <h2>A. Vimeflow Side Pane</h2>
+          <p>
+            Best v1. Reuses split layout, pane lifecycle, Ghostty native
+            rendering, shortcuts, and xterm fallback.
+          </p>
+        </article>
+        <article class="option-card">
+          <h2>B. Overlay Terminal</h2>
+          <p>
+            Avoid. It revives the floating-terminal problem and makes focus,
+            shutdown, and resize harder than a pane.
+          </p>
+        </article>
+        <article class="option-card">
+          <h2>C. Ghostty Internal Split</h2>
+          <p>
+            Blocked for now. Our bridge exposes one TerminalView per surface,
+            not a host-controlled split tree.
+          </p>
+        </article>
+      </section>
+    </main>
+
+    <script>
+      const buttons = [...document.querySelectorAll("button[data-mode]")]
+      const grid = document.getElementById("paneGrid")
+      const burner = document.getElementById("burnerPane")
+
+      buttons.forEach((button) => {
+        button.addEventListener("click", () => {
+          const mode = button.dataset.mode
+          buttons.forEach((item) => {
+            item.dataset.active = item === button ? "true" : "false"
+          })
+          grid.className = `pane-grid ${mode}`
+          burner.hidden = mode === "host-only"
+        })
+      })
+    </script>
+  </body>
+</html>
+

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -96,7 +96,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [CloudFormation Stale References](patterns/cloudformation-stale-references.md)                       | infrastructure     | 2        | 1    | 2026-06-12   |
 | [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 7        | 7    | 2026-06-22   |
 | [Unsafe Block Safety Comments](patterns/unsafe-block-safety-comments.md)                             | security           | 1        | 0    | 2026-06-14   |
-| [Type Contract Safety](patterns/type-contract-safety.md)                                             | code-quality       | 14       | 8    | 2026-06-30   |
+| [Type Contract Safety](patterns/type-contract-safety.md)                                             | code-quality       | 15       | 9    | 2026-07-04   |
 | [String Construction Hygiene](patterns/string-construction-hygiene.md)                               | code-quality       | 2        | 1    | 2026-06-19   |
 | [Agent-State Guards](patterns/agent-state-guards.md)                                                 | correctness        | 14       | 9    | 2026-06-28   |
 | [React Prop Contracts](patterns/react-prop-contracts.md)                                             | react-patterns     | 8        | 6    | 2026-06-22   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -44,12 +44,12 @@ When appending findings to a pattern file, label the source so future readers ca
 | Pattern                                                                                              | Category           | Findings | Refs | Last Updated |
 | ---------------------------------------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md)                                                     | security           | 28       | 8    | 2026-06-22   |
-| [Native Surface Occlusion](patterns/native-surface-occlusion.md)                                     | correctness        | 6        | 1    | 2026-07-03   |
+| [Native Surface Occlusion](patterns/native-surface-occlusion.md)                                     | correctness        | 7        | 1    | 2026-07-04   |
 | [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 65       | 64   | 2026-06-30   |
 | [Imperative Animation Ownership](patterns/imperative-animation-ownership.md)                         | react-patterns     | 7        | 3    | 2026-06-17   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Fixed-Position Portals](patterns/fixed-position-portals.md)                                         | react-patterns     | 2        | 1    | 2026-06-22   |
-| [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 26       | 23   | 2026-06-30   |
+| [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 27       | 23   | 2026-07-04   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)                                             | cross-platform     | 13       | 12   | 2026-06-28   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                                                       | code-quality       | 7        | 0    | 2026-06-11   |
 | [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 15       | 12   | 2026-06-26   |
@@ -101,7 +101,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Agent-State Guards](patterns/agent-state-guards.md)                                                 | correctness        | 14       | 9    | 2026-06-28   |
 | [React Prop Contracts](patterns/react-prop-contracts.md)                                             | react-patterns     | 8        | 6    | 2026-06-22   |
 | [Stale Retained Interactions](patterns/stale-retained-interactions.md)                               | react-patterns     | 2        | 1    | 2026-06-15   |
-| [Retained State Identity](patterns/retained-state-identity.md)                                       | react-patterns     | 1        | 1    | 2026-06-15   |
+| [Retained State Identity](patterns/retained-state-identity.md)                                       | react-patterns     | 2        | 1    | 2026-07-04   |
 | [Authoritative Completion Guard](patterns/authoritative-completion-guard.md)                         | correctness        | 6        | 2    | 2026-06-27   |
 | [Equality Guard Completeness](patterns/equality-guard-completeness.md)                               | correctness        | 2        | 0    | 2026-06-17   |
 | [Resizable Layout Bounds](patterns/resizable-layout-bounds.md)                                       | correctness        | 3        | 1    | 2026-06-18   |

--- a/docs/reviews/patterns/native-surface-occlusion.md
+++ b/docs/reviews/patterns/native-surface-occlusion.md
@@ -2,7 +2,7 @@
 id: native-surface-occlusion
 category: correctness
 created: 2026-06-15
-last_updated: 2026-07-03
+last_updated: 2026-07-04
 ref_count: 1
 ---
 
@@ -72,4 +72,13 @@ React overlays that drive Electron native WebContentsView visibility must regist
 - **Fix:** Added `browser-tab-active` to the shared terminal-background
   collision guard and moved the Flexoki and Gruvbox Light active-tab colors
   to distinct off-ladder values.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 8. Native burner panes assumed primary Ghostty bridge meant secondary support
+
+- **Source:** github-codex-connector | PR #656 round 1 | 2026-07-04
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/terminal/hooks/useBurnerTerminals.ts`
+- **Finding:** The burner hook rendered native secondary panes whenever the primary macOS Ghostty bridge existed. Legacy helper mode exposes only primary update/data/focus/destroy IPC, so the native secondary attach path failed and killed a newly spawned burner instead of falling back to the xterm popup.
+- **Fix:** Added an explicit `canUseNativeGhosttySecondary()` capability check that requires every secondary IPC method, and used it to select native burner rendering. Legacy helper mode now keeps the primary native pane path while burner panes use the xterm popup.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/resource-cleanup.md
+++ b/docs/reviews/patterns/resource-cleanup.md
@@ -2,7 +2,7 @@
 id: resource-cleanup
 category: react-patterns
 created: 2026-04-09
-last_updated: 2026-06-30
+last_updated: 2026-07-04
 ref_count: 23
 ---
 
@@ -262,4 +262,13 @@ causes listener accumulation and duplicate event handling.
   unconditional, but guard every overlay-window/webContents method behind
   `!record.overlayWindow.isDestroyed()`. Added regression coverage for closing
   after overlay-window destruction.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 27. Hoisted preload test env mutation leaked across Vitest worker state
+
+- **Source:** github-claude | PR #656 round 1 | 2026-07-04
+- **Severity:** LOW
+- **File:** `electron/preload.test.ts`
+- **Finding:** A hoisted preload test set `process.env.VITE_GHOSTTY_NATIVE_MACOS_PARENT = '1'` directly so the native bridge existed before importing preload code, but never restored the process-global env value. Later tests in the same worker could inherit native Ghostty mode unexpectedly.
+- **Fix:** Replaced the raw env write with `vi.stubEnv('VITE_GHOSTTY_NATIVE_MACOS_PARENT', '1')` and added `afterAll(() => vi.unstubAllEnvs())`, mirroring the existing explicit global cleanup pattern.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/retained-state-identity.md
+++ b/docs/reviews/patterns/retained-state-identity.md
@@ -2,7 +2,7 @@
 id: retained-state-identity
 category: react-patterns
 created: 2026-06-15
-last_updated: 2026-06-15
+last_updated: 2026-07-04
 ref_count: 1
 ---
 
@@ -21,4 +21,13 @@ When a React component renders retained (stale) content while fresh data for a n
 - **File:** `src/features/agent-status/components/AgentStatusPanel/index.tsx`
 - **Finding:** During retained-body fetching, `bodySnapshotKey` referred to the previously rendered/source pane while `snapshotKey` referred to the current target pane. The `handleScroll` callback wrote user scroll events to `bodySnapshotKey`, so scrolling retained content during the refresh window overwrote the source pane's saved scroll position and caused it to reopen at the wrong offset later.
 - **Fix:** Added an identity guard before `writeStatusScrollAnchor` that returns early when `bodySnapshotKey !== snapshotKey`, and added `snapshotKey` to the `handleScroll` `useCallback` dependencies.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 2. Retained burner entries kept a stale native host PTY after pane restart
+
+- **Source:** github-codex-connector | PR #656 round 1 | 2026-07-04
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/terminal/hooks/useBurnerTerminals.ts`
+- **Finding:** Burner entries are intentionally retained by stable `${sessionId}:${paneId}` identity across pane restarts, but the native secondary request kept the old `hostPtyId`. When the host pane remounted with a new PTY, an open native burner stayed attached to the removed native surface until the user toggled it.
+- **Fix:** Threaded a live pane-key-to-PTY map from `WorkspaceView` into `useBurnerTerminals`, updated retained entries when the host PTY changes, and covered the reattach path with a native burner regression test.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/type-contract-safety.md
+++ b/docs/reviews/patterns/type-contract-safety.md
@@ -2,8 +2,8 @@
 id: type-contract-safety
 category: code-quality
 created: 2026-06-15
-last_updated: 2026-06-30
-ref_count: 8
+last_updated: 2026-07-04
+ref_count: 9
 ---
 
 # Type Contract Safety
@@ -170,4 +170,20 @@ expands.
 - **Fix:** Added `surfaceTone?: string` to the Electron-side menu payload and
   accepted string values in the runtime validator. Extended the themed overlay
   controller test to pass the field through to the renderer.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 15. Preload exposed secondary native Ghostty capability in legacy helper mode
+
+- **Source:** github-codex-connector | PR #656 round 1 | 2026-07-04
+- **Severity:** P2 / MEDIUM
+- **File:** `electron/preload.ts`
+- **Finding:** The preload bridge exposed optional secondary Ghostty IPC methods
+  whenever either native Ghostty flag was enabled. In legacy helper mode, the main
+  process registers only the base helper IPC handlers, so renderer capability
+  detection could select native secondary burners and then hit missing handler
+  rejections.
+- **Fix:** Gate the secondary preload methods separately on
+  `VITE_GHOSTTY_NATIVE_MACOS_PARENT`, while keeping base native Ghostty methods
+  available for both helper and parent modes. Added focused preload tests for
+  parent-mode exposure and legacy helper omission.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/electron/ghostty-native-channels.ts
+++ b/electron/ghostty-native-channels.ts
@@ -7,3 +7,14 @@ export const GHOSTTY_NATIVE_DATA = 'ghostty-native:data'
 export const GHOSTTY_NATIVE_FOCUS = 'ghostty-native:focus'
 
 export const GHOSTTY_NATIVE_DESTROY = 'ghostty-native:destroy'
+
+export const GHOSTTY_NATIVE_SECONDARY_ATTACH = 'ghostty-native:secondary-attach'
+
+export const GHOSTTY_NATIVE_SECONDARY_DATA = 'ghostty-native:secondary-data'
+
+export const GHOSTTY_NATIVE_SECONDARY_FOCUS = 'ghostty-native:secondary-focus'
+
+export const GHOSTTY_NATIVE_SECONDARY_REMOVE = 'ghostty-native:secondary-remove'
+
+export const GHOSTTY_NATIVE_SECONDARY_VISIBLE =
+  'ghostty-native:secondary-visible'

--- a/electron/ghostty-native-parent.test.ts
+++ b/electron/ghostty-native-parent.test.ts
@@ -4,6 +4,10 @@ import {
   GHOSTTY_NATIVE_DATA,
   GHOSTTY_NATIVE_DESTROY,
   GHOSTTY_NATIVE_FOCUS,
+  GHOSTTY_NATIVE_SECONDARY_ATTACH,
+  GHOSTTY_NATIVE_SECONDARY_DATA,
+  GHOSTTY_NATIVE_SECONDARY_REMOVE,
+  GHOSTTY_NATIVE_SECONDARY_VISIBLE,
   GHOSTTY_NATIVE_UPDATE,
 } from './ghostty-native-channels'
 import { BACKEND_EVENT, COMMAND_PALETTE_TOGGLE } from './ipc-channels'
@@ -785,6 +789,207 @@ describe('ghostty native parent', () => {
     })
     expect(webContentsFocus).toHaveBeenCalledOnce()
     expect(sidecar.invoke).toHaveBeenCalledTimes(2)
+
+    controller.dispose()
+  })
+
+  test('attaches secondary child and routes input plus resize to its PTY', () => {
+    const callbacks: {
+      onInput?: (data: string) => void
+      onResize?: (cols: number, rows: number) => void
+      onFocus?: () => void
+    } = {}
+    const surface = {}
+
+    const addon = {
+      create: vi.fn(() => surface),
+      addSecondary: vi.fn((_surface, input, resize, focus) => {
+        callbacks.onInput = input
+        callbacks.onResize = resize
+        callbacks.onFocus = focus
+      }),
+      setFrame: vi.fn(),
+      write: vi.fn(),
+      writeSecondary: vi.fn(),
+      focus: vi.fn(),
+      destroy: vi.fn(),
+    }
+
+    const sidecar = {
+      invoke: vi.fn(() => Promise.resolve(undefined)),
+      onEvent: vi.fn(() => vi.fn()),
+      shutdown: vi.fn(() => Promise.resolve()),
+    } as unknown as Sidecar
+
+    const controller = setupGhosttyNativeParent({
+      sidecar,
+      platform: 'darwin',
+      env: { VITE_GHOSTTY_NATIVE_MACOS_PARENT: '1' },
+      addon,
+    })
+
+    expect(
+      handlers.get(GHOSTTY_NATIVE_SECONDARY_ATTACH)?.(
+        { sender: {} },
+        {
+          sessionId: 'host-pty',
+          paneId: 'pane-1',
+          secondarySessionId: 'burner-pty',
+        }
+      )
+    ).toEqual({ enabled: true })
+
+    expect(addon.create).toHaveBeenCalledOnce()
+    expect(addon.addSecondary).toHaveBeenCalledWith(
+      surface,
+      expect.any(Function),
+      expect.any(Function),
+      expect.any(Function)
+    )
+
+    callbacks.onInput?.('a')
+    callbacks.onResize?.(80, 24)
+    callbacks.onResize?.(80, 24)
+    callbacks.onFocus?.()
+
+    expect(sidecar.invoke).toHaveBeenCalledWith('write_pty', {
+      request: { sessionId: 'burner-pty', data: 'a' },
+    })
+
+    expect(sidecar.invoke).toHaveBeenCalledWith('resize_pty', {
+      request: { sessionId: 'burner-pty', cols: 80, rows: 24 },
+    })
+
+    expect(webContentsSend).toHaveBeenCalledWith(BACKEND_EVENT, {
+      event: 'ghostty-native-focus',
+      payload: { sessionId: 'host-pty', paneId: 'pane-1' },
+    })
+    expect(sidecar.invoke).toHaveBeenCalledTimes(2)
+
+    controller.dispose()
+  })
+
+  test('buffers capped secondary output until the child is attached', () => {
+    const surface = {}
+
+    const addon = {
+      create: vi.fn(() => surface),
+      addSecondary: vi.fn(),
+      setFrame: vi.fn(),
+      write: vi.fn(),
+      writeSecondary: vi.fn(),
+      focus: vi.fn(),
+      destroy: vi.fn(),
+    }
+
+    const sidecar = {
+      invoke: vi.fn(() => Promise.resolve(undefined)),
+      onEvent: vi.fn(() => vi.fn()),
+      shutdown: vi.fn(() => Promise.resolve()),
+    } as unknown as Sidecar
+
+    const controller = setupGhosttyNativeParent({
+      sidecar,
+      platform: 'darwin',
+      env: { VITE_GHOSTTY_NATIVE_MACOS_PARENT: '1' },
+      addon,
+    })
+
+    for (let index = 0; index < 70; index += 1) {
+      expect(
+        handlers.get(GHOSTTY_NATIVE_SECONDARY_DATA)?.(
+          {},
+          {
+            sessionId: 'host-pty',
+            paneId: 'pane-1',
+            secondarySessionId: 'burner-pty',
+            data: `boot-${index}`,
+          }
+        )
+      ).toEqual({ enabled: true })
+    }
+    expect(addon.writeSecondary).not.toHaveBeenCalled()
+
+    handlers.get(GHOSTTY_NATIVE_SECONDARY_ATTACH)?.(
+      { sender: {} },
+      {
+        sessionId: 'host-pty',
+        paneId: 'pane-1',
+        secondarySessionId: 'burner-pty',
+      }
+    )
+
+    expect(addon.writeSecondary).toHaveBeenCalledTimes(64)
+    expect(addon.writeSecondary).toHaveBeenNthCalledWith(1, surface, 'boot-6')
+    expect(addon.writeSecondary).toHaveBeenLastCalledWith(surface, 'boot-69')
+
+    controller.dispose()
+  })
+
+  test('hides and removes secondary child without destroying primary surface', () => {
+    const surface = {}
+
+    const addon = {
+      create: vi.fn(() => surface),
+      addSecondary: vi.fn(),
+      setSecondaryVisible: vi.fn(),
+      removeSecondary: vi.fn(),
+      setFrame: vi.fn(),
+      write: vi.fn(),
+      writeSecondary: vi.fn(),
+      focus: vi.fn(),
+      destroy: vi.fn(),
+    }
+
+    const sidecar = {
+      invoke: vi.fn(() => Promise.resolve(undefined)),
+      onEvent: vi.fn(() => vi.fn()),
+      shutdown: vi.fn(() => Promise.resolve()),
+    } as unknown as Sidecar
+
+    const controller = setupGhosttyNativeParent({
+      sidecar,
+      platform: 'darwin',
+      env: { VITE_GHOSTTY_NATIVE_MACOS_PARENT: '1' },
+      addon,
+    })
+
+    handlers.get(GHOSTTY_NATIVE_SECONDARY_ATTACH)?.(
+      { sender: {} },
+      {
+        sessionId: 'host-pty',
+        paneId: 'pane-1',
+        secondarySessionId: 'burner-pty',
+      }
+    )
+
+    expect(
+      handlers.get(GHOSTTY_NATIVE_SECONDARY_VISIBLE)?.(
+        {},
+        {
+          sessionId: 'host-pty',
+          paneId: 'pane-1',
+          secondarySessionId: 'burner-pty',
+          visible: false,
+        }
+      )
+    ).toEqual({ enabled: true })
+
+    expect(addon.setSecondaryVisible).toHaveBeenCalledWith(surface, false)
+
+    expect(
+      handlers.get(GHOSTTY_NATIVE_SECONDARY_REMOVE)?.(
+        {},
+        {
+          sessionId: 'host-pty',
+          paneId: 'pane-1',
+          secondarySessionId: 'burner-pty',
+        }
+      )
+    ).toEqual({ enabled: true })
+
+    expect(addon.removeSecondary).toHaveBeenCalledWith(surface)
+    expect(addon.destroy).not.toHaveBeenCalled()
 
     controller.dispose()
   })

--- a/electron/ghostty-native-parent.ts
+++ b/electron/ghostty-native-parent.ts
@@ -8,6 +8,11 @@ import {
   GHOSTTY_NATIVE_DATA,
   GHOSTTY_NATIVE_DESTROY,
   GHOSTTY_NATIVE_FOCUS,
+  GHOSTTY_NATIVE_SECONDARY_ATTACH,
+  GHOSTTY_NATIVE_SECONDARY_DATA,
+  GHOSTTY_NATIVE_SECONDARY_FOCUS,
+  GHOSTTY_NATIVE_SECONDARY_REMOVE,
+  GHOSTTY_NATIVE_SECONDARY_VISIBLE,
   GHOSTTY_NATIVE_UPDATE,
 } from './ghostty-native-channels'
 import { dispatchCommandPaletteShortcutForWindow } from './command-palette-shortcut'
@@ -22,6 +27,9 @@ import {
   isString,
   type GhosttyNativeDataRequest,
   type GhosttyNativePaneRequest,
+  type GhosttyNativeSecondaryDataRequest,
+  type GhosttyNativeSecondaryRequest,
+  type GhosttyNativeSecondaryVisibleRequest,
   type GhosttyNativeShortcutContext,
   type GhosttyNativeUpdateRequest,
 } from './ghostty-native-shared'
@@ -31,6 +39,11 @@ interface GhosttyNativePayloadByKind {
   data: GhosttyNativeDataRequest
   focus: GhosttyNativePaneRequest
   destroy: GhosttyNativePaneRequest
+  secondaryAttach: GhosttyNativeSecondaryRequest
+  secondaryData: GhosttyNativeSecondaryDataRequest
+  secondaryFocus: GhosttyNativeSecondaryRequest
+  secondaryRemove: GhosttyNativeSecondaryRequest
+  secondaryVisible: GhosttyNativeSecondaryVisibleRequest
 }
 
 interface GhosttyNativeParentAddon {
@@ -64,6 +77,16 @@ interface GhosttyNativeParentAddon {
   write: (surface: unknown, data: string) => void
   focus: (surface: unknown) => void
   destroy: (surface: unknown) => void
+  addSecondary?: (
+    surface: unknown,
+    onInput: (data: string) => void,
+    onResize: (cols: number, rows: number) => void,
+    onFocus: () => void
+  ) => void
+  setSecondaryVisible?: (surface: unknown, visible: boolean) => void
+  writeSecondary?: (surface: unknown, data: string) => void
+  focusSecondary?: (surface: unknown) => void
+  removeSecondary?: (surface: unknown) => void
 }
 
 interface GhosttyNativeParentDeps {
@@ -79,11 +102,19 @@ interface GhosttyNativeSurfaceState {
   pane: GhosttyNativePaneRequest
   surface: unknown
   pendingData: string[]
+  secondary: GhosttyNativeSecondaryState | null
   // Resize updates pass through this same path. Cache values that reapply
   // Ghostty theme/shortcut state so steady resize only calls setFrame.
   lastBackgroundColor: string | null
   lastResize: { cols: number; rows: number } | null
   lastShortcutDigits: string | null
+}
+
+interface GhosttyNativeSecondaryState {
+  sessionId: string
+  attached: boolean
+  pendingData: string[]
+  lastResize: { cols: number; rows: number } | null
 }
 
 interface GhosttyNativeShortcutInput {
@@ -208,6 +239,20 @@ function isNativePayload<TKind extends keyof GhosttyNativePayloadByKind>(
     case 'focus':
     case 'destroy':
       return true
+    case 'secondaryAttach':
+    case 'secondaryFocus':
+    case 'secondaryRemove':
+      return isNonEmptyString(value.secondarySessionId)
+    case 'secondaryData':
+      return (
+        isNonEmptyString(value.secondarySessionId) &&
+        typeof value.data === 'string'
+      )
+    case 'secondaryVisible':
+      return (
+        isNonEmptyString(value.secondarySessionId) &&
+        typeof value.visible === 'boolean'
+      )
     default:
       return false
   }
@@ -270,6 +315,31 @@ export class GhosttyNativeParentController {
     ipcMain.handle(GHOSTTY_NATIVE_DESTROY, (_event, payload) =>
       this.destroy(requireNativePayload('destroy', payload))
     )
+
+    ipcMain.handle(GHOSTTY_NATIVE_SECONDARY_ATTACH, (event, payload) =>
+      this.attachSecondary(
+        event.sender,
+        requireNativePayload('secondaryAttach', payload)
+      )
+    )
+
+    ipcMain.handle(GHOSTTY_NATIVE_SECONDARY_DATA, (_event, payload) =>
+      this.sendSecondaryData(requireNativePayload('secondaryData', payload))
+    )
+
+    ipcMain.handle(GHOSTTY_NATIVE_SECONDARY_FOCUS, (_event, payload) =>
+      this.focusSecondary(requireNativePayload('secondaryFocus', payload))
+    )
+
+    ipcMain.handle(GHOSTTY_NATIVE_SECONDARY_REMOVE, (_event, payload) =>
+      this.removeSecondary(requireNativePayload('secondaryRemove', payload))
+    )
+
+    ipcMain.handle(GHOSTTY_NATIVE_SECONDARY_VISIBLE, (_event, payload) =>
+      this.setSecondaryVisible(
+        requireNativePayload('secondaryVisible', payload)
+      )
+    )
   }
 
   dispose(): void {
@@ -277,6 +347,11 @@ export class GhosttyNativeParentController {
     ipcMain.removeHandler(GHOSTTY_NATIVE_DATA)
     ipcMain.removeHandler(GHOSTTY_NATIVE_FOCUS)
     ipcMain.removeHandler(GHOSTTY_NATIVE_DESTROY)
+    ipcMain.removeHandler(GHOSTTY_NATIVE_SECONDARY_ATTACH)
+    ipcMain.removeHandler(GHOSTTY_NATIVE_SECONDARY_DATA)
+    ipcMain.removeHandler(GHOSTTY_NATIVE_SECONDARY_FOCUS)
+    ipcMain.removeHandler(GHOSTTY_NATIVE_SECONDARY_REMOVE)
+    ipcMain.removeHandler(GHOSTTY_NATIVE_SECONDARY_VISIBLE)
     for (const key of this.surfaces.keys()) {
       this.destroySurface(key)
     }
@@ -415,6 +490,200 @@ export class GhosttyNativeParentController {
     return { enabled: true }
   }
 
+  private attachSecondary(
+    sender: WebContents,
+    payload: GhosttyNativeSecondaryRequest
+  ): { enabled: boolean } {
+    if (!this.enabled()) {
+      return { enabled: false }
+    }
+
+    const addon = this.getOptionalAddon()
+    if (!addon?.addSecondary) {
+      return { enabled: false }
+    }
+
+    const win = BrowserWindow.fromWebContents(sender)
+    if (!win) {
+      throw new Error('ghostty native secondary attach has no owning window')
+    }
+
+    const state = this.getOrCreatePaneState(payload)
+    const surface = this.getOrCreateSurface(addon, win, state)
+    this.replaceSecondaryIfNeeded(addon, state, payload.secondarySessionId)
+
+    addon.addSecondary(
+      surface,
+      (data) => {
+        if (
+          win.isDestroyed() ||
+          !this.surfaces.has(this.paneKey(state.pane)) ||
+          state.secondary?.sessionId !== payload.secondarySessionId
+        ) {
+          return
+        }
+
+        void this.sidecar.invoke('write_pty', {
+          request: {
+            sessionId: payload.secondarySessionId,
+            data,
+          },
+        })
+      },
+      (cols, rows) => {
+        if (
+          win.isDestroyed() ||
+          !this.surfaces.has(this.paneKey(state.pane)) ||
+          state.secondary?.sessionId !== payload.secondarySessionId
+        ) {
+          return
+        }
+
+        if (
+          state.secondary.lastResize?.cols === cols &&
+          state.secondary.lastResize.rows === rows
+        ) {
+          return
+        }
+
+        state.secondary.lastResize = { cols, rows }
+        void this.sidecar.invoke('resize_pty', {
+          request: {
+            sessionId: payload.secondarySessionId,
+            cols,
+            rows,
+          },
+        })
+      },
+      () => {
+        if (win.isDestroyed() || !this.surfaces.has(this.paneKey(state.pane))) {
+          return
+        }
+
+        win.webContents.send(BACKEND_EVENT, {
+          event: 'ghostty-native-focus',
+          payload: state.pane,
+        })
+      }
+    )
+    if (state.secondary) {
+      state.secondary.attached = true
+    }
+    this.flushPendingSecondaryData(addon, state)
+
+    return { enabled: true }
+  }
+
+  private sendSecondaryData(payload: GhosttyNativeSecondaryDataRequest): {
+    enabled: boolean
+  } {
+    if (!this.enabled()) {
+      return { enabled: false }
+    }
+
+    const addon = this.getOptionalAddon()
+    if (!addon?.writeSecondary) {
+      return { enabled: false }
+    }
+
+    const state = this.getOrCreatePaneState(payload)
+    if (
+      state.secondary &&
+      state.secondary.sessionId !== payload.secondarySessionId
+    ) {
+      return { enabled: true }
+    }
+
+    const secondary = this.ensureSecondaryState(
+      state,
+      payload.secondarySessionId
+    )
+
+    if (!state.surface || !secondary.attached) {
+      secondary.pendingData.push(payload.data)
+
+      if (secondary.pendingData.length > MAX_PENDING_CHUNKS) {
+        secondary.pendingData.shift()
+      }
+
+      return { enabled: true }
+    }
+
+    addon.writeSecondary(state.surface, payload.data)
+
+    return { enabled: true }
+  }
+
+  private focusSecondary(payload: GhosttyNativeSecondaryRequest): {
+    enabled: boolean
+  } {
+    if (!this.enabled()) {
+      return { enabled: false }
+    }
+
+    const addon = this.getOptionalAddon()
+    if (!addon?.focusSecondary) {
+      return { enabled: false }
+    }
+
+    const state = this.getExistingPaneState(payload)
+    if (
+      state?.surface &&
+      state.secondary?.sessionId === payload.secondarySessionId
+    ) {
+      addon.focusSecondary(state.surface)
+    }
+
+    return { enabled: true }
+  }
+
+  private removeSecondary(payload: GhosttyNativeSecondaryRequest): {
+    enabled: boolean
+  } {
+    if (!this.enabled()) {
+      return { enabled: false }
+    }
+
+    const addon = this.getOptionalAddon()
+    if (!addon?.removeSecondary) {
+      return { enabled: false }
+    }
+
+    const state = this.getExistingPaneState(payload)
+    if (
+      state?.surface &&
+      state.secondary?.sessionId === payload.secondarySessionId
+    ) {
+      addon.removeSecondary(state.surface)
+      state.secondary = null
+    }
+
+    return { enabled: true }
+  }
+
+  private setSecondaryVisible(payload: GhosttyNativeSecondaryVisibleRequest): {
+    enabled: boolean
+  } {
+    if (!this.enabled()) {
+      return { enabled: false }
+    }
+
+    const addon = this.getOptionalAddon()
+    if (!addon?.setSecondaryVisible) {
+      return { enabled: false }
+    }
+
+    const state = this.getExistingPaneState(payload)
+    if (
+      state?.surface &&
+      state.secondary?.sessionId === payload.secondarySessionId
+    ) {
+      addon.setSecondaryVisible(state.surface, payload.visible)
+    }
+
+    return { enabled: true }
+  }
+
   private enabled(): boolean {
     return isGhosttyNativeParentEnabled(this.platform, this.env)
   }
@@ -468,6 +737,7 @@ export class GhosttyNativeParentController {
       },
       surface: null,
       pendingData: [],
+      secondary: null,
       lastBackgroundColor: null,
       lastResize: null,
       lastShortcutDigits: null,
@@ -652,6 +922,52 @@ export class GhosttyNativeParentController {
     // that small tail once the native surface exists so startup text is kept.
     for (const data of state.pendingData.splice(0)) {
       addon.write(state.surface, data)
+    }
+  }
+
+  private ensureSecondaryState(
+    state: GhosttyNativeSurfaceState,
+    secondarySessionId: string
+  ): GhosttyNativeSecondaryState {
+    if (state.secondary?.sessionId === secondarySessionId) {
+      return state.secondary
+    }
+
+    state.secondary = {
+      sessionId: secondarySessionId,
+      attached: false,
+      pendingData: [],
+      lastResize: null,
+    }
+
+    return state.secondary
+  }
+
+  private replaceSecondaryIfNeeded(
+    addon: GhosttyNativeParentAddon,
+    state: GhosttyNativeSurfaceState,
+    secondarySessionId: string
+  ): void {
+    if (state.secondary?.sessionId === secondarySessionId) {
+      return
+    }
+
+    if (state.surface && state.secondary) {
+      addon.removeSecondary?.(state.surface)
+    }
+    this.ensureSecondaryState(state, secondarySessionId)
+  }
+
+  private flushPendingSecondaryData(
+    addon: GhosttyNativeParentAddon,
+    state: GhosttyNativeSurfaceState
+  ): void {
+    if (!state.surface || !state.secondary?.attached) {
+      return
+    }
+
+    for (const data of state.secondary.pendingData.splice(0)) {
+      addon.writeSecondary?.(state.surface, data)
     }
   }
 

--- a/electron/ghostty-native-shared.ts
+++ b/electron/ghostty-native-shared.ts
@@ -30,6 +30,18 @@ export interface GhosttyNativeDataRequest extends GhosttyNativePaneRequest {
   data: string
 }
 
+export interface GhosttyNativeSecondaryRequest extends GhosttyNativePaneRequest {
+  secondarySessionId: string
+}
+
+export interface GhosttyNativeSecondaryDataRequest extends GhosttyNativeSecondaryRequest {
+  data: string
+}
+
+export interface GhosttyNativeSecondaryVisibleRequest extends GhosttyNativeSecondaryRequest {
+  visible: boolean
+}
+
 export function isBounds(value: unknown): value is GhosttyNativeBounds {
   return (
     isRecord(value) &&

--- a/electron/preload-ghostty-env.test.ts
+++ b/electron/preload-ghostty-env.test.ts
@@ -1,0 +1,96 @@
+// cspell:ignore Ghostty ghostty GHOSTTY
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { GHOSTTY_NATIVE_UPDATE } from './ghostty-native-channels'
+
+const electronMock = vi.hoisted(() => {
+  let exposedApi: Record<string, unknown> | undefined
+
+  return {
+    get exposed(): Record<string, unknown> | undefined {
+      return exposedApi
+    },
+    reset: (): void => {
+      exposedApi = undefined
+    },
+    contextBridge: {
+      exposeInMainWorld: vi.fn((_apiKey: string, api: unknown): void => {
+        exposedApi = api as Record<string, unknown>
+      }),
+    },
+    ipcRenderer: {
+      invoke: vi.fn(),
+      on: vi.fn(),
+      off: vi.fn(),
+      setMaxListeners: vi.fn(),
+    },
+  }
+})
+
+vi.mock('electron', () => ({
+  contextBridge: electronMock.contextBridge,
+  ipcRenderer: electronMock.ipcRenderer,
+}))
+
+const loadPreloadApi = async (
+  env: Record<string, string>
+): Promise<Record<string, unknown>> => {
+  vi.resetModules()
+  vi.unstubAllEnvs()
+  electronMock.reset()
+  vi.clearAllMocks()
+
+  for (const [key, value] of Object.entries(env)) {
+    vi.stubEnv(key, value)
+  }
+
+  await import('./preload')
+
+  const api = electronMock.exposed
+
+  if (!api) {
+    throw new Error('preload API not exposed')
+  }
+
+  return api
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('preload Ghostty env gating', () => {
+  test('exposes secondary native methods in parent mode', async () => {
+    const api = await loadPreloadApi({
+      VITE_GHOSTTY_NATIVE_MACOS_PARENT: '1',
+    })
+
+    const ghosttyNative = api.ghosttyNative as
+      | Record<string, (request: unknown) => Promise<unknown>>
+      | undefined
+
+    expect(ghosttyNative?.attachSecondary).toEqual(expect.any(Function))
+    expect(ghosttyNative?.setSecondaryVisible).toEqual(expect.any(Function))
+  })
+
+  test('omits secondary native methods in legacy helper mode', async () => {
+    const api = await loadPreloadApi({
+      VITE_GHOSTTY_NATIVE_MACOS: '1',
+    })
+
+    const ghosttyNative = api.ghosttyNative as
+      | Record<string, (request: unknown) => Promise<unknown>>
+      | undefined
+
+    await ghosttyNative?.update({ sessionId: 'pty-1', paneId: 'pane-1' })
+
+    expect(electronMock.ipcRenderer.invoke).toHaveBeenCalledWith(
+      GHOSTTY_NATIVE_UPDATE,
+      { sessionId: 'pty-1', paneId: 'pane-1' }
+    )
+    expect(ghosttyNative?.attachSecondary).toBeUndefined()
+    expect(ghosttyNative?.secondaryData).toBeUndefined()
+    expect(ghosttyNative?.focusSecondary).toBeUndefined()
+    expect(ghosttyNative?.removeSecondary).toBeUndefined()
+    expect(ghosttyNative?.setSecondaryVisible).toBeUndefined()
+  })
+})

--- a/electron/preload.test.ts
+++ b/electron/preload.test.ts
@@ -1,5 +1,5 @@
 // cspell:ignore Ghostty ghostty GHOSTTY
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterAll, beforeEach, describe, expect, test, vi } from 'vitest'
 import { DIALOG_PICK_DIRECTORY } from './ipc-channels'
 import {
   BROWSER_PANE_ACTIVATE_TAB,
@@ -46,7 +46,7 @@ import './preload'
 
 const electronMock = vi.hoisted(() => {
   let exposedApi: Record<string, unknown> | undefined
-  process.env.VITE_GHOSTTY_NATIVE_MACOS_PARENT = '1'
+  vi.stubEnv('VITE_GHOSTTY_NATIVE_MACOS_PARENT', '1')
 
   return {
     get exposed(): Record<string, unknown> | undefined {
@@ -64,6 +64,10 @@ const electronMock = vi.hoisted(() => {
       setMaxListeners: vi.fn(),
     },
   }
+})
+
+afterAll(() => {
+  vi.unstubAllEnvs()
 })
 
 vi.mock('electron', () => ({

--- a/electron/preload.test.ts
+++ b/electron/preload.test.ts
@@ -1,3 +1,4 @@
+// cspell:ignore Ghostty ghostty GHOSTTY
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { DIALOG_PICK_DIRECTORY } from './ipc-channels'
 import {
@@ -30,10 +31,22 @@ import {
   NATIVE_OVERLAY_RENDER,
   type NativeOverlayInvokeChannel,
 } from './native-overlay-channels'
+import {
+  GHOSTTY_NATIVE_DATA,
+  GHOSTTY_NATIVE_DESTROY,
+  GHOSTTY_NATIVE_FOCUS,
+  GHOSTTY_NATIVE_SECONDARY_ATTACH,
+  GHOSTTY_NATIVE_SECONDARY_DATA,
+  GHOSTTY_NATIVE_SECONDARY_FOCUS,
+  GHOSTTY_NATIVE_SECONDARY_REMOVE,
+  GHOSTTY_NATIVE_SECONDARY_VISIBLE,
+  GHOSTTY_NATIVE_UPDATE,
+} from './ghostty-native-channels'
 import './preload'
 
 const electronMock = vi.hoisted(() => {
   let exposedApi: Record<string, unknown> | undefined
+  process.env.VITE_GHOSTTY_NATIVE_MACOS_PARENT = '1'
 
   return {
     get exposed(): Record<string, unknown> | undefined {
@@ -196,6 +209,39 @@ test('exposes dialog.pickDirectory bound to the channel', async () => {
   await api.dialog.pickDirectory()
   expect(electronMock.ipcRenderer.invoke).toHaveBeenCalledWith(
     DIALOG_PICK_DIRECTORY
+  )
+})
+
+describe('preload native Ghostty wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test.each([
+    ['update', GHOSTTY_NATIVE_UPDATE],
+    ['data', GHOSTTY_NATIVE_DATA],
+    ['focus', GHOSTTY_NATIVE_FOCUS],
+    ['destroy', GHOSTTY_NATIVE_DESTROY],
+    ['attachSecondary', GHOSTTY_NATIVE_SECONDARY_ATTACH],
+    ['secondaryData', GHOSTTY_NATIVE_SECONDARY_DATA],
+    ['focusSecondary', GHOSTTY_NATIVE_SECONDARY_FOCUS],
+    ['removeSecondary', GHOSTTY_NATIVE_SECONDARY_REMOVE],
+    ['setSecondaryVisible', GHOSTTY_NATIVE_SECONDARY_VISIBLE],
+  ])(
+    '%s invokes ipcRenderer.invoke with the correct channel',
+    async (method: string, channel: string) => {
+      const api = exposedApi() as {
+        ghosttyNative?: Record<string, (request: unknown) => Promise<unknown>>
+      }
+      const request = { sessionId: 'pty-1', paneId: 'pane-1' }
+
+      await api.ghosttyNative?.[method](request)
+
+      expect(electronMock.ipcRenderer.invoke).toHaveBeenCalledWith(
+        channel,
+        request
+      )
+    }
   )
 })
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -39,6 +39,11 @@ import {
   GHOSTTY_NATIVE_DATA,
   GHOSTTY_NATIVE_DESTROY,
   GHOSTTY_NATIVE_FOCUS,
+  GHOSTTY_NATIVE_SECONDARY_ATTACH,
+  GHOSTTY_NATIVE_SECONDARY_DATA,
+  GHOSTTY_NATIVE_SECONDARY_FOCUS,
+  GHOSTTY_NATIVE_SECONDARY_REMOVE,
+  GHOSTTY_NATIVE_SECONDARY_VISIBLE,
   GHOSTTY_NATIVE_UPDATE,
 } from './ghostty-native-channels'
 import {
@@ -131,6 +136,16 @@ const ghosttyNativeBridge = isNativeGhosttyPreloadEnabled
           ipcRenderer.invoke(GHOSTTY_NATIVE_FOCUS, request),
         destroy: (request: unknown): Promise<unknown> =>
           ipcRenderer.invoke(GHOSTTY_NATIVE_DESTROY, request),
+        attachSecondary: (request: unknown): Promise<unknown> =>
+          ipcRenderer.invoke(GHOSTTY_NATIVE_SECONDARY_ATTACH, request),
+        secondaryData: (request: unknown): Promise<unknown> =>
+          ipcRenderer.invoke(GHOSTTY_NATIVE_SECONDARY_DATA, request),
+        focusSecondary: (request: unknown): Promise<unknown> =>
+          ipcRenderer.invoke(GHOSTTY_NATIVE_SECONDARY_FOCUS, request),
+        removeSecondary: (request: unknown): Promise<unknown> =>
+          ipcRenderer.invoke(GHOSTTY_NATIVE_SECONDARY_REMOVE, request),
+        setSecondaryVisible: (request: unknown): Promise<unknown> =>
+          ipcRenderer.invoke(GHOSTTY_NATIVE_SECONDARY_VISIBLE, request),
       },
     }
   : {}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -125,6 +125,9 @@ const isNativeGhosttyPreloadEnabled =
   process.env.VITE_GHOSTTY_NATIVE_MACOS === '1' ||
   process.env.VITE_GHOSTTY_NATIVE_MACOS_PARENT === '1'
 
+const isNativeGhosttyParentPreloadEnabled =
+  process.env.VITE_GHOSTTY_NATIVE_MACOS_PARENT === '1'
+
 const ghosttyNativeBridge = isNativeGhosttyPreloadEnabled
   ? {
       ghosttyNative: {
@@ -136,16 +139,20 @@ const ghosttyNativeBridge = isNativeGhosttyPreloadEnabled
           ipcRenderer.invoke(GHOSTTY_NATIVE_FOCUS, request),
         destroy: (request: unknown): Promise<unknown> =>
           ipcRenderer.invoke(GHOSTTY_NATIVE_DESTROY, request),
-        attachSecondary: (request: unknown): Promise<unknown> =>
-          ipcRenderer.invoke(GHOSTTY_NATIVE_SECONDARY_ATTACH, request),
-        secondaryData: (request: unknown): Promise<unknown> =>
-          ipcRenderer.invoke(GHOSTTY_NATIVE_SECONDARY_DATA, request),
-        focusSecondary: (request: unknown): Promise<unknown> =>
-          ipcRenderer.invoke(GHOSTTY_NATIVE_SECONDARY_FOCUS, request),
-        removeSecondary: (request: unknown): Promise<unknown> =>
-          ipcRenderer.invoke(GHOSTTY_NATIVE_SECONDARY_REMOVE, request),
-        setSecondaryVisible: (request: unknown): Promise<unknown> =>
-          ipcRenderer.invoke(GHOSTTY_NATIVE_SECONDARY_VISIBLE, request),
+        ...(isNativeGhosttyParentPreloadEnabled
+          ? {
+              attachSecondary: (request: unknown): Promise<unknown> =>
+                ipcRenderer.invoke(GHOSTTY_NATIVE_SECONDARY_ATTACH, request),
+              secondaryData: (request: unknown): Promise<unknown> =>
+                ipcRenderer.invoke(GHOSTTY_NATIVE_SECONDARY_DATA, request),
+              focusSecondary: (request: unknown): Promise<unknown> =>
+                ipcRenderer.invoke(GHOSTTY_NATIVE_SECONDARY_FOCUS, request),
+              removeSecondary: (request: unknown): Promise<unknown> =>
+                ipcRenderer.invoke(GHOSTTY_NATIVE_SECONDARY_REMOVE, request),
+              setSecondaryVisible: (request: unknown): Promise<unknown> =>
+                ipcRenderer.invoke(GHOSTTY_NATIVE_SECONDARY_VISIBLE, request),
+            }
+          : {}),
       },
     }
   : {}

--- a/native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift
+++ b/native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift
@@ -46,6 +46,28 @@ private struct SendablePointer: @unchecked Sendable {
     let value: UnsafeMutableRawPointer?
 }
 
+private final class EmbeddedGhosttyContainerView: NSView {
+    var onLayout: (() -> Void)?
+
+    override func layout() {
+        super.layout()
+        onLayout?()
+    }
+}
+
+private final class EmbeddedGhosttyDividerView: NSView {
+    var vertical = true
+    var onDrag: ((CGFloat) -> Void)?
+
+    override func resetCursorRects() {
+        addCursorRect(bounds, cursor: vertical ? .resizeLeftRight : .resizeUpDown)
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        onDrag?(vertical ? event.deltaX : event.deltaY)
+    }
+}
+
 private extension NSColor {
     static func vimeflowGhosttyHexColor(_ hexColor: String) -> String? {
         let hex = hexColor
@@ -152,6 +174,54 @@ private final class CallbackBox: @unchecked Sendable {
 }
 
 @MainActor
+private final class EmbeddedGhosttyChild {
+    let callbacks: CallbackBox
+    let controller: TerminalController
+    let session: InMemoryTerminalSession
+    let terminalView: TerminalView
+
+    init(callbacks: CallbackBox) {
+        self.callbacks = callbacks
+
+        let controller = TerminalController()
+        self.controller = controller
+
+        let session = InMemoryTerminalSession(
+            write: { [callbacks] data in
+                callbacks.sendInput(data)
+            },
+            resize: { [callbacks] viewport in
+                callbacks.sendResize(
+                    columns: Int(viewport.columns),
+                    rows: Int(viewport.rows)
+                )
+            }
+        )
+        self.session = session
+
+        let view = TerminalView(frame: .zero)
+        view.controller = controller
+        view.configuration = TerminalSurfaceOptions(backend: .inMemory(session))
+        self.terminalView = view
+    }
+
+    func setBackgroundColor(_ hexColor: String) {
+        guard let ghosttyHex = NSColor.vimeflowGhosttyHexColor(hexColor) else {
+            return
+        }
+
+        controller.setTheme(TerminalTheme(
+            light: TerminalConfiguration().background(ghosttyHex),
+            dark: TerminalConfiguration().background(ghosttyHex)
+        ))
+    }
+
+    func receive(_ text: String) {
+        session.receive(text)
+    }
+}
+
+@MainActor
 private final class EmbeddedGhosttySurface: NSObject {
     private static let shortcutDigitByKeyCode: [UInt16: Character] = [
         18: "1",
@@ -166,12 +236,16 @@ private final class EmbeddedGhosttySurface: NSObject {
     ]
 
     private let parentView: NSView
-    private let container = NSView(frame: .zero)
+    private let container = EmbeddedGhosttyContainerView(frame: .zero)
     private let callbacks: CallbackBox
     private var focusMonitor: Any?
     private var contextMenuMonitor: Any?
     private var shortcutMonitor: Any?
     private var shortcutDigits = Set<Character>()
+    private var backgroundHexColor = "000000"
+    private var secondaryChild: EmbeddedGhosttyChild?
+    private var dividerView: EmbeddedGhosttyDividerView?
+    private var secondarySplitRatio: CGFloat = 0.34
 
     private lazy var contextMenu: NSMenu = {
         let menu = NSMenu()
@@ -274,7 +348,7 @@ private final class EmbeddedGhosttySurface: NSObject {
             height: safeHeight
         )
         updateLiveResizePrediction(frame: container.frame)
-        terminalView.frame = container.bounds
+        layoutChildren()
         container.isHidden = safeWidth <= 0 || safeHeight <= 0
     }
 
@@ -297,14 +371,85 @@ private final class EmbeddedGhosttySurface: NSObject {
         }
 
         container.layer?.backgroundColor = color.cgColor
+        backgroundHexColor = ghosttyHex
         controller.setTheme(TerminalTheme(
             light: TerminalConfiguration().background(ghosttyHex),
             dark: TerminalConfiguration().background(ghosttyHex)
         ))
+        secondaryChild?.setBackgroundColor(ghosttyHex)
     }
 
     func receive(_ text: String) {
         session.receive(text)
+    }
+
+    func addSecondary(
+        inputCallback: VimeflowGhosttyInputCallback?,
+        resizeCallback: VimeflowGhosttyResizeCallback?,
+        focusCallback: VimeflowGhosttyFocusCallback?,
+        callbackContext: UnsafeMutableRawPointer?
+    ) {
+        if let secondaryChild {
+            secondaryChild.terminalView.isHidden = false
+            dividerView?.isHidden = false
+            layoutChildren()
+            parentView.window?.makeFirstResponder(secondaryChild.terminalView)
+            return
+        }
+
+        let callbacks = CallbackBox(
+            inputCallback: inputCallback,
+            resizeCallback: resizeCallback,
+            focusCallback: focusCallback,
+            shortcutCallback: nil,
+            renamePaneCallback: nil,
+            callbackContext: callbackContext
+        )
+        let child = EmbeddedGhosttyChild(callbacks: callbacks)
+        child.setBackgroundColor(backgroundHexColor)
+        container.addSubview(child.terminalView)
+        secondaryChild = child
+        ensureDivider()
+        dividerView?.isHidden = false
+        layoutChildren()
+        parentView.window?.makeFirstResponder(child.terminalView)
+    }
+
+    func setSecondaryVisible(_ visible: Bool) {
+        guard let secondaryChild else {
+            return
+        }
+
+        secondaryChild.terminalView.isHidden = !visible
+        dividerView?.isHidden = !visible
+        layoutChildren()
+        if visible {
+            parentView.window?.makeFirstResponder(secondaryChild.terminalView)
+        } else {
+            focus()
+        }
+    }
+
+    func removeSecondary(refocusPrimary: Bool = true) {
+        secondaryChild?.terminalView.removeFromSuperview()
+        secondaryChild = nil
+        dividerView?.isHidden = true
+        layoutChildren()
+        if refocusPrimary {
+            focus()
+        }
+    }
+
+    func receiveSecondary(_ text: String) {
+        secondaryChild?.receive(text)
+    }
+
+    func focusSecondary() {
+        guard let secondaryTerminalView = secondaryChild?.terminalView else {
+            return
+        }
+
+        parentView.window?.makeFirstResponder(secondaryTerminalView)
     }
 
     func focus() {
@@ -324,12 +469,16 @@ private final class EmbeddedGhosttySurface: NSObject {
             NSEvent.removeMonitor(shortcutMonitor)
             self.shortcutMonitor = nil
         }
+        removeSecondary(refocusPrimary: false)
         container.removeFromSuperview()
     }
 
     private func install() {
         container.wantsLayer = true
         container.layer?.backgroundColor = NSColor.black.cgColor
+        container.onLayout = { [weak self] in
+            self?.layoutChildren()
+        }
         container.addSubview(terminalView)
         parentView.addSubview(container, positioned: .above, relativeTo: nil)
         focusMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown]) { [weak self] event in
@@ -409,37 +558,152 @@ private final class EmbeddedGhosttySurface: NSObject {
         return [minMargin, size, maxMargin]
     }
 
-    private func handleMouseDown(_ event: NSEvent) {
-        guard let window = terminalView.window, event.window === window else {
+    private func ensureDivider() {
+        if dividerView != nil {
             return
+        }
+
+        let divider = EmbeddedGhosttyDividerView(frame: .zero)
+        divider.wantsLayer = true
+        divider.layer?.backgroundColor = NSColor.separatorColor.cgColor
+        divider.onDrag = { [weak self] delta in
+            self?.resizeSecondarySplit(delta: delta)
+        }
+        container.addSubview(divider)
+        dividerView = divider
+    }
+
+    private func resizeSecondarySplit(delta: CGFloat) {
+        let bounds = container.bounds
+        if bounds.width < 720 {
+            secondarySplitRatio = clamped(
+                secondarySplitRatio - delta / max(1, bounds.height),
+                min: 0.2,
+                max: 0.65
+            )
+        } else {
+            secondarySplitRatio = clamped(
+                secondarySplitRatio - delta / max(1, bounds.width),
+                min: 0.2,
+                max: 0.65
+            )
+        }
+        layoutChildren()
+    }
+
+    private func clamped(_ value: CGFloat, min minValue: CGFloat, max maxValue: CGFloat) -> CGFloat {
+        min(max(value, minValue), maxValue)
+    }
+
+    private func layoutChildren() {
+        let bounds = container.bounds
+        guard let secondaryTerminalView = secondaryChild?.terminalView,
+              !secondaryTerminalView.isHidden
+        else {
+            terminalView.frame = bounds
+            dividerView?.isHidden = true
+            return
+        }
+
+        let divider: CGFloat = 6
+        dividerView?.isHidden = false
+        if bounds.width < 720 {
+            let secondaryHeight = clamped(
+                floor(bounds.height * secondarySplitRatio),
+                min: 140,
+                max: max(140, bounds.height - 180)
+            )
+            terminalView.frame = NSRect(
+                x: 0,
+                y: secondaryHeight + divider,
+                width: bounds.width,
+                height: max(0, bounds.height - secondaryHeight - divider)
+            )
+            secondaryTerminalView.frame = NSRect(
+                x: 0,
+                y: 0,
+                width: bounds.width,
+                height: secondaryHeight
+            )
+            dividerView?.vertical = false
+            dividerView?.frame = NSRect(
+                x: 0,
+                y: secondaryHeight,
+                width: bounds.width,
+                height: divider
+            )
+        } else {
+            let secondaryWidth = clamped(
+                floor(bounds.width * secondarySplitRatio),
+                min: 260,
+                max: max(260, bounds.width - 320)
+            )
+            terminalView.frame = NSRect(
+                x: 0,
+                y: 0,
+                width: max(0, bounds.width - secondaryWidth - divider),
+                height: bounds.height
+            )
+            secondaryTerminalView.frame = NSRect(
+                x: bounds.width - secondaryWidth,
+                y: 0,
+                width: secondaryWidth,
+                height: bounds.height
+            )
+            dividerView?.vertical = true
+            dividerView?.frame = NSRect(
+                x: bounds.width - secondaryWidth - divider,
+                y: 0,
+                width: divider,
+                height: bounds.height
+            )
+        }
+        if let dividerView {
+            container.window?.invalidateCursorRects(for: dividerView)
+        }
+    }
+
+    private func terminalHit(for event: NSEvent) -> (view: TerminalView, callbacks: CallbackBox)? {
+        if let secondaryChild, !secondaryChild.terminalView.isHidden {
+            let secondaryLocation = secondaryChild.terminalView.convert(event.locationInWindow, from: nil)
+            if secondaryChild.terminalView.bounds.contains(secondaryLocation) {
+                return (secondaryChild.terminalView, secondaryChild.callbacks)
+            }
         }
 
         let terminalLocation = terminalView.convert(event.locationInWindow, from: nil)
-        guard terminalView.bounds.contains(terminalLocation) else {
+        if terminalView.bounds.contains(terminalLocation) {
+            return (terminalView, callbacks)
+        }
+
+        return nil
+    }
+
+    private func handleMouseDown(_ event: NSEvent) {
+        guard let window = container.window, event.window === window else {
             return
         }
 
-        callbacks.focusSurface()
+        terminalHit(for: event)?.callbacks.focusSurface()
     }
 
     private func handleRightMouse(_ event: NSEvent) -> Bool {
-        guard let window = terminalView.window, event.window === window else {
+        guard let window = container.window, event.window === window else {
             return false
         }
 
-        let terminalLocation = terminalView.convert(event.locationInWindow, from: nil)
-        guard terminalView.bounds.contains(terminalLocation) else {
+        guard let hit = terminalHit(for: event) else {
             return false
         }
 
-        focus()
-        NSMenu.popUpContextMenu(contextMenu, with: event, for: terminalView)
+        parentView.window?.makeFirstResponder(hit.view)
+        NSMenu.popUpContextMenu(contextMenu, with: event, for: hit.view)
 
         return true
     }
 
     private func handleKeyDown(_ event: NSEvent) -> Bool {
-        guard let window = terminalView.window, event.window === window else {
+        guard let window = container.window, event.window === window else {
             return false
         }
 
@@ -447,8 +711,16 @@ private final class EmbeddedGhosttySurface: NSObject {
             return false
         }
 
-        if firstResponder !== terminalView,
-           !firstResponder.isDescendant(of: terminalView) {
+        let primaryFocused = firstResponder === terminalView ||
+            firstResponder.isDescendant(of: terminalView)
+        let secondaryFocused =
+            if let secondaryTerminalView = secondaryChild?.terminalView {
+                firstResponder === secondaryTerminalView ||
+                    firstResponder.isDescendant(of: secondaryTerminalView)
+            } else {
+                false
+            }
+        if !primaryFocused && !secondaryFocused {
             return false
         }
 
@@ -615,6 +887,102 @@ public func vimeflowGhosttyWrite(
             .fromOpaque(pointer.value!)
             .takeUnretainedValue()
         surface.receive(text)
+    }
+}
+
+@_cdecl("vimeflow_ghostty_add_secondary")
+public func vimeflowGhosttyAddSecondary(
+    _ surfacePointer: UnsafeMutableRawPointer?,
+    _ inputCallback: VimeflowGhosttyInputCallback?,
+    _ resizeCallback: VimeflowGhosttyResizeCallback?,
+    _ focusCallback: VimeflowGhosttyFocusCallback?,
+    _ callbackContext: UnsafeMutableRawPointer?
+) {
+    guard let surfacePointer else {
+        return
+    }
+
+    let pointer = SendablePointer(value: surfacePointer)
+    let contextPointer = SendablePointer(value: callbackContext)
+    mainActorSync {
+        let surface = Unmanaged<EmbeddedGhosttySurface>
+            .fromOpaque(pointer.value!)
+            .takeUnretainedValue()
+        surface.addSecondary(
+            inputCallback: inputCallback,
+            resizeCallback: resizeCallback,
+            focusCallback: focusCallback,
+            callbackContext: contextPointer.value
+        )
+    }
+}
+
+@_cdecl("vimeflow_ghostty_set_secondary_visible")
+public func vimeflowGhosttySetSecondaryVisible(
+    _ surfacePointer: UnsafeMutableRawPointer?,
+    _ visible: Bool
+) {
+    guard let surfacePointer else {
+        return
+    }
+
+    let pointer = SendablePointer(value: surfacePointer)
+    mainActorSync {
+        let surface = Unmanaged<EmbeddedGhosttySurface>
+            .fromOpaque(pointer.value!)
+            .takeUnretainedValue()
+        surface.setSecondaryVisible(visible)
+    }
+}
+
+@_cdecl("vimeflow_ghostty_remove_secondary")
+public func vimeflowGhosttyRemoveSecondary(_ surfacePointer: UnsafeMutableRawPointer?) {
+    guard let surfacePointer else {
+        return
+    }
+
+    let pointer = SendablePointer(value: surfacePointer)
+    mainActorSync {
+        let surface = Unmanaged<EmbeddedGhosttySurface>
+            .fromOpaque(pointer.value!)
+            .takeUnretainedValue()
+        surface.removeSecondary()
+    }
+}
+
+@_cdecl("vimeflow_ghostty_write_secondary")
+public func vimeflowGhosttyWriteSecondary(
+    _ surfacePointer: UnsafeMutableRawPointer?,
+    _ bytes: UnsafePointer<UInt8>?,
+    _ length: Int32
+) {
+    guard let surfacePointer, let bytes, length > 0 else {
+        return
+    }
+
+    let text = String(decoding: UnsafeBufferPointer(start: bytes, count: Int(length)), as: UTF8.self)
+
+    let pointer = SendablePointer(value: surfacePointer)
+    mainActorSync {
+        let surface = Unmanaged<EmbeddedGhosttySurface>
+            .fromOpaque(pointer.value!)
+            .takeUnretainedValue()
+        surface.receiveSecondary(text)
+    }
+}
+
+@_cdecl("vimeflow_ghostty_focus_secondary")
+public func vimeflowGhosttyFocusSecondary(_ surfacePointer: UnsafeMutableRawPointer?) {
+    guard let surfacePointer else {
+        return
+    }
+
+    let pointer = SendablePointer(value: surfacePointer)
+    mainActorSync {
+        let surface = Unmanaged<EmbeddedGhosttySurface>
+            .fromOpaque(pointer.value!)
+            .takeUnretainedValue()
+        surface.focusSecondary()
     }
 }
 

--- a/native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift
+++ b/native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift
@@ -56,8 +56,36 @@ private final class EmbeddedGhosttyContainerView: NSView {
 }
 
 private final class EmbeddedGhosttyDividerView: NSView {
-    var vertical = true
+    var vertical = true {
+        didSet {
+            needsDisplay = true
+        }
+    }
     var onDrag: ((CGFloat) -> Void)?
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+
+        let scale = window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 2
+        let lineWidth = 1 / scale
+        NSColor.separatorColor.setFill()
+
+        if vertical {
+            NSRect(
+                x: floor((bounds.width - lineWidth) / 2),
+                y: 0,
+                width: lineWidth,
+                height: bounds.height
+            ).fill()
+        } else {
+            NSRect(
+                x: 0,
+                y: floor((bounds.height - lineWidth) / 2),
+                width: bounds.width,
+                height: lineWidth
+            ).fill()
+        }
+    }
 
     override func resetCursorRects() {
         addCursorRect(bounds, cursor: vertical ? .resizeLeftRight : .resizeUpDown)
@@ -564,8 +592,6 @@ private final class EmbeddedGhosttySurface: NSObject {
         }
 
         let divider = EmbeddedGhosttyDividerView(frame: .zero)
-        divider.wantsLayer = true
-        divider.layer?.backgroundColor = NSColor.separatorColor.cgColor
         divider.onDrag = { [weak self] delta in
             self?.resizeSecondarySplit(delta: delta)
         }

--- a/native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift
+++ b/native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift
@@ -56,6 +56,11 @@ private final class EmbeddedGhosttyContainerView: NSView {
 }
 
 private final class EmbeddedGhosttyDividerView: NSView {
+    var isDarkBackground = true {
+        didSet {
+            needsDisplay = true
+        }
+    }
     var vertical = true {
         didSet {
             needsDisplay = true
@@ -68,10 +73,8 @@ private final class EmbeddedGhosttyDividerView: NSView {
 
         let scale = window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 2
         let lineWidth = 1 / scale
-        // System separators can disappear against themed Ghostty canvases.
-        let isDark =
-            effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-        let dividerColor = isDark
+        // App theme and macOS appearance can differ; contrast against Ghostty's canvas.
+        let dividerColor = isDarkBackground
             ? NSColor.white.withAlphaComponent(0.22)
             : NSColor.black.withAlphaComponent(0.12)
         dividerColor.setFill()
@@ -109,6 +112,21 @@ private extension NSColor {
             .trimmingCharacters(in: CharacterSet(charactersIn: "#"))
 
         return hex.count == 6 && Int(hex, radix: 16) != nil ? hex : nil
+    }
+
+    static func vimeflowIsDarkHexColor(_ hexColor: String) -> Bool {
+        guard
+            let hex = vimeflowGhosttyHexColor(hexColor),
+            let value = Int(hex, radix: 16)
+        else {
+            return true
+        }
+
+        let red = Double((value >> 16) & 0xff) / 255
+        let green = Double((value >> 8) & 0xff) / 255
+        let blue = Double(value & 0xff) / 255
+
+        return 0.2126 * red + 0.7152 * green + 0.0722 * blue < 0.5
     }
 
     convenience init?(vimeflowHexColor hexColor: String) {
@@ -406,6 +424,7 @@ private final class EmbeddedGhosttySurface: NSObject {
 
         container.layer?.backgroundColor = color.cgColor
         backgroundHexColor = ghosttyHex
+        dividerView?.isDarkBackground = NSColor.vimeflowIsDarkHexColor(ghosttyHex)
         controller.setTheme(TerminalTheme(
             light: TerminalConfiguration().background(ghosttyHex),
             dark: TerminalConfiguration().background(ghosttyHex)
@@ -598,6 +617,7 @@ private final class EmbeddedGhosttySurface: NSObject {
         }
 
         let divider = EmbeddedGhosttyDividerView(frame: .zero)
+        divider.isDarkBackground = NSColor.vimeflowIsDarkHexColor(backgroundHexColor)
         divider.onDrag = { [weak self] delta in
             self?.resizeSecondarySplit(delta: delta)
         }

--- a/native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift
+++ b/native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift
@@ -68,7 +68,8 @@ private final class EmbeddedGhosttyDividerView: NSView {
 
         let scale = window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 2
         let lineWidth = 1 / scale
-        NSColor.separatorColor.setFill()
+        // System separators can disappear against themed Ghostty canvases.
+        NSColor.labelColor.withAlphaComponent(0.24).setFill()
 
         if vertical {
             NSRect(

--- a/native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift
+++ b/native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift
@@ -69,7 +69,12 @@ private final class EmbeddedGhosttyDividerView: NSView {
         let scale = window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 2
         let lineWidth = 1 / scale
         // System separators can disappear against themed Ghostty canvases.
-        NSColor.labelColor.withAlphaComponent(0.24).setFill()
+        let isDark =
+            effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        let dividerColor = isDark
+            ? NSColor.white.withAlphaComponent(0.22)
+            : NSColor.black.withAlphaComponent(0.12)
+        dividerColor.setFill()
 
         if vertical {
             NSRect(

--- a/native/ghostty-helper/Sources/GhosttyNativeMacosSmoke/GhosttyNativeMacosSmoke.swift
+++ b/native/ghostty-helper/Sources/GhosttyNativeMacosSmoke/GhosttyNativeMacosSmoke.swift
@@ -596,7 +596,7 @@ final class GhosttyNativeMacosSmoke:
 
         let bounds = containerView.bounds
         if bounds.width < 720 {
-            secondarySplitRatio = max(0.2, min(0.65, secondarySplitRatio + delta / max(1, bounds.height)))
+            secondarySplitRatio = max(0.2, min(0.65, secondarySplitRatio - delta / max(1, bounds.height)))
         } else {
             secondarySplitRatio = max(0.2, min(0.65, secondarySplitRatio - delta / max(1, bounds.width)))
         }
@@ -672,7 +672,9 @@ final class GhosttyNativeMacosSmoke:
                 height: bounds.height
             )
         }
-        dividerView?.resetCursorRects()
+        if let dividerView {
+            containerView.window?.invalidateCursorRects(for: dividerView)
+        }
     }
 
     private func appKitFrameFromTopLeft(_ frame: GhosttyNativeFrame) -> NSRect {

--- a/native/ghostty-helper/Sources/GhosttyNativeMacosSmoke/GhosttyNativeMacosSmoke.swift
+++ b/native/ghostty-helper/Sources/GhosttyNativeMacosSmoke/GhosttyNativeMacosSmoke.swift
@@ -34,6 +34,39 @@ private final class GhosttyHelperWindow: NSWindow {
     override var canBecomeMain: Bool { true }
 }
 
+// Smoke-only layout hook. Production child layout belongs in
+// EmbeddedGhosttySurface, then this helper class should be deleted.
+private final class SmokeContainerView: NSView {
+    var onLayout: (() -> Void)?
+
+    override func layout() {
+        super.layout()
+        onLayout?()
+    }
+}
+
+// Smoke-only divider. It proves the nested terminal region can be resized;
+// production should move this behavior into the embedded AppKit surface.
+private final class SmokeDividerView: NSView {
+    var vertical = true
+    var onDrag: ((CGFloat) -> Void)?
+
+    override func resetCursorRects() {
+        addCursorRect(bounds, cursor: vertical ? .resizeLeftRight : .resizeUpDown)
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        onDrag?(vertical ? event.deltaX : event.deltaY)
+    }
+}
+
+// Smoke-only child routing. Keep the role generic so the production nested
+// terminal path can support more than the burner use case.
+private enum SmokeTerminalRole {
+    case primary
+    case secondary
+}
+
 @main
 final class GhosttyNativeMacosSmoke:
     NSObject,
@@ -43,13 +76,20 @@ final class GhosttyNativeMacosSmoke:
     TerminalSurfaceCloseDelegate
 {
     private var window: NSWindow?
-    private var containerView: NSView?
+    private var containerView: SmokeContainerView?
     private var terminalView: TerminalView?
+    private var secondaryTerminalView: TerminalView?
+    private var dividerView: SmokeDividerView?
     private var backendClient: VimeflowBackendClient?
     private var electronHostClient: ElectronHostClient?
     private var ptySessionId: String?
+    private var secondaryPtySessionId: String?
     private var pendingGrid = GhosttyGridSize(columns: 80, rows: 24)
+    private var secondaryPendingGrid = GhosttyGridSize(columns: 80, rows: 12)
     private var lastForwardedGrid: GhosttyGridSize?
+    private var secondaryLastForwardedGrid: GhosttyGridSize?
+    private var secondarySplitRatio: CGFloat = 0.34
+    private var shortcutMonitor: Any?
     private let helperMode = CommandLine.arguments.contains("--electron-helper")
 
     private lazy var controller = TerminalController()
@@ -57,7 +97,7 @@ final class GhosttyNativeMacosSmoke:
     private lazy var session = InMemoryTerminalSession(
         write: { [weak self] data in
             DispatchQueue.main.async {
-                self?.handleTerminalInput(data)
+                self?.handleTerminalInput(data, role: .primary)
             }
         },
         resize: { viewport in
@@ -66,7 +106,29 @@ final class GhosttyNativeMacosSmoke:
                     GhosttyGridSize(
                         columns: Int(viewport.columns),
                         rows: Int(viewport.rows)
-                    )
+                    ),
+                    role: .primary
+                )
+            }
+        }
+    )
+
+    private lazy var secondaryController = TerminalController()
+
+    private lazy var secondarySession = InMemoryTerminalSession(
+        write: { [weak self] data in
+            DispatchQueue.main.async {
+                self?.handleTerminalInput(data, role: .secondary)
+            }
+        },
+        resize: { viewport in
+            DispatchQueue.main.async { [weak self] in
+                self?.handleGhosttyResize(
+                    GhosttyGridSize(
+                        columns: Int(viewport.columns),
+                        rows: Int(viewport.rows)
+                    ),
+                    role: .secondary
                 )
             }
         }
@@ -113,9 +175,12 @@ final class GhosttyNativeMacosSmoke:
         }
         window.title = "Vimeflow Ghostty native smoke"
 
-        let container = NSView()
+        let container = SmokeContainerView()
         container.wantsLayer = true
         container.layer?.backgroundColor = NSColor.black.cgColor
+        container.onLayout = { [weak self] in
+            self?.layoutSmokeTerminalViews()
+        }
         window.contentView = container
 
         let terminalView = TerminalView(frame: .zero)
@@ -124,15 +189,8 @@ final class GhosttyNativeMacosSmoke:
         terminalView.configuration = TerminalSurfaceOptions(
             backend: .inMemory(session)
         )
-        terminalView.translatesAutoresizingMaskIntoConstraints = false
 
         container.addSubview(terminalView)
-        NSLayoutConstraint.activate([
-            terminalView.topAnchor.constraint(equalTo: container.topAnchor),
-            terminalView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
-            terminalView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
-            terminalView.bottomAnchor.constraint(equalTo: container.bottomAnchor),
-        ])
 
         self.window = window
         self.containerView = container
@@ -148,8 +206,10 @@ final class GhosttyNativeMacosSmoke:
             session.receive(
                 "\u{001b}[38;2;141;224;210mVimeflow Ghostty native smoke\u{001b}[0m\r\n"
                     + "GhosttyTerminal is now connected to vimeflow-backend PTY over stdio IPC.\r\n"
+                    + "Smoke controls: Cmd+B show burner, Cmd+Shift+B hide burner, Cmd+Option+B remove burner.\r\n"
                     + "Starting shell...\r\n\r\n"
             )
+            installSmokeShortcuts()
             startBackendPty()
         }
     }
@@ -162,6 +222,13 @@ final class GhosttyNativeMacosSmoke:
         if let ptySessionId {
             backendClient?.killPty(sessionId: ptySessionId)
         }
+        if let secondaryPtySessionId {
+            backendClient?.killPty(sessionId: secondaryPtySessionId)
+        }
+        if let shortcutMonitor {
+            NSEvent.removeMonitor(shortcutMonitor)
+            self.shortcutMonitor = nil
+        }
         backendClient?.shutdown()
         electronHostClient?.sendClosed()
         electronHostClient?.close()
@@ -172,24 +239,35 @@ final class GhosttyNativeMacosSmoke:
     }
 
     func terminalDidResize(columns: Int, rows: Int) {
-        handleGhosttyResize(GhosttyGridSize(columns: columns, rows: rows))
+        handleGhosttyResize(
+            GhosttyGridSize(columns: columns, rows: rows),
+            role: .primary
+        )
     }
 
     func terminalDidClose(processAlive _: Bool) {
         NSApp.terminate(nil)
     }
 
-    private func handleTerminalInput(_ data: Data) {
+    private func handleTerminalInput(_ data: Data, role: SmokeTerminalRole) {
         if helperMode {
             electronHostClient?.sendInput(data)
             return
         }
 
-        guard let ptySessionId else {
+        let targetSessionId =
+            switch role {
+            case .primary:
+                ptySessionId
+            case .secondary:
+                secondaryPtySessionId
+            }
+
+        guard let targetSessionId else {
             return
         }
 
-        backendClient?.writePty(sessionId: ptySessionId, data: data)
+        backendClient?.writePty(sessionId: targetSessionId, data: data)
     }
 
     private func startBackendPty() {
@@ -218,7 +296,7 @@ final class GhosttyNativeMacosSmoke:
             case let .success(pty):
                 self.ptySessionId = pty.id
                 self.window?.title = "Vimeflow Ghostty native smoke - \(pty.shell)"
-                self.forwardResizeIfNeeded(self.pendingGrid)
+                self.forwardResizeIfNeeded(self.pendingGrid, role: .primary)
             case let .failure(error):
                 self.ptySessionId = nil
                 self.showBackendError(error)
@@ -229,19 +307,31 @@ final class GhosttyNativeMacosSmoke:
     private func handleBackendEvent(_ event: VimeflowBackendEvent) {
         switch event {
         case let .ptyData(sessionId, data):
-            guard sessionId == ptySessionId else { return }
-            session.receive(data)
+            if sessionId == ptySessionId {
+                session.receive(data)
+            } else if sessionId == secondaryPtySessionId {
+                secondarySession.receive(data)
+            }
         }
     }
 
-    private func handleGhosttyResize(_ grid: GhosttyGridSize) {
+    private func handleGhosttyResize(_ grid: GhosttyGridSize, role: SmokeTerminalRole) {
         guard grid.columns > 0, grid.rows > 0 else {
             return
         }
 
-        pendingGrid = grid
+        switch role {
+        case .primary:
+            pendingGrid = grid
+        case .secondary:
+            secondaryPendingGrid = grid
+        }
 
         if helperMode {
+            guard role == .primary else {
+                return
+            }
+
             guard lastForwardedGrid != grid else {
                 return
             }
@@ -251,20 +341,40 @@ final class GhosttyNativeMacosSmoke:
             return
         }
 
-        forwardResizeIfNeeded(grid)
+        forwardResizeIfNeeded(grid, role: role)
     }
 
-    private func forwardResizeIfNeeded(_ grid: GhosttyGridSize) {
-        guard let ptySessionId, let backendClient else {
+    private func forwardResizeIfNeeded(_ grid: GhosttyGridSize, role: SmokeTerminalRole) {
+        guard let backendClient else {
             return
         }
 
-        guard lastForwardedGrid != grid else {
+        let targetSessionId =
+            switch role {
+            case .primary:
+                ptySessionId
+            case .secondary:
+                secondaryPtySessionId
+            }
+
+        guard let targetSessionId else {
             return
         }
 
-        lastForwardedGrid = grid
-        backendClient.resizePty(sessionId: ptySessionId, grid: grid)
+        switch role {
+        case .primary:
+            guard lastForwardedGrid != grid else {
+                return
+            }
+            lastForwardedGrid = grid
+        case .secondary:
+            guard secondaryLastForwardedGrid != grid else {
+                return
+            }
+            secondaryLastForwardedGrid = grid
+        }
+
+        backendClient.resizePty(sessionId: targetSessionId, grid: grid)
     }
 
     private func showBackendError(_ error: Error) {
@@ -331,6 +441,10 @@ final class GhosttyNativeMacosSmoke:
             light: TerminalConfiguration().background(ghosttyHex),
             dark: TerminalConfiguration().background(ghosttyHex)
         ))
+        secondaryController.setTheme(TerminalTheme(
+            light: TerminalConfiguration().background(ghosttyHex),
+            dark: TerminalConfiguration().background(ghosttyHex)
+        ))
     }
 
     private func focusHelperWindow() {
@@ -347,6 +461,218 @@ final class GhosttyNativeMacosSmoke:
         } else {
             NSApp.activate(ignoringOtherApps: true)
         }
+    }
+
+    // Smoke-only keyboard controls. Production add/hide/remove will be driven
+    // by Electron IPC from the pane header, not by local AppKit shortcuts.
+    private func installSmokeShortcuts() {
+        shortcutMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown]) { [weak self] event in
+            guard let self, self.handleSmokeShortcut(event) else {
+                return event
+            }
+
+            return nil
+        }
+    }
+
+    private func handleSmokeShortcut(_ event: NSEvent) -> Bool {
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        guard flags.contains(.command),
+              event.charactersIgnoringModifiers?.lowercased() == "b"
+        else {
+            return false
+        }
+
+        if flags.contains(.option) {
+            removeSecondarySmokeTerminal()
+            return true
+        }
+
+        if flags.contains(.shift) {
+            hideSecondarySmokeTerminal()
+            return true
+        }
+
+        showSecondarySmokeTerminal()
+        return true
+    }
+
+    private func showSecondarySmokeTerminal() {
+        if let secondaryTerminalView {
+            secondaryTerminalView.isHidden = false
+            layoutSmokeTerminalViews()
+            window?.makeFirstResponder(secondaryTerminalView)
+            return
+        }
+
+        let secondaryTerminalView = TerminalView(frame: .zero)
+        secondaryTerminalView.controller = secondaryController
+        secondaryTerminalView.configuration = TerminalSurfaceOptions(
+            backend: .inMemory(secondarySession)
+        )
+        containerView?.addSubview(secondaryTerminalView)
+        self.secondaryTerminalView = secondaryTerminalView
+        ensureSmokeDivider()
+        dividerView?.isHidden = false
+        secondarySession.receive(
+            "\u{001b}[38;2;214;163;72mVimeflow burner smoke\u{001b}[0m\r\n"
+                + "Separate TerminalView, TerminalController, and ephemeral PTY.\r\n\r\n"
+        )
+        layoutSmokeTerminalViews()
+        window?.makeFirstResponder(secondaryTerminalView)
+        startSecondaryBackendPty()
+    }
+
+    private func hideSecondarySmokeTerminal() {
+        secondaryTerminalView?.isHidden = true
+        dividerView?.isHidden = true
+        layoutSmokeTerminalViews()
+        if let terminalView {
+            window?.makeFirstResponder(terminalView)
+        }
+    }
+
+    private func removeSecondarySmokeTerminal() {
+        if let secondaryPtySessionId {
+            backendClient?.killPty(sessionId: secondaryPtySessionId)
+        }
+        secondaryPtySessionId = nil
+        secondaryLastForwardedGrid = nil
+        secondaryTerminalView?.removeFromSuperview()
+        secondaryTerminalView = nil
+        dividerView?.isHidden = true
+        layoutSmokeTerminalViews()
+        if let terminalView {
+            window?.makeFirstResponder(terminalView)
+        }
+    }
+
+    private func startSecondaryBackendPty() {
+        guard secondaryPtySessionId == nil else {
+            return
+        }
+
+        let sessionId = UUID().uuidString
+        secondaryPtySessionId = sessionId
+        backendClient?.spawnPty(
+            sessionId: sessionId,
+            cwd: VimeflowBackendClient.defaultWorkingDirectory()
+        ) { [weak self] result in
+            guard let self else { return }
+
+            switch result {
+            case let .success(pty):
+                self.secondaryPtySessionId = pty.id
+                self.forwardResizeIfNeeded(self.secondaryPendingGrid, role: .secondary)
+            case let .failure(error):
+                self.secondaryPtySessionId = nil
+                self.secondarySession.receive(
+                    "\r\n\u{001b}[38;2;243;139;168mBurner spawn failed:\u{001b}[0m "
+                        + "\(error.localizedDescription)\r\n"
+                )
+            }
+        }
+    }
+
+    private func ensureSmokeDivider() {
+        if dividerView != nil {
+            return
+        }
+
+        let divider = SmokeDividerView(frame: .zero)
+        divider.wantsLayer = true
+        divider.layer?.backgroundColor = NSColor.separatorColor.cgColor
+        divider.onDrag = { [weak self] delta in
+            self?.resizeSecondarySplit(delta: delta)
+        }
+        containerView?.addSubview(divider)
+        dividerView = divider
+    }
+
+    private func resizeSecondarySplit(delta: CGFloat) {
+        guard let containerView else {
+            return
+        }
+
+        let bounds = containerView.bounds
+        if bounds.width < 720 {
+            secondarySplitRatio = max(0.2, min(0.65, secondarySplitRatio + delta / max(1, bounds.height)))
+        } else {
+            secondarySplitRatio = max(0.2, min(0.65, secondarySplitRatio - delta / max(1, bounds.width)))
+        }
+        layoutSmokeTerminalViews()
+    }
+
+    private func clamped(_ value: CGFloat, min minValue: CGFloat, max maxValue: CGFloat) -> CGFloat {
+        min(max(value, minValue), maxValue)
+    }
+
+    private func layoutSmokeTerminalViews() {
+        guard let containerView, let terminalView else {
+            return
+        }
+
+        let bounds = containerView.bounds
+        guard let secondaryTerminalView, !secondaryTerminalView.isHidden else {
+            terminalView.frame = bounds
+            dividerView?.isHidden = true
+            return
+        }
+
+        let divider: CGFloat = 6
+        dividerView?.isHidden = false
+        if bounds.width < 720 {
+            let secondaryHeight = clamped(
+                floor(bounds.height * secondarySplitRatio),
+                min: 140,
+                max: max(140, bounds.height - 180)
+            )
+            terminalView.frame = NSRect(
+                x: 0,
+                y: secondaryHeight + divider,
+                width: bounds.width,
+                height: max(0, bounds.height - secondaryHeight - divider)
+            )
+            secondaryTerminalView.frame = NSRect(
+                x: 0,
+                y: 0,
+                width: bounds.width,
+                height: secondaryHeight
+            )
+            dividerView?.vertical = false
+            dividerView?.frame = NSRect(
+                x: 0,
+                y: secondaryHeight,
+                width: bounds.width,
+                height: divider
+            )
+        } else {
+            let secondaryWidth = clamped(
+                floor(bounds.width * secondarySplitRatio),
+                min: 260,
+                max: max(260, bounds.width - 320)
+            )
+            terminalView.frame = NSRect(
+                x: 0,
+                y: 0,
+                width: max(0, bounds.width - secondaryWidth - divider),
+                height: bounds.height
+            )
+            secondaryTerminalView.frame = NSRect(
+                x: bounds.width - secondaryWidth,
+                y: 0,
+                width: secondaryWidth,
+                height: bounds.height
+            )
+            dividerView?.vertical = true
+            dividerView?.frame = NSRect(
+                x: bounds.width - secondaryWidth - divider,
+                y: 0,
+                width: divider,
+                height: bounds.height
+            )
+        }
+        dividerView?.resetCursorRects()
     }
 
     private func appKitFrameFromTopLeft(_ frame: GhosttyNativeFrame) -> NSRect {

--- a/native/ghostty-parent/ghostty_native_parent.cc
+++ b/native/ghostty-parent/ghostty_native_parent.cc
@@ -28,6 +28,12 @@ using SetShortcutDigitsFn = void (*)(void *, const char *);
 using SetBackgroundColorFn = void (*)(void *, const char *);
 using WriteFn = void (*)(void *, const unsigned char *, int);
 using FocusFn = void (*)(void *);
+using AddSecondaryFn = void (*)(void *, InputCallback, ResizeCallback,
+                                FocusCallback, void *);
+using SetSecondaryVisibleFn = void (*)(void *, bool);
+using RemoveSecondaryFn = void (*)(void *);
+using WriteSecondaryFn = void (*)(void *, const unsigned char *, int);
+using FocusSecondaryFn = void (*)(void *);
 using DestroyFn = void (*)(void *);
 
 struct BridgeApi {
@@ -39,6 +45,11 @@ struct BridgeApi {
   SetBackgroundColorFn set_background_color = nullptr;
   WriteFn write = nullptr;
   FocusFn focus = nullptr;
+  AddSecondaryFn add_secondary = nullptr;
+  SetSecondaryVisibleFn set_secondary_visible = nullptr;
+  RemoveSecondaryFn remove_secondary = nullptr;
+  WriteSecondaryFn write_secondary = nullptr;
+  FocusSecondaryFn focus_secondary = nullptr;
   DestroyFn destroy = nullptr;
 };
 
@@ -49,8 +60,12 @@ struct SurfaceHandle {
   napi_threadsafe_function focus_tsfn = nullptr;
   napi_threadsafe_function shortcut_tsfn = nullptr;
   napi_threadsafe_function rename_pane_tsfn = nullptr;
+  napi_threadsafe_function secondary_input_tsfn = nullptr;
+  napi_threadsafe_function secondary_resize_tsfn = nullptr;
+  napi_threadsafe_function secondary_focus_tsfn = nullptr;
   void *swift_surface = nullptr;
   std::atomic_bool callbacks_released = false;
+  std::atomic_bool secondary_callbacks_released = true;
   std::mutex callback_mutex;
 };
 
@@ -125,6 +140,16 @@ bool EnsureBridge(napi_env env, const std::string &path) {
                  reinterpret_cast<void **>(&bridge.write)) &&
       LoadSymbol(env, "vimeflow_ghostty_focus",
                  reinterpret_cast<void **>(&bridge.focus)) &&
+      LoadSymbol(env, "vimeflow_ghostty_add_secondary",
+                 reinterpret_cast<void **>(&bridge.add_secondary)) &&
+      LoadSymbol(env, "vimeflow_ghostty_set_secondary_visible",
+                 reinterpret_cast<void **>(&bridge.set_secondary_visible)) &&
+      LoadSymbol(env, "vimeflow_ghostty_remove_secondary",
+                 reinterpret_cast<void **>(&bridge.remove_secondary)) &&
+      LoadSymbol(env, "vimeflow_ghostty_write_secondary",
+                 reinterpret_cast<void **>(&bridge.write_secondary)) &&
+      LoadSymbol(env, "vimeflow_ghostty_focus_secondary",
+                 reinterpret_cast<void **>(&bridge.focus_secondary)) &&
       LoadSymbol(env, "vimeflow_ghostty_destroy",
                  reinterpret_cast<void **>(&bridge.destroy))) {
     bridge.loaded_path = path;
@@ -162,6 +187,28 @@ napi_threadsafe_function AcquireSurfaceCallback(
 
   std::lock_guard<std::mutex> lock(surface->callback_mutex);
   if (surface->callbacks_released.load(std::memory_order_relaxed)) {
+    return nullptr;
+  }
+
+  napi_threadsafe_function tsfn = surface->*member;
+  if (tsfn == nullptr ||
+      napi_acquire_threadsafe_function(tsfn) != napi_ok) {
+    return nullptr;
+  }
+
+  return tsfn;
+}
+
+napi_threadsafe_function AcquireSecondaryCallback(
+    SurfaceHandle *surface, napi_threadsafe_function SurfaceHandle::*member) {
+  if (surface->callbacks_released.load(std::memory_order_acquire) ||
+      surface->secondary_callbacks_released.load(std::memory_order_acquire)) {
+    return nullptr;
+  }
+
+  std::lock_guard<std::mutex> lock(surface->callback_mutex);
+  if (surface->callbacks_released.load(std::memory_order_relaxed) ||
+      surface->secondary_callbacks_released.load(std::memory_order_relaxed)) {
     return nullptr;
   }
 
@@ -215,6 +262,66 @@ void OnResize(void *context, int columns, int rows) {
                                     napi_tsfn_nonblocking) == napi_ok) {
     payload.release();
   }
+  napi_release_threadsafe_function(tsfn, napi_tsfn_release);
+}
+
+void OnSecondaryInput(void *context, const unsigned char *data, int length) {
+  if (context == nullptr || data == nullptr || length <= 0) {
+    return;
+  }
+
+  auto *surface = static_cast<SurfaceHandle *>(context);
+  napi_threadsafe_function tsfn =
+      AcquireSecondaryCallback(surface, &SurfaceHandle::secondary_input_tsfn);
+  if (tsfn == nullptr) {
+    return;
+  }
+
+  auto payload = std::make_unique<InputPayload>();
+  payload->data.assign(reinterpret_cast<const char *>(data),
+                       static_cast<size_t>(length));
+  if (napi_call_threadsafe_function(tsfn, payload.get(),
+                                    napi_tsfn_nonblocking) == napi_ok) {
+    payload.release();
+  }
+  napi_release_threadsafe_function(tsfn, napi_tsfn_release);
+}
+
+void OnSecondaryResize(void *context, int columns, int rows) {
+  if (context == nullptr) {
+    return;
+  }
+
+  auto *surface = static_cast<SurfaceHandle *>(context);
+  napi_threadsafe_function tsfn =
+      AcquireSecondaryCallback(surface, &SurfaceHandle::secondary_resize_tsfn);
+  if (tsfn == nullptr) {
+    return;
+  }
+
+  auto payload = std::make_unique<ResizePayload>();
+  payload->columns = columns;
+  payload->rows = rows;
+  if (napi_call_threadsafe_function(tsfn, payload.get(),
+                                    napi_tsfn_nonblocking) == napi_ok) {
+    payload.release();
+  }
+  napi_release_threadsafe_function(tsfn, napi_tsfn_release);
+}
+
+void OnSecondaryFocus(void *context) {
+  if (context == nullptr) {
+    return;
+  }
+
+  auto *surface = static_cast<SurfaceHandle *>(context);
+  napi_threadsafe_function tsfn =
+      AcquireSecondaryCallback(surface, &SurfaceHandle::secondary_focus_tsfn);
+  if (tsfn == nullptr) {
+    return;
+  }
+
+  napi_call_threadsafe_function(tsfn, nullptr, napi_tsfn_nonblocking);
   napi_release_threadsafe_function(tsfn, napi_tsfn_release);
 }
 
@@ -358,6 +465,7 @@ bool CreateThreadsafeFunction(napi_env env, napi_value callback,
              nullptr, call_js, result) == napi_ok;
 }
 
+void ReleaseSecondaryCallbacks(SurfaceHandle *surface);
 void ReleaseSurfaceCallbacks(SurfaceHandle *surface);
 
 void FinalizeSurface(napi_env env, void *data, void *) {
@@ -366,13 +474,45 @@ void FinalizeSurface(napi_env env, void *data, void *) {
     return;
   }
 
-  ReleaseSurfaceCallbacks(surface);
   if (surface->swift_surface != nullptr && bridge.destroy != nullptr) {
     bridge.destroy(surface->swift_surface);
     surface->swift_surface = nullptr;
   }
+  ReleaseSecondaryCallbacks(surface);
+  ReleaseSurfaceCallbacks(surface);
 
   delete surface;
+}
+
+void ReleaseSecondaryCallbacks(SurfaceHandle *surface) {
+  bool expected = false;
+  if (!surface->secondary_callbacks_released.compare_exchange_strong(
+          expected, true, std::memory_order_acq_rel)) {
+    return;
+  }
+
+  napi_threadsafe_function secondary_input_tsfn = nullptr;
+  napi_threadsafe_function secondary_resize_tsfn = nullptr;
+  napi_threadsafe_function secondary_focus_tsfn = nullptr;
+  {
+    std::lock_guard<std::mutex> lock(surface->callback_mutex);
+    secondary_input_tsfn = surface->secondary_input_tsfn;
+    secondary_resize_tsfn = surface->secondary_resize_tsfn;
+    secondary_focus_tsfn = surface->secondary_focus_tsfn;
+    surface->secondary_input_tsfn = nullptr;
+    surface->secondary_resize_tsfn = nullptr;
+    surface->secondary_focus_tsfn = nullptr;
+  }
+
+  if (secondary_input_tsfn != nullptr) {
+    napi_release_threadsafe_function(secondary_input_tsfn, napi_tsfn_abort);
+  }
+  if (secondary_resize_tsfn != nullptr) {
+    napi_release_threadsafe_function(secondary_resize_tsfn, napi_tsfn_abort);
+  }
+  if (secondary_focus_tsfn != nullptr) {
+    napi_release_threadsafe_function(secondary_focus_tsfn, napi_tsfn_abort);
+  }
 }
 
 void ReleaseSurfaceCallbacks(SurfaceHandle *surface) {
@@ -416,6 +556,18 @@ void ReleaseSurfaceCallbacks(SurfaceHandle *surface) {
   if (rename_pane_tsfn != nullptr) {
     napi_release_threadsafe_function(rename_pane_tsfn, napi_tsfn_abort);
   }
+}
+
+bool HasSecondaryCallbacks(SurfaceHandle *surface) {
+  if (surface->secondary_callbacks_released.load(std::memory_order_acquire)) {
+    return false;
+  }
+
+  std::lock_guard<std::mutex> lock(surface->callback_mutex);
+  return !surface->secondary_callbacks_released.load(std::memory_order_relaxed) &&
+         surface->secondary_input_tsfn != nullptr &&
+         surface->secondary_resize_tsfn != nullptr &&
+         surface->secondary_focus_tsfn != nullptr;
 }
 
 napi_value Create(napi_env env, napi_callback_info info) {
@@ -575,6 +727,129 @@ napi_value Write(napi_env env, napi_callback_info info) {
   return nullptr;
 }
 
+napi_value AddSecondary(napi_env env, napi_callback_info info) {
+  size_t argc = 4;
+  napi_value args[4];
+  napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+  if (argc < 4) {
+    return Throw(
+        env,
+        "addSecondary(surface, onInput, onResize, onFocus) expected");
+  }
+
+  SurfaceHandle *surface = GetSurface(env, args[0]);
+  if (surface == nullptr || surface->swift_surface == nullptr) {
+    return nullptr;
+  }
+
+  if (HasSecondaryCallbacks(surface)) {
+    bridge.set_secondary_visible(surface->swift_surface, true);
+    return nullptr;
+  }
+
+  napi_threadsafe_function input_tsfn = nullptr;
+  napi_threadsafe_function resize_tsfn = nullptr;
+  napi_threadsafe_function focus_tsfn = nullptr;
+  if (!CreateThreadsafeFunction(env, args[1], "vimeflow-ghostty-secondary-input",
+                                CallJsInput, &input_tsfn) ||
+      !CreateThreadsafeFunction(env, args[2], "vimeflow-ghostty-secondary-resize",
+                                CallJsResize, &resize_tsfn) ||
+      !CreateThreadsafeFunction(env, args[3], "vimeflow-ghostty-secondary-focus",
+                                CallJsFocus, &focus_tsfn)) {
+    if (input_tsfn != nullptr) {
+      napi_release_threadsafe_function(input_tsfn, napi_tsfn_abort);
+    }
+    if (resize_tsfn != nullptr) {
+      napi_release_threadsafe_function(resize_tsfn, napi_tsfn_abort);
+    }
+    if (focus_tsfn != nullptr) {
+      napi_release_threadsafe_function(focus_tsfn, napi_tsfn_abort);
+    }
+    return Throw(env, "failed to create Ghostty secondary callbacks");
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(surface->callback_mutex);
+    surface->secondary_input_tsfn = input_tsfn;
+    surface->secondary_resize_tsfn = resize_tsfn;
+    surface->secondary_focus_tsfn = focus_tsfn;
+    surface->secondary_callbacks_released.store(false,
+                                                std::memory_order_release);
+  }
+
+  bridge.add_secondary(surface->swift_surface, OnSecondaryInput,
+                       OnSecondaryResize, OnSecondaryFocus, surface);
+
+  return nullptr;
+}
+
+napi_value SetSecondaryVisible(napi_env env, napi_callback_info info) {
+  size_t argc = 2;
+  napi_value args[2];
+  napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+  if (argc < 2) {
+    return Throw(env, "setSecondaryVisible(surface, visible) expected");
+  }
+
+  SurfaceHandle *surface = GetSurface(env, args[0]);
+  if (surface == nullptr || surface->swift_surface == nullptr) {
+    return nullptr;
+  }
+
+  bool visible = false;
+  napi_get_value_bool(env, args[1], &visible);
+  bridge.set_secondary_visible(surface->swift_surface, visible);
+
+  return nullptr;
+}
+
+napi_value RemoveSecondary(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+
+  SurfaceHandle *surface = GetSurface(env, args[0]);
+  if (surface != nullptr && surface->swift_surface != nullptr) {
+    bridge.remove_secondary(surface->swift_surface);
+    ReleaseSecondaryCallbacks(surface);
+  }
+
+  return nullptr;
+}
+
+napi_value WriteSecondary(napi_env env, napi_callback_info info) {
+  size_t argc = 2;
+  napi_value args[2];
+  napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+  if (argc < 2) {
+    return Throw(env, "writeSecondary(surface, data) expected");
+  }
+
+  SurfaceHandle *surface = GetSurface(env, args[0]);
+  if (surface == nullptr || surface->swift_surface == nullptr) {
+    return nullptr;
+  }
+
+  const std::string data = GetString(env, args[1]);
+  bridge.write_secondary(surface->swift_surface,
+                         reinterpret_cast<const unsigned char *>(data.data()),
+                         static_cast<int>(data.size()));
+
+  return nullptr;
+}
+
+napi_value FocusSecondary(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+  SurfaceHandle *surface = GetSurface(env, args[0]);
+  if (surface != nullptr && surface->swift_surface != nullptr) {
+    bridge.focus_secondary(surface->swift_surface);
+  }
+
+  return nullptr;
+}
+
 napi_value Focus(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
@@ -595,6 +870,7 @@ napi_value Destroy(napi_env env, napi_callback_info info) {
   if (surface != nullptr && surface->swift_surface != nullptr) {
     bridge.destroy(surface->swift_surface);
     surface->swift_surface = nullptr;
+    ReleaseSecondaryCallbacks(surface);
     ReleaseSurfaceCallbacks(surface);
   }
 
@@ -615,6 +891,16 @@ napi_value Init(napi_env env, napi_value exports) {
        nullptr},
       {"focus", nullptr, Focus, nullptr, nullptr, nullptr, napi_default,
        nullptr},
+      {"addSecondary", nullptr, AddSecondary, nullptr, nullptr, nullptr,
+       napi_default, nullptr},
+      {"setSecondaryVisible", nullptr, SetSecondaryVisible, nullptr, nullptr,
+       nullptr, napi_default, nullptr},
+      {"writeSecondary", nullptr, WriteSecondary, nullptr, nullptr, nullptr,
+       napi_default, nullptr},
+      {"focusSecondary", nullptr, FocusSecondary, nullptr, nullptr, nullptr,
+       napi_default, nullptr},
+      {"removeSecondary", nullptr, RemoveSecondary, nullptr, nullptr, nullptr,
+       napi_default, nullptr},
       {"destroy", nullptr, Destroy, nullptr, nullptr, nullptr, napi_default,
        nullptr},
   };

--- a/scripts/smoke-ghostty-native-parent.js
+++ b/scripts/smoke-ghostty-native-parent.js
@@ -11,7 +11,18 @@ const nativeDir = join(repoRoot, 'dist-native', 'ghostty-parent')
 const addonPath = join(nativeDir, 'ghostty_native_parent.node')
 const bridgePath = join(nativeDir, 'libGhosttyElectronBridge.dylib')
 
-const expectedExports = ['create', 'setFrame', 'write', 'focus', 'destroy']
+const expectedExports = [
+  'create',
+  'setFrame',
+  'write',
+  'focus',
+  'addSecondary',
+  'setSecondaryVisible',
+  'writeSecondary',
+  'focusSecondary',
+  'removeSecondary',
+  'destroy',
+]
 
 const requireFile = (file) => {
   if (!existsSync(file)) {

--- a/src/components/StatusBar.test.tsx
+++ b/src/components/StatusBar.test.tsx
@@ -275,10 +275,10 @@ describe('StatusBar', () => {
   })
 
   test('shows the burner open state when a burner shell is visible', () => {
-    renderStatusBar({ burnerCount: 2, burnerOpen: true })
+    renderStatusBar({ burnerCount: 1, burnerOpen: true })
 
     expect(screen.getByTestId('status-bar-burner')).toHaveTextContent(
-      'burner open ×2'
+      'burner open'
     )
   })
 

--- a/src/components/StatusBar.test.tsx
+++ b/src/components/StatusBar.test.tsx
@@ -274,6 +274,14 @@ describe('StatusBar', () => {
     )
   })
 
+  test('shows the burner open state when a burner shell is visible', () => {
+    renderStatusBar({ burnerCount: 2, burnerOpen: true })
+
+    expect(screen.getByTestId('status-bar-burner')).toHaveTextContent(
+      'burner open ×2'
+    )
+  })
+
   test('omits the burner count segment when none are running', () => {
     renderStatusBar({ burnerCount: 0 })
 

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -40,8 +40,10 @@ export interface StatusBarProps {
   /** Whether the editor/diff dock is open — drives the toggle's icon tone. */
   dockOpen: boolean
   onToggleDock: () => void
-  /** Total running burner shells across all sessions (VIM-53/71 cue). */
+  /** Burner shells currently visible in a pane. Hidden shells are pane-local. */
   burnerCount?: number
+  /** True when one burner shell is visibly shown. */
+  burnerOpen?: boolean
 }
 
 interface Segment {
@@ -177,11 +179,19 @@ const buildSegments = ({
   session,
   contextPct,
   burnerCount = 0,
+  burnerOpen = false,
 }: Pick<
   StatusBarProps,
-  'session' | 'contextPct' | 'burnerCount'
+  'session' | 'contextPct' | 'burnerCount' | 'burnerOpen'
 >): Segment[] => {
   // Global across sessions, so it surfaces even when no session is active.
+  const burnerText =
+    burnerOpen && burnerCount > 1
+      ? `burner open ×${burnerCount}`
+      : burnerOpen
+        ? 'burner open'
+        : `burner ×${burnerCount}`
+
   const burnerSegment: Segment | null =
     burnerCount > 0
       ? {
@@ -196,7 +206,7 @@ const buildSegments = ({
                 aria-hidden="true"
                 className="h-[5px] w-[5px] rounded-full bg-current"
               />
-              burner ×{burnerCount}
+              {burnerText}
             </span>
           ),
         }
@@ -313,8 +323,14 @@ export const StatusBar = ({
   dockOpen,
   onToggleDock,
   burnerCount = 0,
+  burnerOpen = false,
 }: StatusBarProps): ReactElement => {
-  const segments = buildSegments({ session, contextPct, burnerCount })
+  const segments = buildSegments({
+    session,
+    contextPct,
+    burnerCount,
+    burnerOpen,
+  })
 
   return (
     <footer

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -185,12 +185,7 @@ const buildSegments = ({
   'session' | 'contextPct' | 'burnerCount' | 'burnerOpen'
 >): Segment[] => {
   // Global across sessions, so it surfaces even when no session is active.
-  const burnerText =
-    burnerOpen && burnerCount > 1
-      ? `burner open ×${burnerCount}`
-      : burnerOpen
-        ? 'burner open'
-        : `burner ×${burnerCount}`
+  const burnerText = burnerOpen ? 'burner open' : `burner ×${burnerCount}`
 
   const burnerSegment: Segment | null =
     burnerCount > 0

--- a/src/features/terminal/components/SplitView/SplitView.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.tsx
@@ -92,6 +92,8 @@ export interface SplitViewProps {
   layoutRegistry?: PaneLayoutRegistry
   /** Pane-keys with a foreground command running — drives the amber button tint (VIM-71). */
   activeBurnerPaneKeys?: ReadonlySet<string>
+  /** Pane-keys whose burner secondary terminal is currently visible. */
+  openBurnerPaneKeys?: ReadonlySet<string>
   /** Pane-keys with a live burner shell (idle or active) — drives a11y state (VIM-53). */
   runningBurnerPaneKeys?: ReadonlySet<string>
   deferTerminalFit?: boolean
@@ -185,6 +187,7 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
       onBurner = undefined,
       layoutRegistry = BUILTIN_PANE_LAYOUT_REGISTRY,
       activeBurnerPaneKeys = undefined,
+      openBurnerPaneKeys = undefined,
       runningBurnerPaneKeys = undefined,
       deferTerminalFit = false,
     }: SplitViewProps,
@@ -666,6 +669,7 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
                         onRequestActive={onSetActivePane}
                         onRequestFocus={onRequestFocus}
                         activeBurnerPaneKeys={activeBurnerPaneKeys}
+                        openBurnerPaneKeys={openBurnerPaneKeys}
                         runningBurnerPaneKeys={runningBurnerPaneKeys}
                         isActive={isActive}
                         shortcutContext={nativeShortcutContext}

--- a/src/features/terminal/components/TerminalPane/Header.tsx
+++ b/src/features/terminal/components/TerminalPane/Header.tsx
@@ -22,6 +22,7 @@ export interface HeaderProps {
   onClose?: () => void
   onBurner?: () => void
   burnerActive?: boolean
+  burnerOpen?: boolean
   burnerShellExists?: boolean
   /**
    * VIM-167: when true, the header acts as the pane's drag handle for the
@@ -48,6 +49,7 @@ export const Header = ({
   onClose = undefined,
   onBurner = undefined,
   burnerActive = false,
+  burnerOpen = false,
   burnerShellExists = false,
   draggable = false,
   onHeaderDragStart = undefined,
@@ -124,6 +126,7 @@ export const Header = ({
           onClose={onClose}
           onBurner={onBurner}
           burnerActive={burnerActive}
+          burnerOpen={burnerOpen}
           burnerShellExists={burnerShellExists}
         />
       </div>

--- a/src/features/terminal/components/TerminalPane/HeaderActions.test.tsx
+++ b/src/features/terminal/components/TerminalPane/HeaderActions.test.tsx
@@ -161,6 +161,24 @@ describe('HeaderActions', () => {
     expect(button.className).toContain('text-on-surface-muted') // still gray, not amber
   })
 
+  test('opened burner uses pressed state on its pane button', () => {
+    render(
+      <HeaderActions
+        isCollapsed={expanded}
+        onToggleCollapse={vi.fn()}
+        onBurner={vi.fn()}
+        burnerOpen
+        burnerShellExists
+      />
+    )
+
+    const button = screen.getByRole('button', {
+      name: 'hide burner terminal',
+    })
+    expect(button).toHaveAttribute('aria-pressed', 'true')
+    expect(button.className).toContain('aria-pressed:bg-primary/10')
+  })
+
   test('renders visible pane shortcut hint when provided', () => {
     render(
       <HeaderActions

--- a/src/features/terminal/components/TerminalPane/HeaderActions.tsx
+++ b/src/features/terminal/components/TerminalPane/HeaderActions.tsx
@@ -3,9 +3,19 @@ import { IconButton } from '@/components/IconButton'
 import { Tooltip } from '@/components/Tooltip'
 import { TOOLTIP_SUPPRESSED } from '@/lib/constants'
 
-const burnerButtonLabel = (active: boolean, shellExists: boolean): string => {
+const burnerButtonLabel = (
+  active: boolean,
+  open: boolean,
+  shellExists: boolean
+): string => {
   if (active) {
-    return 'open burner terminal (running)'
+    return open
+      ? 'hide burner terminal (running)'
+      : 'open burner terminal (running)'
+  }
+
+  if (open) {
+    return 'hide burner terminal'
   }
 
   if (shellExists) {
@@ -29,6 +39,8 @@ export interface HeaderActionsProps {
    * drives the amber button tint (the sole running cue).
    */
   burnerActive?: boolean
+  /** This pane's burner secondary terminal is currently visible. */
+  burnerOpen?: boolean
   /**
    * A burner shell exists for this pane but no foreground command is running.
    * Exposed to assistive tech so an idle-but-live shell is distinguishable
@@ -45,9 +57,14 @@ export const HeaderActions = ({
   onClose = undefined,
   onBurner = undefined,
   burnerActive = false,
+  burnerOpen = false,
   burnerShellExists = false,
 }: HeaderActionsProps): ReactElement => {
-  const burnerLabel = burnerButtonLabel(burnerActive, burnerShellExists)
+  const burnerLabel = burnerButtonLabel(
+    burnerActive,
+    burnerOpen,
+    burnerShellExists
+  )
   const collapseLabel = isCollapsed ? 'expand status' : 'collapse status'
 
   return (
@@ -68,6 +85,7 @@ export const HeaderActions = ({
             label={burnerLabel}
             showTooltip={TOOLTIP_SUPPRESSED}
             size="sm"
+            pressed={burnerOpen}
             onClick={(event) => {
               event.stopPropagation()
               onBurner()

--- a/src/features/terminal/components/TerminalPane/index.test.tsx
+++ b/src/features/terminal/components/TerminalPane/index.test.tsx
@@ -172,6 +172,7 @@ describe('TerminalPane index', () => {
     expect(onBurner).toHaveBeenCalledWith({
       sessionId: 's1',
       paneId: 'p0',
+      hostPtyId: 'pty-s1',
       cwd: '/home/user/repo',
     })
   })

--- a/src/features/terminal/components/TerminalPane/index.tsx
+++ b/src/features/terminal/components/TerminalPane/index.tsx
@@ -64,6 +64,8 @@ export interface TerminalPaneProps {
   onRequestFocus?: () => void
   /** Pane-keys with a foreground command running — drives the amber button tint (VIM-71). */
   activeBurnerPaneKeys?: ReadonlySet<string>
+  /** Pane-keys whose burner secondary terminal is currently visible. */
+  openBurnerPaneKeys?: ReadonlySet<string>
   /** Pane-keys with a live burner shell (idle or active) — drives a11y state (VIM-53). */
   runningBurnerPaneKeys?: ReadonlySet<string>
   onCwdChange?: (cwd: string) => void
@@ -106,6 +108,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
       onRequestActive = undefined,
       onRequestFocus = undefined,
       activeBurnerPaneKeys = undefined,
+      openBurnerPaneKeys = undefined,
       runningBurnerPaneKeys = undefined,
       onCwdChange = undefined,
       onCommandSubmit = undefined,
@@ -232,8 +235,13 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
       // slot's click-to-activate never runs — without this the active-pane
       // state would stay on the previously-focused pane.
       onRequestActive?.(session.id, pane.id)
-      onBurner?.({ sessionId: session.id, paneId: pane.id, cwd: pane.cwd })
-    }, [onRequestActive, onBurner, session.id, pane.id, pane.cwd])
+      onBurner?.({
+        sessionId: session.id,
+        paneId: pane.id,
+        hostPtyId: pane.ptyId,
+        cwd: pane.cwd,
+      })
+    }, [onRequestActive, onBurner, session.id, pane.id, pane.ptyId, pane.cwd])
 
     const handleRestart = useCallback(
       (restartSessionId: string): void => {
@@ -297,6 +305,9 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
           onBurner={onBurner ? handleBurner : undefined}
           burnerActive={
             activeBurnerPaneKeys?.has(`${session.id}:${pane.id}`) ?? false
+          }
+          burnerOpen={
+            openBurnerPaneKeys?.has(`${session.id}:${pane.id}`) ?? false
           }
           burnerShellExists={
             runningBurnerPaneKeys?.has(`${session.id}:${pane.id}`) ?? false

--- a/src/features/terminal/hooks/useBurnerTerminals.test.ts
+++ b/src/features/terminal/hooks/useBurnerTerminals.test.ts
@@ -1,10 +1,16 @@
-import { test, expect, vi } from 'vitest'
-import { renderHook, act } from '@testing-library/react'
+// cspell:ignore ghostty
+import { afterEach, test, expect, vi } from 'vitest'
+import { render, renderHook, act, waitFor } from '@testing-library/react'
 import type { ReactElement, ReactNode } from 'react'
 import { useBurnerTerminals, type BurnerTarget } from './useBurnerTerminals'
 import type { FocusedPaneRef } from '../../command-palette/hooks/usePaneRenameChord'
 import type { ITerminalService } from '../services/terminalService'
 import * as chordRegistry from '../../command-palette/chordRegistry'
+
+afterEach(() => {
+  delete (window as unknown as { vimeflow?: unknown }).vimeflow
+  vi.unstubAllGlobals()
+})
 
 const makeFocusedPane = (
   sessionId = 's1',
@@ -192,19 +198,69 @@ test('hasVisibleBurner tracks only the visible popup, not hidden live shells', a
   )
 
   expect(result.current.hasVisibleBurner).toBe(false)
+  expect(result.current.visibleBurnerPaneKey).toBeNull()
 
   await act(async () => {
     await result.current.toggle()
   })
 
   expect(result.current.hasVisibleBurner).toBe(true)
+  expect(result.current.visibleBurnerPaneKey).toBe('s1:p0')
 
   await act(async () => {
     await result.current.toggle()
   })
 
   expect(result.current.hasVisibleBurner).toBe(false)
+  expect(result.current.visibleBurnerPaneKey).toBeNull()
   expect(result.current.renderNode).not.toBeNull()
+})
+
+test('drops a native burner when secondary attach is unavailable', async () => {
+  vi.stubGlobal('navigator', { platform: 'MacIntel' })
+  const attachSecondary = vi.fn(() => Promise.resolve({ enabled: false }))
+  const testWindow = window as unknown as { vimeflow?: unknown }
+  testWindow.vimeflow = {
+    ghosttyNative: {
+      update: vi.fn(),
+      data: vi.fn(),
+      focus: vi.fn(),
+      destroy: vi.fn(),
+      attachSecondary,
+    },
+  }
+
+  const service = makeService()
+  const focused = makeFocusedPane('s1', 'p0', '/repo')
+
+  const { result } = renderHook(() =>
+    useBurnerTerminals({ service, resolveFocusedPane: () => focused })
+  )
+
+  await act(async () => {
+    await result.current.toggle({
+      sessionId: 's1',
+      paneId: 'p0',
+      hostPtyId: 'host-pty',
+      cwd: '/repo',
+    })
+  })
+
+  const rendered = render(result.current.renderNode)
+
+  await waitFor(() => {
+    expect(service.kill).toHaveBeenCalledWith({ sessionId: 'burner-pty' })
+  })
+
+  expect(attachSecondary).toHaveBeenCalledWith({
+    sessionId: 'host-pty',
+    paneId: 'p0',
+    secondarySessionId: 'burner-pty',
+  })
+  expect(result.current.runningByPane.size).toBe(0)
+  expect(result.current.visibleBurnerPaneKey).toBeNull()
+
+  rendered.unmount()
 })
 
 test('renderNode stays non-null when hidden while a shell is alive', async () => {

--- a/src/features/terminal/hooks/useBurnerTerminals.test.ts
+++ b/src/features/terminal/hooks/useBurnerTerminals.test.ts
@@ -29,6 +29,7 @@ const makeService = (): ITerminalService =>
       .mockResolvedValue({ sessionId: 'burner-pty', pid: 7, cwd: '/repo' }),
     kill: vi.fn().mockResolvedValue(undefined),
     write: vi.fn().mockResolvedValue(undefined),
+    onData: vi.fn().mockResolvedValue(() => undefined),
     onExit: vi.fn().mockResolvedValue(() => undefined),
     onBurnerForeground: vi.fn().mockResolvedValue(() => undefined),
   }) as unknown as ITerminalService
@@ -219,6 +220,7 @@ test('hasVisibleBurner tracks only the visible popup, not hidden live shells', a
 test('drops a native burner when secondary attach is unavailable', async () => {
   vi.stubGlobal('navigator', { platform: 'MacIntel' })
   const attachSecondary = vi.fn(() => Promise.resolve({ enabled: false }))
+  const removeSecondary = vi.fn(() => Promise.resolve({}))
   const testWindow = window as unknown as { vimeflow?: unknown }
   testWindow.vimeflow = {
     ghosttyNative: {
@@ -227,6 +229,10 @@ test('drops a native burner when secondary attach is unavailable', async () => {
       focus: vi.fn(),
       destroy: vi.fn(),
       attachSecondary,
+      secondaryData: vi.fn(() => Promise.resolve({})),
+      focusSecondary: vi.fn(() => Promise.resolve({})),
+      removeSecondary,
+      setSecondaryVisible: vi.fn(() => Promise.resolve({})),
     },
   }
 
@@ -259,6 +265,110 @@ test('drops a native burner when secondary attach is unavailable', async () => {
   })
   expect(result.current.runningByPane.size).toBe(0)
   expect(result.current.visibleBurnerPaneKey).toBeNull()
+
+  rendered.unmount()
+})
+
+test('uses the xterm popup for legacy native Ghostty without secondary IPC', async () => {
+  vi.stubGlobal('navigator', { platform: 'MacIntel' })
+  const testWindow = window as unknown as { vimeflow?: unknown }
+  testWindow.vimeflow = {
+    ghosttyNative: {
+      update: vi.fn(),
+      data: vi.fn(),
+      focus: vi.fn(),
+      destroy: vi.fn(),
+    },
+  }
+
+  const service = makeService()
+  const focused = makeFocusedPane('s1', 'p0', '/repo')
+
+  const { result } = renderHook(() =>
+    useBurnerTerminals({ service, resolveFocusedPane: () => focused })
+  )
+
+  await act(async () => {
+    await result.current.toggle({
+      sessionId: 's1',
+      paneId: 'p0',
+      hostPtyId: 'host-pty',
+      cwd: '/repo',
+    })
+  })
+
+  const popup = firstPopup(result.current.renderNode)
+
+  expect(popup.props.burnerPtyId).toBe('burner-pty')
+  expect(result.current.hasVisibleBurner).toBe(true)
+  expect(service.kill).not.toHaveBeenCalled()
+})
+
+test('reattaches a native burner when the host pane pty rotates', async () => {
+  vi.stubGlobal('navigator', { platform: 'MacIntel' })
+  const attachSecondary = vi.fn(() => Promise.resolve({}))
+  const removeSecondary = vi.fn(() => Promise.resolve({}))
+  const testWindow = window as unknown as { vimeflow?: unknown }
+  testWindow.vimeflow = {
+    ghosttyNative: {
+      update: vi.fn(),
+      data: vi.fn(),
+      focus: vi.fn(),
+      destroy: vi.fn(),
+      attachSecondary,
+      secondaryData: vi.fn(() => Promise.resolve({})),
+      focusSecondary: vi.fn(() => Promise.resolve({})),
+      removeSecondary,
+      setSecondaryVisible: vi.fn(() => Promise.resolve({})),
+    },
+  }
+
+  const service = makeService()
+  const focused = makeFocusedPane('s1', 'p0', '/repo')
+
+  const { result, rerender } = renderHook(
+    (props: { ptys: ReadonlyMap<string, string> }) =>
+      useBurnerTerminals({
+        service,
+        resolveFocusedPane: () => focused,
+        livePaneKeys: new Set<string>(['s1:p0']),
+        livePanePtyIds: props.ptys,
+      }),
+    { initialProps: { ptys: new Map([['s1:p0', 'host-old']]) } }
+  )
+
+  await act(async () => {
+    await result.current.toggle({
+      sessionId: 's1',
+      paneId: 'p0',
+      hostPtyId: 'host-old',
+      cwd: '/repo',
+    })
+  })
+
+  const rendered = render(result.current.renderNode)
+
+  await waitFor(() => {
+    expect(attachSecondary).toHaveBeenCalledWith({
+      sessionId: 'host-old',
+      paneId: 'p0',
+      secondarySessionId: 'burner-pty',
+    })
+  })
+
+  act(() => {
+    rerender({ ptys: new Map([['s1:p0', 'host-new']]) })
+  })
+  rendered.rerender(result.current.renderNode)
+
+  await waitFor(() => {
+    rendered.rerender(result.current.renderNode)
+    expect(attachSecondary).toHaveBeenCalledWith({
+      sessionId: 'host-new',
+      paneId: 'p0',
+      secondarySessionId: 'burner-pty',
+    })
+  })
 
   rendered.unmount()
 })

--- a/src/features/terminal/hooks/useBurnerTerminals.ts
+++ b/src/features/terminal/hooks/useBurnerTerminals.ts
@@ -16,11 +16,11 @@ import type { NotifyPaneReady } from './useTerminal'
 import type { FocusedPaneRef } from '../../command-palette/hooks/usePaneRenameChord'
 import {
   attachNativeGhosttySecondary,
+  canUseNativeGhosttySecondary,
   focusNativeGhosttySecondary,
   removeNativeGhosttySecondary,
   sendNativeGhosttySecondaryData,
   setNativeGhosttySecondaryVisible,
-  shouldUseNativeGhostty,
   type NativeGhosttySecondaryRequest,
 } from '../nativeGhosttyClient'
 import { parseOsc7Cwd } from '../components/TerminalPane/osc7'
@@ -261,6 +261,12 @@ export interface UseBurnerTerminalsArgs {
    * the sync target even before the interactive shell's pwd catches up.
    */
   agentPaneCwds?: ReadonlyMap<string, string>
+  /**
+   * Live `${sessionId}:${paneId}` → current pane ptyId. Pane restarts preserve
+   * the stable pane key but rotate the native host ptyId; open native burners
+   * reattach when this value changes.
+   */
+  livePanePtyIds?: ReadonlyMap<string, string>
 }
 
 export interface UseBurnerTerminals {
@@ -307,6 +313,7 @@ export const useBurnerTerminals = ({
   dropAllForPty,
   livePaneCwds,
   agentPaneCwds,
+  livePanePtyIds,
 }: UseBurnerTerminalsArgs): UseBurnerTerminals => {
   // Authoritative handles live in a ref so they never serialize; a projection
   // is mirrored into state so renderNode + cues re-render.
@@ -695,6 +702,29 @@ export const useBurnerTerminals = ({
     commit()
   }, [livePaneKeys, killBurner, commit])
 
+  useEffect(() => {
+    if (!livePanePtyIds) {
+      return
+    }
+
+    const updates: [string, BurnerEntry][] = []
+    entriesRef.current.forEach((entry, key) => {
+      const hostPtyId = livePanePtyIds.get(key)
+      if (!hostPtyId || entry.hostPtyId === hostPtyId) {
+        return
+      }
+
+      updates.push([key, { ...entry, hostPtyId }])
+    })
+
+    if (updates.length > 0) {
+      for (const [key, entry] of updates) {
+        entriesRef.current.set(key, entry)
+      }
+      commit()
+    }
+  }, [livePanePtyIds, commit])
+
   // Memoized so consumers threading it down only re-render on actual change.
   const runningByPane = useMemo(() => {
     const map = new Map<string, BurnerStatus>()
@@ -718,7 +748,7 @@ export const useBurnerTerminals = ({
           [...entries.entries()].map(([key, entry]): ReactNode => {
             const targetCwd = agentPaneCwds?.get(key) ?? livePaneCwds?.get(key)
 
-            if (shouldUseNativeGhostty() && entry.hostPtyId) {
+            if (canUseNativeGhosttySecondary() && entry.hostPtyId) {
               return createElement(NativeGhosttyBurnerTerminal, {
                 key: `${key}:${entry.burnerPtyId}`,
                 open: visibleKey === key,
@@ -781,7 +811,7 @@ export const useBurnerTerminals = ({
     activeByPane,
     hasVisibleBurner:
       visibleKey !== null &&
-      (!shouldUseNativeGhostty() || !entries.get(visibleKey)?.hostPtyId),
+      (!canUseNativeGhosttySecondary() || !entries.get(visibleKey)?.hostPtyId),
     visibleBurnerPaneKey: visibleKey,
   }
 }

--- a/src/features/terminal/hooks/useBurnerTerminals.ts
+++ b/src/features/terminal/hooks/useBurnerTerminals.ts
@@ -716,11 +716,9 @@ export const useBurnerTerminals = ({
           Fragment,
           null,
           [...entries.entries()].map(([key, entry]): ReactNode => {
-            const useNativeBurner =
-              shouldUseNativeGhostty() && entry.hostPtyId !== undefined
             const targetCwd = agentPaneCwds?.get(key) ?? livePaneCwds?.get(key)
 
-            if (useNativeBurner && entry.hostPtyId) {
+            if (shouldUseNativeGhostty() && entry.hostPtyId) {
               return createElement(NativeGhosttyBurnerTerminal, {
                 key: `${key}:${entry.burnerPtyId}`,
                 open: visibleKey === key,

--- a/src/features/terminal/hooks/useBurnerTerminals.ts
+++ b/src/features/terminal/hooks/useBurnerTerminals.ts
@@ -1,3 +1,4 @@
+// cspell:ignore Ghostty ghostty
 import {
   createElement,
   Fragment,
@@ -13,11 +14,23 @@ import { registerChord } from '../../command-palette/chordRegistry'
 import type { ITerminalService } from '../services/terminalService'
 import type { NotifyPaneReady } from './useTerminal'
 import type { FocusedPaneRef } from '../../command-palette/hooks/usePaneRenameChord'
+import {
+  attachNativeGhosttySecondary,
+  focusNativeGhosttySecondary,
+  removeNativeGhosttySecondary,
+  sendNativeGhosttySecondaryData,
+  setNativeGhosttySecondaryVisible,
+  shouldUseNativeGhostty,
+  type NativeGhosttySecondaryRequest,
+} from '../nativeGhosttyClient'
+import { parseOsc7Cwd } from '../components/TerminalPane/osc7'
 
 type BurnerStatus = 'running' | 'exited'
 
 interface BurnerEntry {
   burnerPtyId: string
+  hostPaneId: string
+  hostPtyId?: string
   pid: number
   status: BurnerStatus
   /** The cwd the shell spawned at (the `<Body>` attach snapshot). */
@@ -38,6 +51,7 @@ interface BurnerEntry {
 export interface BurnerTarget {
   sessionId: string
   paneId: string
+  hostPtyId?: string
   cwd: string
 }
 
@@ -71,6 +85,150 @@ const CLEAR_LINE = '\x05\x15'
 
 // Compare OSC 7 cwds forgiving a trailing slash (root stays "/").
 const normalizeCwd = (value: string): string => value.replace(/\/+$/, '') || '/'
+const OSC7_SEQUENCE_PATTERN = /\u001b\]7;([^\u0007\u001b]*)(?:\u0007|\u001b\\)/g
+
+interface NativeGhosttyBurnerTerminalProps {
+  open: boolean
+  hostPtyId: string
+  paneId: string
+  burnerPtyId: string
+  service: ITerminalService
+  onPaneReady?: NotifyPaneReady
+  onCwdChange?: (cwd: string) => void
+  onUnavailable: () => void
+}
+
+const NativeGhosttyBurnerTerminal = ({
+  open,
+  hostPtyId,
+  paneId,
+  burnerPtyId,
+  service,
+  onPaneReady = undefined,
+  onCwdChange = undefined,
+  onUnavailable,
+}: NativeGhosttyBurnerTerminalProps): null => {
+  const onCwdChangeRef = useRef(onCwdChange)
+  onCwdChangeRef.current = onCwdChange
+  const onUnavailableRef = useRef(onUnavailable)
+  onUnavailableRef.current = onUnavailable
+
+  const request = useMemo<NativeGhosttySecondaryRequest>(
+    () => ({
+      sessionId: hostPtyId,
+      paneId,
+      secondarySessionId: burnerPtyId,
+    }),
+    [burnerPtyId, hostPtyId, paneId]
+  )
+
+  const handleNativeOutput = useCallback((data: string): void => {
+    for (const match of data.matchAll(OSC7_SEQUENCE_PATTERN)) {
+      const cwd = parseOsc7Cwd(match[1])
+      if (cwd) {
+        onCwdChangeRef.current?.(cwd)
+      }
+    }
+  }, [])
+
+  const sendOutputToNative = useCallback(
+    async (data: string): Promise<void> => {
+      try {
+        await sendNativeGhosttySecondaryData({ ...request, data })
+      } catch {
+        // Best effort: if native attach disappears, burner lifecycle still owns the PTY.
+      }
+    },
+    [request]
+  )
+
+  useEffect(() => {
+    const lifecycle = { cancelled: false }
+    const isCancelled = (): boolean => lifecycle.cancelled
+    let releasePaneReady: (() => void) | null = null
+    let unsubscribeOutput: (() => void) | null = null
+
+    const drainBufferedOutput = (data: string): void => {
+      handleNativeOutput(data)
+      void sendOutputToNative(data)
+    }
+
+    const attach = async (): Promise<void> => {
+      let enabled = false
+      try {
+        enabled = await attachNativeGhosttySecondary(request)
+      } catch {
+        if (!isCancelled()) {
+          onUnavailableRef.current()
+        }
+
+        return
+      }
+      if (!enabled || isCancelled()) {
+        if (!enabled && !isCancelled()) {
+          onUnavailableRef.current()
+        }
+
+        return
+      }
+
+      const unsubscribe = await service.onData((ptyId, data) => {
+        if (ptyId !== burnerPtyId) {
+          return
+        }
+
+        handleNativeOutput(data)
+        void sendOutputToNative(data)
+      })
+
+      if (isCancelled()) {
+        unsubscribe()
+
+        return
+      }
+
+      unsubscribeOutput = unsubscribe
+      releasePaneReady = onPaneReady?.(burnerPtyId, drainBufferedOutput) ?? null
+    }
+
+    void attach()
+
+    return (): void => {
+      lifecycle.cancelled = true
+      releasePaneReady?.()
+      unsubscribeOutput?.()
+      void (async (): Promise<void> => {
+        try {
+          await removeNativeGhosttySecondary(request)
+        } catch {
+          // Best-effort cleanup can race Electron shutdown.
+        }
+      })()
+    }
+  }, [
+    burnerPtyId,
+    handleNativeOutput,
+    onPaneReady,
+    request,
+    sendOutputToNative,
+    service,
+  ])
+
+  useEffect(() => {
+    void (async (): Promise<void> => {
+      try {
+        await setNativeGhosttySecondaryVisible({ ...request, visible: open })
+        if (open) {
+          await focusNativeGhosttySecondary(request)
+        }
+      } catch {
+        // Best effort: losing the native child should not break burner state.
+      }
+    })()
+  }, [open, request])
+
+  return null
+}
 
 export interface UseBurnerTerminalsArgs {
   service: ITerminalService
@@ -128,6 +286,8 @@ export interface UseBurnerTerminals {
   activeByPane: ReadonlyMap<string, boolean>
   /** True while a burner popup is visibly open over the workspace. */
   hasVisibleBurner: boolean
+  /** Stable pane key for the burner currently shown, including native Ghostty. */
+  visibleBurnerPaneKey: string | null
 }
 
 /**
@@ -305,6 +465,8 @@ export const useBurnerTerminals = ({
         registerPending?.(result.sessionId)
         entriesRef.current.set(key, {
           burnerPtyId: result.sessionId,
+          hostPaneId: target.paneId,
+          hostPtyId: target.hostPtyId,
           pid: result.pid,
           status: 'running',
           cwd: result.cwd,
@@ -334,11 +496,24 @@ export const useBurnerTerminals = ({
       const key = paneKey(target.sessionId, target.paneId)
       showIntentRef.current = key
       await spawnIfNeeded(target, key)
+      const entry = entriesRef.current.get(key)
+      if (
+        entry &&
+        (entry.hostPaneId !== target.paneId ||
+          entry.hostPtyId !== target.hostPtyId)
+      ) {
+        entriesRef.current.set(key, {
+          ...entry,
+          hostPaneId: target.paneId,
+          hostPtyId: target.hostPtyId,
+        })
+        commit()
+      }
       if (entriesRef.current.has(key) && showIntentRef.current === key) {
         setVisibleKey(key)
       }
     },
-    [spawnIfNeeded]
+    [commit, spawnIfNeeded]
   )
 
   const toggle = useCallback(
@@ -359,6 +534,7 @@ export const useBurnerTerminals = ({
         await show({
           sessionId: focused.session.id,
           paneId: focused.pane.id,
+          hostPtyId: focused.pane.ptyId,
           cwd: focused.pane.cwd,
         })
 
@@ -540,7 +716,33 @@ export const useBurnerTerminals = ({
           Fragment,
           null,
           [...entries.entries()].map(([key, entry]): ReactNode => {
+            const useNativeBurner =
+              shouldUseNativeGhostty() && entry.hostPtyId !== undefined
             const targetCwd = agentPaneCwds?.get(key) ?? livePaneCwds?.get(key)
+
+            if (useNativeBurner && entry.hostPtyId) {
+              return createElement(NativeGhosttyBurnerTerminal, {
+                key: `${key}:${entry.burnerPtyId}`,
+                open: visibleKey === key,
+                hostPtyId: entry.hostPtyId,
+                paneId: entry.hostPaneId,
+                burnerPtyId: entry.burnerPtyId,
+                service,
+                onPaneReady: notifyPaneReady,
+                onCwdChange: (cwd: string): void => setBurnerCwd(key, cwd),
+                onUnavailable: (): void => {
+                  const current = entriesRef.current.get(key)
+                  if (current?.burnerPtyId !== entry.burnerPtyId) {
+                    return
+                  }
+
+                  killBurner(current.burnerPtyId)
+                  entriesRef.current.delete(key)
+                  setVisibleKey((visible) => (visible === key ? null : visible))
+                  commit()
+                },
+              })
+            }
 
             return createElement(BurnerTerminalPopup, {
               // Keyed by pty so a re-spawned (post-exit) shell remounts a fresh
@@ -579,6 +781,9 @@ export const useBurnerTerminals = ({
     toggle,
     runningByPane,
     activeByPane,
-    hasVisibleBurner: visibleKey !== null,
+    hasVisibleBurner:
+      visibleKey !== null &&
+      (!shouldUseNativeGhostty() || !entries.get(visibleKey)?.hostPtyId),
+    visibleBurnerPaneKey: visibleKey,
   }
 }

--- a/src/features/terminal/nativeGhosttyClient.test.ts
+++ b/src/features/terminal/nativeGhosttyClient.test.ts
@@ -2,7 +2,9 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import type { ITerminalService } from './services/terminalService'
 import {
+  attachNativeGhosttySecondary,
   attachNativeGhosttyOutput,
+  sendNativeGhosttySecondaryData,
   shouldUseNativeGhostty,
   type NativeGhosttyApi,
 } from './nativeGhosttyClient'
@@ -82,6 +84,51 @@ describe('nativeGhosttyClient', () => {
 
     await vi.waitFor(() => {
       expect(onUnavailable).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  test('secondary APIs return unavailable when preload has not exposed them', async () => {
+    const api: NativeGhosttyApi = {
+      update: vi.fn(() => Promise.resolve({})),
+      data: vi.fn(() => Promise.resolve({})),
+      focus: vi.fn(() => Promise.resolve({})),
+      destroy: vi.fn(() => Promise.resolve({})),
+    }
+    vi.stubGlobal('window', { vimeflow: { ghosttyNative: api } })
+
+    await expect(
+      attachNativeGhosttySecondary({
+        sessionId: 'host-pty',
+        paneId: 'pane-1',
+        secondarySessionId: 'burner-pty',
+      })
+    ).resolves.toBe(false)
+  })
+
+  test('secondary data forwards through the optional native bridge', async () => {
+    const api: NativeGhosttyApi = {
+      update: vi.fn(() => Promise.resolve({})),
+      data: vi.fn(() => Promise.resolve({})),
+      focus: vi.fn(() => Promise.resolve({})),
+      destroy: vi.fn(() => Promise.resolve({})),
+      secondaryData: vi.fn(() => Promise.resolve({})),
+    }
+    vi.stubGlobal('window', { vimeflow: { ghosttyNative: api } })
+
+    await expect(
+      sendNativeGhosttySecondaryData({
+        sessionId: 'host-pty',
+        paneId: 'pane-1',
+        secondarySessionId: 'burner-pty',
+        data: 'hello',
+      })
+    ).resolves.toBe(true)
+
+    expect(api.secondaryData).toHaveBeenCalledWith({
+      sessionId: 'host-pty',
+      paneId: 'pane-1',
+      secondarySessionId: 'burner-pty',
+      data: 'hello',
     })
   })
 })

--- a/src/features/terminal/nativeGhosttyClient.test.ts
+++ b/src/features/terminal/nativeGhosttyClient.test.ts
@@ -4,6 +4,7 @@ import type { ITerminalService } from './services/terminalService'
 import {
   attachNativeGhosttySecondary,
   attachNativeGhosttyOutput,
+  canUseNativeGhosttySecondary,
   sendNativeGhosttySecondaryData,
   shouldUseNativeGhostty,
   type NativeGhosttyApi,
@@ -103,6 +104,38 @@ describe('nativeGhosttyClient', () => {
         secondarySessionId: 'burner-pty',
       })
     ).resolves.toBe(false)
+  })
+
+  test('keeps native secondary burners disabled for the legacy helper bridge', () => {
+    const api: NativeGhosttyApi = {
+      update: vi.fn(() => Promise.resolve({})),
+      data: vi.fn(() => Promise.resolve({})),
+      focus: vi.fn(() => Promise.resolve({})),
+      destroy: vi.fn(() => Promise.resolve({})),
+    }
+    vi.stubGlobal('navigator', { platform: 'MacIntel' })
+    vi.stubGlobal('window', { vimeflow: { ghosttyNative: api } })
+
+    expect(shouldUseNativeGhostty()).toBe(true)
+    expect(canUseNativeGhosttySecondary()).toBe(false)
+  })
+
+  test('enables native secondary burners when every secondary API is present', () => {
+    const api: NativeGhosttyApi = {
+      update: vi.fn(() => Promise.resolve({})),
+      data: vi.fn(() => Promise.resolve({})),
+      focus: vi.fn(() => Promise.resolve({})),
+      destroy: vi.fn(() => Promise.resolve({})),
+      attachSecondary: vi.fn(() => Promise.resolve({})),
+      secondaryData: vi.fn(() => Promise.resolve({})),
+      focusSecondary: vi.fn(() => Promise.resolve({})),
+      removeSecondary: vi.fn(() => Promise.resolve({})),
+      setSecondaryVisible: vi.fn(() => Promise.resolve({})),
+    }
+    vi.stubGlobal('navigator', { platform: 'MacIntel' })
+    vi.stubGlobal('window', { vimeflow: { ghosttyNative: api } })
+
+    expect(canUseNativeGhosttySecondary()).toBe(true)
   })
 
   test('secondary data forwards through the optional native bridge', async () => {

--- a/src/features/terminal/nativeGhosttyClient.ts
+++ b/src/features/terminal/nativeGhosttyClient.ts
@@ -96,6 +96,21 @@ const isDisabledResult = (value: unknown): boolean =>
 export const shouldUseNativeGhostty = (): boolean =>
   isMacRenderer() && Boolean(nativeGhosttyApi())
 
+export const canUseNativeGhosttySecondary = (): boolean => {
+  const api = nativeGhosttyApi()
+
+  return (
+    isMacRenderer() &&
+    Boolean(
+      api?.attachSecondary &&
+      api.secondaryData &&
+      api.focusSecondary &&
+      api.removeSecondary &&
+      api.setSecondaryVisible
+    )
+  )
+}
+
 export const updateNativeGhostty = async (
   request: NativeGhosttyUpdateRequest
 ): Promise<boolean> => {

--- a/src/features/terminal/nativeGhosttyClient.ts
+++ b/src/features/terminal/nativeGhosttyClient.ts
@@ -32,11 +32,32 @@ export interface NativeGhosttyDataRequest extends NativeGhosttyPaneRef {
   data: string
 }
 
+export interface NativeGhosttySecondaryRequest extends NativeGhosttyPaneRef {
+  secondarySessionId: string
+}
+
+export interface NativeGhosttySecondaryDataRequest extends NativeGhosttySecondaryRequest {
+  data: string
+}
+
+export interface NativeGhosttySecondaryVisibleRequest extends NativeGhosttySecondaryRequest {
+  visible: boolean
+}
+
 export interface NativeGhosttyApi {
   update: (request: NativeGhosttyUpdateRequest) => Promise<unknown>
   data: (request: NativeGhosttyDataRequest) => Promise<unknown>
   focus: (request: NativeGhosttyPaneRef) => Promise<unknown>
   destroy: (request: NativeGhosttyPaneRef) => Promise<unknown>
+  attachSecondary?: (request: NativeGhosttySecondaryRequest) => Promise<unknown>
+  secondaryData?: (
+    request: NativeGhosttySecondaryDataRequest
+  ) => Promise<unknown>
+  focusSecondary?: (request: NativeGhosttySecondaryRequest) => Promise<unknown>
+  removeSecondary?: (request: NativeGhosttySecondaryRequest) => Promise<unknown>
+  setSecondaryVisible?: (
+    request: NativeGhosttySecondaryVisibleRequest
+  ) => Promise<unknown>
 }
 
 export interface NativeGhosttyOutputOptions {
@@ -118,6 +139,64 @@ export const destroyNativeGhostty = async (
   request: NativeGhosttyPaneRef
 ): Promise<void> => {
   await nativeGhosttyApi()?.destroy(request)
+}
+
+export const attachNativeGhosttySecondary = async (
+  request: NativeGhosttySecondaryRequest
+): Promise<boolean> => {
+  const api = nativeGhosttyApi()
+  if (!api?.attachSecondary) {
+    return false
+  }
+
+  const result = await api.attachSecondary(request)
+
+  return !isDisabledResult(result)
+}
+
+export const sendNativeGhosttySecondaryData = async (
+  request: NativeGhosttySecondaryDataRequest
+): Promise<boolean> => {
+  const api = nativeGhosttyApi()
+  if (!api?.secondaryData) {
+    return false
+  }
+
+  const result = await api.secondaryData(request)
+
+  return !isDisabledResult(result)
+}
+
+export const focusNativeGhosttySecondary = async (
+  request: NativeGhosttySecondaryRequest
+): Promise<boolean> => {
+  const api = nativeGhosttyApi()
+  if (!api?.focusSecondary) {
+    return false
+  }
+
+  const result = await api.focusSecondary(request)
+
+  return !isDisabledResult(result)
+}
+
+export const removeNativeGhosttySecondary = async (
+  request: NativeGhosttySecondaryRequest
+): Promise<void> => {
+  await nativeGhosttyApi()?.removeSecondary?.(request)
+}
+
+export const setNativeGhosttySecondaryVisible = async (
+  request: NativeGhosttySecondaryVisibleRequest
+): Promise<boolean> => {
+  const api = nativeGhosttyApi()
+  if (!api?.setSecondaryVisible) {
+    return false
+  }
+
+  const result = await api.setSecondaryVisible(request)
+
+  return !isDisabledResult(result)
 }
 
 export const attachNativeGhosttyOutput = async (

--- a/src/features/workspace/WorkspaceView.command-palette.test.tsx
+++ b/src/features/workspace/WorkspaceView.command-palette.test.tsx
@@ -351,6 +351,7 @@ describe('WorkspaceView - Command Palette Integration', () => {
       runningByPane: new Map(),
       activeByPane: new Map(),
       hasVisibleBurner: false,
+      visibleBurnerPaneKey: null,
     })
   })
 

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -1271,6 +1271,7 @@ const WorkspaceViewContent = (): ReactElement => {
     runningByPane: runningBurnerByPane,
     activeByPane: activeBurnerByPane,
     hasVisibleBurner,
+    visibleBurnerPaneKey,
   } = useBurnerTerminals({
     service: terminalService,
     resolveFocusedPane,
@@ -1293,7 +1294,8 @@ const WorkspaceViewContent = (): ReactElement => {
     void toggleBurnerRef.current()
   }, [])
 
-  // Pane-keys with a live burner shell — drives the status-bar count.
+  // Pane-keys with a live burner shell. Hidden native burners stay here, but
+  // the bottom bar only counts the currently visible secondary terminal.
   const runningBurnerPaneKeys = useMemo(
     () =>
       new Set(
@@ -1313,6 +1315,14 @@ const WorkspaceViewContent = (): ReactElement => {
           .map(([key]) => key)
       ),
     [activeBurnerByPane]
+  )
+
+  const openBurnerPaneKeys = useMemo(
+    () =>
+      visibleBurnerPaneKey === null
+        ? new Set<string>()
+        : new Set([visibleBurnerPaneKey]),
+    [visibleBurnerPaneKey]
   )
 
   const requestFocus = useCallback((target: FocusTarget): void => {
@@ -2856,6 +2866,7 @@ const WorkspaceViewContent = (): ReactElement => {
               }}
               onBurner={(target): void => void toggleBurner(target)}
               activeBurnerPaneKeys={activeBurnerPaneKeys}
+              openBurnerPaneKeys={openBurnerPaneKeys}
               runningBurnerPaneKeys={runningBurnerPaneKeys}
             />
           </div>
@@ -2905,7 +2916,8 @@ const WorkspaceViewContent = (): ReactElement => {
           onOpenPalette={commandPalette.open}
           dockOpen={isDockOpen}
           onToggleDock={handleToggleDock}
-          burnerCount={runningBurnerPaneKeys.size}
+          burnerCount={openBurnerPaneKeys.size}
+          burnerOpen={openBurnerPaneKeys.size > 0}
         />
       </main>
 

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -1236,6 +1236,16 @@ const WorkspaceViewContent = (): ReactElement => {
     [sessions]
   )
 
+  const livePanePtyIds = useMemo(
+    () =>
+      new Map(
+        sessions.flatMap((s) =>
+          s.panes.map((p) => [`${s.id}:${p.id}`, p.ptyId] as const)
+        )
+      ),
+    [sessions]
+  )
+
   // Preferred burner sync targets from the active agent's structured cwd.
   // This captures agent-driven worktree moves that may not be reflected in the
   // host shell's pwd yet; `useBurnerTerminals` falls back to `livePaneCwds`.
@@ -1282,6 +1292,7 @@ const WorkspaceViewContent = (): ReactElement => {
     dropAllForPty,
     livePaneCwds,
     agentPaneCwds,
+    livePanePtyIds,
   })
 
   // Stable wrapper for the `:burner` palette command so the command-list memo

--- a/src/features/workspace/components/TerminalZone.tsx
+++ b/src/features/workspace/components/TerminalZone.tsx
@@ -74,6 +74,8 @@ export interface TerminalZoneProps {
   onBurner?: (target: BurnerTarget) => void
   /** Pane-keys with a foreground command running — drives the amber button tint (VIM-71). */
   activeBurnerPaneKeys?: ReadonlySet<string>
+  /** Pane-keys whose burner secondary terminal is currently visible. */
+  openBurnerPaneKeys?: ReadonlySet<string>
   /** Pane-keys with a live burner shell (idle or active) — drives a11y state (VIM-53). */
   runningBurnerPaneKeys?: ReadonlySet<string>
   layoutRegistry?: PaneLayoutRegistry
@@ -104,6 +106,7 @@ export const TerminalZone = forwardRef<TerminalZoneHandle, TerminalZoneProps>(
       onContainerFocus = undefined,
       onBurner = undefined,
       activeBurnerPaneKeys = undefined,
+      openBurnerPaneKeys = undefined,
       runningBurnerPaneKeys = undefined,
       layoutRegistry = undefined,
     }: TerminalZoneProps,
@@ -211,6 +214,7 @@ export const TerminalZone = forwardRef<TerminalZoneHandle, TerminalZoneProps>(
                     onBurner={onBurner}
                     layoutRegistry={layoutRegistry}
                     activeBurnerPaneKeys={activeBurnerPaneKeys}
+                    openBurnerPaneKeys={openBurnerPaneKeys}
                     runningBurnerPaneKeys={runningBurnerPaneKeys}
                     deferTerminalFit={deferTerminalFit}
                   />

--- a/src/lib/backend.ts
+++ b/src/lib/backend.ts
@@ -32,6 +32,11 @@ export interface BackendApi {
     data: (request: unknown) => Promise<unknown>
     focus: (request: unknown) => Promise<unknown>
     destroy: (request: unknown) => Promise<unknown>
+    attachSecondary?: (request: unknown) => Promise<unknown>
+    secondaryData?: (request: unknown) => Promise<unknown>
+    focusSecondary?: (request: unknown) => Promise<unknown>
+    removeSecondary?: (request: unknown) => Promise<unknown>
+    setSecondaryVisible?: (request: unknown) => Promise<unknown>
   }
 
   nativeOverlay?: {


### PR DESCRIPTION
## Summary
- add native Ghostty secondary-pane IPC for burner terminals
- wire burner open/hide state into pane chrome and status bar
- keep the Xterm popup path for non-native Ghostty fallback

## Validation
- npm test via pre-push hook: 367 files, 4545 passed, 3 skipped
- lint-staged on commits: eslint, tsc --noEmit, prettier
- focused vitest for StatusBar, TerminalPane, and useBurnerTerminals


Refs VIM-286