### PR TITLE
[codex] Fix Ghostty native app shortcut forwarding

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -81,7 +81,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 33       | 16   | 2026-07-05   |
 | [Module Boundaries](patterns/module-boundaries.md)                                                   | code-quality       | 17       | 3    | 2026-06-25   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 13       | 3    | 2026-06-15   |
-| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 31       | 6    | 2026-07-05   |
+| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 32       | 7    | 2026-07-05   |
 | [Verify Render Target](patterns/verify-render-target.md)                                             | code-quality       | 3        | 1    | 2026-07-01   |
 | [UI Visual Regression](patterns/ui-visual-regression.md)                                             | code-quality       | 27       | 15   | 2026-07-05   |
 | [Status Indicator Display](patterns/status-indicator-display.md)                                     | code-quality       | 3        | 0    | 2026-05-26   |
@@ -101,7 +101,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [React Prop Contracts](patterns/react-prop-contracts.md)                                             | react-patterns     | 8        | 6    | 2026-06-22   |
 | [Stale Retained Interactions](patterns/stale-retained-interactions.md)                               | react-patterns     | 10       | 9    | 2026-07-04   |
 | [Retained State Identity](patterns/retained-state-identity.md)                                       | react-patterns     | 4        | 4    | 2026-07-05   |
-| [Authoritative Completion Guard](patterns/authoritative-completion-guard.md)                         | correctness        | 7        | 3    | 2026-07-05   |
+| [Authoritative Completion Guard](patterns/authoritative-completion-guard.md)                         | correctness        | 7        | 4    | 2026-07-05   |
 | [Equality Guard Completeness](patterns/equality-guard-completeness.md)                               | correctness        | 2        | 0    | 2026-06-17   |
 | [Resizable Layout Bounds](patterns/resizable-layout-bounds.md)                                       | correctness        | 3        | 2    | 2026-06-18   |
 | [Schema Version Decoupling](patterns/schema-version-decoupling.md)                                   | correctness        | 1        | 0    | 2026-06-19   |
@@ -109,6 +109,6 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Vite HMR Static Dependencies](patterns/vite-hmr-static-deps.md)                                     | code-quality       | 3        | 2    | 2026-06-18   |
 | [Custom Pane Layout Preservation](patterns/custom-pane-layout-preservation.md)                       | correctness        | 13       | 5    | 2026-06-22   |
 | [Pane Slot Identity](patterns/pane-slot-identity.md)                                                 | correctness        | 3        | 1    | 2026-06-22   |
-| [Transient UI Side Effects](patterns/transient-ui-side-effects.md)                                   | react-patterns     | 12       | 6    | 2026-07-05   |
+| [Transient UI Side Effects](patterns/transient-ui-side-effects.md)                                   | react-patterns     | 13       | 7    | 2026-07-05   |
 | [Async Global State Mutation](patterns/async-global-state-mutation.md)                               | backend            | 1        | 0    | 2026-06-19   |
 | [Boolean Sentinel Consistency](patterns/boolean-sentinel-consistency.md)                             | code-quality       | 2        | 1    | 2026-06-22   |

--- a/docs/reviews/patterns/authoritative-completion-guard.md
+++ b/docs/reviews/patterns/authoritative-completion-guard.md
@@ -3,7 +3,7 @@ id: authoritative-completion-guard
 category: correctness
 created: 2026-06-16
 last_updated: 2026-07-05
-ref_count: 3
+ref_count: 4
 ---
 
 # Authoritative Completion Guard

--- a/docs/reviews/patterns/keyboard-shortcut-guards.md
+++ b/docs/reviews/patterns/keyboard-shortcut-guards.md
@@ -3,7 +3,7 @@ id: keyboard-shortcut-guards
 category: keyboard-shortcuts
 created: 2026-05-18
 last_updated: 2026-07-05
-ref_count: 6
+ref_count: 7
 ---
 
 # Keyboard Shortcut Guards
@@ -407,4 +407,20 @@ against three classes of false-fire:
   back into the diff panel.
 - **Fix:** Move focus to the stable diff root at the start of `toggleFilesList`, mirroring
   the pinned-toggle handoff before any changed-files subtree is hidden or remounted.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 32. Native Cmd+N forwarding dropped auto-repeat state
