### PR TITLE
Sync Ghostty foreground color with theme

### DIFF
--- a/electron/ghostty-native-helper.test.ts
+++ b/electron/ghostty-native-helper.test.ts
@@ -655,6 +655,7 @@ describe('ghostty native helper', () => {
       height: 0,
       visible: false,
       backgroundColor: '#000000',
+      foregroundColor: '#ffffff',
     })
 
     update?.(

--- a/electron/ghostty-native-helper.ts
+++ b/electron/ghostty-native-helper.ts
@@ -63,6 +63,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const HEADER_END = Buffer.from('\r\n\r\n', 'ascii')
 const CONTENT_LENGTH_HEADER = Buffer.from('Content-Length:', 'ascii')
 const GHOSTTY_NATIVE_FALLBACK_BACKGROUND_COLOR = '#000000'
+const GHOSTTY_NATIVE_FALLBACK_FOREGROUND_COLOR = '#ffffff'
 // ponytail: Content-Length guard for a local helper; make this configurable only if real Ghostty events exceed 16 MiB.
 const MAX_FRAME_BYTES = 16 * 1024 * 1024
 
@@ -171,6 +172,9 @@ export class GhosttyNativeHelperController {
         backgroundColor: isHexColor(payload.backgroundColor)
           ? payload.backgroundColor
           : GHOSTTY_NATIVE_FALLBACK_BACKGROUND_COLOR,
+        foregroundColor: isHexColor(payload.foregroundColor)
+          ? payload.foregroundColor
+          : GHOSTTY_NATIVE_FALLBACK_FOREGROUND_COLOR,
         bottomCornerRadius: frame.visible
           ? Math.max(0, Math.round(payload.bottomCornerRadius ?? 0))
           : 0,
@@ -259,6 +263,7 @@ export class GhosttyNativeHelperController {
           height: 0,
           visible: false,
           backgroundColor: GHOSTTY_NATIVE_FALLBACK_BACKGROUND_COLOR,
+          foregroundColor: GHOSTTY_NATIVE_FALLBACK_FOREGROUND_COLOR,
         })
       )
     }
@@ -588,6 +593,8 @@ function isGhosttyNativeUpdateRequest(
     isBounds(value.bounds) &&
     (value.backgroundColor === undefined ||
       isHexColor(value.backgroundColor)) &&
+    (value.foregroundColor === undefined ||
+      isHexColor(value.foregroundColor)) &&
     isOptionalFiniteNumber(value.bottomCornerRadius) &&
     typeof value.parentHeight === 'number' &&
     Number.isFinite(value.parentHeight) &&

--- a/electron/ghostty-native-parent.test.ts
+++ b/electron/ghostty-native-parent.test.ts
@@ -166,6 +166,42 @@ describe('ghostty native parent', () => {
     ).toThrow('invalid ghostty native parent update payload')
   })
 
