### PR TITLE
Render new session dialog in native overlay

### DIFF
--- a/crates/backend/src/runtime/state.rs
+++ b/crates/backend/src/runtime/state.rs
@@ -568,7 +568,7 @@ impl BackendState {
         let state = Connection::open(&state_db).map_err(|e| format!("open state db: {e}"))?;
         state
             .execute_batch(
-                "CREATE TABLE threads (
+                "CREATE TABLE IF NOT EXISTS threads (
                     id TEXT PRIMARY KEY,
                     rollout_path TEXT NOT NULL,
                     cwd TEXT,
@@ -578,7 +578,7 @@ impl BackendState {
             .map_err(|e| format!("create threads table: {e}"))?;
         state
             .execute(
-                "INSERT INTO threads (id, rollout_path, cwd, updated_at_ms)
+                "INSERT OR REPLACE INTO threads (id, rollout_path, cwd, updated_at_ms)
                  VALUES (?1, ?2, ?3, ?4)",
                 params![
                     format!("tid-e2e-{session_id}"),
@@ -592,7 +592,7 @@ impl BackendState {
         let logs_db = codex_home.join("logs.sqlite");
         let logs = Connection::open(&logs_db).map_err(|e| format!("open logs db: {e}"))?;
         logs.execute_batch(
-            "CREATE TABLE logs (
+            "CREATE TABLE IF NOT EXISTS logs (
                 id INTEGER PRIMARY KEY,
                 ts INTEGER NOT NULL,
                 ts_nanos INTEGER NOT NULL,
@@ -601,7 +601,7 @@ impl BackendState {
                 process_uuid TEXT NOT NULL,
                 thread_id TEXT
             );
-            CREATE INDEX idx_logs_ts ON logs(ts DESC, ts_nanos DESC, id DESC);",
+            CREATE INDEX IF NOT EXISTS idx_logs_ts ON logs(ts DESC, ts_nanos DESC, id DESC);",
         )
         .map_err(|e| format!("create logs table: {e}"))?;
 

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -44,7 +44,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | Pattern                                                                                              | Category           | Findings | Refs | Last Updated |
 | ---------------------------------------------------------------------------------------------------- | ------------------ | -------- | ---- | ------------ |
 | [Filesystem Scope](patterns/filesystem-scope.md)                                                     | security           | 28       | 8    | 2026-06-22   |
-| [Native Surface Occlusion](patterns/native-surface-occlusion.md)                                     | correctness        | 7        | 1    | 2026-07-04   |
+| [Native Surface Occlusion](patterns/native-surface-occlusion.md)                                     | correctness        | 8        | 2    | 2026-07-05   |
 | [React Lifecycle](patterns/react-lifecycle.md)                                                       | react-patterns     | 65       | 64   | 2026-06-30   |
 | [Imperative Animation Ownership](patterns/imperative-animation-ownership.md)                         | react-patterns     | 7        | 3    | 2026-06-17   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
@@ -76,10 +76,10 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Git Operations](patterns/git-operations.md)                                                         | correctness        | 27       | 12   | 2026-07-03   |
 | [CodeMirror Integration](patterns/codemirror-integration.md)                                         | editor             | 20       | 5    | 2026-06-17   |
 | [Editor File Existence Probe](patterns/editor-file-existence-probe.md)                               | files              | 3        | 0    | 2026-06-18   |
-| [Error Surfacing](patterns/error-surfacing.md)                                                       | error-handling     | 47       | 46   | 2026-06-28   |
+| [Error Surfacing](patterns/error-surfacing.md)                                                       | error-handling     | 48       | 47   | 2026-07-05   |
 | [File Tree Paths](patterns/file-tree-paths.md)                                                       | files              | 4        | 0    | 2026-04-10   |
 | [Scope Boundary](patterns/scope-boundary.md)                                                         | review-process     | 8        | 3    | 2026-06-01   |
-| [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 30       | 16   | 2026-07-03   |
+| [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 29       | 17   | 2026-07-05   |
 | [Module Boundaries](patterns/module-boundaries.md)                                                   | code-quality       | 18       | 7    | 2026-06-28   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 13       | 3    | 2026-06-15   |
 | [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 30       | 6    | 2026-07-02   |
@@ -100,7 +100,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [String Construction Hygiene](patterns/string-construction-hygiene.md)                               | code-quality       | 2        | 1    | 2026-06-19   |
 | [Agent-State Guards](patterns/agent-state-guards.md)                                                 | correctness        | 14       | 9    | 2026-06-28   |
 | [React Prop Contracts](patterns/react-prop-contracts.md)                                             | react-patterns     | 8        | 6    | 2026-06-22   |
-| [Stale Retained Interactions](patterns/stale-retained-interactions.md)                               | react-patterns     | 2        | 1    | 2026-06-15   |
+| [Stale Retained Interactions](patterns/stale-retained-interactions.md)                               | react-patterns     | 2        | 2    | 2026-06-15   |
 | [Retained State Identity](patterns/retained-state-identity.md)                                       | react-patterns     | 2        | 1    | 2026-07-04   |
 | [Authoritative Completion Guard](patterns/authoritative-completion-guard.md)                         | correctness        | 6        | 2    | 2026-06-27   |
 | [Equality Guard Completeness](patterns/equality-guard-completeness.md)                               | correctness        | 2        | 0    | 2026-06-17   |

--- a/docs/reviews/patterns/e2e-testing.md
+++ b/docs/reviews/patterns/e2e-testing.md
@@ -2,8 +2,8 @@
 id: e2e-testing
 category: e2e-testing
 created: 2026-04-19
-last_updated: 2026-07-03
-ref_count: 16
+last_updated: 2026-07-05
+ref_count: 17
 ---
 
 # E2E Testing
@@ -318,3 +318,17 @@ completely different root causes. The generic fast-failure modes:
   agent WDIO suite, while preserving the after-suite cleanup for post-job
   headroom.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 32. E2E Codex watcher seed must tolerate retried partial SQLite setup
+
+- **Source:** deterministic CI failure | PR #660 round 1 | 2026-07-05
+- **Severity:** HIGH
+- **File:** `crates/backend/src/runtime/state.rs`
+- **Finding:** The Linux agent smoke suite retried `e2e_start_codex_watcher`
+  after a partial SQLite setup left `state.sqlite` initialized. The helper used
+  plain `CREATE TABLE` statements, so the retry failed with `table threads
+already exists` before the spec could assert agent status rendering.
+- **Fix:** Made the e2e-only Codex watcher seed idempotent with
+  `CREATE TABLE IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`, and
+  `INSERT OR REPLACE` for the seeded thread row.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/error-surfacing.md
+++ b/docs/reviews/patterns/error-surfacing.md
@@ -2,8 +2,8 @@
 id: error-surfacing
 category: error-handling
 created: 2026-04-10
-last_updated: 2026-06-28
-ref_count: 46
+last_updated: 2026-07-05
+ref_count: 47
 ---
 
 # Error Surfacing
@@ -462,4 +462,17 @@ failed" must mean the editor shows the original file, not the requested one.
   the write could emit an unhandled `EPIPE` and terminate the Electron main process.
 - **Fix:** Register a warn-only stdin error handler immediately after spawn and wrap the
   cooperative shutdown write in a best-effort try/catch before killing the helper.
+- **Commit:** same commit as this entry
+
+### 47. Native directory picker rejection escaped overlay action handler
+
+- **Source:** github-claude | PR #660 round 1 | 2026-07-05
+- **Severity:** LOW
+- **File:** `src/features/sessions/components/NewSessionDialog/NewSessionDialog.tsx`
+- **Finding:** The native-overlay Browse action awaited the Electron directory picker
+  inside a fire-and-forget async IIFE with `finally` for overlay resume, but no
+  `catch`, so an IPC rejection could surface as an unhandled promise rejection.
+- **Fix:** Catch picker rejections inside the native Browse action and keep the
+  `finally` resume path intact. Added regression coverage that a rejected picker
+  still resumes the native overlay.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/native-surface-occlusion.md
+++ b/docs/reviews/patterns/native-surface-occlusion.md
@@ -2,8 +2,8 @@
 id: native-surface-occlusion
 category: correctness
 created: 2026-06-15
-last_updated: 2026-07-04
-ref_count: 1
+last_updated: 2026-07-05
+ref_count: 2
 ---
 
 # Native Surface Occlusion
@@ -82,3 +82,18 @@ React overlays that drive Electron native WebContentsView visibility must regist
 - **Finding:** The burner hook rendered native secondary panes whenever the primary macOS Ghostty bridge existed. Legacy helper mode exposes only primary update/data/focus/destroy IPC, so the native secondary attach path failed and killed a newly spawned burner instead of falling back to the xterm popup.
 - **Fix:** Added an explicit `canUseNativeGhosttySecondary()` capability check that requires every secondary IPC method, and used it to select native burner rendering. Legacy helper mode now keeps the primary native pane path while burner panes use the xterm popup.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 9. Hidden local Browse button bypassed native overlay suspension
+
+- **Source:** github-codex-connector | PR #660 round 1 | 2026-07-05
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/sessions/components/NewSessionDialog/NewSessionDialog.tsx`
+- **Finding:** Native-overlay mode kept the local dialog tree mounted and focusable
+  while visually hidden, so keyboard users could activate the local Browse button.
+  That path opened the regular directory picker without suspending the native
+  overlay, letting the overlay remain above the AppKit sheet.
+- **Fix:** Added a `browseDisabled` prop to `WorkingDirectoryField` and disabled
+  the local Browse button while native-overlay mode is active, leaving the native
+  serialized Browse action as the only picker path. Added unit coverage for the
+  disabled local path.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/stale-retained-interactions.md
+++ b/docs/reviews/patterns/stale-retained-interactions.md
@@ -3,7 +3,7 @@ id: stale-retained-interactions
 category: react-patterns
 created: 2026-06-15
 last_updated: 2026-06-15
-ref_count: 1
+ref_count: 2
 ---
 
 # Stale Retained Interactions

--- a/electron/native-overlay-channels.ts
+++ b/electron/native-overlay-channels.ts
@@ -4,10 +4,13 @@ export const NATIVE_OVERLAY_CLOSE = 'native-overlay:close'
 
 export const NATIVE_OVERLAY_ACTION_RESULT = 'native-overlay:action-result'
 
+export const NATIVE_OVERLAY_RESUME = 'native-overlay:resume'
+
 export type NativeOverlayInvokeChannel =
   | typeof NATIVE_OVERLAY_OPEN
   | typeof NATIVE_OVERLAY_CLOSE
   | typeof NATIVE_OVERLAY_ACTION_RESULT
+  | typeof NATIVE_OVERLAY_RESUME
 
 export const NATIVE_OVERLAY_ACTION = 'native-overlay:action'
 

--- a/electron/native-overlay.test.ts
+++ b/electron/native-overlay.test.ts
@@ -9,6 +9,7 @@ import {
   NATIVE_OVERLAY_OPEN,
   NATIVE_OVERLAY_READY,
   NATIVE_OVERLAY_RENDER,
+  NATIVE_OVERLAY_RESUME,
 } from './native-overlay-channels'
 import { COMMAND_PALETTE_TOGGLE } from './ipc-channels'
 import { NativeOverlayController } from './native-overlay'
@@ -31,6 +32,7 @@ interface FakeWebContents {
   send: ReturnType<typeof vi.fn>
   focus: ReturnType<typeof vi.fn>
   isDestroyed: ReturnType<typeof vi.fn>
+  executeJavaScript: ReturnType<typeof vi.fn>
   setWindowOpenHandler: ReturnType<typeof vi.fn>
   on: ReturnType<typeof vi.fn>
   removeListener: ReturnType<typeof vi.fn>
@@ -70,6 +72,7 @@ const electronMock = vi.hoisted(() => {
       send: vi.fn(),
       focus: vi.fn(),
       isDestroyed: vi.fn(() => false),
+      executeJavaScript: vi.fn(() => Promise.resolve(undefined)),
       setWindowOpenHandler: vi.fn(),
       on: vi.fn((event: string, handler: EventHandler): void => {
         handlersByEvent.set(event, [
@@ -153,6 +156,7 @@ const electronMock = vi.hoisted(() => {
         webContents.send.mockClear()
         webContents.focus.mockClear()
         webContents.isDestroyed.mockClear()
+        webContents.executeJavaScript.mockClear()
         webContents.setWindowOpenHandler.mockClear()
         webContents.on.mockClear()
         webContents.removeListener.mockClear()
@@ -164,6 +168,7 @@ const electronMock = vi.hoisted(() => {
         this.show.mockClear()
         this.showInactive.mockClear()
         this.hide.mockClear()
+        this.moveTop.mockClear()
         this.close.mockClear()
         this.loadURL.mockClear()
         this.on.mockClear()
@@ -1112,6 +1117,52 @@ describe('NativeOverlayController', () => {
       NATIVE_OVERLAY_ACTION_RESULT,
       result
     )
+  })
+
+  test('action can suspend and resume an interactive overlay for native modal work', async () => {
+    const openPromise = handler(NATIVE_OVERLAY_OPEN)(
+      { sender: electronMock.owner.webContents },
+      request
+    )
+    const overlayWindow = finishOverlayLoad()
+    await acknowledgeOverlayReady(overlayWindow)
+    await openPromise
+
+    overlayWindow.setAlwaysOnTop.mockClear()
+    overlayWindow.setIgnoreMouseEvents.mockClear()
+    overlayWindow.showInactive.mockClear()
+    overlayWindow.moveTop.mockClear()
+    overlayWindow.hide.mockClear()
+    overlayWindow.webContents.executeJavaScript.mockClear()
+
+    handler(NATIVE_OVERLAY_ACTION)(
+      { sender: overlayWindow.webContents },
+      {
+        surfaceId: request.surfaceId,
+        actionId: 'browse',
+        closeOnSelect: false,
+        suspendOnSelect: true,
+      }
+    )
+
+    expect(overlayWindow.hide).not.toHaveBeenCalled()
+    expect(overlayWindow.webContents.executeJavaScript).toHaveBeenCalledOnce()
+    expect(overlayWindow.setAlwaysOnTop).toHaveBeenLastCalledWith(false)
+    expect(overlayWindow.setIgnoreMouseEvents).toHaveBeenLastCalledWith(true)
+
+    handler(NATIVE_OVERLAY_RESUME)(
+      { sender: electronMock.owner.webContents },
+      { surfaceId: request.surfaceId }
+    )
+
+    expect(overlayWindow.setIgnoreMouseEvents).toHaveBeenLastCalledWith(false)
+    expect(overlayWindow.showInactive).toHaveBeenCalledOnce()
+    expect(overlayWindow.setAlwaysOnTop).toHaveBeenLastCalledWith(
+      true,
+      'screen-saver'
+    )
+    expect(overlayWindow.moveTop).toHaveBeenCalledOnce()
+    expect(overlayWindow.webContents.executeJavaScript).toHaveBeenCalledTimes(2)
   })
 
   test('rejects native overlay on non-macOS platforms', async () => {

--- a/electron/native-overlay.ts
+++ b/electron/native-overlay.ts
@@ -19,6 +19,7 @@ import {
   NATIVE_OVERLAY_OPEN,
   NATIVE_OVERLAY_READY,
   NATIVE_OVERLAY_RENDER,
+  NATIVE_OVERLAY_RESUME,
 } from './native-overlay-channels'
 import { dispatchCommandPaletteShortcutForWindow } from './command-palette-shortcut'
 
@@ -139,7 +140,58 @@ interface NativeOverlayCommandPaletteDialogPayload {
   actions: NativeOverlayCommandPaletteActions
 }
 
-type NativeOverlayDialogPayload = NativeOverlayCommandPaletteDialogPayload
+interface NativeOverlayNewSessionCommandOption {
+  id: string
+  label: string
+  accentVar: string
+  glyph?: string
+  materialIcon?: string
+}
+
+interface NativeOverlayNewSessionLayoutOption {
+  id: string
+  label: string
+  capacity: number
+  cols: string
+  rows: string
+  areas: readonly (readonly string[])[]
+}
+
+interface NativeOverlayNewSessionPaneOption {
+  index: number
+  areaName: string
+  commandId: string
+}
+
+interface NativeOverlayNewSessionActions {
+  focusName: string
+  resetName: string
+  browse: string
+  cancel: string
+  create: string
+  selectPanePrefix: string
+  pickLayoutPrefix: string
+  pickCommandPrefix: string
+}
+
+interface NativeOverlayNewSessionDialogPayload {
+  kind: 'dialog'
+  dialog: 'new-session'
+  ariaLabel: string
+  name: string
+  path: string
+  nameEdited: boolean
+  selectedLayoutId: string
+  activeCommandPaneIndex: number
+  layouts: NativeOverlayNewSessionLayoutOption[]
+  panes: NativeOverlayNewSessionPaneOption[]
+  commands: NativeOverlayNewSessionCommandOption[]
+  actions: NativeOverlayNewSessionActions
+}
+
+type NativeOverlayDialogPayload =
+  | NativeOverlayCommandPaletteDialogPayload
+  | NativeOverlayNewSessionDialogPayload
 
 type SerializableOverlayPayload =
   | NativeOverlayMenuPayload
@@ -170,6 +222,7 @@ interface NativeOverlayActionEvent {
   surfaceId: string
   actionId: string
   closeOnSelect?: boolean
+  suspendOnSelect?: boolean
   feedback?: 'copy'
   index?: number
 }
@@ -240,6 +293,17 @@ interface IpcMainLike {
 
 const OVERLAY_RENDER_TIMEOUT_MS = 1000
 
+const OVERLAY_CURSOR_RESET_SCRIPT = `
+(() => {
+  document.documentElement.style.cursor = 'default'
+  document.body.style.cursor = 'default'
+  window.setTimeout(() => {
+    document.documentElement.style.cursor = ''
+    document.body.style.cursor = ''
+  }, 80)
+})()
+`
+
 const MENU_KEY_MAP: Readonly<Partial<Record<string, string>>> = {
   ' ': ' ',
   ArrowDown: 'ArrowDown',
@@ -263,6 +327,25 @@ const MENU_KEY_MAP: Readonly<Partial<Record<string, string>>> = {
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const resetOverlayCursor = (overlayWindow: BrowserWindow): void => {
+  if (overlayWindow.webContents.isDestroyed()) {
+    return
+  }
+
+  // AppKit modal panels can leave Chromium's last cursor active while this
+  // transparent window temporarily ignores mouse events.
+  void (async (): Promise<void> => {
+    try {
+      await overlayWindow.webContents.executeJavaScript(
+        OVERLAY_CURSOR_RESET_SCRIPT,
+        true
+      )
+    } catch {
+      // Cursor reset is cosmetic; overlay ordering should continue if it fails.
+    }
+  })()
+}
 
 const isString = (value: unknown): value is string =>
   typeof value === 'string' && value.length > 0
@@ -378,9 +461,66 @@ const isCommandPaletteActions = (
 ): value is NativeOverlayCommandPaletteActions =>
   isRecord(value) && isString(value.selectIndex) && isString(value.executeIndex)
 
-const isDialogPayload = (value: unknown): value is NativeOverlayDialogPayload =>
+const isStringMatrix = (
+  value: unknown
+): value is readonly (readonly string[])[] =>
+  Array.isArray(value) &&
+  value.length > 0 &&
+  value.every(
+    (row) =>
+      Array.isArray(row) &&
+      row.length > 0 &&
+      row.every((entry) => typeof entry === 'string')
+  )
+
+const isNewSessionCommandOption = (
+  value: unknown
+): value is NativeOverlayNewSessionCommandOption =>
   isRecord(value) &&
-  value.kind === 'dialog' &&
+  isString(value.id) &&
+  isString(value.label) &&
+  isString(value.accentVar) &&
+  (value.glyph === undefined || typeof value.glyph === 'string') &&
+  (value.materialIcon === undefined || typeof value.materialIcon === 'string')
+
+const isNewSessionLayoutOption = (
+  value: unknown
+): value is NativeOverlayNewSessionLayoutOption =>
+  isRecord(value) &&
+  isString(value.id) &&
+  isString(value.label) &&
+  isFiniteNumber(value.capacity) &&
+  value.capacity > 0 &&
+  isString(value.cols) &&
+  isString(value.rows) &&
+  isStringMatrix(value.areas)
+
+const isNewSessionPaneOption = (
+  value: unknown
+): value is NativeOverlayNewSessionPaneOption =>
+  isRecord(value) &&
+  isFiniteNumber(value.index) &&
+  value.index >= 0 &&
+  isString(value.areaName) &&
+  isString(value.commandId)
+
+const isNewSessionActions = (
+  value: unknown
+): value is NativeOverlayNewSessionActions =>
+  isRecord(value) &&
+  isString(value.focusName) &&
+  isString(value.resetName) &&
+  isString(value.browse) &&
+  isString(value.cancel) &&
+  isString(value.create) &&
+  isString(value.selectPanePrefix) &&
+  isString(value.pickLayoutPrefix) &&
+  isString(value.pickCommandPrefix)
+
+const isCommandPaletteDialogPayload = (
+  value: unknown
+): value is NativeOverlayCommandPaletteDialogPayload =>
+  isRecord(value) &&
   value.dialog === 'command-palette' &&
   isString(value.ariaLabel) &&
   typeof value.query === 'string' &&
@@ -392,6 +532,34 @@ const isDialogPayload = (value: unknown): value is NativeOverlayDialogPayload =>
   Array.isArray(value.results) &&
   value.results.every(isCommandPaletteItem) &&
   isCommandPaletteActions(value.actions)
+
+const isNewSessionDialogPayload = (
+  value: unknown
+): value is NativeOverlayNewSessionDialogPayload =>
+  isRecord(value) &&
+  value.dialog === 'new-session' &&
+  isString(value.ariaLabel) &&
+  typeof value.name === 'string' &&
+  typeof value.path === 'string' &&
+  typeof value.nameEdited === 'boolean' &&
+  isString(value.selectedLayoutId) &&
+  isFiniteNumber(value.activeCommandPaneIndex) &&
+  value.activeCommandPaneIndex >= 0 &&
+  Array.isArray(value.layouts) &&
+  value.layouts.length > 0 &&
+  value.layouts.every(isNewSessionLayoutOption) &&
+  Array.isArray(value.panes) &&
+  value.panes.length > 0 &&
+  value.panes.every(isNewSessionPaneOption) &&
+  Array.isArray(value.commands) &&
+  value.commands.length > 0 &&
+  value.commands.every(isNewSessionCommandOption) &&
+  isNewSessionActions(value.actions)
+
+const isDialogPayload = (value: unknown): value is NativeOverlayDialogPayload =>
+  isRecord(value) &&
+  value.kind === 'dialog' &&
+  (isCommandPaletteDialogPayload(value) || isNewSessionDialogPayload(value))
 
 const isThemeSnapshot = (value: unknown): value is NativeOverlayThemeSnapshot =>
   isRecord(value) &&
@@ -438,6 +606,8 @@ const isActionEvent = (value: unknown): value is NativeOverlayActionEvent =>
   isString(value.actionId) &&
   (value.closeOnSelect === undefined ||
     typeof value.closeOnSelect === 'boolean') &&
+  (value.suspendOnSelect === undefined ||
+    typeof value.suspendOnSelect === 'boolean') &&
   (value.feedback === undefined || value.feedback === 'copy') &&
   (value.index === undefined || isFiniteNumber(value.index))
 
@@ -503,6 +673,7 @@ export class NativeOverlayController {
     ipc.handle(NATIVE_OVERLAY_READY, this.handleReady)
     ipc.handle(NATIVE_OVERLAY_ACTION, this.handleAction)
     ipc.handle(NATIVE_OVERLAY_ACTION_RESULT, this.handleActionResult)
+    ipc.handle(NATIVE_OVERLAY_RESUME, this.handleResume)
     this.registeredIpc = ipc
   }
 
@@ -513,6 +684,7 @@ export class NativeOverlayController {
       this.registeredIpc.removeHandler(NATIVE_OVERLAY_READY)
       this.registeredIpc.removeHandler(NATIVE_OVERLAY_ACTION)
       this.registeredIpc.removeHandler(NATIVE_OVERLAY_ACTION_RESULT)
+      this.registeredIpc.removeHandler(NATIVE_OVERLAY_RESUME)
       this.registeredIpc = null
     }
 
@@ -691,11 +863,28 @@ export class NativeOverlayController {
     const owner = surface.owner
     if (payload.closeOnSelect !== false) {
       this.closeSurface(payload.surfaceId, 'action', false)
+    } else if (payload.suspendOnSelect === true) {
+      this.suspendSurface(payload.surfaceId)
     }
 
     if (!owner.isDestroyed()) {
       owner.send(NATIVE_OVERLAY_ACTION, payload)
     }
+  }
+
+  private readonly handleResume = (
+    event: IpcMainInvokeEvent,
+    payload: unknown
+  ): void => {
+    if (!isCloseRequest(payload)) {
+      return
+    }
+
+    if (!this.surfaceFromOwnerSender(payload.surfaceId, event.sender)) {
+      return
+    }
+
+    this.resumeSurface(payload.surfaceId)
   }
 
   private readonly handleActionResult = (
@@ -1012,6 +1201,49 @@ export class NativeOverlayController {
         surface.owner.send(NATIVE_OVERLAY_CLOSED, { surfaceId, reason })
       }
     }
+  }
+
+  private suspendSurface(surfaceId: string): void {
+    const surface = this.surfaces.get(surfaceId)
+    if (!surface || surface.kind === 'tooltip') {
+      return
+    }
+
+    const record = this.overlays.get(surface.parentId)
+    if (
+      record?.activeSurfaceId !== surfaceId ||
+      record.menu.window.isDestroyed()
+    ) {
+      return
+    }
+
+    const overlayWindow = record.menu.window
+    resetOverlayCursor(overlayWindow)
+    overlayWindow.setAlwaysOnTop(false)
+    overlayWindow.setIgnoreMouseEvents(true)
+  }
+
+  private resumeSurface(surfaceId: string): void {
+    const surface = this.surfaces.get(surfaceId)
+    if (!surface || surface.kind === 'tooltip') {
+      return
+    }
+
+    const record = this.overlays.get(surface.parentId)
+    if (
+      record?.activeSurfaceId !== surfaceId ||
+      record.menu.window.isDestroyed()
+    ) {
+      return
+    }
+
+    record.syncBounds()
+    const overlayWindow = record.menu.window
+    overlayWindow.setIgnoreMouseEvents(false)
+    overlayWindow.showInactive()
+    overlayWindow.setAlwaysOnTop(true, 'screen-saver')
+    overlayWindow.moveTop()
+    resetOverlayCursor(overlayWindow)
   }
 
   private surfaceFromOverlaySender(

--- a/electron/preload.test.ts
+++ b/electron/preload.test.ts
@@ -29,6 +29,7 @@ import {
   NATIVE_OVERLAY_OPEN,
   NATIVE_OVERLAY_READY,
   NATIVE_OVERLAY_RENDER,
+  NATIVE_OVERLAY_RESUME,
   type NativeOverlayInvokeChannel,
 } from './native-overlay-channels'
 import {
@@ -112,6 +113,7 @@ const nativeOverlayInvokeCases: readonly [
 ][] = [
   ['open', NATIVE_OVERLAY_OPEN, { surfaceId: 'surface-1' }],
   ['close', NATIVE_OVERLAY_CLOSE, { surfaceId: 'surface-1' }],
+  ['resume', NATIVE_OVERLAY_RESUME, { surfaceId: 'surface-1' }],
   ['actionResult', NATIVE_OVERLAY_ACTION_RESULT, { surfaceId: 'surface-1' }],
 ]
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -16,6 +16,7 @@ import {
   NATIVE_OVERLAY_OPEN,
   NATIVE_OVERLAY_READY,
   NATIVE_OVERLAY_RENDER,
+  NATIVE_OVERLAY_RESUME,
 } from './native-overlay-channels'
 import {
   BROWSER_PANE_ACTIVATE_TAB,
@@ -252,6 +253,8 @@ contextBridge.exposeInMainWorld('vimeflow', {
       ipcRenderer.invoke(NATIVE_OVERLAY_CLOSE, request),
     actionResult: (request: unknown): Promise<unknown> =>
       ipcRenderer.invoke(NATIVE_OVERLAY_ACTION_RESULT, request),
+    resume: (request: unknown): Promise<unknown> =>
+      ipcRenderer.invoke(NATIVE_OVERLAY_RESUME, request),
     onAction: (callback: (payload: unknown) => void): (() => void) => {
       const handler = (_event: IpcRendererEvent, payload: unknown): void => {
         callback(payload)

--- a/src/components/Dialog.test.tsx
+++ b/src/components/Dialog.test.tsx
@@ -65,6 +65,7 @@ const installNativeOverlayBridge = (
       open,
       close,
       actionResult: vi.fn(() => Promise.resolve()),
+      resume: vi.fn(() => Promise.resolve()),
       onAction: vi.fn(() => vi.fn()),
       onClose: vi.fn(() => vi.fn()),
     },

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -22,8 +22,10 @@ import {
 } from '@/components/base/floating/nativeOverlay'
 
 export type {
+  NativeOverlayActionEvent,
   NativeOverlayActionHandler,
   NativeOverlayCommandPaletteDialogPayload,
+  NativeOverlayNewSessionDialogPayload,
 } from '@/components/base/floating/nativeOverlay'
 
 type DialogPlacement = 'center' | 'top'
@@ -309,20 +311,26 @@ const DialogRoot = ({
     nativeAttempt === 'pending' || nativeAttempt === 'active'
 
   useEffect(() => {
-    if (!open) {
-      nativeOverlayGenerationRef.current += 1
-      closeNativeOverlay(surfaceId)
-      setNativeAttempt('idle')
-
-      return
-    }
-
     if (
+      open &&
       nativeOverlay &&
       transport === 'native-overlay' &&
       nativeUnsupportedReason !== null
     ) {
       warnNativeOverlayFallback(nativeUnsupportedReason)
+    }
+
+    if (
+      !open ||
+      !nativeOverlay ||
+      transport !== 'native-overlay' ||
+      nativeUnsupportedReason !== null
+    ) {
+      nativeOverlayGenerationRef.current += 1
+      closeNativeOverlay(surfaceId)
+      setNativeAttempt('idle')
+
+      return
     }
   }, [nativeOverlay, nativeUnsupportedReason, open, surfaceId, transport])
 

--- a/src/components/Menu.test.tsx
+++ b/src/components/Menu.test.tsx
@@ -49,6 +49,7 @@ const installNativeOverlayBridge = (): {
       open,
       close,
       actionResult: vi.fn(() => Promise.resolve()),
+      resume: vi.fn(() => Promise.resolve()),
       onAction: vi.fn((callback: (event: unknown) => void) => {
         actionListener = callback
 

--- a/src/components/NativeOverlayHost.test.tsx
+++ b/src/components/NativeOverlayHost.test.tsx
@@ -178,6 +178,75 @@ const commandPaletteRequest: NativeOverlayRequest = {
   },
 }
 
+const newSessionRequest: NativeOverlayRequest = {
+  surfaceId: 'dialog-2',
+  kind: 'dialog',
+  anchorRect: { x: 0, y: 0, width: 900, height: 600 },
+  placement: 'top',
+  payload: {
+    kind: 'dialog',
+    dialog: 'new-session',
+    ariaLabel: 'New session',
+    name: 'vimeflow-core',
+    path: '~/code/vimeflow-core',
+    nameEdited: false,
+    selectedLayoutId: 'vsplit',
+    activeCommandPaneIndex: 1,
+    layouts: [
+      {
+        id: 'single',
+        label: 'Single',
+        capacity: 1,
+        cols: 'minmax(0,1fr)',
+        rows: 'minmax(0,1fr)',
+        areas: [['p0']],
+      },
+      {
+        id: 'vsplit',
+        label: 'Vertical split',
+        capacity: 2,
+        cols: 'minmax(0,1fr) minmax(0,1fr)',
+        rows: 'minmax(0,1fr)',
+        areas: [['p0', 'p1']],
+      },
+    ],
+    panes: [
+      { index: 0, areaName: 'p0', commandId: 'claude' },
+      { index: 1, areaName: 'p1', commandId: 'shell' },
+    ],
+    commands: [
+      {
+        id: 'claude',
+        label: 'Claude Code',
+        accentVar: '--color-agent-claude-accent',
+        glyph: 'C',
+      },
+      {
+        id: 'codex',
+        label: 'Codex CLI',
+        accentVar: '--color-agent-codex-accent',
+        glyph: 'X',
+      },
+      {
+        id: 'shell',
+        label: 'Shell',
+        accentVar: '--color-agent-shell-accent',
+        glyph: '$',
+      },
+    ],
+    actions: {
+      focusName: 'new-session:focus-name',
+      resetName: 'new-session:reset-name',
+      browse: 'new-session:browse',
+      cancel: 'new-session:cancel',
+      create: 'new-session:create',
+      selectPanePrefix: 'new-session:select-pane:',
+      pickLayoutPrefix: 'new-session:pick-layout:',
+      pickCommandPrefix: 'new-session:pick-command:',
+    },
+  },
+}
+
 let cleanupHostBridgeEvents: (() => void) | null = null
 
 const installNativeOverlayHostBridge = (): {
@@ -264,6 +333,7 @@ const installNativeOverlayHostBridge = (): {
       open: vi.fn(() => Promise.resolve({ accepted: true })),
       close: ownerOverlayClose,
       actionResult: vi.fn(() => Promise.resolve()),
+      resume: vi.fn(() => Promise.resolve()),
       onAction: vi.fn(() => vi.fn()),
       onClose: vi.fn(() => vi.fn()),
     },
@@ -368,6 +438,53 @@ describe('NativeOverlayHost', () => {
     })
 
     expect(screen.getByRole('dialog', { name: 'Command palette' })).toBe(dialog)
+  })
+
+  test('renders new session dialog requests and dispatches actions', async () => {
+    const user = userEvent.setup()
+    const bridge = installNativeOverlayHostBridge()
+    render(<NativeOverlayHost />)
+
+    bridge.emitRender(newSessionRequest)
+
+    const dialog = await screen.findByRole('dialog', {
+      name: 'New session',
+    })
+    expect(dialog).toBeInTheDocument()
+    expect(screen.getByText('vimeflow-core')).toBeInTheDocument()
+    expect(screen.getByText('~/code/vimeflow-core')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Single 1' }))
+    expect(bridge.action).toHaveBeenCalledWith({
+      surfaceId: 'dialog-2',
+      actionId: 'new-session:pick-layout:single',
+      closeOnSelect: false,
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Codex CLI' }))
+    expect(bridge.action).toHaveBeenCalledWith({
+      surfaceId: 'dialog-2',
+      actionId: 'new-session:pick-command:1:codex',
+      closeOnSelect: false,
+    })
+
+    const browseButton = screen.getByRole('button', { name: 'Browse' })
+    expect(browseButton).toHaveClass('cursor-pointer')
+
+    await user.click(browseButton)
+    expect(bridge.action).toHaveBeenCalledWith({
+      surfaceId: 'dialog-2',
+      actionId: 'new-session:browse',
+      closeOnSelect: false,
+      suspendOnSelect: true,
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Create session' }))
+    expect(bridge.action).toHaveBeenCalledWith({
+      surfaceId: 'dialog-2',
+      actionId: 'new-session:create',
+      closeOnSelect: true,
+    })
   })
 
   test('scrolls the selected command palette row into view', async () => {

--- a/src/components/NativeOverlayHost.tsx
+++ b/src/components/NativeOverlayHost.tsx
@@ -13,6 +13,9 @@ import type {
   NativeOverlayMenuItem,
   NativeOverlayMenuRequest,
   NativeOverlayMenuSection,
+  NativeOverlayCommandPaletteDialogPayload,
+  NativeOverlayNewSessionCommandOption,
+  NativeOverlayNewSessionDialogPayload,
   NativeOverlayRequest,
   NativeOverlayTooltipRequest,
 } from '@/components/base/floating/nativeOverlay'
@@ -25,6 +28,7 @@ interface NativeOverlayHostBridge {
     surfaceId: string
     actionId: string
     closeOnSelect?: boolean
+    suspendOnSelect?: boolean
     feedback?: 'copy'
     index?: number
   }) => Promise<unknown>
@@ -44,6 +48,14 @@ interface NativeOverlayKeyboardEvent {
   metaKey: boolean
   shiftKey: boolean
   repeat: boolean
+}
+
+type NativeOverlayNewSessionRequest = NativeOverlayDialogRequest & {
+  payload: NativeOverlayNewSessionDialogPayload
+}
+
+type NativeOverlayCommandPaletteRequest = NativeOverlayDialogRequest & {
+  payload: NativeOverlayCommandPaletteDialogPayload
 }
 
 const COPY_FEEDBACK_MS = 1300
@@ -76,8 +88,10 @@ const isDialogRequest = (value: unknown): value is NativeOverlayDialogRequest =>
   (value as { kind?: unknown }).kind === 'dialog' &&
   (value as { payload?: { kind?: unknown; dialog?: unknown } }).payload
     ?.kind === 'dialog' &&
-  (value as { payload?: { dialog?: unknown } }).payload?.dialog ===
-    'command-palette'
+  ((value as { payload?: { dialog?: unknown } }).payload?.dialog ===
+    'command-palette' ||
+    (value as { payload?: { dialog?: unknown } }).payload?.dialog ===
+      'new-session')
 
 const isCopyActionResult = (
   value: unknown
@@ -191,6 +205,36 @@ const OVERLAY_COMMAND_PALETTE_FOOTER_KEY_CLASSES =
   'inline-flex min-w-[18px] h-[18px] px-[5px] items-center justify-center ' +
   'rounded-[4px] border font-mono text-[10px] font-semibold ' +
   'bg-surface-container-highest/60 text-on-surface-variant border-outline-variant/60'
+
+const OVERLAY_NEW_SESSION_PANEL_CLASSES =
+  'w-[min(560px,calc(100vw-32px))] max-h-[min(680px,calc(100vh-48px))] ' +
+  'flex flex-col overflow-hidden rounded-2xl border border-outline-variant/30 ' +
+  'bg-surface-container-high/95 shadow-2xl backdrop-blur-md backdrop-saturate-150'
+
+const OVERLAY_NEW_SESSION_LABEL_CLASSES =
+  'text-[10.5px] font-semibold uppercase tracking-[0.08em] text-on-surface-muted'
+
+const OVERLAY_NEW_SESSION_FIELD_CLASSES =
+  'mt-2 flex h-11 min-w-0 items-center gap-2 rounded-[9px] ' +
+  'bg-surface-container-lowest px-3 text-[13px] text-on-surface'
+
+const OVERLAY_NEW_SESSION_LAYOUT_BUTTON_CLASSES =
+  'flex w-full items-center justify-between gap-2 rounded-[8px] px-2 py-1.5 ' +
+  'text-left text-[12px] transition-colors'
+
+const OVERLAY_NEW_SESSION_PANE_BUTTON_CLASSES =
+  'flex min-h-0 min-w-0 flex-col items-center justify-center gap-1.5 ' +
+  'rounded-[10px] border border-dashed p-2 text-center transition-colors'
+
+const OVERLAY_NEW_SESSION_COMMAND_BUTTON_CLASSES =
+  'inline-flex items-center gap-1.5 rounded-[8px] border px-2 py-1 ' +
+  'text-[11px] transition-colors'
+
+const OVERLAY_NEW_SESSION_BROWSE_BUTTON_CLASSES =
+  'h-11 cursor-pointer rounded-[9px] border border-outline-variant/45 px-3 ' +
+  'text-[12px] text-on-surface-variant transition-colors ' +
+  'hover:border-primary-container/50 hover:bg-primary-container/12 hover:text-on-surface ' +
+  'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary'
 
 const OVERLAY_MENU_COMPOSITE_PRIMARY_CLASSES =
   'flex min-w-0 flex-1 items-center gap-2.5 rounded text-left outline-none ' +
@@ -350,7 +394,7 @@ const NativeOverlayCommandPalette = ({
   request,
   close,
 }: {
-  request: NativeOverlayDialogRequest
+  request: NativeOverlayCommandPaletteRequest
   close: () => void
 }): ReactElement => {
   const rowRefs = useRef(new Map<string, HTMLDivElement>())
@@ -549,6 +593,311 @@ const NativeOverlayCommandPalette = ({
   )
 }
 
+const overlayCommandGlyph = (
+  command: NativeOverlayNewSessionCommandOption,
+  size = 15
+): ReactElement => (
+  <span
+    aria-hidden="true"
+    className="flex shrink-0 items-center justify-center rounded-lg font-mono leading-none"
+    style={{
+      width: size + 14,
+      height: size + 14,
+      color: `var(${command.accentVar})`,
+      background: `color-mix(in srgb, var(${command.accentVar}) 16%, transparent)`,
+      fontSize: size,
+    }}
+  >
+    {command.materialIcon === undefined ? (
+      (command.glyph ?? command.label.slice(0, 1))
+    ) : (
+      <span
+        className="material-symbols-outlined leading-none"
+        style={{ fontSize: size }}
+      >
+        {command.materialIcon}
+      </span>
+    )}
+  </span>
+)
+
+const commandForId = (
+  commands: readonly NativeOverlayNewSessionCommandOption[],
+  commandId: string
+): NativeOverlayNewSessionCommandOption =>
+  commands.find((command) => command.id === commandId) ?? commands[0]
+
+const layoutButtonClass = (selected: boolean): string =>
+  `${OVERLAY_NEW_SESSION_LAYOUT_BUTTON_CLASSES} ${
+    selected
+      ? 'bg-primary-container/15 text-primary'
+      : 'text-on-surface-variant hover:bg-surface-container-high/60'
+  }`
+
+const paneButtonClass = (selected: boolean): string =>
+  `${OVERLAY_NEW_SESSION_PANE_BUTTON_CLASSES} ${
+    selected
+      ? 'border-primary-container/60 bg-primary-container/10'
+      : 'border-outline-variant/50 bg-surface-container/40 hover:bg-surface-container/70'
+  }`
+
+const commandButtonClass = (selected: boolean): string =>
+  `${OVERLAY_NEW_SESSION_COMMAND_BUTTON_CLASSES} ${
+    selected
+      ? 'border-primary-container/60 bg-primary-container/15 text-primary'
+      : 'border-outline-variant/40 bg-surface-container-lowest/40 text-on-surface-variant hover:bg-surface-container-high/60'
+  }`
+
+const NativeOverlayNewSession = ({
+  request,
+  close,
+}: {
+  request: NativeOverlayNewSessionRequest
+  close: () => void
+}): ReactElement => {
+  const payload = request.payload
+
+  const selectedLayout =
+    payload.layouts.find((layout) => layout.id === payload.selectedLayoutId) ??
+    payload.layouts[0]
+
+  const activePane =
+    payload.panes.find(
+      (pane) => pane.index === payload.activeCommandPaneIndex
+    ) ?? payload.panes[0]
+
+  const dispatchAction = (
+    actionId: string,
+    closeOnSelect = false,
+    suspendOnSelect = false
+  ): void => {
+    void nativeOverlayHostBridge()?.action({
+      surfaceId: request.surfaceId,
+      actionId,
+      closeOnSelect,
+      ...(suspendOnSelect ? { suspendOnSelect: true } : {}),
+    })
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={payload.ariaLabel}
+      className={OVERLAY_DIALOG_BACKDROP_CLASSES}
+      onMouseDown={(event): void => {
+        if (event.target === event.currentTarget) {
+          event.preventDefault()
+          close()
+        }
+      }}
+    >
+      <div className={OVERLAY_NEW_SESSION_PANEL_CLASSES}>
+        <div className="flex items-center gap-2.5 px-5 pb-1 pt-3.5">
+          <span
+            className="material-symbols-outlined text-base text-primary-container"
+            aria-hidden="true"
+          >
+            bolt
+          </span>
+          <span className="flex-1 text-[14.5px] font-semibold text-on-surface">
+            New session
+          </span>
+          <IconButton
+            icon="close"
+            label="Close"
+            onClick={(): void => dispatchAction(payload.actions.cancel, true)}
+          />
+        </div>
+
+        <div className="min-h-0 overflow-auto px-5 pb-5 pt-2">
+          <label className={OVERLAY_NEW_SESSION_LABEL_CLASSES}>
+            Session name
+          </label>
+          <div className={OVERLAY_NEW_SESSION_FIELD_CLASSES}>
+            <span
+              className="material-symbols-outlined text-[15px] text-on-surface-muted"
+              aria-hidden="true"
+            >
+              edit
+            </span>
+            <button
+              type="button"
+              className="min-w-0 flex-1 truncate text-left font-medium outline-none"
+              onClick={(): void => dispatchAction(payload.actions.focusName)}
+            >
+              {payload.name}
+            </button>
+            {payload.nameEdited ? (
+              <button
+                type="button"
+                className="rounded-full border border-primary-container/40 px-2 py-0.5 font-mono text-[9.5px] text-primary-container"
+                onClick={(): void => dispatchAction(payload.actions.resetName)}
+              >
+                reset
+              </button>
+            ) : (
+              <span className="rounded-full border border-outline-variant/50 px-2 py-0.5 font-mono text-[9.5px] text-on-surface-muted">
+                folder name
+              </span>
+            )}
+          </div>
+
+          <div className={`${OVERLAY_NEW_SESSION_LABEL_CLASSES} mt-4`}>
+            Working directory
+          </div>
+          <div className="mt-2 flex items-center gap-2">
+            <div className={`${OVERLAY_NEW_SESSION_FIELD_CLASSES} mt-0 flex-1`}>
+              <span
+                className="material-symbols-outlined text-base text-primary-container"
+                aria-hidden="true"
+              >
+                folder_open
+              </span>
+              <span className="min-w-0 truncate font-mono text-[12px]">
+                {payload.path}
+              </span>
+            </div>
+            <button
+              type="button"
+              className={OVERLAY_NEW_SESSION_BROWSE_BUTTON_CLASSES}
+              onClick={(): void =>
+                dispatchAction(payload.actions.browse, false, true)
+              }
+            >
+              Browse
+            </button>
+          </div>
+
+          <div className="mt-4 flex min-h-[232px] items-start gap-4">
+            <div className="w-[158px] shrink-0">
+              <div className={OVERLAY_NEW_SESSION_LABEL_CLASSES}>Layout</div>
+              <div className="mt-2 max-h-[240px] overflow-auto pr-1">
+                {payload.layouts.map((layout) => (
+                  <button
+                    key={layout.id}
+                    type="button"
+                    className={layoutButtonClass(
+                      layout.id === payload.selectedLayoutId
+                    )}
+                    onClick={(): void =>
+                      dispatchAction(
+                        `${payload.actions.pickLayoutPrefix}${layout.id}`
+                      )
+                    }
+                  >
+                    <span className="truncate">{layout.label}</span>
+                    <span className="font-mono text-[10px] text-on-surface-muted">
+                      {layout.capacity}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="min-w-0 flex-1">
+              <div className={OVERLAY_NEW_SESSION_LABEL_CLASSES}>
+                Starting command
+              </div>
+              <div className="mt-0.5 text-[11px] text-on-surface-muted">
+                choose a panel, then its starting command
+              </div>
+              <div className="mt-2.5 rounded-2xl border border-outline-variant/30 bg-surface-container-lowest/60 p-2 shadow-[inset_0_1px_0_color-mix(in_srgb,var(--color-on-surface)_8%,transparent)]">
+                <div
+                  className="grid h-[152px] gap-2"
+                  style={{
+                    gridTemplateColumns: selectedLayout.cols,
+                    gridTemplateRows: selectedLayout.rows,
+                    gridTemplateAreas: selectedLayout.areas
+                      .map((row) => `"${row.join(' ')}"`)
+                      .join(' '),
+                  }}
+                >
+                  {payload.panes.map((pane) => {
+                    const command = commandForId(
+                      payload.commands,
+                      pane.commandId
+                    )
+
+                    const selected =
+                      pane.index === payload.activeCommandPaneIndex
+
+                    return (
+                      <button
+                        key={pane.areaName}
+                        type="button"
+                        className={paneButtonClass(selected)}
+                        style={{ gridArea: pane.areaName }}
+                        onClick={(): void =>
+                          dispatchAction(
+                            `${payload.actions.selectPanePrefix}${String(
+                              pane.index
+                            )}`
+                          )
+                        }
+                      >
+                        {overlayCommandGlyph(command)}
+                        <span className="max-w-full truncate text-xs font-semibold text-on-surface-variant">
+                          {command.label}
+                        </span>
+                      </button>
+                    )
+                  })}
+                </div>
+              </div>
+
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                {payload.commands.map((command) => (
+                  <button
+                    key={command.id}
+                    type="button"
+                    className={commandButtonClass(
+                      command.id === activePane.commandId
+                    )}
+                    onClick={(): void =>
+                      dispatchAction(
+                        `${payload.actions.pickCommandPrefix}${String(
+                          activePane.index
+                        )}:${command.id}`
+                      )
+                    }
+                  >
+                    {overlayCommandGlyph(command, 12)}
+                    <span>{command.label}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-end gap-2.5 bg-surface-container-lowest/40 px-5 py-3.5">
+          <button
+            type="button"
+            className="rounded-[9px] border border-outline-variant/35 px-3 py-2 text-[12px] text-on-surface-variant hover:bg-surface-container-high/60"
+            onClick={(): void => dispatchAction(payload.actions.cancel, true)}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="inline-flex items-center gap-1.5 rounded-[9px] bg-primary px-3 py-2 text-[12px] font-semibold text-on-primary hover:bg-primary/90"
+            onClick={(): void => dispatchAction(payload.actions.create, true)}
+          >
+            <span
+              className="material-symbols-outlined text-[15px]"
+              aria-hidden="true"
+            >
+              bolt
+            </span>
+            Create session
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export const NativeOverlayHost = ({
   mode = 'menu',
 }: {
@@ -706,7 +1055,21 @@ export const NativeOverlayHost = ({
 
   if (!isMenuRequest(request)) {
     if (isDialogRequest(request)) {
-      return <NativeOverlayCommandPalette request={request} close={close} />
+      if (request.payload.dialog === 'new-session') {
+        return (
+          <NativeOverlayNewSession
+            request={request as NativeOverlayNewSessionRequest}
+            close={close}
+          />
+        )
+      }
+
+      return (
+        <NativeOverlayCommandPalette
+          request={request as NativeOverlayCommandPaletteRequest}
+          close={close}
+        />
+      )
     }
 
     return null

--- a/src/components/Tooltip.test.tsx
+++ b/src/components/Tooltip.test.tsx
@@ -41,6 +41,7 @@ const installNativeOverlayBridge = (): {
       open,
       close,
       actionResult: vi.fn(() => Promise.resolve()),
+      resume: vi.fn(() => Promise.resolve()),
       onAction: vi.fn(() => vi.fn()),
       onClose: vi.fn(() => vi.fn()),
     },

--- a/src/components/base/floating/nativeOverlay.test.ts
+++ b/src/components/base/floating/nativeOverlay.test.ts
@@ -71,6 +71,7 @@ const installBridge = (
       }),
       close: vi.fn(() => Promise.resolve()),
       actionResult,
+      resume: vi.fn(() => Promise.resolve()),
       onAction: vi.fn((callback: (event: unknown) => void) => {
         actionListener = callback
 

--- a/src/components/base/floating/nativeOverlay.ts
+++ b/src/components/base/floating/nativeOverlay.ts
@@ -123,8 +123,58 @@ export interface NativeOverlayCommandPaletteDialogPayload {
   actions: NativeOverlayCommandPaletteActions
 }
 
+export interface NativeOverlayNewSessionCommandOption {
+  id: string
+  label: string
+  accentVar: string
+  glyph?: string
+  materialIcon?: string
+}
+
+export interface NativeOverlayNewSessionLayoutOption {
+  id: string
+  label: string
+  capacity: number
+  cols: string
+  rows: string
+  areas: readonly (readonly string[])[]
+}
+
+export interface NativeOverlayNewSessionPaneOption {
+  index: number
+  areaName: string
+  commandId: string
+}
+
+export interface NativeOverlayNewSessionActions {
+  focusName: string
+  resetName: string
+  browse: string
+  cancel: string
+  create: string
+  selectPanePrefix: string
+  pickLayoutPrefix: string
+  pickCommandPrefix: string
+}
+
+export interface NativeOverlayNewSessionDialogPayload {
+  kind: 'dialog'
+  dialog: 'new-session'
+  ariaLabel: string
+  name: string
+  path: string
+  nameEdited: boolean
+  selectedLayoutId: string
+  activeCommandPaneIndex: number
+  layouts: NativeOverlayNewSessionLayoutOption[]
+  panes: NativeOverlayNewSessionPaneOption[]
+  commands: NativeOverlayNewSessionCommandOption[]
+  actions: NativeOverlayNewSessionActions
+}
+
 export type NativeOverlayDialogPayload =
-  NativeOverlayCommandPaletteDialogPayload
+  | NativeOverlayCommandPaletteDialogPayload
+  | NativeOverlayNewSessionDialogPayload
 
 // Native overlay payloads are plain data only. Menu and tooltip are supported
 // today; dialog has a narrow command-palette model. Popover and future dialog
@@ -163,6 +213,7 @@ export interface NativeOverlayActionEvent {
   surfaceId: string
   actionId: string
   closeOnSelect?: boolean
+  suspendOnSelect?: boolean
   feedback?: 'copy'
   index?: number
 }
@@ -224,6 +275,7 @@ interface NativeOverlayBridge {
   open: (request: NativeOverlayRequest) => Promise<NativeOverlayOpenResult>
   close: (request: { surfaceId: string; reason: 'renderer' }) => Promise<void>
   actionResult: (request: NativeOverlayActionResultEvent) => Promise<void>
+  resume: (request: { surfaceId: string }) => Promise<void>
   onAction: (callback: (event: unknown) => void) => () => void
   onClose: (callback: (event: unknown) => void) => () => void
 }
@@ -256,6 +308,8 @@ const isActionEvent = (value: unknown): value is NativeOverlayActionEvent =>
   typeof value.actionId === 'string' &&
   (value.closeOnSelect === undefined ||
     typeof value.closeOnSelect === 'boolean') &&
+  (value.suspendOnSelect === undefined ||
+    typeof value.suspendOnSelect === 'boolean') &&
   (value.feedback === undefined || value.feedback === 'copy') &&
   (value.index === undefined || typeof value.index === 'number')
 

--- a/src/features/command-palette/CommandPalette.test.tsx
+++ b/src/features/command-palette/CommandPalette.test.tsx
@@ -61,6 +61,7 @@ const installNativeOverlayBridge = (): {
       open,
       close: vi.fn(() => Promise.resolve()),
       actionResult: vi.fn(() => Promise.resolve()),
+      resume: vi.fn(() => Promise.resolve()),
       onAction: vi.fn((callback: (event: unknown) => void) => {
         actionListener = callback
 

--- a/src/features/sessions/components/NewSessionDialog/NewSessionDialog.test.tsx
+++ b/src/features/sessions/components/NewSessionDialog/NewSessionDialog.test.tsx
@@ -70,11 +70,19 @@ const setNavigatorPlatform = (platform: string): void => {
 
 const installNativeOverlayBridge = (): {
   open: ReturnType<typeof vi.fn>
+  onAction: ReturnType<typeof vi.fn>
   resume: ReturnType<typeof vi.fn>
   emitAction: (event: unknown) => void
 } => {
   let actionListener: ((event: unknown) => void) | null = null
   const open = vi.fn(() => Promise.resolve({ accepted: true }))
+
+  const onAction = vi.fn((callback: (event: unknown) => void) => {
+    actionListener = callback
+
+    return vi.fn()
+  })
+
   const resume = vi.fn(() => Promise.resolve())
 
   window.vimeflow = {
@@ -85,17 +93,17 @@ const installNativeOverlayBridge = (): {
       close: vi.fn(() => Promise.resolve()),
       actionResult: vi.fn(() => Promise.resolve()),
       resume,
-      onAction: vi.fn((callback: (event: unknown) => void) => {
-        actionListener = callback
-
-        return vi.fn()
-      }),
+      onAction,
       onClose: vi.fn(() => vi.fn()),
+    },
+    dialog: {
+      pickDirectory: vi.fn(() => Promise.resolve(null)),
     },
   }
 
   return {
     open,
+    onAction,
     resume,
     emitAction: (event): void => {
       actionListener?.(event)
@@ -253,6 +261,9 @@ describe('NewSessionDialog', () => {
     vi.stubEnv('VITE_NATIVE_OVERLAY', '1')
     setNavigatorPlatform('MacIntel')
     const bridge = installNativeOverlayBridge()
+    window.vimeflow!.dialog!.pickDirectory = vi.fn(() =>
+      Promise.reject(new Error('IPC unavailable'))
+    )
     const { onCreate } = setup({ nativeOverlay: true })
 
     await waitFor(() => {
@@ -331,6 +342,17 @@ describe('NewSessionDialog', () => {
         layout: 'vsplit',
         panes: [{ command: 'claude' }, { command: 'codex' }],
       })
+    })
+  })
+
+  test('disables the local Browse button while native overlay is active', async () => {
+    vi.stubEnv('VITE_NATIVE_OVERLAY', '1')
+    setNavigatorPlatform('MacIntel')
+    installNativeOverlayBridge()
+    setup({ nativeOverlay: true })
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /browse/i })).toBeDisabled()
     })
   })
 })

--- a/src/features/sessions/components/NewSessionDialog/NewSessionDialog.test.tsx
+++ b/src/features/sessions/components/NewSessionDialog/NewSessionDialog.test.tsx
@@ -1,8 +1,13 @@
-import { render, screen, within } from '@testing-library/react'
+import { act, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, test, vi } from 'vitest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
 import { BUILTIN_PANE_LAYOUT_REGISTRY } from '../../../terminal/layout-registry'
 import { NewSessionDialog } from './NewSessionDialog'
+
+interface CapturedNativeOverlayRequest {
+  surfaceId: string
+  payload: Record<string, unknown>
+}
 
 const setup = (
   overrides: Partial<Parameters<typeof NewSessionDialog>[0]> = {}
@@ -40,6 +45,82 @@ const renderWithOpen = (
       layoutRegistry={BUILTIN_PANE_LAYOUT_REGISTRY}
     />
   )
+
+let restorePlatform: (() => void) | null = null
+
+const setNavigatorPlatform = (platform: string): void => {
+  restorePlatform?.()
+  const original = Object.getOwnPropertyDescriptor(window.navigator, 'platform')
+
+  Object.defineProperty(window.navigator, 'platform', {
+    configurable: true,
+    value: platform,
+  })
+
+  restorePlatform = (): void => {
+    if (original === undefined) {
+      delete (window.navigator as unknown as { platform?: string }).platform
+
+      return
+    }
+
+    Object.defineProperty(window.navigator, 'platform', original)
+  }
+}
+
+const installNativeOverlayBridge = (): {
+  open: ReturnType<typeof vi.fn>
+  resume: ReturnType<typeof vi.fn>
+  emitAction: (event: unknown) => void
+} => {
+  let actionListener: ((event: unknown) => void) | null = null
+  const open = vi.fn(() => Promise.resolve({ accepted: true }))
+  const resume = vi.fn(() => Promise.resolve())
+
+  window.vimeflow = {
+    invoke: <T,>(): Promise<T> => Promise.resolve(null as T),
+    listen: vi.fn(() => Promise.resolve(vi.fn())),
+    nativeOverlay: {
+      open,
+      close: vi.fn(() => Promise.resolve()),
+      actionResult: vi.fn(() => Promise.resolve()),
+      resume,
+      onAction: vi.fn((callback: (event: unknown) => void) => {
+        actionListener = callback
+
+        return vi.fn()
+      }),
+      onClose: vi.fn(() => vi.fn()),
+    },
+  }
+
+  return {
+    open,
+    resume,
+    emitAction: (event): void => {
+      actionListener?.(event)
+    },
+  }
+}
+
+const isCapturedNativeOverlayRequest = (
+  value: unknown
+): value is CapturedNativeOverlayRequest =>
+  typeof value === 'object' &&
+  value !== null &&
+  !Array.isArray(value) &&
+  typeof (value as { surfaceId?: unknown }).surfaceId === 'string' &&
+  typeof (value as { payload?: unknown }).payload === 'object' &&
+  (value as { payload?: unknown }).payload !== null &&
+  !Array.isArray((value as { payload?: unknown }).payload)
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.resetModules()
+  restorePlatform?.()
+  restorePlatform = null
+  delete window.vimeflow
+})
 
 describe('NewSessionDialog', () => {
   test('opens as a dialog named "New session"', () => {
@@ -166,5 +247,90 @@ describe('NewSessionDialog', () => {
     )
 
     expect(input).toHaveValue('custom name')
+  })
+
+  test('serializes native overlay state and handles overlay actions', async () => {
+    vi.stubEnv('VITE_NATIVE_OVERLAY', '1')
+    setNavigatorPlatform('MacIntel')
+    const bridge = installNativeOverlayBridge()
+    const { onCreate } = setup({ nativeOverlay: true })
+
+    await waitFor(() => {
+      expect(bridge.open).toHaveBeenCalled()
+    })
+
+    const initialRequest = bridge.open.mock.calls[0]?.[0]
+    if (!isCapturedNativeOverlayRequest(initialRequest)) {
+      throw new Error('expected native overlay request')
+    }
+
+    expect(initialRequest.payload).toMatchObject({
+      kind: 'dialog',
+      dialog: 'new-session',
+      name: 'vimeflow-core',
+      path: '~/code/vimeflow-core',
+      selectedLayoutId: 'single',
+    })
+
+    const surfaceId = initialRequest.surfaceId
+
+    act(() => {
+      bridge.emitAction({
+        surfaceId,
+        actionId: 'new-session:pick-layout:vsplit',
+      })
+    })
+
+    await waitFor(() => {
+      const latestRequest =
+        bridge.open.mock.calls[bridge.open.mock.calls.length - 1]?.[0]
+      expect(latestRequest).toMatchObject({
+        payload: { selectedLayoutId: 'vsplit' },
+      })
+    })
+
+    act(() => {
+      bridge.emitAction({
+        surfaceId,
+        actionId: 'new-session:pick-command:1:codex',
+      })
+    })
+
+    await waitFor(() => {
+      const latestRequest =
+        bridge.open.mock.calls[bridge.open.mock.calls.length - 1]?.[0]
+      expect(latestRequest).toMatchObject({
+        payload: {
+          panes: [{ commandId: 'claude' }, { commandId: 'codex' }],
+        },
+      })
+    })
+
+    act(() => {
+      bridge.emitAction({
+        surfaceId,
+        actionId: 'new-session:browse',
+      })
+    })
+
+    await waitFor(() => {
+      expect(bridge.resume).toHaveBeenCalledWith({ surfaceId })
+    })
+
+    act(() => {
+      bridge.emitAction({
+        surfaceId,
+        actionId: 'new-session:create',
+      })
+    })
+
+    await waitFor(() => {
+      expect(onCreate).toHaveBeenCalledWith({
+        name: 'vimeflow-core',
+        cwd: '~/code/vimeflow-core',
+        layout: 'vsplit',
+        panes: [{ command: 'claude' }, { command: 'codex' }],
+      })
+    })
   })
 })

--- a/src/features/sessions/components/NewSessionDialog/NewSessionDialog.tsx
+++ b/src/features/sessions/components/NewSessionDialog/NewSessionDialog.tsx
@@ -1,20 +1,35 @@
 import {
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
   type ReactElement,
 } from 'react'
 import { Button } from '@/components/Button'
-import { Dialog } from '@/components/Dialog'
+import {
+  Dialog,
+  type NativeOverlayActionEvent,
+  type NativeOverlayActionHandler,
+  type NativeOverlayNewSessionDialogPayload,
+} from '@/components/Dialog'
 import { IconButton } from '@/components/IconButton'
+import type {
+  CommandId,
+  CreateSessionOptions,
+  PaneLayoutId,
+} from '@/features/sessions/types'
+import { deriveSessionName } from '@/features/sessions/utils/sessionPaths'
 import { LayoutSwitcher } from '@/features/terminal/components/LayoutSwitcher'
-import type { PaneLayoutRegistry } from '../../../terminal/layout-registry'
-import type { CommandId, CreateSessionOptions, PaneLayoutId } from '../../types'
-import { deriveSessionName } from '../../utils/sessionPaths'
+import {
+  gridAreaNameForSlotId,
+  type PaneLayoutRegistry,
+} from '@/features/terminal/layout-registry'
 import { CommandBoard } from './CommandBoard'
 import { WorkingDirectoryField } from './WorkingDirectoryField'
+import { COMMANDS, COMMAND_ORDER } from './commands'
 import { getLastLayout, setLastLayout } from './lastLayoutStore'
+import { pickDirectory } from './pickDirectory'
 
 interface NewSessionDialogProps {
   open: boolean
@@ -23,6 +38,7 @@ interface NewSessionDialogProps {
   defaultCwd: string
   /** Builtin + saved custom layouts available for switching. */
   layoutRegistry: PaneLayoutRegistry
+  nativeOverlay?: boolean
 }
 
 const DEFAULT_ASSIGN: CommandId[] = ['claude', 'shell', 'shell', 'shell']
@@ -32,18 +48,32 @@ const LABEL =
 
 const TITLE_ID = 'new-session-dialog-title'
 
+const NATIVE_ACTION_FOCUS_NAME = 'new-session:focus-name'
+const NATIVE_ACTION_RESET_NAME = 'new-session:reset-name'
+const NATIVE_ACTION_BROWSE = 'new-session:browse'
+const NATIVE_ACTION_CANCEL = 'new-session:cancel'
+const NATIVE_ACTION_CREATE = 'new-session:create'
+const NATIVE_ACTION_SELECT_PANE_PREFIX = 'new-session:select-pane:'
+const NATIVE_ACTION_PICK_LAYOUT_PREFIX = 'new-session:pick-layout:'
+const NATIVE_ACTION_PICK_COMMAND_PREFIX = 'new-session:pick-command:'
+
 export const NewSessionDialog = ({
   open,
   onOpenChange,
   onCreate,
   defaultCwd,
   layoutRegistry,
+  nativeOverlay = false,
 }: NewSessionDialogProps): ReactElement => {
   const [path, setPath] = useState(defaultCwd)
   const [name, setName] = useState(() => deriveSessionName(defaultCwd))
   const [nameEdited, setNameEdited] = useState(false)
   const [layoutId, setLayoutId] = useState<PaneLayoutId>('single')
   const [assign, setAssign] = useState<CommandId[]>(DEFAULT_ASSIGN)
+  // Native overlay renders this dialog in a separate BrowserWindow, so it gets
+  // serializable state instead of React children. This index tells that layer
+  // which pane's command picker is active.
+  const [activeCommandPaneIndex, setActiveCommandPaneIndex] = useState(0)
   const [openMenuCount, setOpenMenuCount] = useState(0)
 
   const nameInputRef = useRef<HTMLInputElement>(null)
@@ -85,6 +115,7 @@ export const NewSessionDialog = ({
     setPath(defaultCwdRef.current)
     setName(deriveSessionName(defaultCwdRef.current))
     setNameEdited(false)
+    setActiveCommandPaneIndex(0)
     // Default to the layout the user last created with (if it still exists),
     // so they don't re-pick their preferred layout every time.
     // localStorage holds an arbitrary string; getLayout returns null for an
@@ -100,15 +131,45 @@ export const NewSessionDialog = ({
 
   const layout = layoutRegistry.getFallbackLayout(layoutId)
 
-  const applyPath = (next: string): void => {
-    setPath(next)
+  useEffect(() => {
+    setActiveCommandPaneIndex((current) =>
+      Math.min(current, Math.max(0, layout.capacity - 1))
+    )
+  }, [layout.capacity])
 
-    if (!nameEdited) {
-      setName(deriveSessionName(next))
-    }
-  }
+  const applyPath = useCallback(
+    (next: string): void => {
+      setPath(next)
 
-  const handleCreate = (): void => {
+      if (!nameEdited) {
+        setName(deriveSessionName(next))
+      }
+    },
+    [nameEdited]
+  )
+
+  const handleOpenNativeDirectoryPicker = useCallback(
+    (event?: NativeOverlayActionEvent): void => {
+      void (async (): Promise<void> => {
+        try {
+          const picked = await pickDirectory()
+
+          if (picked !== null) {
+            applyPath(picked)
+          }
+        } finally {
+          if (event !== undefined) {
+            void window.vimeflow?.nativeOverlay?.resume({
+              surfaceId: event.surfaceId,
+            })
+          }
+        }
+      })()
+    },
+    [applyPath]
+  )
+
+  const handleCreate = useCallback((): void => {
     const panes = Array.from({ length: layout.capacity }, (_, i) => ({
       command: assign[i] ?? 'shell',
     }))
@@ -121,7 +182,154 @@ export const NewSessionDialog = ({
     })
     setLastLayout(layoutId)
     onOpenChange(false)
-  }
+  }, [assign, layout.capacity, layoutId, name, onCreate, onOpenChange, path])
+
+  const nativeOverlayPayload = useMemo(
+    (): NativeOverlayNewSessionDialogPayload => ({
+      kind: 'dialog',
+      dialog: 'new-session',
+      ariaLabel: 'New session',
+      name,
+      path,
+      nameEdited,
+      selectedLayoutId: layoutId,
+      activeCommandPaneIndex,
+      layouts: layoutRegistry.layouts.map((entry) => ({
+        id: entry.id,
+        label: entry.name,
+        capacity: entry.capacity,
+        cols: entry.cols,
+        rows: entry.rows,
+        areas: entry.areas.map((row) => [...row]),
+      })),
+      panes: layout.definition.addOrder.map((slotId, index) => ({
+        index,
+        areaName: gridAreaNameForSlotId(slotId),
+        commandId: assign[index] ?? 'shell',
+      })),
+      commands: COMMAND_ORDER.map((commandId) => {
+        const command = COMMANDS[commandId]
+
+        return {
+          id: command.id,
+          label: command.label,
+          accentVar: command.accentVar,
+          ...(command.glyph === undefined ? {} : { glyph: command.glyph }),
+          ...(command.materialIcon === undefined
+            ? {}
+            : { materialIcon: command.materialIcon }),
+        }
+      }),
+      actions: {
+        focusName: NATIVE_ACTION_FOCUS_NAME,
+        resetName: NATIVE_ACTION_RESET_NAME,
+        browse: NATIVE_ACTION_BROWSE,
+        cancel: NATIVE_ACTION_CANCEL,
+        create: NATIVE_ACTION_CREATE,
+        selectPanePrefix: NATIVE_ACTION_SELECT_PANE_PREFIX,
+        pickLayoutPrefix: NATIVE_ACTION_PICK_LAYOUT_PREFIX,
+        pickCommandPrefix: NATIVE_ACTION_PICK_COMMAND_PREFIX,
+      },
+    }),
+    [
+      activeCommandPaneIndex,
+      assign,
+      layout.definition.addOrder,
+      layoutId,
+      layoutRegistry.layouts,
+      name,
+      nameEdited,
+      path,
+    ]
+  )
+
+  const nativeOverlayActions = useMemo((): ReadonlyMap<
+    string,
+    NativeOverlayActionHandler
+  > => {
+    const actions = new Map<string, NativeOverlayActionHandler>([
+      [
+        NATIVE_ACTION_FOCUS_NAME,
+        {
+          retainSession: true,
+          run: (): void => {
+            nameInputRef.current?.focus()
+          },
+        },
+      ],
+      [
+        NATIVE_ACTION_RESET_NAME,
+        {
+          retainSession: true,
+          run: (): void => {
+            setNameEdited(false)
+            setName(deriveSessionName(path))
+            nameInputRef.current?.focus()
+          },
+        },
+      ],
+      [
+        NATIVE_ACTION_BROWSE,
+        {
+          retainSession: true,
+          run: handleOpenNativeDirectoryPicker,
+        },
+      ],
+      [
+        NATIVE_ACTION_CANCEL,
+        (): void => {
+          onOpenChange(false)
+        },
+      ],
+      [NATIVE_ACTION_CREATE, handleCreate],
+    ])
+
+    layoutRegistry.layouts.forEach((entry) => {
+      actions.set(`${NATIVE_ACTION_PICK_LAYOUT_PREFIX}${entry.id}`, {
+        retainSession: true,
+        run: (): void => {
+          setLayoutId(entry.id)
+        },
+      })
+    })
+
+    layout.definition.addOrder.forEach((_slotId, paneIndex) => {
+      actions.set(`${NATIVE_ACTION_SELECT_PANE_PREFIX}${String(paneIndex)}`, {
+        retainSession: true,
+        run: (): void => {
+          setActiveCommandPaneIndex(paneIndex)
+        },
+      })
+
+      COMMAND_ORDER.forEach((commandId) => {
+        actions.set(
+          `${NATIVE_ACTION_PICK_COMMAND_PREFIX}${String(
+            paneIndex
+          )}:${commandId}`,
+          {
+            retainSession: true,
+            run: (): void => {
+              setAssign((prev) => {
+                const next = [...prev]
+                next[paneIndex] = commandId
+
+                return next
+              })
+            },
+          }
+        )
+      })
+    })
+
+    return actions
+  }, [
+    handleOpenNativeDirectoryPicker,
+    handleCreate,
+    layout.definition.addOrder,
+    layoutRegistry.layouts,
+    onOpenChange,
+    path,
+  ])
 
   return (
     <Dialog
@@ -131,6 +339,9 @@ export const NewSessionDialog = ({
       initialFocusRef={nameInputRef}
       dismissDisabled={openMenuCount > 0}
       restoreFocus={!createdRef.current}
+      nativeOverlay={nativeOverlay}
+      nativeOverlayPayload={nativeOverlayPayload}
+      nativeOverlayActions={nativeOverlayActions}
       panelClassName="flex w-[min(560px,100%)] max-w-[560px] flex-col overflow-hidden rounded-2xl border border-outline-variant/30 bg-surface-container-high/95 shadow-2xl backdrop-blur-md backdrop-saturate-150"
     >
       {/* header */}

--- a/src/features/sessions/components/NewSessionDialog/NewSessionDialog.tsx
+++ b/src/features/sessions/components/NewSessionDialog/NewSessionDialog.tsx
@@ -157,6 +157,8 @@ export const NewSessionDialog = ({
           if (picked !== null) {
             applyPath(picked)
           }
+        } catch {
+          return
         } finally {
           if (event !== undefined) {
             void window.vimeflow?.nativeOverlay?.resume({
@@ -410,7 +412,11 @@ export const NewSessionDialog = ({
 
         <label className={`${LABEL} mt-4 block`}>Working directory</label>
         <div className="mt-2">
-          <WorkingDirectoryField path={path} onChange={applyPath} />
+          <WorkingDirectoryField
+            path={path}
+            onChange={applyPath}
+            browseDisabled={nativeOverlay}
+          />
         </div>
 
         <div className="mt-4 flex min-h-[232px] items-start gap-4">

--- a/src/features/sessions/components/NewSessionDialog/WorkingDirectoryField.test.tsx
+++ b/src/features/sessions/components/NewSessionDialog/WorkingDirectoryField.test.tsx
@@ -1,12 +1,16 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, test, vi } from 'vitest'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { pickDirectory } from './pickDirectory'
 import { WorkingDirectoryField } from './WorkingDirectoryField'
 
 vi.mock('./pickDirectory', () => ({ pickDirectory: vi.fn() }))
 
 describe('WorkingDirectoryField', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   test('Browse… picks a directory and reports it', async () => {
     vi.mocked(pickDirectory).mockResolvedValue('/Users/x/picked')
     const onChange = vi.fn()
@@ -31,6 +35,22 @@ describe('WorkingDirectoryField', () => {
     const user = userEvent.setup()
     render(<WorkingDirectoryField path="~/code/vf" onChange={onChange} />)
     await user.click(screen.getByRole('button', { name: /browse/i }))
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  test('disabled Browse does not open the directory picker', async () => {
+    vi.mocked(pickDirectory).mockResolvedValue('/Users/x/picked')
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <WorkingDirectoryField
+        path="~/code/vf"
+        onChange={onChange}
+        browseDisabled
+      />
+    )
+    await user.click(screen.getByRole('button', { name: /browse/i }))
+    expect(pickDirectory).not.toHaveBeenCalled()
     expect(onChange).not.toHaveBeenCalled()
   })
 })

--- a/src/features/sessions/components/NewSessionDialog/WorkingDirectoryField.tsx
+++ b/src/features/sessions/components/NewSessionDialog/WorkingDirectoryField.tsx
@@ -6,11 +6,13 @@ import { pickDirectory } from './pickDirectory'
 interface WorkingDirectoryFieldProps {
   path: string
   onChange: (path: string) => void
+  browseDisabled?: boolean
 }
 
 export const WorkingDirectoryField = ({
   path,
   onChange,
+  browseDisabled = false,
 }: WorkingDirectoryFieldProps): ReactElement => {
   const handleBrowse = async (): Promise<void> => {
     let picked: string | null
@@ -41,6 +43,7 @@ export const WorkingDirectoryField = ({
         variant="default"
         leadingIcon="drive_folder_upload"
         className="h-11"
+        disabled={browseDisabled}
         onClick={() => {
           void handleBrowse()
         }}

--- a/src/features/terminal/components/LayoutSwitcher/LayoutDisplayCustomLayouts.test.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutDisplayCustomLayouts.test.tsx
@@ -81,6 +81,7 @@ const installNativeOverlayBridge = (): {
       open,
       close: vi.fn().mockResolvedValue(undefined),
       actionResult: vi.fn().mockResolvedValue(undefined),
+      resume: vi.fn().mockResolvedValue(undefined),
       onAction: vi.fn((callback: (event: unknown) => void) => {
         actionListener = callback
 

--- a/src/features/terminal/components/TerminalPane/GitRefChip.test.tsx
+++ b/src/features/terminal/components/TerminalPane/GitRefChip.test.tsx
@@ -43,6 +43,7 @@ const installNativeOverlayBridge = (): {
       open,
       close: vi.fn().mockResolvedValue(undefined),
       actionResult: vi.fn().mockResolvedValue(undefined),
+      resume: vi.fn().mockResolvedValue(undefined),
       onAction: vi.fn(() => vi.fn()),
       onClose: vi.fn(() => vi.fn()),
     },

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -3042,6 +3042,7 @@ const WorkspaceViewContent = (): ReactElement => {
             onCreated: () => claimTerminal(),
           })
         }}
+        nativeOverlay
       />
 
       <LayoutCreatorModal

--- a/src/features/workspace/components/NewSessionButton.tsx
+++ b/src/features/workspace/components/NewSessionButton.tsx
@@ -18,28 +18,32 @@ export const NewSessionButton = ({
   shortcutHint,
   ariaKeyshortcuts,
   ref = undefined,
-}: NewSessionButtonProps): ReactElement => (
-  <Tooltip content="New session" shortcut={shortcutHint} placement="bottom">
-    <Button
-      ref={ref}
-      variant="flat-primary"
-      onClick={onClick}
-      aria-label="New session"
-      aria-keyshortcuts={ariaKeyshortcuts}
-      data-testid="sidebar-new-session"
-      className="vf-new-session-button group min-w-[38px] max-w-[150px] flex-1 shrink self-stretch h-auto overflow-hidden rounded-[10px] px-0"
-    >
-      <span className="vf-new-session-button-content flex min-w-0 items-center justify-center">
-        <span
-          className="material-symbols-outlined text-[19px]"
-          aria-hidden="true"
-        >
-          add
+}: NewSessionButtonProps): ReactElement => {
+  const tooltip = shortcutHint ? `New session ${shortcutHint}` : 'New session'
+
+  return (
+    <Tooltip content={tooltip} placement="bottom" nativeOverlay>
+      <Button
+        ref={ref}
+        variant="flat-primary"
+        onClick={onClick}
+        aria-label="New session"
+        aria-keyshortcuts={ariaKeyshortcuts}
+        data-testid="sidebar-new-session"
+        className="vf-new-session-button group min-w-[38px] max-w-[150px] flex-1 shrink self-stretch h-auto overflow-hidden rounded-[10px] px-0"
+      >
+        <span className="vf-new-session-button-content flex min-w-0 items-center justify-center">
+          <span
+            className="material-symbols-outlined text-[19px]"
+            aria-hidden="true"
+          >
+            add
+          </span>
+          <span className="vf-new-session-label overflow-hidden whitespace-nowrap font-body text-[13px] font-semibold">
+            New session
+          </span>
         </span>
-        <span className="vf-new-session-label overflow-hidden whitespace-nowrap font-body text-[13px] font-semibold">
-          New session
-        </span>
-      </span>
-    </Button>
-  </Tooltip>
-)
+      </Button>
+    </Tooltip>
+  )
+}

--- a/src/lib/backend.ts
+++ b/src/lib/backend.ts
@@ -43,6 +43,7 @@ export interface BackendApi {
     open: (request: unknown) => Promise<{ accepted: boolean; reason?: string }>
     close: (request: unknown) => Promise<void>
     actionResult: (request: unknown) => Promise<void>
+    resume: (request: unknown) => Promise<void>
     onAction: (callback: (event: unknown) => void) => UnlistenFn
     onClose: (callback: (event: unknown) => void) => UnlistenFn
   }


### PR DESCRIPTION
## Summary
- render the New Session dialog through the native overlay BrowserWindow for Ghostty
- suspend the overlay around the native directory picker so the AppKit sheet appears above it without losing dialog state
- move the New Session button tooltip onto the native overlay path so it is not clipped by the sidebar edge

## Validation
- Codex review: no actionable findings
- Claude review: one non-blocking maintainability note only
- Ponytail review: Lean already. Ship.
- npm run test -- electron/native-overlay.test.ts src/components/NativeOverlayHost.test.tsx
- npm run test -- src/features/sessions/components/NewSessionDialog/NewSessionDialog.test.tsx
- npm run test -- src/features/workspace/WorkspaceView.notifyInfo.test.tsx
- pre-push full suite: 368 files passed, 4563 tests passed, 3 skipped

Refs VIM-288