+
+- **Source:** github-codex-connector | PR #666 round 1 | 2026-07-05
+- **Severity:** P2 / MEDIUM
+- **File:** `native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift`,
+  `native/ghostty-parent/ghostty_native_parent.cc`, `electron/ghostty-native-parent.ts`
+- **Finding:** The native Ghostty Cmd+N forwarding path synthesized renderer
+  `keydown` events without preserving `NSEvent.isARepeat`. Held Cmd+N repeats
+  therefore reached `useNewSessionShortcut` as `event.repeat === false`,
+  bypassing its held-key guard and allowing multiple session spawns.
+- **Fix:** Threaded repeat state through the Swift callback, C++ N-API bridge,
+  and TypeScript shortcut payload, then set `KeyboardEventInit.repeat` on the
+  synthetic event. Added regression coverage that forwarded KeyN includes
+  `repeat: true`.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/transient-ui-side-effects.md
+++ b/docs/reviews/patterns/transient-ui-side-effects.md
@@ -3,7 +3,7 @@ id: transient-ui-side-effects
 category: react-patterns
 created: 2026-06-20
 last_updated: 2026-07-05
-ref_count: 6
+ref_count: 7
 ---
 
 # Transient UI Side Effects
@@ -179,3 +179,19 @@ to persistent state through a separate, explicit path.
 - **Fix:** Reset the category to the default from `closeCommentDraft`, and add a
   hook regression test that closes a non-default draft before opening a new one.
 - **Commit:** same commit as this entry
