### PR TITLE
feat(agent): emit agent-reply from Claude Code assistant turns (VIM-292)

### DIFF
--- a/crates/backend/src/agent/adapter/claude_code/transcript.rs
+++ b/crates/backend/src/agent/adapter/claude_code/transcript.rs
@@ -409,7 +409,7 @@ fn process_line(
     match dto.line_type.as_deref().unwrap_or("") {
         "assistant" => {
             process_assistant_message(&dto, session_id, cwd, events, in_flight, replay_done);
-            emit_reply_if_present(&dto, session_id, events);
+            emit_reply_if_present(&dto, session_id, events, replay_done);
         }
         "user" => {
             process_user_message(
@@ -522,7 +522,12 @@ fn emit_reply_if_present(
     dto: &ClaudeTranscriptLineDto,
     session_id: &str,
     events: &Arc<dyn EventSink>,
+    replay_done: bool,
 ) {
+    if !replay_done {
+        return;
+    }
+
     let ended = matches!(
         dto.message.as_ref().and_then(|m| m.stop_reason.as_deref()),
         Some("end_turn" | "stop_sequence" | "max_tokens")
@@ -1793,7 +1798,7 @@ mod tests {
         assert!(in_flight.is_empty(), "matched tool_use should be removed");
     }
 
-    fn drive_assistant_line(concrete: &Arc<FakeEventSink>, line: &str) {
+    fn drive_assistant_line(concrete: &Arc<FakeEventSink>, line: &str, replay_done: bool) {
         let events: Arc<dyn EventSink> = concrete.clone();
         let mut emitter = TestRunEmitter::new(events.clone());
         let mut in_flight: InFlightToolCalls = HashMap::new();
@@ -1814,7 +1819,7 @@ mod tests {
             &mut last_title_memo,
             &mut None,
             &mut None,
-            true,
+            replay_done,
         );
     }
 
@@ -1822,7 +1827,7 @@ mod tests {
     fn assistant_end_turn_with_reply_block_emits_agent_reply() {
         let concrete = Arc::new(FakeEventSink::new());
         let line = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"done\n<<<VIMEFLOW_REPLY\n{\"v\":1,\"nonce\":\"abc\",\"replies\":[{\"id\":1,\"status\":\"answered\",\"text\":\"because latency\"}]}\nVIMEFLOW_REPLY>>>"}],"stop_reason":"end_turn"}}"#;
-        drive_assistant_line(&concrete, line);
+        drive_assistant_line(&concrete, line, true);
 
         let replies: Vec<_> = concrete
             .recorded()
@@ -1839,7 +1844,19 @@ mod tests {
     fn assistant_end_turn_without_sentinel_emits_no_reply() {
         let concrete = Arc::new(FakeEventSink::new());
         let line = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"just done"}],"stop_reason":"end_turn"}}"#;
-        drive_assistant_line(&concrete, line);
+        drive_assistant_line(&concrete, line, true);
+
+        assert!(concrete
+            .recorded()
+            .iter()
+            .all(|(name, _)| name != "agent-reply"));
+    }
+
+    #[test]
+    fn assistant_replay_with_reply_block_emits_no_reply() {
+        let concrete = Arc::new(FakeEventSink::new());
+        let line = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"done\n<<<VIMEFLOW_REPLY\n{\"v\":1,\"nonce\":\"stale\",\"replies\":[{\"id\":1,\"status\":\"answered\",\"text\":\"old answer\"}]}\nVIMEFLOW_REPLY>>>"}],"stop_reason":"end_turn"}}"#;
+        drive_assistant_line(&concrete, line, false);
 
         assert!(concrete
             .recorded()

--- a/crates/backend/src/agent/adapter/claude_code/transcript.rs
+++ b/crates/backend/src/agent/adapter/claude_code/transcript.rs
@@ -20,13 +20,14 @@ use super::transcript_dto::{ClaudeToolResultDto, ClaudeToolUseDto, ClaudeTranscr
 use crate::agent::adapter::base::{TranscriptDecoder, TranscriptHandle, TranscriptTailService};
 use crate::agent::adapter::types::ValidateTranscriptError;
 use crate::agent::events::{
-    emit_agent_cwd, emit_agent_session_title, emit_agent_tool_call, emit_agent_turn,
-    emit_lifecycle_on_change, record_lifecycle,
+    emit_agent_cwd, emit_agent_reply, emit_agent_session_title, emit_agent_tool_call,
+    emit_agent_turn, emit_lifecycle_on_change, record_lifecycle,
 };
+use crate::agent::reply::{extract_agent_reply, AgentReplyOutcome};
 use crate::agent::sanitize_title;
 use crate::agent::types::{
-    AgentCwdEvent, AgentPhase, AgentSessionTitleEvent, AgentToolCallEvent, AgentTurnEvent,
-    TitleSource, ToolCallStatus,
+    AgentCwdEvent, AgentPhase, AgentReplyEvent, AgentSessionTitleEvent, AgentToolCallEvent,
+    AgentTurnEvent, TitleSource, ToolCallStatus,
 };
 use crate::runtime::EventSink;
 
@@ -408,6 +409,7 @@ fn process_line(
     match dto.line_type.as_deref().unwrap_or("") {
         "assistant" => {
             process_assistant_message(&dto, session_id, cwd, events, in_flight, replay_done);
+            emit_reply_if_present(&dto, session_id, events);
         }
         "user" => {
             process_user_message(
@@ -511,6 +513,59 @@ fn emit_title(
 /// feed look as if everything happened at once.
 fn extract_timestamp(timestamp: Option<&str>) -> String {
     timestamp.map(str::to_string).unwrap_or_else(now_iso8601)
+}
+
+/// If a COMPLETED assistant turn's reply carries the VIM-283 sentinel block,
+/// extract it and emit `agent-reply`. Fires once per finished turn (gated on the
+/// terminal `stop_reason`), mirroring the Codex `emit_reply_if_present`.
+fn emit_reply_if_present(
+    dto: &ClaudeTranscriptLineDto,
+    session_id: &str,
+    events: &Arc<dyn EventSink>,
+) {
+    let ended = matches!(
+        dto.message.as_ref().and_then(|m| m.stop_reason.as_deref()),
+        Some("end_turn" | "stop_sequence" | "max_tokens")
+    );
+    if !ended {
+        return;
+    }
+
+    let Some(blocks) = message_content_items(dto) else {
+        return;
+    };
+
+    // The completed reply prose is the assistant's `text` content blocks.
+    let reply_text = blocks
+        .iter()
+        .filter(|block| text_block_type(block) == Some("text"))
+        .filter_map(text_block_text)
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let Some(outcome) = extract_agent_reply(&reply_text) else {
+        return;
+    };
+
+    let (raw_text, nonce, replies) = match outcome {
+        AgentReplyOutcome::Structured {
+            raw,
+            nonce,
+            replies,
+        } => (raw, Some(nonce), Some(replies)),
+        AgentReplyOutcome::Malformed { raw, nonce } => (raw, nonce, None),
+    };
+
+    let event = AgentReplyEvent {
+        session_id: session_id.to_string(),
+        nonce,
+        raw_text,
+        replies,
+    };
+
+    if let Err(e) = emit_agent_reply(events.as_ref(), &event) {
+        log::warn!("Failed to emit agent-reply event: {}", e);
+    }
 }
 
 /// Extract tool_use entries from an assistant message.
@@ -1736,6 +1791,60 @@ mod tests {
 
         assert_eq!(concrete.count("agent-tool-call"), 1);
         assert!(in_flight.is_empty(), "matched tool_use should be removed");
+    }
+
+    fn drive_assistant_line(concrete: &Arc<FakeEventSink>, line: &str) {
+        let events: Arc<dyn EventSink> = concrete.clone();
+        let mut emitter = TestRunEmitter::new(events.clone());
+        let mut in_flight: InFlightToolCalls = HashMap::new();
+        let mut num_turns = 0;
+        let mut last_cwd = None;
+        let mut last_title_memo: Option<String> = None;
+
+        process_line(
+            line,
+            "sess-1",
+            None,
+            &events,
+            &mut emitter,
+            &mut in_flight,
+            &mut num_turns,
+            &mut last_cwd,
+            "claude-agent-sid",
+            &mut last_title_memo,
+            &mut None,
+            &mut None,
+            true,
+        );
+    }
+
+    #[test]
+    fn assistant_end_turn_with_reply_block_emits_agent_reply() {
+        let concrete = Arc::new(FakeEventSink::new());
+        let line = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"done\n<<<VIMEFLOW_REPLY\n{\"v\":1,\"nonce\":\"abc\",\"replies\":[{\"id\":1,\"status\":\"answered\",\"text\":\"because latency\"}]}\nVIMEFLOW_REPLY>>>"}],"stop_reason":"end_turn"}}"#;
+        drive_assistant_line(&concrete, line);
+
+        let replies: Vec<_> = concrete
+            .recorded()
+            .into_iter()
+            .filter(|(name, _)| name == "agent-reply")
+            .collect();
+        assert_eq!(replies.len(), 1);
+        assert_eq!(replies[0].1["sessionId"], "sess-1");
+        assert_eq!(replies[0].1["nonce"], "abc");
+        assert_eq!(replies[0].1["replies"][0]["id"], 1);
+    }
+
+    #[test]
+    fn assistant_end_turn_without_sentinel_emits_no_reply() {
+        let concrete = Arc::new(FakeEventSink::new());
+        let line = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"just done"}],"stop_reason":"end_turn"}}"#;
+        drive_assistant_line(&concrete, line);
+
+        assert!(concrete
+            .recorded()
+            .iter()
+            .all(|(name, _)| name != "agent-reply"));
     }
 
     /// Regression: `summarize_input` must preserve the absent vs present-null


