### PR TITLE
Restore Ghostty burner sync control

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -52,7 +52,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 27       | 23   | 2026-07-04   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)                                             | cross-platform     | 13       | 12   | 2026-06-28   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                                                       | code-quality       | 7        | 0    | 2026-06-11   |
-| [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 15       | 12   | 2026-06-26   |
+| [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 16       | 12   | 2026-07-04   |
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 8        | 2    | 2026-06-19   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 8        | 2    | 2026-06-28   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -84,7 +84,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 13       | 3    | 2026-06-15   |
 | [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 30       | 6    | 2026-07-02   |
 | [Verify Render Target](patterns/verify-render-target.md)                                             | code-quality       | 3        | 1    | 2026-07-01   |
-| [UI Visual Regression](patterns/ui-visual-regression.md)                                             | code-quality       | 25       | 15   | 2026-07-03   |
+| [UI Visual Regression](patterns/ui-visual-regression.md)                                             | code-quality       | 26       | 16   | 2026-07-04   |
 | [Status Indicator Display](patterns/status-indicator-display.md)                                     | code-quality       | 3        | 0    | 2026-05-26   |
 | [Parser Resilience](patterns/parser-resilience.md)                                                   | code-quality       | 17       | 10   | 2026-07-03   |
 | [Persisted State Invariants](patterns/persisted-state-invariants.md)                                 | correctness        | 14       | 7    | 2026-06-23   |

--- a/docs/reviews/patterns/derived-state-consistency.md
+++ b/docs/reviews/patterns/derived-state-consistency.md
@@ -2,7 +2,7 @@
 id: derived-state-consistency
 category: code-quality
 created: 2026-06-07
-last_updated: 2026-06-26
+last_updated: 2026-07-04
 ref_count: 12
 ---
 
@@ -185,4 +185,19 @@ base data is technically "correct."
 - **Finding:** The dialog passed an empty or whitespace-only session name through to
   session creation, bypassing the derived folder-name fallback used for nullish names.
 - **Fix:** Trim the submitted name and fall back to `deriveSessionName(path)` when it is blank.
+- **Commit:** same commit as this entry
+
+### 16. Blocked burner sync status survived after the foreground command exited
+
+- **Source:** github-claude | PR #658 round 1 | 2026-07-04
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/HeaderActions.tsx`
+- **Finding:** Clicking sync while a burner foreground command was active set
+  the visible sync state to `blocked`, but the cleanup effect only watched
+  whether the sync affordance disappeared. If the command exited while the
+  burner stayed open and out of sync, the header kept showing the blocked icon
+  and instruction even though the next click could sync normally.
+- **Fix:** Added a focused effect that resets `blocked` back to `idle` when
+  `burnerActive` becomes false while the sync affordance remains visible, plus
+  regression coverage for the active-to-idle rerender transition.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/ui-visual-regression.md
+++ b/docs/reviews/patterns/ui-visual-regression.md
@@ -2,8 +2,8 @@
 id: ui-visual-regression
 category: code-quality
 created: 2026-06-11
-last_updated: 2026-07-03
-ref_count: 15
+last_updated: 2026-07-04
+ref_count: 16
 ---
 
 # UI Visual Regression
@@ -312,4 +312,18 @@ test case for the state that triggers the collision.
 - **Fix:** Added a corner-radius conversion helper that applies the same
   native point scale before calling `updateNativeGhostty`, and covered both the
   helper and IPC payload with regression tests for mismatched viewport metrics.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 26. Active burner sync toggle lost compact sizing
+
+- **Source:** github-codex-connector | PR #658 round 1 | 2026-07-04
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/HeaderActions.tsx`
+- **Finding:** The burner toggle class composition checked `burnerActive`
+  before `showBurnerSync`, so an active burner with a drifted cwd kept the
+  amber running tint but skipped the `!h-5 !w-5 rounded-md` sizing required by
+  the combined sync/toggle pill.
+- **Fix:** Made the sync-pill branch own the compact sizing and select the
+  active amber tint versus idle primary tint inside that branch. Added a
+  regression test covering the active, open, out-of-sync state.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/src/features/terminal/components/SplitView/SplitView.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.tsx
@@ -89,6 +89,8 @@ export interface SplitViewProps {
   ) => void
   /** Toggle a pane's ephemeral burner terminal (VIM-53). */
   onBurner?: (target: BurnerTarget) => void
+  /** Sync a pane's burner terminal back to its host pane cwd. */
+  onSyncBurner?: (target: BurnerTarget) => void
   layoutRegistry?: PaneLayoutRegistry
   /** Pane-keys with a foreground command running — drives the amber button tint (VIM-71). */
   activeBurnerPaneKeys?: ReadonlySet<string>
@@ -96,6 +98,8 @@ export interface SplitViewProps {
   openBurnerPaneKeys?: ReadonlySet<string>
   /** Pane-keys with a live burner shell (idle or active) — drives a11y state (VIM-53). */
   runningBurnerPaneKeys?: ReadonlySet<string>
+  /** Pane-keys whose burner terminal cwd has drifted from its host pane cwd. */
+  outOfSyncBurnerPaneKeys?: ReadonlySet<string>
   deferTerminalFit?: boolean
 }
 
@@ -185,10 +189,12 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
       onClosePane = undefined,
       onPanePlacementsChange = undefined,
       onBurner = undefined,
+      onSyncBurner = undefined,
       layoutRegistry = BUILTIN_PANE_LAYOUT_REGISTRY,
       activeBurnerPaneKeys = undefined,
       openBurnerPaneKeys = undefined,
       runningBurnerPaneKeys = undefined,
+      outOfSyncBurnerPaneKeys = undefined,
       deferTerminalFit = false,
     }: SplitViewProps,
     ref
@@ -666,11 +672,13 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
                         onRestart={onSessionRestart}
                         onClose={closeHandler}
                         onBurner={onBurner}
+                        onSyncBurner={onSyncBurner}
                         onRequestActive={onSetActivePane}
                         onRequestFocus={onRequestFocus}
                         activeBurnerPaneKeys={activeBurnerPaneKeys}
                         openBurnerPaneKeys={openBurnerPaneKeys}
                         runningBurnerPaneKeys={runningBurnerPaneKeys}
+                        outOfSyncBurnerPaneKeys={outOfSyncBurnerPaneKeys}
                         isActive={isActive}
                         shortcutContext={nativeShortcutContext}
                         shortcutHint={

--- a/src/features/terminal/components/TerminalPane/Header.tsx
+++ b/src/features/terminal/components/TerminalPane/Header.tsx
@@ -21,9 +21,11 @@ export interface HeaderProps {
   onToggleCollapse: () => void
   onClose?: () => void
   onBurner?: () => void
+  onSyncBurner?: () => void
   burnerActive?: boolean
   burnerOpen?: boolean
   burnerShellExists?: boolean
+  burnerOutOfSync?: boolean
   /**
    * VIM-167: when true, the header acts as the pane's drag handle for the
    * drag-into-slot interaction. The terminal body stays non-draggable so xterm
@@ -48,9 +50,11 @@ export const Header = ({
   onToggleCollapse,
   onClose = undefined,
   onBurner = undefined,
+  onSyncBurner = undefined,
   burnerActive = false,
   burnerOpen = false,
   burnerShellExists = false,
+  burnerOutOfSync = false,
   draggable = false,
   onHeaderDragStart = undefined,
   onHeaderDragEnd = undefined,
@@ -125,9 +129,11 @@ export const Header = ({
           hideCollapseToggle={hideCollapseToggle || autoCollapsed}
           onClose={onClose}
           onBurner={onBurner}
+          onSyncBurner={onSyncBurner}
           burnerActive={burnerActive}
           burnerOpen={burnerOpen}
           burnerShellExists={burnerShellExists}
+          burnerOutOfSync={burnerOutOfSync}
         />
       </div>
     </div>

--- a/src/features/terminal/components/TerminalPane/HeaderActions.test.tsx
+++ b/src/features/terminal/components/TerminalPane/HeaderActions.test.tsx
@@ -128,6 +128,29 @@ describe('HeaderActions', () => {
     expect(screen.queryByTestId('burner-live-dot')).toBeNull()
   })
 
+  test('active out-of-sync burner toggle keeps compact pill sizing', () => {
+    render(
+      <HeaderActions
+        isCollapsed={expanded}
+        onToggleCollapse={vi.fn()}
+        onBurner={vi.fn()}
+        onSyncBurner={vi.fn()}
+        burnerOpen
+        burnerOutOfSync
+        burnerActive
+      />
+    )
+
+    const button = screen.getByRole('button', {
+      name: /hide burner terminal \(running\)/i,
+    })
+    expect(button.className).toContain('!h-5')
+    expect(button.className).toContain('!w-5')
+    expect(button.className).toContain('rounded-md')
+    expect(button.className).toContain('bg-agent-shell-accent/15')
+    expect(button.className).toContain('text-agent-shell-accent')
+  })
+
   test('no running cue when the pane burner is not running', () => {
     render(
       <HeaderActions

--- a/src/features/terminal/components/TerminalPane/HeaderActions.test.tsx
+++ b/src/features/terminal/components/TerminalPane/HeaderActions.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, within } from '@testing-library/react'
+import { act, fireEvent, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, test, vi } from 'vitest'
 import { HeaderActions } from './HeaderActions'
@@ -177,6 +177,153 @@ describe('HeaderActions', () => {
     })
     expect(button).toHaveAttribute('aria-pressed', 'true')
     expect(button.className).toContain('aria-pressed:bg-primary/10')
+  })
+
+  test('renders burner sync only when the open burner cwd has drifted', () => {
+    const onSyncBurner = vi.fn()
+
+    const { rerender } = render(
+      <HeaderActions
+        isCollapsed={expanded}
+        onToggleCollapse={vi.fn()}
+        onBurner={vi.fn()}
+        onSyncBurner={onSyncBurner}
+        burnerOutOfSync
+      />
+    )
+
+    expect(
+      screen.queryByRole('button', { name: /sync burner terminal/i })
+    ).toBeNull()
+
+    rerender(
+      <HeaderActions
+        isCollapsed={expanded}
+        onToggleCollapse={vi.fn()}
+        onBurner={vi.fn()}
+        onSyncBurner={onSyncBurner}
+        burnerOpen
+      />
+    )
+
+    expect(
+      screen.queryByRole('button', { name: /sync burner terminal/i })
+    ).toBeNull()
+
+    rerender(
+      <HeaderActions
+        isCollapsed={expanded}
+        onToggleCollapse={vi.fn()}
+        onBurner={vi.fn()}
+        onSyncBurner={onSyncBurner}
+        burnerOpen
+        burnerOutOfSync
+      />
+    )
+
+    expect(
+      screen.getByRole('button', { name: /sync burner terminal/i })
+    ).toBeInTheDocument()
+
+    expect(screen.getByTestId('burner-control-pill').className).toContain(
+      'h-[22px]'
+    )
+  })
+
+  test('burner sync sits before the burner toggle and stops click propagation', () => {
+    const onSyncBurner = vi.fn()
+    const onParentClick = vi.fn()
+
+    render(
+      <div onClick={onParentClick}>
+        <HeaderActions
+          isCollapsed={expanded}
+          onToggleCollapse={vi.fn()}
+          onBurner={vi.fn()}
+          onSyncBurner={onSyncBurner}
+          burnerOpen
+          burnerOutOfSync
+        />
+      </div>
+    )
+
+    const sync = screen.getByRole('button', { name: /sync burner terminal/i })
+    const burner = screen.getByRole('button', { name: /hide burner terminal/i })
+
+    expect(
+      sync.compareDocumentPosition(burner) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+
+    fireEvent.click(sync)
+
+    expect(onSyncBurner).toHaveBeenCalledTimes(1)
+    expect(onParentClick).not.toHaveBeenCalled()
+    expect(sync.className).toContain('animate-spin')
+  })
+
+  test('burner sync shows failure if the cwd remains out of sync', () => {
+    vi.useFakeTimers()
+    const onSyncBurner = vi.fn()
+
+    try {
+      render(
+        <HeaderActions
+          isCollapsed={expanded}
+          onToggleCollapse={vi.fn()}
+          onBurner={vi.fn()}
+          onSyncBurner={onSyncBurner}
+          burnerOpen
+          burnerOutOfSync
+        />
+      )
+
+      fireEvent.click(
+        screen.getByRole('button', { name: /sync burner terminal/i })
+      )
+
+      act(() => {
+        vi.advanceTimersByTime(1200)
+      })
+
+      expect(onSyncBurner).toHaveBeenCalledTimes(1)
+      expect(
+        screen.getByRole('button', {
+          name: /sync failed; check burner terminal/i,
+        })
+      ).toHaveTextContent('sync_problem')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  test('burner sync shows a blocked failure while the burner shell has a foreground command', () => {
+    const onSyncBurner = vi.fn()
+
+    render(
+      <HeaderActions
+        isCollapsed={expanded}
+        onToggleCollapse={vi.fn()}
+        onBurner={vi.fn()}
+        onSyncBurner={onSyncBurner}
+        burnerOpen
+        burnerOutOfSync
+        burnerActive
+      />
+    )
+
+    const sync = screen.getByRole('button', { name: /sync burner terminal/i })
+
+    expect(sync).not.toBeDisabled()
+    expect(sync).toHaveTextContent('sync')
+
+    fireEvent.click(sync)
+
+    expect(onSyncBurner).not.toHaveBeenCalled()
+    expect(
+      screen.getByRole('button', {
+        name: /stop the running command, then sync pwd/i,
+      })
+    ).toHaveTextContent('sync_problem')
   })
 
   test('renders visible pane shortcut hint when provided', () => {

--- a/src/features/terminal/components/TerminalPane/HeaderActions.test.tsx
+++ b/src/features/terminal/components/TerminalPane/HeaderActions.test.tsx
@@ -326,6 +326,48 @@ describe('HeaderActions', () => {
     ).toHaveTextContent('sync_problem')
   })
 
+  test('burner sync clears blocked status when the foreground command exits', () => {
+    const onSyncBurner = vi.fn()
+
+    const { rerender } = render(
+      <HeaderActions
+        isCollapsed={expanded}
+        onToggleCollapse={vi.fn()}
+        onBurner={vi.fn()}
+        onSyncBurner={onSyncBurner}
+        burnerOpen
+        burnerOutOfSync
+        burnerActive
+      />
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /sync burner terminal/i })
+    )
+
+    expect(
+      screen.getByRole('button', {
+        name: /stop the running command, then sync pwd/i,
+      })
+    ).toHaveTextContent('sync_problem')
+
+    rerender(
+      <HeaderActions
+        isCollapsed={expanded}
+        onToggleCollapse={vi.fn()}
+        onBurner={vi.fn()}
+        onSyncBurner={onSyncBurner}
+        burnerOpen
+        burnerOutOfSync
+      />
+    )
+
+    expect(
+      screen.getByRole('button', { name: /sync burner terminal/i })
+    ).toHaveTextContent('sync')
+    expect(onSyncBurner).not.toHaveBeenCalled()
+  })
+
   test('renders visible pane shortcut hint when provided', () => {
     render(
       <HeaderActions

--- a/src/features/terminal/components/TerminalPane/HeaderActions.tsx
+++ b/src/features/terminal/components/TerminalPane/HeaderActions.tsx
@@ -141,10 +141,14 @@ export const HeaderActions = ({
         }}
         // Running keeps the amber status tint; pressed still reflects open/hidden.
         className={
-          burnerActive
-            ? 'bg-agent-shell-accent/15 text-agent-shell-accent'
-            : showBurnerSync
-              ? '!h-5 !w-5 rounded-md bg-primary/10 text-primary hover:bg-primary/15'
+          showBurnerSync
+            ? `!h-5 !w-5 rounded-md ${
+                burnerActive
+                  ? 'bg-agent-shell-accent/15 text-agent-shell-accent'
+                  : 'bg-primary/10 text-primary hover:bg-primary/15'
+              }`
+            : burnerActive
+              ? 'bg-agent-shell-accent/15 text-agent-shell-accent'
               : undefined
         }
       />

--- a/src/features/terminal/components/TerminalPane/HeaderActions.tsx
+++ b/src/features/terminal/components/TerminalPane/HeaderActions.tsx
@@ -97,6 +97,12 @@ export const HeaderActions = ({
     }
   }, [showBurnerSync])
 
+  useEffect(() => {
+    if (showBurnerSync && !burnerActive && burnerSyncStatus === 'blocked') {
+      setBurnerSyncStatus('idle')
+    }
+  }, [burnerActive, burnerSyncStatus, showBurnerSync])
+
   useEffect(
     () => (): void => {
       if (syncFailureTimeoutRef.current) {

--- a/src/features/terminal/components/TerminalPane/HeaderActions.tsx
+++ b/src/features/terminal/components/TerminalPane/HeaderActions.tsx
@@ -1,7 +1,11 @@
-import type { ReactElement } from 'react'
+import { useEffect, useRef, useState, type ReactElement } from 'react'
 import { IconButton } from '@/components/IconButton'
 import { Tooltip } from '@/components/Tooltip'
 import { TOOLTIP_SUPPRESSED } from '@/lib/constants'
+
+const SYNC_FAILURE_TIMEOUT_MS = 1200
+
+type BurnerSyncStatus = 'idle' | 'syncing' | 'blocked' | 'failed'
 
 const burnerButtonLabel = (
   active: boolean,
@@ -47,6 +51,10 @@ export interface HeaderActionsProps {
    * from "no shell" (VIM-53 a11y).
    */
   burnerShellExists?: boolean
+  /** The visible burner terminal cwd has drifted from this pane's cwd. */
+  burnerOutOfSync?: boolean
+  /** Align this pane's burner terminal back to this pane's cwd. */
+  onSyncBurner?: () => void
 }
 
 export const HeaderActions = ({
@@ -59,13 +67,83 @@ export const HeaderActions = ({
   burnerActive = false,
   burnerOpen = false,
   burnerShellExists = false,
+  burnerOutOfSync = false,
+  onSyncBurner = undefined,
 }: HeaderActionsProps): ReactElement => {
+  const [burnerSyncStatus, setBurnerSyncStatus] =
+    useState<BurnerSyncStatus>('idle')
+
+  const syncFailureTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  )
+
   const burnerLabel = burnerButtonLabel(
     burnerActive,
     burnerOpen,
     burnerShellExists
   )
+
+  const showBurnerSync = Boolean(
+    onBurner && onSyncBurner && burnerOpen && burnerOutOfSync
+  )
+
+  useEffect(() => {
+    if (!showBurnerSync) {
+      if (syncFailureTimeoutRef.current) {
+        clearTimeout(syncFailureTimeoutRef.current)
+        syncFailureTimeoutRef.current = null
+      }
+      setBurnerSyncStatus('idle')
+    }
+  }, [showBurnerSync])
+
+  useEffect(
+    () => (): void => {
+      if (syncFailureTimeoutRef.current) {
+        clearTimeout(syncFailureTimeoutRef.current)
+      }
+    },
+    []
+  )
+
+  const burnerSyncFailed =
+    burnerSyncStatus === 'blocked' || burnerSyncStatus === 'failed'
+
+  const burnerSyncLabel = burnerSyncFailed
+    ? burnerSyncStatus === 'blocked'
+      ? 'stop the running command, then sync pwd'
+      : 'sync failed; check burner terminal'
+    : burnerSyncStatus === 'syncing'
+      ? 'syncing burner terminal'
+      : 'sync burner terminal'
+
+  const burnerSyncIcon = burnerSyncFailed ? 'sync_problem' : 'sync'
+
   const collapseLabel = isCollapsed ? 'expand status' : 'collapse status'
+
+  const burnerButton = onBurner ? (
+    <Tooltip content={burnerLabel} placement="bottom" nativeOverlay>
+      <IconButton
+        icon="terminal"
+        label={burnerLabel}
+        showTooltip={TOOLTIP_SUPPRESSED}
+        size="sm"
+        pressed={burnerOpen}
+        onClick={(event) => {
+          event.stopPropagation()
+          onBurner()
+        }}
+        // Running keeps the amber status tint; pressed still reflects open/hidden.
+        className={
+          burnerActive
+            ? 'bg-agent-shell-accent/15 text-agent-shell-accent'
+            : showBurnerSync
+              ? '!h-5 !w-5 rounded-md bg-primary/10 text-primary hover:bg-primary/15'
+              : undefined
+        }
+      />
+    </Tooltip>
+  ) : null
 
   return (
     <>
@@ -78,26 +156,48 @@ export const HeaderActions = ({
         </span>
       )}
 
-      {onBurner && (
-        <Tooltip content={burnerLabel} placement="bottom" nativeOverlay>
-          <IconButton
-            icon="terminal"
-            label={burnerLabel}
-            showTooltip={TOOLTIP_SUPPRESSED}
-            size="sm"
-            pressed={burnerOpen}
-            onClick={(event) => {
-              event.stopPropagation()
-              onBurner()
-            }}
-            // Running is a status tint, not a toggle — no `pressed` (it would override the accent).
-            className={
-              burnerActive
-                ? 'bg-agent-shell-accent/15 text-agent-shell-accent'
-                : undefined
-            }
-          />
-        </Tooltip>
+      {showBurnerSync ? (
+        <div
+          data-testid="burner-control-pill"
+          className="inline-flex h-[22px] shrink-0 items-center gap-px rounded-lg border border-primary/20 bg-primary/10 p-px"
+        >
+          <Tooltip content={burnerSyncLabel} placement="bottom" nativeOverlay>
+            <IconButton
+              icon={burnerSyncIcon}
+              label={burnerSyncLabel}
+              showTooltip={TOOLTIP_SUPPRESSED}
+              size="sm"
+              className={`!h-5 !w-5 rounded-md ${
+                burnerSyncStatus === 'syncing'
+                  ? 'animate-spin text-agent-shell-accent'
+                  : burnerSyncFailed
+                    ? 'bg-error/10 text-error hover:bg-error/15'
+                    : 'text-agent-shell-accent hover:bg-agent-shell-accent/15'
+              }`}
+              onClick={(event) => {
+                event.stopPropagation()
+                if (syncFailureTimeoutRef.current) {
+                  clearTimeout(syncFailureTimeoutRef.current)
+                  syncFailureTimeoutRef.current = null
+                }
+                if (burnerActive) {
+                  setBurnerSyncStatus('blocked')
+
+                  return
+                }
+                setBurnerSyncStatus('syncing')
+                onSyncBurner?.()
+                syncFailureTimeoutRef.current = setTimeout(() => {
+                  syncFailureTimeoutRef.current = null
+                  setBurnerSyncStatus('failed')
+                }, SYNC_FAILURE_TIMEOUT_MS)
+              }}
+            />
+          </Tooltip>
+          {burnerButton}
+        </div>
+      ) : (
+        burnerButton
       )}
 
       {!hideCollapseToggle && (

--- a/src/features/terminal/components/TerminalPane/index.test.tsx
+++ b/src/features/terminal/components/TerminalPane/index.test.tsx
@@ -177,6 +177,37 @@ describe('TerminalPane index', () => {
     })
   })
 
+  test('the burner sync button activates its pane and syncs that pane burner', async () => {
+    const onBurner = vi.fn()
+    const onSyncBurner = vi.fn()
+    const onRequestActive = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <TerminalPane
+        {...baseProps}
+        onBurner={onBurner}
+        onSyncBurner={onSyncBurner}
+        onRequestActive={onRequestActive}
+        openBurnerPaneKeys={new Set(['s1:p0'])}
+        outOfSyncBurnerPaneKeys={new Set(['s1:p0'])}
+      />
+    )
+
+    await user.click(
+      screen.getByRole('button', { name: /sync burner terminal/i })
+    )
+
+    expect(onRequestActive).toHaveBeenCalledWith('s1', 'p0')
+    expect(onSyncBurner).toHaveBeenCalledWith({
+      sessionId: 's1',
+      paneId: 'p0',
+      hostPtyId: 'pty-s1',
+      cwd: '/home/user/repo',
+    })
+    expect(onBurner).not.toHaveBeenCalled()
+  })
+
   test('clicking an inactive terminal body requests pane activation', async () => {
     const onRequestActive = vi.fn()
     const user = userEvent.setup()

--- a/src/features/terminal/components/TerminalPane/index.tsx
+++ b/src/features/terminal/components/TerminalPane/index.tsx
@@ -59,6 +59,8 @@ export interface TerminalPaneProps {
   onClose?: (sessionId: string, paneId: string) => void
   /** Toggle this pane's ephemeral burner terminal (VIM-53). */
   onBurner?: (target: BurnerTarget) => void
+  /** Sync this pane's burner terminal back to the pane cwd. */
+  onSyncBurner?: (target: BurnerTarget) => void
   /** Make this pane active — the burner button focuses its pane (spec §8). */
   onRequestActive?: (sessionId: string, paneId: string) => void
   onRequestFocus?: () => void
@@ -68,6 +70,8 @@ export interface TerminalPaneProps {
   openBurnerPaneKeys?: ReadonlySet<string>
   /** Pane-keys with a live burner shell (idle or active) — drives a11y state (VIM-53). */
   runningBurnerPaneKeys?: ReadonlySet<string>
+  /** Pane-keys whose burner terminal cwd has drifted from its host pane cwd. */
+  outOfSyncBurnerPaneKeys?: ReadonlySet<string>
   onCwdChange?: (cwd: string) => void
   onCommandSubmit?: (ptyId: string, command: string) => void
   onRestart?: (sessionId: string, paneId?: string) => void
@@ -105,11 +109,13 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
       mode = 'spawn',
       onClose = undefined,
       onBurner = undefined,
+      onSyncBurner = undefined,
       onRequestActive = undefined,
       onRequestFocus = undefined,
       activeBurnerPaneKeys = undefined,
       openBurnerPaneKeys = undefined,
       runningBurnerPaneKeys = undefined,
+      outOfSyncBurnerPaneKeys = undefined,
       onCwdChange = undefined,
       onCommandSubmit = undefined,
       onRestart = undefined,
@@ -243,6 +249,23 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
       })
     }, [onRequestActive, onBurner, session.id, pane.id, pane.ptyId, pane.cwd])
 
+    const handleSyncBurner = useCallback((): void => {
+      onRequestActive?.(session.id, pane.id)
+      onSyncBurner?.({
+        sessionId: session.id,
+        paneId: pane.id,
+        hostPtyId: pane.ptyId,
+        cwd: pane.cwd,
+      })
+    }, [
+      onRequestActive,
+      onSyncBurner,
+      session.id,
+      pane.id,
+      pane.ptyId,
+      pane.cwd,
+    ])
+
     const handleRestart = useCallback(
       (restartSessionId: string): void => {
         if (!pane.active) {
@@ -303,6 +326,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
           onToggleCollapse={handleToggleCollapse}
           onClose={onClose ? handleClose : undefined}
           onBurner={onBurner ? handleBurner : undefined}
+          onSyncBurner={onSyncBurner ? handleSyncBurner : undefined}
           burnerActive={
             activeBurnerPaneKeys?.has(`${session.id}:${pane.id}`) ?? false
           }
@@ -311,6 +335,9 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
           }
           burnerShellExists={
             runningBurnerPaneKeys?.has(`${session.id}:${pane.id}`) ?? false
+          }
+          burnerOutOfSync={
+            outOfSyncBurnerPaneKeys?.has(`${session.id}:${pane.id}`) ?? false
           }
           draggable={paneDraggable}
           onHeaderDragStart={onHeaderDragStart}

--- a/src/features/terminal/hooks/useBurnerTerminals.test.ts
+++ b/src/features/terminal/hooks/useBurnerTerminals.test.ts
@@ -1046,7 +1046,35 @@ test('the align callback writes `cd <live host cwd>` + Enter to the burner pty',
   // prefix (Ctrl-E, Ctrl-U) clears any half-typed input so the cd runs clean.
   expect(service.write).toHaveBeenCalledWith({
     sessionId: 'burner-pty',
-    data: "\x05\x15cd '/repo/projects/simple-tui'\r",
+    data: "\x05\x15cd '/repo/projects/simple-tui' && printf '\\033]7;%s\\007' \"$PWD\"\r",
+  })
+})
+
+test('syncToPaneCwd writes the live host cwd for a target pane', async () => {
+  const service = makeService()
+  const focused = makeFocusedPane('s1', 'p0', '/repo')
+  const livePaneCwds = new Map([['s1:p0', '/repo/current']])
+  const target: BurnerTarget = { sessionId: 's1', paneId: 'p0', cwd: '/repo' }
+
+  const { result } = renderHook(() =>
+    useBurnerTerminals({
+      service,
+      resolveFocusedPane: () => focused,
+      livePaneCwds,
+    })
+  )
+
+  await act(async () => {
+    await result.current.toggle(target)
+  })
+
+  act(() => {
+    result.current.syncToPaneCwd(target)
+  })
+
+  expect(service.write).toHaveBeenCalledWith({
+    sessionId: 'burner-pty',
+    data: "\x05\x15cd '/repo/current' && printf '\\033]7;%s\\007' \"$PWD\"\r",
   })
 })
 
@@ -1078,7 +1106,7 @@ test('the align callback prefers the agent cwd over the live host cwd', async ()
 
   expect(service.write).toHaveBeenCalledWith({
     sessionId: 'burner-pty',
-    data: "\x05\x15cd '/repo/.claude/worktrees/agent-task'\r",
+    data: "\x05\x15cd '/repo/.claude/worktrees/agent-task' && printf '\\033]7;%s\\007' \"$PWD\"\r",
   })
 })
 
@@ -1107,7 +1135,7 @@ test('the align callback falls back to the live host cwd when no agent cwd is av
 
   expect(service.write).toHaveBeenCalledWith({
     sessionId: 'burner-pty',
-    data: "\x05\x15cd '/repo/current-shell-pwd'\r",
+    data: "\x05\x15cd '/repo/current-shell-pwd' && printf '\\033]7;%s\\007' \"$PWD\"\r",
   })
 })
 
@@ -1140,7 +1168,7 @@ test('the align callback resolves the latest host cwd at click-time, not a stale
 
   expect(service.write).toHaveBeenCalledWith({
     sessionId: 'burner-pty',
-    data: "\x05\x15cd '/repo/second'\r",
+    data: "\x05\x15cd '/repo/second' && printf '\\033]7;%s\\007' \"$PWD\"\r",
   })
 })
 
@@ -1168,7 +1196,7 @@ test('quotes the cwd so spaces and apostrophes survive as one cd argument', asyn
   // POSIX single-quote escaping: a literal ' becomes '\'' , whole path wrapped.
   expect(service.write).toHaveBeenCalledWith({
     sessionId: 'burner-pty',
-    data: "\x05\x15cd '/repo/my proj'\\''s dir'\r",
+    data: "\x05\x15cd '/repo/my proj'\\''s dir' && printf '\\033]7;%s\\007' \"$PWD\"\r",
   })
 })
 
@@ -1382,12 +1410,14 @@ test('marks the align button out-of-sync when the burner cwd differs from the ho
     firstPopup(result.current.renderNode).props.onCwdChange?.('/repo/sub')
   })
   expect(firstPopup(result.current.renderNode).props.outOfSync).toBe(true)
+  expect(result.current.outOfSyncByPane.get('s1:p0')).toBe(true)
 
   // Synced back (the cd lands, or the user cd's back) → highlight clears.
   act(() => {
     firstPopup(result.current.renderNode).props.onCwdChange?.('/repo')
   })
   expect(firstPopup(result.current.renderNode).props.outOfSync).toBe(false)
+  expect(result.current.outOfSyncByPane.get('s1:p0')).toBe(false)
 })
 
 test('the host pane moving makes the burner out-of-sync', async () => {

--- a/src/features/terminal/hooks/useBurnerTerminals.ts
+++ b/src/features/terminal/hooks/useBurnerTerminals.ts
@@ -82,6 +82,7 @@ const hasControlBytes = (value: string): boolean => {
 // Ctrl-E then Ctrl-U: move to end of line and kill it, so the injected cd runs
 // on a clean prompt instead of merging with whatever the user half-typed.
 const CLEAR_LINE = '\x05\x15'
+const PRINT_OSC7_CWD = `printf '\\033]7;%s\\007' "$PWD"`
 
 // Compare OSC 7 cwds forgiving a trailing slash (root stays "/").
 const normalizeCwd = (value: string): string => value.replace(/\/+$/, '') || '/'
@@ -278,6 +279,8 @@ export interface UseBurnerTerminals {
   renderNode: ReactNode
   /** Toggle the popup for a target pane (defaults to the focused pane). */
   toggle: (target?: BurnerTarget) => Promise<void>
+  /** Sync a pane's burner shell to its host pane's current directory. */
+  syncToPaneCwd: (target: BurnerTarget) => void
   /**
    * Running burner shells keyed by `${sessionId}:${paneId}` — drives the
    * live-but-hidden cues. Global across sessions (hide ≠ kill survives a
@@ -290,6 +293,8 @@ export interface UseBurnerTerminals {
    * distinct from `runningByPane`, which only means a shell exists.
    */
   activeByPane: ReadonlyMap<string, boolean>
+  /** Burner shells whose current cwd differs from their host pane cwd. */
+  outOfSyncByPane: ReadonlyMap<string, boolean>
   /** True while a burner popup is visibly open over the workspace. */
   hasVisibleBurner: boolean
   /** Stable pane key for the burner currently shown, including native Ghostty. */
@@ -392,7 +397,8 @@ export const useBurnerTerminals = ({
   // real `cd` (queues behind any running command, shows in history), resolved at
   // call-time from refs so it prefers the active agent's structured worktree cwd
   // while falling back to the host pane's current cwd. The burner's own `cd`
-  // still never moves the pane (no OSC 7 wiring on the popup).
+  // still never moves the pane; the synthetic OSC 7 only updates this burner
+  // entry so the header sync affordance can settle after a successful cd.
   const alignCwd = useCallback(
     (key: string): void => {
       const entry = entriesRef.current.get(key)
@@ -419,7 +425,7 @@ export const useBurnerTerminals = ({
         try {
           await service.write({
             sessionId: ptyId,
-            data: `${CLEAR_LINE}cd ${singleQuote(cwd)}\r`,
+            data: `${CLEAR_LINE}cd ${singleQuote(cwd)} && ${PRINT_OSC7_CWD}\r`,
           })
         } catch (err) {
           // eslint-disable-next-line no-console
@@ -558,6 +564,13 @@ export const useBurnerTerminals = ({
       await show(target)
     },
     [resolveFocusedPane, visibleKey, show, hide]
+  )
+
+  const syncToPaneCwd = useCallback(
+    (target: BurnerTarget): void => {
+      alignCwd(paneKey(target.sessionId, target.paneId))
+    },
+    [alignCwd]
   )
 
   // `Mod+;` then backtick chord — registered once, calls the latest toggle via a ref.
@@ -740,13 +753,28 @@ export const useBurnerTerminals = ({
     return map
   }, [entries])
 
+  const outOfSyncByPane = useMemo(() => {
+    const map = new Map<string, boolean>()
+    entries.forEach((entry, key) => {
+      const targetCwd = agentPaneCwds?.get(key) ?? livePaneCwds?.get(key)
+      map.set(
+        key,
+        entry.status === 'running' &&
+          targetCwd !== undefined &&
+          normalizeCwd(entry.currentCwd) !== normalizeCwd(targetCwd)
+      )
+    })
+
+    return map
+  }, [agentPaneCwds, entries, livePaneCwds])
+
   const renderNode: ReactNode =
     entries.size > 0
       ? createElement(
           Fragment,
           null,
           [...entries.entries()].map(([key, entry]): ReactNode => {
-            const targetCwd = agentPaneCwds?.get(key) ?? livePaneCwds?.get(key)
+            const outOfSync = outOfSyncByPane.get(key) ?? false
 
             if (canUseNativeGhosttySecondary() && entry.hostPtyId) {
               return createElement(NativeGhosttyBurnerTerminal, {
@@ -795,10 +823,7 @@ export const useBurnerTerminals = ({
               // Track the burner's own cwd (isolated, never the host pane) and
               // light the button amber once it has wandered from its host pane.
               onCwdChange: (cwd: string): void => setBurnerCwd(key, cwd),
-              outOfSync:
-                entry.status === 'running' &&
-                targetCwd !== undefined &&
-                normalizeCwd(entry.currentCwd) !== normalizeCwd(targetCwd),
+              outOfSync,
             })
           })
         )
@@ -807,8 +832,10 @@ export const useBurnerTerminals = ({
   return {
     renderNode,
     toggle,
+    syncToPaneCwd,
     runningByPane,
     activeByPane,
+    outOfSyncByPane,
     hasVisibleBurner:
       visibleKey !== null &&
       (!canUseNativeGhosttySecondary() || !entries.get(visibleKey)?.hostPtyId),

--- a/src/features/workspace/WorkspaceView.command-palette.test.tsx
+++ b/src/features/workspace/WorkspaceView.command-palette.test.tsx
@@ -348,8 +348,10 @@ describe('WorkspaceView - Command Palette Integration', () => {
     vi.mocked(useBurnerTerminals).mockReturnValue({
       renderNode: null,
       toggle: vi.fn().mockResolvedValue(undefined),
+      syncToPaneCwd: vi.fn(),
       runningByPane: new Map(),
       activeByPane: new Map(),
+      outOfSyncByPane: new Map(),
       hasVisibleBurner: false,
       visibleBurnerPaneKey: null,
     })

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -1278,8 +1278,10 @@ const WorkspaceViewContent = (): ReactElement => {
   const {
     renderNode: burnerTerminalNode,
     toggle: toggleBurner,
+    syncToPaneCwd: syncBurnerToPaneCwd,
     runningByPane: runningBurnerByPane,
     activeByPane: activeBurnerByPane,
+    outOfSyncByPane: outOfSyncBurnerByPane,
     hasVisibleBurner,
     visibleBurnerPaneKey,
   } = useBurnerTerminals({
@@ -1334,6 +1336,16 @@ const WorkspaceViewContent = (): ReactElement => {
         ? new Set<string>()
         : new Set([visibleBurnerPaneKey]),
     [visibleBurnerPaneKey]
+  )
+
+  const outOfSyncBurnerPaneKeys = useMemo(
+    () =>
+      new Set(
+        [...outOfSyncBurnerByPane]
+          .filter(([, outOfSync]) => outOfSync)
+          .map(([key]) => key)
+      ),
+    [outOfSyncBurnerByPane]
   )
 
   const requestFocus = useCallback((target: FocusTarget): void => {
@@ -2876,9 +2888,11 @@ const WorkspaceViewContent = (): ReactElement => {
                 setActiveContainerId(TERMINAL_CONTAINER_ID)
               }}
               onBurner={(target): void => void toggleBurner(target)}
+              onSyncBurner={syncBurnerToPaneCwd}
               activeBurnerPaneKeys={activeBurnerPaneKeys}
               openBurnerPaneKeys={openBurnerPaneKeys}
               runningBurnerPaneKeys={runningBurnerPaneKeys}
+              outOfSyncBurnerPaneKeys={outOfSyncBurnerPaneKeys}
             />
           </div>
           {!dockBeforeTerminal ? dockPanel : null}

--- a/src/features/workspace/components/TerminalZone.tsx
+++ b/src/features/workspace/components/TerminalZone.tsx
@@ -72,12 +72,16 @@ export interface TerminalZoneProps {
   onContainerFocus?: () => void
   /** Toggle a pane's ephemeral burner terminal (VIM-53). */
   onBurner?: (target: BurnerTarget) => void
+  /** Sync a pane's burner terminal back to its host pane cwd. */
+  onSyncBurner?: (target: BurnerTarget) => void
   /** Pane-keys with a foreground command running — drives the amber button tint (VIM-71). */
   activeBurnerPaneKeys?: ReadonlySet<string>
   /** Pane-keys whose burner secondary terminal is currently visible. */
   openBurnerPaneKeys?: ReadonlySet<string>
   /** Pane-keys with a live burner shell (idle or active) — drives a11y state (VIM-53). */
   runningBurnerPaneKeys?: ReadonlySet<string>
+  /** Pane-keys whose burner terminal cwd has drifted from its host pane cwd. */
+  outOfSyncBurnerPaneKeys?: ReadonlySet<string>
   layoutRegistry?: PaneLayoutRegistry
 }
 
@@ -105,9 +109,11 @@ export const TerminalZone = forwardRef<TerminalZoneHandle, TerminalZoneProps>(
       isZoneFocused = true,
       onContainerFocus = undefined,
       onBurner = undefined,
+      onSyncBurner = undefined,
       activeBurnerPaneKeys = undefined,
       openBurnerPaneKeys = undefined,
       runningBurnerPaneKeys = undefined,
+      outOfSyncBurnerPaneKeys = undefined,
       layoutRegistry = undefined,
     }: TerminalZoneProps,
     ref
@@ -212,10 +218,12 @@ export const TerminalZone = forwardRef<TerminalZoneHandle, TerminalZoneProps>(
                     onClosePane={removePane}
                     onPanePlacementsChange={setSessionPlacements}
                     onBurner={onBurner}
+                    onSyncBurner={onSyncBurner}
                     layoutRegistry={layoutRegistry}
                     activeBurnerPaneKeys={activeBurnerPaneKeys}
                     openBurnerPaneKeys={openBurnerPaneKeys}
                     runningBurnerPaneKeys={runningBurnerPaneKeys}
+                    outOfSyncBurnerPaneKeys={outOfSyncBurnerPaneKeys}
                     deferTerminalFit={deferTerminalFit}
                   />
                 </div>


### PR DESCRIPTION
## Summary
- show the burner sync control only when an open burner terminal cwd drifts from its host pane
- send a guarded cd plus OSC7 confirmation so successful sync clears the control
- distinguish blocked sync from failed/unconfirmed sync in the header action state

## Verification
- npm run test -- src/features/terminal/components/TerminalPane/HeaderActions.test.tsx src/features/terminal/hooks/useBurnerTerminals.test.ts src/features/terminal/components/TerminalPane/index.test.tsx
- npm run lint -- src/features/terminal/components/TerminalPane/HeaderActions.tsx src/features/terminal/components/TerminalPane/HeaderActions.test.tsx src/features/terminal/hooks/useBurnerTerminals.ts src/features/terminal/hooks/useBurnerTerminals.test.ts
- git diff --check
- npm run type-check
- pre-push hook: npm run test (368 files, 4557 passed, 3 skipped)

Refs VIM-287