+  test('rejects invalid native update foreground color', () => {
+    const sidecar = {
+      invoke: vi.fn(() => Promise.resolve(undefined)),
+      onEvent: vi.fn(() => vi.fn()),
+      shutdown: vi.fn(() => Promise.resolve()),
+    } as unknown as Sidecar
+
+    setupGhosttyNativeParent({
+      sidecar,
+      platform: 'darwin',
+      env: { VITE_GHOSTTY_NATIVE_MACOS_PARENT: '1' },
+      addon: {
+        create: vi.fn(),
+        setFrame: vi.fn(),
+        write: vi.fn(),
+        focus: vi.fn(),
+        destroy: vi.fn(),
+      },
+    })
+
+    expect(() =>
+      handlers.get(GHOSTTY_NATIVE_UPDATE)?.(
+        { sender: {} },
+        {
+          sessionId: 'pty-1',
+          paneId: 'pane-1',
+          cwd: '/tmp',
+          foregroundColor: 'not-a-color',
+          visible: true,
+          parentHeight: 900,
+          bounds: { x: 10, y: 20, width: 300, height: 200 },
+        }
+      )
+    ).toThrow('invalid ghostty native parent update payload')
+  })
+
   test('returns disabled instead of throwing when addon artifacts are missing', () => {
     const sidecar = {
       invoke: vi.fn(() => Promise.resolve(undefined)),
@@ -319,13 +355,14 @@ describe('ghostty native parent', () => {
     controller.dispose()
   })
 
-  test('forwards native background color updates to AppKit', () => {
+  test('forwards native theme color updates to AppKit', () => {
     const surface = {}
 
     const addon = {
       create: vi.fn(() => surface),
       setFrame: vi.fn(),
       setBackgroundColor: vi.fn(),
+      setForegroundColor: vi.fn(),
       write: vi.fn(),
       focus: vi.fn(),
       destroy: vi.fn(),
@@ -351,6 +388,7 @@ describe('ghostty native parent', () => {
         paneId: 'pane-1',
         cwd: '/tmp',
         backgroundColor: '#fffcf0',
+        foregroundColor: '#100f0f',
         visible: true,
         parentHeight: 900,
         bounds: { x: 10, y: 20, width: 300, height: 200 },
@@ -358,6 +396,7 @@ describe('ghostty native parent', () => {
     )
 
     expect(addon.setBackgroundColor).toHaveBeenCalledWith(surface, '#fffcf0')
+    expect(addon.setForegroundColor).toHaveBeenCalledWith(surface, '#100f0f')
 
     handlers.get(GHOSTTY_NATIVE_UPDATE)?.(
       { sender: {} },
@@ -366,6 +405,7 @@ describe('ghostty native parent', () => {
         paneId: 'pane-1',
         cwd: '/tmp',
         backgroundColor: '#fffcf0',
+        foregroundColor: '#100f0f',
         visible: true,
         parentHeight: 900,
         bounds: { x: 10, y: 20, width: 300, height: 200 },
@@ -373,6 +413,7 @@ describe('ghostty native parent', () => {
     )
 
     expect(addon.setBackgroundColor).toHaveBeenCalledTimes(1)
+    expect(addon.setForegroundColor).toHaveBeenCalledTimes(1)
 
     controller.dispose()
   })

--- a/electron/ghostty-native-parent.ts
+++ b/electron/ghostty-native-parent.ts
@@ -74,6 +74,7 @@ interface GhosttyNativeParentAddon {
   ) => void
   setShortcutDigits?: (surface: unknown, digits: string) => void
   setBackgroundColor?: (surface: unknown, color: string) => void
+  setForegroundColor?: (surface: unknown, color: string) => void
   write: (surface: unknown, data: string) => void
   focus: (surface: unknown) => void
   destroy: (surface: unknown) => void
@@ -106,6 +107,7 @@ interface GhosttyNativeSurfaceState {
   // Resize updates pass through this same path. Cache values that reapply
   // Ghostty theme/shortcut state so steady resize only calls setFrame.
   lastBackgroundColor: string | null
+  lastForegroundColor: string | null
   lastResize: { cols: number; rows: number } | null
   lastShortcutDigits: string | null
 }
@@ -227,6 +229,8 @@ function isNativePayload<TKind extends keyof GhosttyNativePayloadByKind>(
         isBounds(value.bounds) &&
         (value.backgroundColor === undefined ||
           isHexColor(value.backgroundColor)) &&
+        (value.foregroundColor === undefined ||
+          isHexColor(value.foregroundColor)) &&
         isOptionalFiniteNumber(value.bottomCornerRadius) &&
         typeof value.parentHeight === 'number' &&
         Number.isFinite(value.parentHeight) &&
@@ -408,6 +412,13 @@ export class GhosttyNativeParentController {
     ) {
       state.lastBackgroundColor = payload.backgroundColor
       addon.setBackgroundColor?.(surface, payload.backgroundColor)
+    }
+    if (
+      isHexColor(payload.foregroundColor) &&
+      state.lastForegroundColor !== payload.foregroundColor
+    ) {
+      state.lastForegroundColor = payload.foregroundColor
+      addon.setForegroundColor?.(surface, payload.foregroundColor)
     }
     addon.setFrame(
       surface,
@@ -739,6 +750,7 @@ export class GhosttyNativeParentController {
       pendingData: [],
       secondary: null,
       lastBackgroundColor: null,
+      lastForegroundColor: null,
       lastResize: null,
       lastShortcutDigits: null,
     }

--- a/electron/ghostty-native-shared.ts
+++ b/electron/ghostty-native-shared.ts
@@ -20,6 +20,7 @@ export interface GhosttyNativeUpdateRequest extends GhosttyNativePaneRequest {
   cwd: string
   bounds: GhosttyNativeBounds
   backgroundColor?: string
+  foregroundColor?: string
   bottomCornerRadius?: number
   parentHeight: number
   visible: boolean

--- a/native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift
+++ b/native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift
@@ -231,6 +231,8 @@ private final class EmbeddedGhosttyChild {
     let controller: TerminalController
     let session: InMemoryTerminalSession
     let terminalView: TerminalView
+    private var backgroundHexColor = "000000"
+    private var foregroundHexColor = "ffffff"
 
     init(callbacks: CallbackBox) {
         self.callbacks = callbacks
@@ -262,9 +264,27 @@ private final class EmbeddedGhosttyChild {
             return
         }
 
+        backgroundHexColor = ghosttyHex
+        applyTheme()
+    }
+
+    func setForegroundColor(_ hexColor: String) {
+        guard let ghosttyHex = NSColor.vimeflowGhosttyHexColor(hexColor) else {
+            return
+        }
+
+        foregroundHexColor = ghosttyHex
+        applyTheme()
+    }
+
+    private func applyTheme() {
         controller.setTheme(TerminalTheme(
-            light: TerminalConfiguration().background(ghosttyHex),
-            dark: TerminalConfiguration().background(ghosttyHex)
+            light: TerminalConfiguration()
+                .background(backgroundHexColor)
+                .foreground(foregroundHexColor),
+            dark: TerminalConfiguration()
+                .background(backgroundHexColor)
+                .foreground(foregroundHexColor)
         ))
     }
 
@@ -295,6 +315,7 @@ private final class EmbeddedGhosttySurface: NSObject {
     private var shortcutMonitor: Any?
     private var shortcutDigits = Set<Character>()
     private var backgroundHexColor = "000000"
+    private var foregroundHexColor = "ffffff"
     private var secondaryChild: EmbeddedGhosttyChild?
     private var dividerView: EmbeddedGhosttyDividerView?
     private var secondarySplitRatio: CGFloat = 0.34
@@ -425,11 +446,29 @@ private final class EmbeddedGhosttySurface: NSObject {
         container.layer?.backgroundColor = color.cgColor
         backgroundHexColor = ghosttyHex
         dividerView?.isDarkBackground = NSColor.vimeflowIsDarkHexColor(ghosttyHex)
-        controller.setTheme(TerminalTheme(
-            light: TerminalConfiguration().background(ghosttyHex),
-            dark: TerminalConfiguration().background(ghosttyHex)
-        ))
+        applyTheme()
         secondaryChild?.setBackgroundColor(ghosttyHex)
+    }
+
+    func setForegroundColor(_ hexColor: String) {
+        guard let ghosttyHex = NSColor.vimeflowGhosttyHexColor(hexColor) else {
+            return
+        }
+
+        foregroundHexColor = ghosttyHex
+        applyTheme()
+        secondaryChild?.setForegroundColor(ghosttyHex)
+    }
+
+    private func applyTheme() {
+        controller.setTheme(TerminalTheme(
+            light: TerminalConfiguration()
+                .background(backgroundHexColor)
+                .foreground(foregroundHexColor),
+            dark: TerminalConfiguration()
+                .background(backgroundHexColor)
+                .foreground(foregroundHexColor)
+        ))
     }
 
     func receive(_ text: String) {
@@ -460,6 +499,7 @@ private final class EmbeddedGhosttySurface: NSObject {
         )
         let child = EmbeddedGhosttyChild(callbacks: callbacks)
         child.setBackgroundColor(backgroundHexColor)
+        child.setForegroundColor(foregroundHexColor)
         container.addSubview(child.terminalView)
         secondaryChild = child
         ensureDivider()
@@ -918,6 +958,25 @@ public func vimeflowGhosttySetBackgroundColor(
             .fromOpaque(pointer.value!)
             .takeUnretainedValue()
         surface.setBackgroundColor(color)
+    }
+}
+
+@_cdecl("vimeflow_ghostty_set_foreground_color")
+public func vimeflowGhosttySetForegroundColor(
+    _ surfacePointer: UnsafeMutableRawPointer?,
+    _ colorPointer: UnsafePointer<CChar>?
+) {
+    guard let surfacePointer, let colorPointer else {
+        return
+    }
+
+    let pointer = SendablePointer(value: surfacePointer)
+    let color = String(cString: colorPointer)
+    mainActorSync {
+        let surface = Unmanaged<EmbeddedGhosttySurface>
+            .fromOpaque(pointer.value!)
+            .takeUnretainedValue()
+        surface.setForegroundColor(color)
     }
 }
 

--- a/native/ghostty-helper/Sources/GhosttyNativeMacosSmoke/ElectronHostClient.swift
+++ b/native/ghostty-helper/Sources/GhosttyNativeMacosSmoke/ElectronHostClient.swift
@@ -7,6 +7,7 @@ struct GhosttyNativeFrame: Sendable {
     let height: Double
     let visible: Bool
     let backgroundColor: String
+    let foregroundColor: String
     let bottomCornerRadius: Double
 }
 
@@ -173,7 +174,8 @@ final class ElectronHostClient: @unchecked Sendable {
                 let width = frame["width"] as? Double,
                 let height = frame["height"] as? Double,
                 let visible = frame["visible"] as? Bool,
-                let backgroundColor = frame["backgroundColor"] as? String
+                let backgroundColor = frame["backgroundColor"] as? String,
+                let foregroundColor = frame["foregroundColor"] as? String
             else {
                 return nil
             }
@@ -187,6 +189,7 @@ final class ElectronHostClient: @unchecked Sendable {
                     height: height,
                     visible: visible,
                     backgroundColor: backgroundColor,
+                    foregroundColor: foregroundColor,
                     bottomCornerRadius: bottomCornerRadius
                 )
             )

--- a/native/ghostty-helper/Sources/GhosttyNativeMacosSmoke/GhosttyNativeMacosSmoke.swift
+++ b/native/ghostty-helper/Sources/GhosttyNativeMacosSmoke/GhosttyNativeMacosSmoke.swift
@@ -89,6 +89,8 @@ final class GhosttyNativeMacosSmoke:
     private var lastForwardedGrid: GhosttyGridSize?
     private var secondaryLastForwardedGrid: GhosttyGridSize?
     private var secondarySplitRatio: CGFloat = 0.34
+    private var backgroundHexColor = "000000"
+    private var foregroundHexColor = "ffffff"
     private var shortcutMonitor: Any?
     private let helperMode = CommandLine.arguments.contains("--electron-helper")
 
@@ -410,6 +412,7 @@ final class GhosttyNativeMacosSmoke:
         guard let window else { return }
 
         setBackgroundColor(frame.backgroundColor)
+        setForegroundColor(frame.foregroundColor)
         let safeBottomCornerRadius = max(0, frame.bottomCornerRadius)
         containerView?.layer?.cornerRadius = CGFloat(safeBottomCornerRadius)
         containerView?.layer?.maskedCorners = [
@@ -437,13 +440,35 @@ final class GhosttyNativeMacosSmoke:
         }
 
         containerView?.layer?.backgroundColor = color.cgColor
+        backgroundHexColor = ghosttyHex
+        applyTheme()
+    }
+
+    private func setForegroundColor(_ hexColor: String) {
+        guard let ghosttyHex = NSColor.vimeflowGhosttyHexColor(hexColor) else {
+            return
+        }
+
+        foregroundHexColor = ghosttyHex
+        applyTheme()
+    }
+
+    private func applyTheme() {
         controller.setTheme(TerminalTheme(
-            light: TerminalConfiguration().background(ghosttyHex),
-            dark: TerminalConfiguration().background(ghosttyHex)
+            light: TerminalConfiguration()
+                .background(backgroundHexColor)
+                .foreground(foregroundHexColor),
+            dark: TerminalConfiguration()
+                .background(backgroundHexColor)
+                .foreground(foregroundHexColor)
         ))
         secondaryController.setTheme(TerminalTheme(
-            light: TerminalConfiguration().background(ghosttyHex),
-            dark: TerminalConfiguration().background(ghosttyHex)
+            light: TerminalConfiguration()
+                .background(backgroundHexColor)
+                .foreground(foregroundHexColor),
+            dark: TerminalConfiguration()
+                .background(backgroundHexColor)
+                .foreground(foregroundHexColor)
         ))
     }
 

--- a/native/ghostty-parent/ghostty_native_parent.cc
+++ b/native/ghostty-parent/ghostty_native_parent.cc
@@ -26,6 +26,7 @@ using SetFrameFn = void (*)(
     void *, double, double, double, double, double, double);
 using SetShortcutDigitsFn = void (*)(void *, const char *);
 using SetBackgroundColorFn = void (*)(void *, const char *);
+using SetForegroundColorFn = void (*)(void *, const char *);
 using WriteFn = void (*)(void *, const unsigned char *, int);
 using FocusFn = void (*)(void *);
 using AddSecondaryFn = void (*)(void *, InputCallback, ResizeCallback,
@@ -43,6 +44,7 @@ struct BridgeApi {
   SetFrameFn set_frame = nullptr;
   SetShortcutDigitsFn set_shortcut_digits = nullptr;
   SetBackgroundColorFn set_background_color = nullptr;
+  SetForegroundColorFn set_foreground_color = nullptr;
   WriteFn write = nullptr;
   FocusFn focus = nullptr;
   AddSecondaryFn add_secondary = nullptr;
@@ -136,6 +138,8 @@ bool EnsureBridge(napi_env env, const std::string &path) {
                  reinterpret_cast<void **>(&bridge.set_shortcut_digits)) &&
       LoadSymbol(env, "vimeflow_ghostty_set_background_color",
                  reinterpret_cast<void **>(&bridge.set_background_color)) &&
+      LoadSymbol(env, "vimeflow_ghostty_set_foreground_color",
+                 reinterpret_cast<void **>(&bridge.set_foreground_color)) &&
       LoadSymbol(env, "vimeflow_ghostty_write",
                  reinterpret_cast<void **>(&bridge.write)) &&
       LoadSymbol(env, "vimeflow_ghostty_focus",
@@ -706,6 +710,25 @@ napi_value SetBackgroundColor(napi_env env, napi_callback_info info) {
   return nullptr;
 }
 
+napi_value SetForegroundColor(napi_env env, napi_callback_info info) {
+  size_t argc = 2;
+  napi_value args[2];
+  napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+  if (argc < 2) {
+    return Throw(env, "setForegroundColor(surface, color) expected");
+  }
+
+  SurfaceHandle *surface = GetSurface(env, args[0]);
+  if (surface == nullptr || surface->swift_surface == nullptr) {
+    return nullptr;
+  }
+
+  const std::string color = GetString(env, args[1]);
+  bridge.set_foreground_color(surface->swift_surface, color.c_str());
+
+  return nullptr;
+}
+
 napi_value Write(napi_env env, napi_callback_info info) {
   size_t argc = 2;
   napi_value args[2];
@@ -886,6 +909,8 @@ napi_value Init(napi_env env, napi_value exports) {
       {"setShortcutDigits", nullptr, SetShortcutDigits, nullptr, nullptr,
        nullptr, napi_default, nullptr},
       {"setBackgroundColor", nullptr, SetBackgroundColor, nullptr, nullptr,
+       nullptr, napi_default, nullptr},
+      {"setForegroundColor", nullptr, SetForegroundColor, nullptr, nullptr,
        nullptr, napi_default, nullptr},
       {"write", nullptr, Write, nullptr, nullptr, nullptr, napi_default,
        nullptr},

--- a/src/features/terminal/components/TerminalPane/GhosttyBody.test.tsx
+++ b/src/features/terminal/components/TerminalPane/GhosttyBody.test.tsx
@@ -168,7 +168,7 @@ describe('GhosttyBody', () => {
     expect(destroyNativeGhostty).toHaveBeenCalledWith(paneRef)
   })
 
-  test('sends displayed theme background to native frame updates', async () => {
+  test('sends displayed theme colors to native frame updates', async () => {
     render(
       <GhosttyBody
         paneId="pane-1"
@@ -183,6 +183,7 @@ describe('GhosttyBody', () => {
       expect(updateNativeGhostty).toHaveBeenCalledWith(
         expect.objectContaining({
           backgroundColor: obsidianLens.terminal.background,
+          foregroundColor: obsidianLens.terminal.foreground,
         })
       )
     })
@@ -196,6 +197,7 @@ describe('GhosttyBody', () => {
       expect(updateNativeGhostty).toHaveBeenCalledWith(
         expect.objectContaining({
           backgroundColor: flexoki.terminal.background,
+          foregroundColor: flexoki.terminal.foreground,
         })
       )
     })

--- a/src/features/terminal/components/TerminalPane/GhosttyBody.tsx
+++ b/src/features/terminal/components/TerminalPane/GhosttyBody.tsx
@@ -117,6 +117,7 @@ export const nativeGhosttyCornerRadiusFromCssPixels = (
 // so tiny DOM float churn does not become repeated native resize IPC.
 const nativeGhosttyFrameKey = ({
   backgroundColor,
+  foregroundColor,
   bottomCornerRadius,
   bounds,
   parentHeight,
@@ -124,6 +125,7 @@ const nativeGhosttyFrameKey = ({
   visible,
 }: {
   backgroundColor: string
+  foregroundColor: string
   bottomCornerRadius: number
   bounds: NativeGhosttyBounds
   parentHeight: number
@@ -143,6 +145,7 @@ const nativeGhosttyFrameKey = ({
     frameVisible ? Math.max(0, Math.round(bottomCornerRadius)) : 0,
     frameVisible ? '1' : '0',
     backgroundColor,
+    foregroundColor,
     shortcutContext?.activePaneId ?? '',
     ...(shortcutContext?.paneIds ?? []),
   ].join(':')
@@ -174,6 +177,7 @@ export const GhosttyBody = ({
 }: GhosttyBodyProps): ReactElement => {
   const theme = useTheme()
   const backgroundColor = theme.terminal.background
+  const foregroundColor = theme.terminal.foreground
   const containerRef = useRef<HTMLDivElement | null>(null)
   const frameIdRef = useRef<number | null>(null)
   const inFlightNativeFrameRef = useRef<Promise<void> | null>(null)
@@ -467,6 +471,7 @@ export const GhosttyBody = ({
     const snapshot = {
       key: nativeGhosttyFrameKey({
         backgroundColor,
+        foregroundColor,
         bottomCornerRadius: nativeBottomCornerRadius,
         bounds,
         parentHeight,
@@ -478,6 +483,7 @@ export const GhosttyBody = ({
         cwd,
         bounds,
         backgroundColor,
+        foregroundColor,
         bottomCornerRadius: nativeBottomCornerRadius,
         parentHeight,
         visible,
@@ -495,6 +501,7 @@ export const GhosttyBody = ({
     flushQueuedNativeFrame()
   }, [
     backgroundColor,
+    foregroundColor,
     bottomCornerRadius,
     cwd,
     flushQueuedNativeFrame,

--- a/src/features/terminal/nativeGhosttyClient.ts
+++ b/src/features/terminal/nativeGhosttyClient.ts
@@ -22,6 +22,7 @@ export interface NativeGhosttyUpdateRequest extends NativeGhosttyPaneRef {
   cwd: string
   bounds: NativeGhosttyBounds
   backgroundColor: string
+  foregroundColor: string
   bottomCornerRadius?: number
   parentHeight: number
   visible: boolean


### PR DESCRIPTION
## Summary
- send the active terminal foreground color with Ghostty native frame updates
- apply Ghostty background and foreground together in the Swift bridge so light themes stay readable
- keep the legacy helper frame path compatible with the same color payload

## Root Cause
Ghostty native frames only received the themed background color. Switching to a light theme could update the canvas while leaving terminal text on the previous/default white foreground.

## Validation
- npm run test -- src/features/terminal/components/TerminalPane/GhosttyBody.test.tsx electron/ghostty-native-parent.test.ts electron/ghostty-native-helper.test.ts
- npm run type-check -- --pretty false
- npm run lint
- npm run format:check
- npm run ghostty:native-parent:build
- git diff --check
- pre-push full suite: 368 files passed, 4566 tests passed, 3 skipped

Refs VIM-289