### PR DESCRIPTION
Extends the `agent-reply` capture (VIM-283 / #659) to the **Claude Code** adapter, so the inline agent Q&A thread (VIM-249 / #662) works with Claude Code sessions, not just Codex.

## What

When a Claude Code assistant turn completes (`stop_reason` ∈ `end_turn` / `stop_sequence` / `max_tokens`), its `text` content blocks are concatenated and run through the shared, adapter-agnostic `crate::agent::reply::extract_agent_reply`. If they carry the VIM-249 sentinel block, it emits the typed `agent-reply` event — mirroring the Codex `emit_reply_if_present` helper exactly.

- New `emit_reply_if_present(dto, session_id, events)` in `claude_code/transcript.rs`, called in the `"assistant"` arm of `process_line` after `process_assistant_message`.
- Reuses the existing `message_content_items` + `text_block_text` helpers — **no new DTO field** (Claude carries the full reply in the assistant message `content[]`).
- No contract change, no frontend change — the reply shape and the diff thread are shared.

## Scope note (why not all three at once)

VIM-292 originally bundled Kimi + OpenCode. On inspection they're a **different shape**: both stream the reply as text-part deltas (`content.part` / `message.part.updated`), not a single completed-reply field, so each needs a stateful buffer-and-flush on its decoder — and OpenCode's exact text-part shape isn't even in its sample fixture. Split into **VIM-293** so this clean, verified Claude Code wiring ships now without waiting on the larger streaming work.

## Tests

- `assistant_end_turn_with_reply_block_emits_agent_reply` — a completed assistant turn with a sentinel block emits `agent-reply` (asserts `sessionId` / `nonce` / typed reply).
- `assistant_end_turn_without_sentinel_emits_no_reply` — a normal turn emits nothing.
- Full Claude Code adapter module: **183 passing**.

> `cargo fmt --check` flags the file, but that's the repo-wide local rustfmt 1.9.0 version skew (it flags lines this PR never touched, and 80 diffs on a clean `main`) — CI's pinned rustfmt is authoritative.

Closes VIM-292
Part of VIM-284

🤖 Generated with [Claude Code](https://claude.com/claude-code)