+
+### 13. No-op native dock shortcuts left focus on the renderer proxy
+
+- **Source:** github-claude | PR #666 round 1 | 2026-07-05
+- **Severity:** HIGH
+- **File:** `electron/ghostty-native-parent.ts`
+- **Finding:** Native Ghostty shortcut forwarding used a static refocus
+  allowlist that excluded dock-opening shortcuts such as Cmd+G, Cmd+E, Cmd+N,
+  and Cmd+0. When React handled one of those chords as a no-op and left focus
+  on the hidden renderer proxy, the active Ghostty pane did not regain
+  keyboard focus.
+- **Fix:** Changed the post-dispatch probe to return both same-pane activity and
+  whether focus moved into the dock. Ghostty is refocused only when the same
+  pane remains active and the dock did not take focus, so no-op dock shortcuts
+  recover terminal focus without stealing it from successful dock opens.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/electron/ghostty-native-parent.test.ts
+++ b/electron/ghostty-native-parent.test.ts
@@ -31,12 +31,14 @@ const {
 } = vi.hoisted(() => ({
   existsSync: vi.fn(() => false),
   isDestroyed: vi.fn(() => false),
-  webContentsExecuteJavaScript: vi.fn((script: string, gesture?: boolean) => {
-    void script
-    void gesture
+  webContentsExecuteJavaScript: vi.fn(
+    (script: string, gesture?: boolean): Promise<unknown> => {
+      void script
+      void gesture
 
-    return Promise.resolve(false)
-  }),
+      return Promise.resolve(false)
+    }
+  ),
   webContentsFocus: vi.fn(),
   webContentsIsDestroyed: vi.fn(() => false),
   webContentsSend: vi.fn(),

--- a/electron/ghostty-native-parent.test.ts
+++ b/electron/ghostty-native-parent.test.ts
@@ -1045,7 +1045,8 @@ describe('ghostty native parent', () => {
         control: boolean,
         meta: boolean,
         alt: boolean,
-        shift: boolean
+        shift: boolean,
+        repeat: boolean
       ) => void
     } = {}
     const surface = { id: 'surface-1' }
@@ -1090,8 +1091,11 @@ describe('ghostty native parent', () => {
       }
     )
 
-    webContentsExecuteJavaScript.mockResolvedValue(true)
-    callbacks.onShortcut?.('2', 'Digit2', false, true, false, false)
+    webContentsExecuteJavaScript.mockResolvedValue({
+      activeGhosttyPane: true,
+      dockHasFocus: false,
+    })
+    callbacks.onShortcut?.('2', 'Digit2', false, true, false, false, false)
 
     await new Promise((resolve) => {
       setTimeout(resolve, 0)
@@ -1114,7 +1118,11 @@ describe('ghostty native parent', () => {
     webContentsExecuteJavaScript.mockClear()
     addon.focus.mockClear()
 
-    callbacks.onShortcut?.('g', 'KeyG', false, true, false, false)
+    webContentsExecuteJavaScript.mockResolvedValueOnce({
+      activeGhosttyPane: true,
+      dockHasFocus: true,
+    })
+    callbacks.onShortcut?.('g', 'KeyG', false, true, false, false, false)
 
     await new Promise((resolve) => {
       setTimeout(resolve, 0)
@@ -1129,7 +1137,7 @@ describe('ghostty native parent', () => {
     webContentsExecuteJavaScript.mockClear()
     addon.focus.mockClear()
 
-    callbacks.onShortcut?.('b', 'KeyB', false, true, false, false)
+    callbacks.onShortcut?.('b', 'KeyB', false, true, false, false, false)
 
     await new Promise((resolve) => {
       setTimeout(resolve, 0)
@@ -1144,7 +1152,11 @@ describe('ghostty native parent', () => {
     webContentsExecuteJavaScript.mockClear()
     addon.focus.mockClear()
 
-    callbacks.onShortcut?.('0', 'Digit0', false, true, false, false)
+    webContentsExecuteJavaScript.mockResolvedValueOnce({
+      activeGhosttyPane: true,
+      dockHasFocus: true,
+    })
+    callbacks.onShortcut?.('0', 'Digit0', false, true, false, false, false)
 
     await new Promise((resolve) => {
       setTimeout(resolve, 0)
@@ -1154,6 +1166,42 @@ describe('ghostty native parent', () => {
     expect(webContentsExecuteJavaScript).toHaveBeenCalledOnce()
     expect(webContentsExecuteJavaScript.mock.calls[0]?.[0]).toContain('Digit0')
     expect(addon.focus).not.toHaveBeenCalled()
+
+    webContentsFocus.mockClear()
+    webContentsExecuteJavaScript.mockClear()
+    addon.focus.mockClear()
+
+    webContentsExecuteJavaScript.mockResolvedValueOnce({
+      activeGhosttyPane: true,
+      dockHasFocus: false,
+    })
+    callbacks.onShortcut?.('e', 'KeyE', false, true, false, false, false)
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0)
+    })
+
+    expect(webContentsFocus).toHaveBeenCalledOnce()
+    expect(webContentsExecuteJavaScript).toHaveBeenCalledOnce()
+    expect(webContentsExecuteJavaScript.mock.calls[0]?.[0]).toContain('KeyE')
+    expect(addon.focus).toHaveBeenCalledWith(surface)
+
+    webContentsFocus.mockClear()
+    webContentsExecuteJavaScript.mockClear()
+    addon.focus.mockClear()
+
+    callbacks.onShortcut?.('n', 'KeyN', false, true, false, false, true)
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0)
+    })
+
+    expect(webContentsFocus).toHaveBeenCalledOnce()
+    expect(webContentsExecuteJavaScript).toHaveBeenCalledOnce()
+    expect(webContentsExecuteJavaScript.mock.calls[0]?.[0]).toContain('repeat')
+    expect(webContentsExecuteJavaScript.mock.calls[0]?.[0]).toContain(
+      '"repeat":true'
+    )
 
     controller.dispose()
   })
@@ -1166,7 +1214,8 @@ describe('ghostty native parent', () => {
         control: boolean,
         meta: boolean,
         alt: boolean,
-        shift: boolean
+        shift: boolean,
+        repeat: boolean
       ) => void
     } = {}
     const surface = { id: 'surface-1' }
@@ -1212,7 +1261,7 @@ describe('ghostty native parent', () => {
     )
 
     const isMac = process.platform === 'darwin'
-    callbacks.onShortcut?.(';', 'Semicolon', !isMac, isMac, false, false)
+    callbacks.onShortcut?.(';', 'Semicolon', !isMac, isMac, false, false, false)
 
     expect(webContentsFocus).toHaveBeenCalledOnce()
     expect(webContentsSend).toHaveBeenCalledWith(COMMAND_PALETTE_TOGGLE)

--- a/electron/ghostty-native-parent.test.ts
+++ b/electron/ghostty-native-parent.test.ts
@@ -1129,6 +1129,21 @@ describe('ghostty native parent', () => {
     webContentsExecuteJavaScript.mockClear()
     addon.focus.mockClear()
 
+    callbacks.onShortcut?.('b', 'KeyB', false, true, false, false)
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0)
+    })
+
+    expect(webContentsFocus).toHaveBeenCalledOnce()
+    expect(webContentsExecuteJavaScript).toHaveBeenCalledOnce()
+    expect(webContentsExecuteJavaScript.mock.calls[0]?.[0]).toContain('KeyB')
+    expect(addon.focus).toHaveBeenCalledWith(surface)
+
+    webContentsFocus.mockClear()
+    webContentsExecuteJavaScript.mockClear()
+    addon.focus.mockClear()
+
     callbacks.onShortcut?.('0', 'Digit0', false, true, false, false)
 
     await new Promise((resolve) => {

--- a/electron/ghostty-native-parent.test.ts
+++ b/electron/ghostty-native-parent.test.ts
@@ -1037,7 +1037,7 @@ describe('ghostty native parent', () => {
     controller.dispose()
   })
 
-  test('forwards native command digit shortcuts into the app renderer', async () => {
+  test('forwards native app shortcuts into the app renderer', async () => {
     const callbacks: {
       onShortcut?: (
         key: string,
@@ -1109,6 +1109,36 @@ describe('ghostty native parent', () => {
       'data-workspace-overlay-id="pane-rename"'
     )
     expect(addon.focus).toHaveBeenCalledWith(surface)
+
+    webContentsFocus.mockClear()
+    webContentsExecuteJavaScript.mockClear()
+    addon.focus.mockClear()
+
+    callbacks.onShortcut?.('g', 'KeyG', false, true, false, false)
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0)
+    })
+
+    expect(webContentsFocus).toHaveBeenCalledOnce()
+    expect(webContentsExecuteJavaScript).toHaveBeenCalledOnce()
+    expect(webContentsExecuteJavaScript.mock.calls[0]?.[0]).toContain('KeyG')
+    expect(addon.focus).not.toHaveBeenCalled()
+
+    webContentsFocus.mockClear()
+    webContentsExecuteJavaScript.mockClear()
+    addon.focus.mockClear()
+
+    callbacks.onShortcut?.('0', 'Digit0', false, true, false, false)
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0)
+    })
+
+    expect(webContentsFocus).toHaveBeenCalledOnce()
+    expect(webContentsExecuteJavaScript).toHaveBeenCalledOnce()
+    expect(webContentsExecuteJavaScript.mock.calls[0]?.[0]).toContain('Digit0')
+    expect(addon.focus).not.toHaveBeenCalled()
 
     controller.dispose()
   })

--- a/electron/ghostty-native-parent.ts
+++ b/electron/ghostty-native-parent.ts
@@ -169,6 +169,13 @@ const ghosttyShortcutEventInit = (
   cancelable: true,
 })
 
+const shouldRefocusGhosttyAfterWorkspaceShortcut = (
+  input: GhosttyNativeShortcutInput
+): boolean =>
+  /^Digit[1-9]$/.test(input.code) ||
+  input.code === 'Backslash' ||
+  input.code === 'KeyZ'
+
 const isShortcutContext = (
   value: unknown
 ): value is GhosttyNativeShortcutContext =>
@@ -917,7 +924,10 @@ export class GhosttyNativeParentController {
         false
       )
 
-      if (shouldRefocus === true) {
+      if (
+        shouldRefocusGhosttyAfterWorkspaceShortcut(input) &&
+        shouldRefocus === true
+      ) {
         addon.focus(state.surface)
       }
     } catch {

--- a/electron/ghostty-native-parent.ts
+++ b/electron/ghostty-native-parent.ts
@@ -59,7 +59,8 @@ interface GhosttyNativeParentAddon {
       control: boolean,
       meta: boolean,
       alt: boolean,
-      shift: boolean
+      shift: boolean,
+      repeat: boolean
     ) => void,
     onRenamePane: () => void
   ) => unknown
@@ -126,6 +127,12 @@ interface GhosttyNativeShortcutInput {
   meta: boolean
   alt: boolean
   shift: boolean
+  repeat: boolean
+}
+
+interface GhosttyNativeShortcutDispatchState {
+  activeGhosttyPane: boolean
+  dockHasFocus: boolean
 }
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -165,19 +172,39 @@ const ghosttyShortcutEventInit = (
   metaKey: input.meta,
   altKey: input.alt,
   shiftKey: input.shift,
+  repeat: input.repeat,
   bubbles: true,
   cancelable: true,
 })
 
+const isShortcutDispatchState = (
+  value: unknown
+): value is GhosttyNativeShortcutDispatchState =>
+  isRecord(value) &&
+  typeof value.activeGhosttyPane === 'boolean' &&
+  typeof value.dockHasFocus === 'boolean'
+
 // Keep this paired with GhosttyElectronBridge.workspaceShortcutByKeyCode until
 // VIM-294 replaces the native forwarding allowlist with a shared registry.
 const shouldRefocusGhosttyAfterWorkspaceShortcut = (
-  input: GhosttyNativeShortcutInput
-): boolean =>
-  /^Digit[1-9]$/.test(input.code) ||
-  input.code === 'Backslash' ||
-  input.code === 'KeyB' ||
-  input.code === 'KeyZ'
+  input: GhosttyNativeShortcutInput,
+  dispatchState: GhosttyNativeShortcutDispatchState
+): boolean => {
+  if (!dispatchState.activeGhosttyPane || dispatchState.dockHasFocus) {
+    return false
+  }
+
+  return (
+    /^Digit[1-9]$/.test(input.code) ||
+    input.code === 'Backslash' ||
+    input.code === 'Digit0' ||
+    input.code === 'KeyB' ||
+    input.code === 'KeyE' ||
+    input.code === 'KeyG' ||
+    input.code === 'KeyN' ||
+    input.code === 'KeyZ'
+  )
+}
 
 const isShortcutContext = (
   value: unknown
@@ -829,7 +856,7 @@ export class GhosttyNativeParentController {
           payload: state.pane,
         })
       },
-      (key, code, control, meta, alt, shift) => {
+      (key, code, control, meta, alt, shift, repeat) => {
         if (win.isDestroyed() || !this.surfaces.has(this.paneKey(state.pane))) {
           return
         }
@@ -855,6 +882,7 @@ export class GhosttyNativeParentController {
           meta,
           alt,
           shift,
+          repeat,
         })
       },
       () => {
@@ -914,13 +942,17 @@ export class GhosttyNativeParentController {
             requestAnimationFrame(() => {
               const renameInputOpen =
                 document.querySelector('[data-workspace-overlay-id="pane-rename"]') !== null
+              const activeElement = document.activeElement
+              const dockHasFocus =
+                activeElement instanceof Element &&
+                activeElement.closest('[data-container-id="dock"]') !== null
               const activeGhosttyPane = Array.from(
                 document.querySelectorAll('[data-pane-kind="shell"][data-pane-active="true"]')
               ).some((node) =>
                 node.getAttribute('data-pane-id') === ${JSON.stringify(state.pane.paneId)} &&
                 node.getAttribute('data-pty-id') === ${JSON.stringify(state.pane.sessionId)}
               )
-              resolve(!renameInputOpen && activeGhosttyPane)
+              resolve({ activeGhosttyPane: !renameInputOpen && activeGhosttyPane, dockHasFocus })
             })
           })
         })()`,
@@ -928,8 +960,8 @@ export class GhosttyNativeParentController {
       )
 
       if (
-        shouldRefocusGhosttyAfterWorkspaceShortcut(input) &&
-        shouldRefocus === true
+        isShortcutDispatchState(shouldRefocus) &&
+        shouldRefocusGhosttyAfterWorkspaceShortcut(input, shouldRefocus)
       ) {
         addon.focus(state.surface)
       }

--- a/electron/ghostty-native-parent.ts
+++ b/electron/ghostty-native-parent.ts
@@ -176,6 +176,7 @@ const shouldRefocusGhosttyAfterWorkspaceShortcut = (
 ): boolean =>
   /^Digit[1-9]$/.test(input.code) ||
   input.code === 'Backslash' ||
+  input.code === 'KeyB' ||
   input.code === 'KeyZ'
 
 const isShortcutContext = (

--- a/electron/ghostty-native-parent.ts
+++ b/electron/ghostty-native-parent.ts
@@ -169,6 +169,8 @@ const ghosttyShortcutEventInit = (
   cancelable: true,
 })
 
+// Keep this paired with GhosttyElectronBridge.workspaceShortcutByKeyCode until
+// VIM-294 replaces the native forwarding allowlist with a shared registry.
 const shouldRefocusGhosttyAfterWorkspaceShortcut = (
   input: GhosttyNativeShortcutInput
 ): boolean =>

--- a/native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift
+++ b/native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift
@@ -307,6 +307,23 @@ private final class EmbeddedGhosttySurface: NSObject {
         25: "9"
     ]
 
+    // App-owned shortcuts must cross the AppKit -> Electron boundary while
+    // Ghostty has focus. Keep this list explicit; Cmd+R/reload is a later scope.
+    private static let workspaceShortcutByKeyCode: [UInt16: (key: String, code: String)] = [
+        5: ("g", "KeyG"),
+        6: ("z", "KeyZ"),
+        11: ("b", "KeyB"),
+        14: ("e", "KeyE"),
+        29: ("0", "Digit0"),
+        42: ("\\", "Backslash"),
+        45: ("n", "KeyN")
+    ]
+
+    private static let workspaceShortcutCodesAllowingExtraModifiers = Set([
+        "Digit0",
+        "Backslash"
+    ])
+
     private let parentView: NSView
     private let container = EmbeddedGhosttyContainerView(frame: .zero)
     private let callbacks: CallbackBox
@@ -834,6 +851,23 @@ private final class EmbeddedGhosttySurface: NSObject {
             )
 
             return true
+        }
+
+        if let shortcut = Self.workspaceShortcutByKeyCode[event.keyCode] {
+            let allowsExtraModifiers =
+                Self.workspaceShortcutCodesAllowingExtraModifiers.contains(shortcut.code)
+            if allowsExtraModifiers || (!flags.contains(.option) && !flags.contains(.shift)) {
+                callbacks.forwardShortcut(
+                    key: shortcut.key,
+                    code: shortcut.code,
+                    control: flags.contains(.control),
+                    meta: flags.contains(.command),
+                    alt: flags.contains(.option),
+                    shift: flags.contains(.shift)
+                )
+
+                return true
+            }
         }
 
         guard let digit = Self.shortcutDigitByKeyCode[event.keyCode] else {

--- a/native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift
+++ b/native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift
@@ -25,6 +25,7 @@ public typealias VimeflowGhosttyShortcutCallback = @convention(c) (
     Bool,
     Bool,
     Bool,
+    Bool,
     Bool
 ) -> Void
 
@@ -203,7 +204,8 @@ private final class CallbackBox: @unchecked Sendable {
         control: Bool,
         meta: Bool,
         alt: Bool,
-        shift: Bool
+        shift: Bool,
+        repeatEvent: Bool
     ) {
         key.withCString { keyPointer in
             code.withCString { codePointer in
@@ -214,7 +216,8 @@ private final class CallbackBox: @unchecked Sendable {
                     control,
                     meta,
                     alt,
-                    shift
+                    shift,
+                    repeatEvent
                 )
             }
         }
@@ -848,7 +851,8 @@ private final class EmbeddedGhosttySurface: NSObject {
                 control: flags.contains(.control),
                 meta: flags.contains(.command),
                 alt: flags.contains(.option),
-                shift: flags.contains(.shift)
+                shift: flags.contains(.shift),
+                repeatEvent: event.isARepeat
             )
 
             return true
@@ -864,7 +868,8 @@ private final class EmbeddedGhosttySurface: NSObject {
                     control: flags.contains(.control),
                     meta: flags.contains(.command),
                     alt: flags.contains(.option),
-                    shift: flags.contains(.shift)
+                    shift: flags.contains(.shift),
+                    repeatEvent: event.isARepeat
                 )
 
                 return true
@@ -885,7 +890,8 @@ private final class EmbeddedGhosttySurface: NSObject {
             control: flags.contains(.control),
             meta: flags.contains(.command),
             alt: flags.contains(.option),
-            shift: flags.contains(.shift)
+            shift: flags.contains(.shift),
+            repeatEvent: event.isARepeat
         )
 
         return true

--- a/native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift
+++ b/native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift
@@ -308,7 +308,8 @@ private final class EmbeddedGhosttySurface: NSObject {
     ]
 
     // App-owned shortcuts must cross the AppKit -> Electron boundary while
-    // Ghostty has focus. Keep this list explicit; Cmd+R/reload is a later scope.
+    // Ghostty has focus. VIM-294 tracks replacing this explicit list with a
+    // shared shortcut registry; Cmd+R/reload is still a later scope.
     private static let workspaceShortcutByKeyCode: [UInt16: (key: String, code: String)] = [
         5: ("g", "KeyG"),
         6: ("z", "KeyZ"),

--- a/native/ghostty-parent/ghostty_native_parent.cc
+++ b/native/ghostty-parent/ghostty_native_parent.cc
@@ -14,7 +14,7 @@ using InputCallback = void (*)(void *, const unsigned char *, int);
 using ResizeCallback = void (*)(void *, int, int);
 using FocusCallback = void (*)(void *);
 using ShortcutCallback = void (*)(void *, const char *, const char *, bool,
-                                  bool, bool, bool);
+                                  bool, bool, bool, bool);
 using RenamePaneCallback = void (*)(void *);
 using CreateFn = void *(*)(void *, InputCallback, ResizeCallback,
                            FocusCallback, ShortcutCallback,
@@ -87,6 +87,7 @@ struct ShortcutPayload {
   bool meta = false;
   bool alt = false;
   bool shift = false;
+  bool repeat = false;
 };
 
 BridgeApi bridge;
@@ -346,7 +347,7 @@ void OnFocus(void *context) {
 }
 
 void OnShortcut(void *context, const char *key, const char *code, bool control,
-                bool meta, bool alt, bool shift) {
+                bool meta, bool alt, bool shift, bool repeat) {
   if (context == nullptr || key == nullptr || code == nullptr) {
     return;
   }
@@ -365,6 +366,7 @@ void OnShortcut(void *context, const char *key, const char *code, bool control,
   payload->meta = meta;
   payload->alt = alt;
   payload->shift = shift;
+  payload->repeat = repeat;
   if (napi_call_threadsafe_function(tsfn, payload.get(),
                                     napi_tsfn_nonblocking) == napi_ok) {
     payload.release();
@@ -439,7 +441,7 @@ void CallJsShortcut(napi_env env, napi_value callback, void *, void *data) {
   }
 
   napi_value global;
-  napi_value argv[6];
+  napi_value argv[7];
   if (napi_get_global(env, &global) == napi_ok &&
       napi_create_string_utf8(env, payload->key.data(), payload->key.size(),
                               &argv[0]) == napi_ok &&
@@ -448,9 +450,10 @@ void CallJsShortcut(napi_env env, napi_value callback, void *, void *data) {
       napi_get_boolean(env, payload->control, &argv[2]) == napi_ok &&
       napi_get_boolean(env, payload->meta, &argv[3]) == napi_ok &&
       napi_get_boolean(env, payload->alt, &argv[4]) == napi_ok &&
-      napi_get_boolean(env, payload->shift, &argv[5]) == napi_ok) {
+      napi_get_boolean(env, payload->shift, &argv[5]) == napi_ok &&
+      napi_get_boolean(env, payload->repeat, &argv[6]) == napi_ok) {
     napi_value ignored;
-    napi_call_function(env, global, callback, 6, argv, &ignored);
+    napi_call_function(env, global, callback, 7, argv, &ignored);
   }
 }
 


### PR DESCRIPTION
## Summary
- Forward app-owned macOS shortcuts from the focused native Ghostty view into Electron/React
- Restore shortcuts such as `Cmd+0` and `Cmd+G` while leaving `Cmd+R` for later scope
- Avoid refocusing Ghostty after forwarded dock shortcuts so the dock can actually take focus

## Root cause
Ghostty is an AppKit `NSView`, so React document keydown handlers do not see command-key events while Ghostty owns focus unless the native bridge forwards them explicitly. The bridge only forwarded command-palette and selected pane-digit shortcuts.

## Follow-up
- VIM-294 tracks centralizing the shortcut registry and table-driven Ghostty forwarding coverage
- VIM-295 tracks a generic hunk comment category
- VIM-296 tracks Ctrl+J/K behavior inside the diff comment editor

## Verification
- `npm test -- electron/ghostty-native-parent.test.ts`
- `npx tsc -p electron/tsconfig.json`
- `npm run ghostty:native-parent:build`
- `git diff --check`


Refs VIM-299