### PR TITLE
feat: animate burner sync pill

### DIFF
--- a/docs/exploration/2026-07-06-burner-sync-pill-demo.html
+++ b/docs/exploration/2026-07-06-burner-sync-pill-demo.html
@@ -1,0 +1,501 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Vimeflow Burner Sync Pill Demo</title>
+    <style>
+      @font-face {
+        font-family: 'Material Symbols Outlined';
+        font-style: normal;
+        font-weight: 400;
+        src: url('../../node_modules/@fontsource-variable/material-symbols-outlined/files/material-symbols-outlined-latin-wght-normal.woff2')
+          format('woff2');
+      }
+
+      :root {
+        --void: #08070d;
+        --panel: #17121f;
+        --bar: #241d38;
+        --on: #e3ddf2;
+        --muted: #a89fc4;
+        --faint: #7a7392;
+        --lav: #c9bdf0;
+        --lav-bg: rgba(201, 189, 240, 0.16);
+        --scratch: #f0c674;
+        --coral: #ff94a5;
+        --mint: #7defa1;
+        --mono:
+          ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+        --body: Inter, ui-sans-serif, system-ui, -apple-system, sans-serif;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      html,
+      body {
+        height: 100%;
+      }
+
+      body {
+        margin: 0;
+        display: grid;
+        place-items: center;
+        padding: 28px;
+        background:
+          radial-gradient(
+            900px circle at 50% -20%,
+            rgba(203, 166, 247, 0.09),
+            transparent 56%
+          ),
+          var(--void);
+        color: var(--on);
+        font-family: var(--body);
+      }
+
+      button {
+        font: inherit;
+      }
+
+      .material-symbols-outlined {
+        display: inline-block;
+        font-family: 'Material Symbols Outlined';
+        font-size: 18px;
+        font-feature-settings: 'liga';
+        font-variation-settings:
+          'FILL' 0,
+          'wght' 400,
+          'GRAD' 0,
+          'opsz' 20;
+        line-height: 1;
+      }
+
+      .wrap {
+        display: grid;
+        gap: 18px;
+        justify-items: center;
+      }
+
+      .win {
+        width: min(460px, calc(100vw - 40px));
+        overflow: hidden;
+        border: 1px solid rgba(150, 140, 180, 0.14);
+        border-radius: 15px;
+        background: var(--panel);
+        box-shadow:
+          0 34px 90px rgba(0, 0, 0, 0.55),
+          0 0 0 1px rgba(255, 255, 255, 0.02) inset;
+      }
+
+      .titlebar {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        height: 47px;
+        padding: 8px 10px 8px 12px;
+        border-bottom: 1px solid rgba(201, 189, 240, 0.1);
+        background: linear-gradient(180deg, var(--bar), #1d172d);
+      }
+
+      .avatar {
+        display: grid;
+        width: 27px;
+        height: 27px;
+        flex: 0 0 auto;
+        place-items: center;
+        border: 1.5px solid rgba(240, 198, 116, 0.5);
+        border-radius: 999px;
+        background: radial-gradient(circle at 35% 30%, #3a2f1a, #1c1710);
+        color: var(--scratch);
+        font-family: var(--mono);
+        font-size: 14px;
+        font-weight: 700;
+      }
+
+      .title {
+        font-family: var(--mono);
+        font-size: 15px;
+        color: #d8d2ea;
+      }
+
+      .spacer {
+        flex: 1;
+      }
+
+      .term-ctl {
+        display: inline-flex;
+        align-items: center;
+      }
+
+      .tp-toggle,
+      .tp-sync {
+        position: relative;
+        display: inline-grid;
+        place-items: center;
+        border: 0;
+        background: transparent;
+        color: var(--muted);
+        cursor: pointer;
+        transition:
+          background 160ms,
+          color 160ms,
+          width 200ms cubic-bezier(0.2, 0.8, 0.2, 1),
+          height 200ms cubic-bezier(0.2, 0.8, 0.2, 1),
+          border-radius 200ms cubic-bezier(0.2, 0.8, 0.2, 1);
+      }
+
+      .tp-toggle {
+        width: 32px;
+        height: 32px;
+        border-radius: 8px;
+      }
+
+      .tp-toggle:hover {
+        background: rgba(255, 255, 255, 0.06);
+        color: var(--on);
+      }
+
+      .tp-sync {
+        width: 0;
+        height: 32px;
+        overflow: hidden;
+        opacity: 0;
+        pointer-events: none;
+      }
+
+      .win.is-open .tp-toggle {
+        width: 32px;
+        height: 32px;
+        border-radius: 8px;
+        background: var(--lav-bg);
+        color: #ded4fb;
+        box-shadow: inset 0 0 0 1px rgba(201, 189, 240, 0.22);
+      }
+
+      .win.is-open .tp-toggle:hover {
+        background: rgba(201, 189, 240, 0.24);
+      }
+
+      .win.is-open.is-drift .term-ctl {
+        gap: 3px;
+        padding: 3px;
+        border: 1px solid rgba(201, 189, 240, 0.18);
+        border-radius: 11px;
+        background: rgba(201, 189, 240, 0.1);
+      }
+
+      .win.is-open.is-drift .tp-toggle {
+        width: 30px;
+        height: 28px;
+        border-radius: 8px;
+        box-shadow: none;
+      }
+
+      .win.is-open.is-drift .tp-sync {
+        width: 30px;
+        height: 28px;
+        border-radius: 8px;
+        color: var(--scratch);
+        opacity: 1;
+        pointer-events: auto;
+      }
+
+      .win.is-open.is-drift .tp-sync:hover {
+        background: rgba(240, 198, 116, 0.18);
+      }
+
+      .win.is-busy.is-open.is-drift .tp-sync {
+        color: var(--faint);
+        cursor: not-allowed;
+      }
+
+      .win.is-busy.is-open.is-drift .tp-sync:hover {
+        background: transparent;
+        color: var(--muted);
+      }
+
+      .tp-sync .material-symbols-outlined {
+        transform-origin: center;
+      }
+
+      .tp-sync.spin .material-symbols-outlined {
+        animation: syncSpin 480ms cubic-bezier(0.2, 0.8, 0.2, 1);
+      }
+
+      .tp-sync.fail {
+        animation: shake 420ms cubic-bezier(0.36, 0.07, 0.19, 0.97);
+        color: var(--coral) !important;
+      }
+
+      .win.is-open.is-drift .tp-sync.fail {
+        background: rgba(255, 148, 165, 0.2) !important;
+      }
+
+      .body {
+        display: grid;
+        gap: 10px;
+        min-height: 190px;
+        padding: 18px;
+        font-family: var(--mono);
+        font-size: 12px;
+      }
+
+      .row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        border-radius: 9px;
+        background: rgba(12, 10, 20, 0.42);
+        padding: 10px 12px;
+      }
+
+      .label {
+        color: var(--faint);
+      }
+
+      .path {
+        color: var(--lav);
+      }
+
+      .status {
+        color: var(--mint);
+      }
+
+      .win.is-drift .status {
+        color: var(--scratch);
+      }
+
+      .win.is-busy .status {
+        color: var(--coral);
+      }
+
+      .controls {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 8px;
+        max-width: 460px;
+      }
+
+      .hbtn {
+        min-width: 92px;
+        border: 1px solid rgba(201, 189, 240, 0.14);
+        border-radius: 999px;
+        background: rgba(20, 18, 32, 0.86);
+        color: var(--muted);
+        cursor: pointer;
+        padding: 7px 11px;
+        font-family: var(--mono);
+        font-size: 11px;
+      }
+
+      .hbtn.on {
+        border-color: rgba(201, 189, 240, 0.42);
+        background: var(--lav-bg);
+        color: #ded4fb;
+      }
+
+      .hbtn.amber.on {
+        border-color: rgba(240, 198, 116, 0.34);
+        background: rgba(240, 198, 116, 0.14);
+        color: var(--scratch);
+      }
+
+      @keyframes shake {
+        0%,
+        100% {
+          transform: translateX(0);
+        }
+        20% {
+          transform: translateX(-3px);
+        }
+        40% {
+          transform: translateX(3px);
+        }
+        60% {
+          transform: translateX(-2px);
+        }
+        80% {
+          transform: translateX(2px);
+        }
+      }
+
+      @keyframes syncSpin {
+        from {
+          transform: rotate(0deg);
+        }
+        to {
+          transform: rotate(360deg);
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        * {
+          animation: none !important;
+          transition: none !important;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="wrap">
+      <section
+        class="win is-open is-drift"
+        id="win"
+        aria-label="Burner sync pill demo"
+      >
+        <header class="titlebar">
+          <span class="avatar">$</span>
+          <span class="title">vimeflow</span>
+          <span class="spacer"></span>
+          <div class="term-ctl" aria-label="Burner controls">
+            <button
+              class="tp-sync"
+              id="syncBtn"
+              type="button"
+              aria-label="sync burner pwd to main pane"
+            >
+              <span class="material-symbols-outlined" aria-hidden="true"
+                >sync</span
+              >
+            </button>
+            <button
+              class="tp-toggle"
+              id="toggleBtn"
+              type="button"
+              aria-label="toggle burner terminal"
+            >
+              <span class="material-symbols-outlined" aria-hidden="true"
+                >terminal</span
+              >
+            </button>
+          </div>
+        </header>
+        <div class="body">
+          <div class="row">
+            <span class="label">main pwd</span>
+            <span class="path">~/ghostty-burner-pane-spike</span>
+          </div>
+          <div class="row">
+            <span class="label">burner pwd</span>
+            <span class="path" id="burnerPath">~/src/middleware</span>
+          </div>
+          <div class="row">
+            <span class="label">state</span>
+            <span class="status" id="status">drifted, idle</span>
+          </div>
+        </div>
+      </section>
+
+      <nav class="controls" aria-label="Demo states">
+        <button class="hbtn" type="button" data-open="0">closed</button>
+        <button class="hbtn on" type="button" data-open="1">open</button>
+        <button class="hbtn amber on" type="button" data-drift="1">
+          drifted
+        </button>
+        <button class="hbtn" type="button" data-drift="0">in sync</button>
+        <button class="hbtn on" type="button" data-busy="0">idle</button>
+        <button class="hbtn" type="button" data-busy="1">running</button>
+      </nav>
+    </main>
+
+    <script>
+      const win = document.getElementById('win')
+      const syncBtn = document.getElementById('syncBtn')
+      const toggleBtn = document.getElementById('toggleBtn')
+      const burnerPath = document.getElementById('burnerPath')
+      const status = document.getElementById('status')
+
+      const setActive = (selector, key, value) => {
+        document.querySelectorAll(`.hbtn${selector}`).forEach((button) => {
+          button.classList.toggle('on', button.dataset[key] === value)
+        })
+      }
+
+      const render = () => {
+        const open = win.classList.contains('is-open')
+        const drift = win.classList.contains('is-drift')
+        const busy = win.classList.contains('is-busy')
+
+        burnerPath.textContent = drift
+          ? '~/src/middleware'
+          : '~/ghostty-burner-pane-spike'
+        status.textContent = open
+          ? `${drift ? 'drifted' : 'in sync'}, ${busy ? 'running' : 'idle'}`
+          : 'closed'
+        syncBtn.querySelector('.material-symbols-outlined').textContent = busy
+          ? 'sync_problem'
+          : 'sync'
+      }
+
+      const setOpen = (open) => {
+        win.classList.toggle('is-open', open)
+        setActive('[data-open]', 'open', open ? '1' : '0')
+        render()
+      }
+
+      const setDrift = (drift) => {
+        win.classList.toggle('is-drift', drift)
+        setActive('[data-drift]', 'drift', drift ? '1' : '0')
+        render()
+      }
+
+      const setBusy = (busy) => {
+        win.classList.toggle('is-busy', busy)
+        setActive('[data-busy]', 'busy', busy ? '1' : '0')
+        render()
+      }
+
+      const failSync = () => {
+        syncBtn.classList.remove('fail')
+        void syncBtn.offsetWidth
+        syncBtn.classList.add('fail')
+        setTimeout(() => syncBtn.classList.remove('fail'), 520)
+      }
+
+      document.querySelectorAll('[data-open]').forEach((button) => {
+        button.addEventListener('click', () => {
+          setOpen(button.dataset.open === '1')
+        })
+      })
+
+      document.querySelectorAll('[data-drift]').forEach((button) => {
+        button.addEventListener('click', () => {
+          setDrift(button.dataset.drift === '1')
+        })
+      })
+
+      document.querySelectorAll('[data-busy]').forEach((button) => {
+        button.addEventListener('click', () => {
+          setBusy(button.dataset.busy === '1')
+        })
+      })
+
+      toggleBtn.addEventListener('click', () => {
+        setOpen(!win.classList.contains('is-open'))
+      })
+
+      syncBtn.addEventListener('click', () => {
+        if (!win.classList.contains('is-drift')) {
+          return
+        }
+
+        if (win.classList.contains('is-busy')) {
+          failSync()
+          return
+        }
+
+        syncBtn.classList.add('spin')
+        setTimeout(() => {
+          syncBtn.classList.remove('spin')
+          setDrift(false)
+        }, 480)
+      })
+
+      render()
+    </script>
+  </body>
+</html>

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -59,7 +59,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 87       | 41   | 2026-07-04   |
 | [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 10       | 5    | 2026-07-05   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 95       | 90   | 2026-07-05   |
-| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 99       | 88   | 2026-07-05   |
+| [Accessibility](patterns/accessibility.md)                                                           | a11y               | 100      | 89   | 2026-07-07   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
 | [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 90       | 83   | 2026-07-05   |
 | [Canonical Path Dedupe](patterns/canonical-path-dedupe.md)                                           | correctness        | 2        | 0    | 2026-06-14   |

--- a/docs/reviews/patterns/accessibility.md
+++ b/docs/reviews/patterns/accessibility.md
@@ -2,8 +2,8 @@
 id: accessibility
 category: a11y
 created: 2026-04-09
-last_updated: 2026-07-05
-ref_count: 88
+last_updated: 2026-07-07
+ref_count: 89
 ---
 
 # Accessibility
@@ -920,4 +920,13 @@ handlers must not trap focus without implementing the promised behavior.
 - **File:** `src/components/Dialog.tsx`
 - **Finding:** While native overlay transport owned the visible dialog, the local DOM fallback stayed mounted with `role="dialog"` and `aria-modal="true"` and still received initial focus. Keyboard and assistive-technology users could be moved into an invisible modal subtree.
 - **Fix:** Mark the hidden local fallback `aria-hidden` and `inert`, skip local initial focus, and skip dialog-stack registration while native transport is active. Added regression tests for hidden fallback attributes and focus retention outside the local subtree.
+- **Commit:** same commit as this entry
+
+### 100. Disabled sync button blur dropped keyboard focus
+
+- **Source:** github-claude + github-codex-connector | PR #669 round 1 | 2026-07-07
+- **Severity:** MEDIUM / P2
+- **File:** `src/features/terminal/components/TerminalPane/HeaderActions.tsx`
+- **Finding:** The burner sync collapse effect inferred focus from `document.activeElement` after the sync button had already become disabled. Chromium can blur a focused disabled control before passive effects run, leaving focus on another element or body and causing the intended handoff to the burner toggle to be skipped.
+- **Fix:** Tracked sync-button focus intent with focus/blur handlers, preserved the intent for disabled-triggered blur, and restored focus to the burner toggle when the sync control collapses. Expanded the regression test to simulate active focus moving away before collapse.
 - **Commit:** same commit as this entry

--- a/electron/native-overlay.test.ts
+++ b/electron/native-overlay.test.ts
@@ -453,6 +453,84 @@ describe('NativeOverlayController', () => {
     expect(menuWindow.hide).not.toHaveBeenCalled()
   })
 
+  test('closes active tooltip before opening an interactive menu', async () => {
+    const tooltipOpenPromise = handler(NATIVE_OVERLAY_OPEN)(
+      { sender: electronMock.owner.webContents },
+      tooltipRequest
+    )
+    const menuWindow = finishOverlayLoad()
+    const tooltipWindow = finishOverlayLoad(1)
+
+    await Promise.resolve()
+    await acknowledgeOverlayReady(tooltipWindow, tooltipRequest.surfaceId)
+    await tooltipOpenPromise
+
+    tooltipWindow.webContents.send.mockClear()
+    tooltipWindow.hide.mockClear()
+    electronMock.owner.webContents.send.mockClear()
+
+    const menuOpenPromise = handler(NATIVE_OVERLAY_OPEN)(
+      { sender: electronMock.owner.webContents },
+      request
+    )
+
+    await Promise.resolve()
+    expect(tooltipWindow.webContents.send).toHaveBeenCalledWith(
+      NATIVE_OVERLAY_CLEAR
+    )
+    expect(tooltipWindow.hide).toHaveBeenCalledOnce()
+    expect(electronMock.owner.webContents.send).toHaveBeenCalledWith(
+      NATIVE_OVERLAY_CLOSED,
+      { surfaceId: tooltipRequest.surfaceId, reason: 'replaced' }
+    )
+
+    expect(menuWindow.webContents.send).toHaveBeenCalledWith(
+      NATIVE_OVERLAY_RENDER,
+      request
+    )
+
+    await acknowledgeOverlayReady(menuWindow)
+    await expect(menuOpenPromise).resolves.toEqual({ accepted: true })
+  })
+
+  test('settles a pending tooltip open before opening an interactive menu', async () => {
+    const tooltipOpenPromise = handler(NATIVE_OVERLAY_OPEN)(
+      { sender: electronMock.owner.webContents },
+      tooltipRequest
+    )
+    const menuWindow = finishOverlayLoad()
+    const tooltipWindow = finishOverlayLoad(1)
+
+    await Promise.resolve()
+    expect(tooltipWindow.webContents.send).toHaveBeenCalledWith(
+      NATIVE_OVERLAY_RENDER,
+      tooltipRequest
+    )
+
+    const menuOpenPromise = handler(NATIVE_OVERLAY_OPEN)(
+      { sender: electronMock.owner.webContents },
+      request
+    )
+
+    await Promise.resolve()
+    await expect(tooltipOpenPromise).resolves.toEqual({
+      accepted: false,
+      reason: 'render-timeout',
+    })
+
+    expect(tooltipWindow.webContents.send).toHaveBeenCalledWith(
+      NATIVE_OVERLAY_CLEAR
+    )
+    expect(tooltipWindow.hide).toHaveBeenCalledOnce()
+    expect(menuWindow.webContents.send).toHaveBeenCalledWith(
+      NATIVE_OVERLAY_RENDER,
+      request
+    )
+
+    await acknowledgeOverlayReady(menuWindow)
+    await expect(menuOpenPromise).resolves.toEqual({ accepted: true })
+  })
+
   test('updates the active tooltip surface without closing its owner session', async () => {
     const tooltipOpenPromise = handler(NATIVE_OVERLAY_OPEN)(
       { sender: electronMock.owner.webContents },

--- a/electron/native-overlay.test.ts
+++ b/electron/native-overlay.test.ts
@@ -453,6 +453,88 @@ describe('NativeOverlayController', () => {
     expect(menuWindow.hide).not.toHaveBeenCalled()
   })
 
+  test('updates the active tooltip surface without closing its owner session', async () => {
+    const tooltipOpenPromise = handler(NATIVE_OVERLAY_OPEN)(
+      { sender: electronMock.owner.webContents },
+      tooltipRequest
+    )
+    const tooltipWindow = finishOverlayLoad(1)
+
+    await Promise.resolve()
+    await acknowledgeOverlayReady(tooltipWindow, tooltipRequest.surfaceId)
+    await tooltipOpenPromise
+
+    const refreshedTooltipRequest = {
+      ...tooltipRequest,
+      anchorRect: { ...tooltipRequest.anchorRect, width: 32 },
+    }
+
+    tooltipWindow.webContents.send.mockClear()
+    tooltipWindow.hide.mockClear()
+    electronMock.owner.webContents.send.mockClear()
+
+    const refreshPromise = handler(NATIVE_OVERLAY_OPEN)(
+      { sender: electronMock.owner.webContents },
+      refreshedTooltipRequest
+    )
+
+    await Promise.resolve()
+    expect(tooltipWindow.webContents.send).toHaveBeenCalledWith(
+      NATIVE_OVERLAY_RENDER,
+      refreshedTooltipRequest
+    )
+
+    await acknowledgeOverlayReady(tooltipWindow, tooltipRequest.surfaceId)
+    await expect(refreshPromise).resolves.toEqual({ accepted: true })
+
+    expect(tooltipWindow.webContents.send).not.toHaveBeenCalledWith(
+      NATIVE_OVERLAY_CLEAR
+    )
+    expect(tooltipWindow.hide).not.toHaveBeenCalled()
+    expect(electronMock.owner.webContents.send).not.toHaveBeenCalledWith(
+      NATIVE_OVERLAY_CLOSED,
+      expect.objectContaining({ surfaceId: tooltipRequest.surfaceId })
+    )
+  })
+
+  test('resolves a pending active tooltip open before refreshing the same surface', async () => {
+    const tooltipOpenPromise = handler(NATIVE_OVERLAY_OPEN)(
+      { sender: electronMock.owner.webContents },
+      tooltipRequest
+    )
+    const tooltipWindow = finishOverlayLoad(1)
+
+    const refreshedTooltipRequest = {
+      ...tooltipRequest,
+      anchorRect: { ...tooltipRequest.anchorRect, width: 32 },
+    }
+
+    await Promise.resolve()
+    expect(tooltipWindow.webContents.send).toHaveBeenCalledWith(
+      NATIVE_OVERLAY_RENDER,
+      tooltipRequest
+    )
+
+    const refreshPromise = handler(NATIVE_OVERLAY_OPEN)(
+      { sender: electronMock.owner.webContents },
+      refreshedTooltipRequest
+    )
+
+    await Promise.resolve()
+    await expect(tooltipOpenPromise).resolves.toEqual({ accepted: true })
+    await expect(refreshPromise).resolves.toEqual({ accepted: true })
+
+    expect(tooltipWindow.webContents.send).toHaveBeenCalledWith(
+      NATIVE_OVERLAY_RENDER,
+      refreshedTooltipRequest
+    )
+
+    expect(tooltipWindow.webContents.send).not.toHaveBeenCalledWith(
+      NATIVE_OVERLAY_CLEAR
+    )
+    expect(tooltipWindow.hide).not.toHaveBeenCalled()
+  })
+
   test('opens dialog requests on the interactive menu layer', async () => {
     const openPromise = handler(NATIVE_OVERLAY_OPEN)(
       { sender: electronMock.owner.webContents },

--- a/electron/native-overlay.ts
+++ b/electron/native-overlay.ts
@@ -843,7 +843,10 @@ export class NativeOverlayController {
     record: NativeOverlayRecord,
     payload: NativeOverlayRequest
   ): Promise<NativeOverlayOpenResult> {
-    if (record.activeTooltipSurfaceId !== null) {
+    const isActiveTooltipRefresh =
+      record.activeTooltipSurfaceId === payload.surfaceId
+
+    if (record.activeTooltipSurfaceId !== null && !isActiveTooltipRefresh) {
       this.closeSurface(record.activeTooltipSurfaceId, 'replaced', true, false)
     }
 
@@ -868,6 +871,13 @@ export class NativeOverlayController {
       parentId: parent.id,
       kind: 'tooltip',
     })
+
+    if (isActiveTooltipRefresh) {
+      this.resolvePendingReady(payload.surfaceId, true)
+      record.tooltip.window.webContents.send(NATIVE_OVERLAY_RENDER, payload)
+
+      return { accepted: true }
+    }
 
     const readyPromise = this.waitForReady(payload.surfaceId)
     record.tooltip.window.webContents.send(NATIVE_OVERLAY_RENDER, payload)

--- a/electron/native-overlay.ts
+++ b/electron/native-overlay.ts
@@ -795,6 +795,10 @@ export class NativeOverlayController {
     record: NativeOverlayRecord,
     payload: NativeOverlayRequest
   ): Promise<NativeOverlayOpenResult> {
+    if (record.activeTooltipSurfaceId !== null) {
+      this.closeSurface(record.activeTooltipSurfaceId, 'replaced', true, false)
+    }
+
     if (
       record.activeSurfaceId !== null &&
       record.activeSurfaceId !== payload.surfaceId

--- a/src/features/terminal/components/TerminalPane/HeaderActions.test.tsx
+++ b/src/features/terminal/components/TerminalPane/HeaderActions.test.tsx
@@ -219,6 +219,13 @@ describe('HeaderActions', () => {
       screen.queryByRole('button', { name: /sync burner terminal/i })
     ).toBeNull()
 
+    expect(screen.getByTestId('burner-control-pill')).toHaveAttribute(
+      'data-state',
+      'closed'
+    )
+    expect(screen.getByTestId('burner-control-pill')).toHaveClass('gap-0')
+    expect(screen.getByTestId('burner-control-pill')).toHaveClass('p-0')
+
     rerender(
       <HeaderActions
         isCollapsed={expanded}
@@ -232,6 +239,11 @@ describe('HeaderActions', () => {
     expect(
       screen.queryByRole('button', { name: /sync burner terminal/i })
     ).toBeNull()
+
+    expect(screen.getByTestId('burner-control-pill')).toHaveAttribute(
+      'data-state',
+      'closed'
+    )
 
     rerender(
       <HeaderActions
@@ -248,9 +260,44 @@ describe('HeaderActions', () => {
       screen.getByRole('button', { name: /sync burner terminal/i })
     ).toBeInTheDocument()
 
+    expect(
+      screen.getByRole('button', { name: /sync burner terminal/i }).className
+    ).toContain('!w-5')
+
     expect(screen.getByTestId('burner-control-pill').className).toContain(
       'h-[22px]'
     )
+
+    expect(screen.getByTestId('burner-control-pill')).toHaveAttribute(
+      'data-state',
+      'open'
+    )
+    expect(screen.getByTestId('burner-control-pill')).toHaveClass('gap-px')
+    expect(screen.getByTestId('burner-control-pill')).toHaveClass('p-px')
+    expect(screen.getByTestId('burner-control-pill')).toHaveClass(
+      'transition-[background-color,border-color,gap,padding]'
+    )
+
+    rerender(
+      <HeaderActions
+        isCollapsed={expanded}
+        onToggleCollapse={vi.fn()}
+        onBurner={vi.fn()}
+        onSyncBurner={onSyncBurner}
+        burnerOpen
+      />
+    )
+
+    expect(
+      screen.queryByRole('button', { name: /sync burner terminal/i })
+    ).toBeNull()
+
+    expect(screen.getByTestId('burner-control-pill')).toHaveAttribute(
+      'data-state',
+      'closed'
+    )
+    expect(screen.getByTestId('burner-control-pill')).toHaveClass('gap-0')
+    expect(screen.getByTestId('burner-control-pill')).toHaveClass('p-0')
   })
 
   test('burner sync sits before the burner toggle and stops click propagation', () => {
@@ -281,10 +328,98 @@ describe('HeaderActions', () => {
 
     expect(onSyncBurner).toHaveBeenCalledTimes(1)
     expect(onParentClick).not.toHaveBeenCalled()
-    expect(sync.className).toContain('animate-spin')
+    expect(sync.className).toContain('vf-burner-sync-spin')
   })
 
-  test('burner sync shows failure if the cwd remains out of sync', () => {
+  test('burner sync resolves with the prototype spin before collapsing', () => {
+    vi.useFakeTimers()
+    const onSyncBurner = vi.fn()
+
+    try {
+      const { rerender } = render(
+        <HeaderActions
+          isCollapsed={expanded}
+          onToggleCollapse={vi.fn()}
+          onBurner={vi.fn()}
+          onSyncBurner={onSyncBurner}
+          burnerOpen
+          burnerOutOfSync
+        />
+      )
+
+      const sync = screen.getByRole('button', {
+        name: /sync burner terminal/i,
+      })
+
+      act(() => {
+        sync.focus()
+      })
+
+      fireEvent.click(sync)
+
+      expect(onSyncBurner).toHaveBeenCalledTimes(1)
+      expect(sync.className).toContain('vf-burner-sync-spin')
+
+      rerender(
+        <HeaderActions
+          isCollapsed={expanded}
+          onToggleCollapse={vi.fn()}
+          onBurner={vi.fn()}
+          onSyncBurner={onSyncBurner}
+          burnerOpen
+        />
+      )
+
+      expect(
+        screen.getByRole('button', { name: /syncing burner terminal/i })
+      ).toBeInTheDocument()
+
+      expect(screen.getByTestId('burner-control-pill')).toHaveAttribute(
+        'data-state',
+        'open'
+      )
+
+      act(() => {
+        vi.advanceTimersByTime(480)
+      })
+
+      expect(
+        screen.queryByRole('button', { name: /sync burner terminal/i })
+      ).toBeNull()
+
+      expect(screen.getByTestId('burner-control-pill')).toHaveAttribute(
+        'data-state',
+        'closed'
+      )
+
+      expect(
+        screen.getByRole('button', { name: /hide burner terminal/i })
+      ).toHaveFocus()
+
+      rerender(
+        <HeaderActions
+          isCollapsed={expanded}
+          onToggleCollapse={vi.fn()}
+          onBurner={vi.fn()}
+          onSyncBurner={onSyncBurner}
+          burnerOpen
+          burnerOutOfSync
+        />
+      )
+
+      const syncAgain = screen.getByRole('button', {
+        name: /sync burner terminal/i,
+      })
+      fireEvent.click(syncAgain)
+
+      expect(onSyncBurner).toHaveBeenCalledTimes(2)
+      expect(syncAgain.className).toContain('vf-burner-sync-spin')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  test('burner sync returns to retry state if the cwd remains out of sync', () => {
     vi.useFakeTimers()
     const onSyncBurner = vi.fn()
 
@@ -310,10 +445,16 @@ describe('HeaderActions', () => {
 
       expect(onSyncBurner).toHaveBeenCalledTimes(1)
       expect(
-        screen.getByRole('button', {
+        screen.queryByRole('button', {
           name: /sync failed; check burner terminal/i,
         })
-      ).toHaveTextContent('sync_problem')
+      ).toBeNull()
+
+      expect(
+        screen.getByRole('button', {
+          name: /sync burner terminal/i,
+        })
+      ).toHaveTextContent('sync')
     } finally {
       vi.useRealTimers()
     }

--- a/src/features/terminal/components/TerminalPane/HeaderActions.test.tsx
+++ b/src/features/terminal/components/TerminalPane/HeaderActions.test.tsx
@@ -379,6 +379,11 @@ describe('HeaderActions', () => {
         'open'
       )
 
+      sync.setAttribute('disabled', '')
+      fireEvent.blur(sync)
+      screen.getByRole('button', { name: /collapse status/i }).focus()
+      expect(sync).not.toHaveFocus()
+
       act(() => {
         vi.advanceTimersByTime(480)
       })

--- a/src/features/terminal/components/TerminalPane/HeaderActions.tsx
+++ b/src/features/terminal/components/TerminalPane/HeaderActions.tsx
@@ -3,9 +3,9 @@ import { IconButton } from '@/components/IconButton'
 import { Tooltip } from '@/components/Tooltip'
 import { TOOLTIP_SUPPRESSED } from '@/lib/constants'
 
-const SYNC_FAILURE_TIMEOUT_MS = 1200
+const SYNC_RESOLVE_SPIN_MS = 480
 
-type BurnerSyncStatus = 'idle' | 'syncing' | 'blocked' | 'failed'
+type BurnerSyncStatus = 'idle' | 'syncing' | 'blocked'
 
 const burnerButtonLabel = (
   active: boolean,
@@ -72,10 +72,8 @@ export const HeaderActions = ({
 }: HeaderActionsProps): ReactElement => {
   const [burnerSyncStatus, setBurnerSyncStatus] =
     useState<BurnerSyncStatus>('idle')
-
-  const syncFailureTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null
-  )
+  const burnerButtonRef = useRef<HTMLButtonElement | null>(null)
+  const syncButtonRef = useRef<HTMLButtonElement | null>(null)
 
   const burnerLabel = burnerButtonLabel(
     burnerActive,
@@ -83,18 +81,28 @@ export const HeaderActions = ({
     burnerShellExists
   )
 
+  const canShowBurnerSync = Boolean(onBurner && onSyncBurner && burnerOpen)
+
   const showBurnerSync = Boolean(
-    onBurner && onSyncBurner && burnerOpen && burnerOutOfSync
+    canShowBurnerSync && (burnerOutOfSync || burnerSyncStatus === 'syncing')
   )
 
   useEffect(() => {
     if (!showBurnerSync) {
-      if (syncFailureTimeoutRef.current) {
-        clearTimeout(syncFailureTimeoutRef.current)
-        syncFailureTimeoutRef.current = null
-      }
       setBurnerSyncStatus('idle')
     }
+  }, [showBurnerSync])
+
+  useEffect(() => {
+    if (
+      showBurnerSync ||
+      document.activeElement !== syncButtonRef.current ||
+      burnerButtonRef.current === null
+    ) {
+      return
+    }
+
+    burnerButtonRef.current.focus()
   }, [showBurnerSync])
 
   useEffect(() => {
@@ -103,33 +111,44 @@ export const HeaderActions = ({
     }
   }, [burnerActive, burnerSyncStatus, showBurnerSync])
 
-  useEffect(
-    () => (): void => {
-      if (syncFailureTimeoutRef.current) {
-        clearTimeout(syncFailureTimeoutRef.current)
-      }
-    },
-    []
-  )
+  useEffect(() => {
+    if (!canShowBurnerSync || burnerSyncStatus !== 'syncing') {
+      return undefined
+    }
 
-  const burnerSyncFailed =
-    burnerSyncStatus === 'blocked' || burnerSyncStatus === 'failed'
+    const timeoutId = setTimeout(() => {
+      setBurnerSyncStatus('idle')
+    }, SYNC_RESOLVE_SPIN_MS)
 
-  const burnerSyncLabel = burnerSyncFailed
-    ? burnerSyncStatus === 'blocked'
-      ? 'stop the running command, then sync pwd'
-      : 'sync failed; check burner terminal'
+    return (): void => clearTimeout(timeoutId)
+  }, [burnerSyncStatus, canShowBurnerSync])
+
+  const burnerSyncBlocked = burnerSyncStatus === 'blocked'
+
+  const burnerSyncLabel = burnerSyncBlocked
+    ? 'stop the running command, then sync pwd'
     : burnerSyncStatus === 'syncing'
       ? 'syncing burner terminal'
       : 'sync burner terminal'
 
-  const burnerSyncIcon = burnerSyncFailed ? 'sync_problem' : 'sync'
+  const burnerSyncIcon = burnerSyncBlocked ? 'sync_problem' : 'sync'
 
   const collapseLabel = isCollapsed ? 'expand status' : 'collapse status'
+
+  const burnerButtonClassName = showBurnerSync
+    ? `!h-5 !w-5 rounded-md ${
+        burnerActive
+          ? 'bg-agent-shell-accent/15 text-agent-shell-accent'
+          : 'bg-primary/10 text-primary hover:bg-primary/15'
+      }`
+    : burnerActive
+      ? 'bg-agent-shell-accent/15 text-agent-shell-accent'
+      : undefined
 
   const burnerButton = onBurner ? (
     <Tooltip content={burnerLabel} placement="bottom" nativeOverlay>
       <IconButton
+        ref={burnerButtonRef}
         icon="terminal"
         label={burnerLabel}
         showTooltip={TOOLTIP_SUPPRESSED}
@@ -140,17 +159,7 @@ export const HeaderActions = ({
           onBurner()
         }}
         // Running keeps the amber status tint; pressed still reflects open/hidden.
-        className={
-          showBurnerSync
-            ? `!h-5 !w-5 rounded-md ${
-                burnerActive
-                  ? 'bg-agent-shell-accent/15 text-agent-shell-accent'
-                  : 'bg-primary/10 text-primary hover:bg-primary/15'
-              }`
-            : burnerActive
-              ? 'bg-agent-shell-accent/15 text-agent-shell-accent'
-              : undefined
-        }
+        className={burnerButtonClassName}
       />
     </Tooltip>
   ) : null
@@ -166,30 +175,39 @@ export const HeaderActions = ({
         </span>
       )}
 
-      {showBurnerSync ? (
+      {burnerButton ? (
         <div
           data-testid="burner-control-pill"
-          className="inline-flex h-[22px] shrink-0 items-center gap-px rounded-lg border border-primary/20 bg-primary/10 p-px"
+          data-state={showBurnerSync ? 'open' : 'closed'}
+          className={`inline-flex h-[22px] shrink-0 items-center rounded-lg border transition-[background-color,border-color,gap,padding] duration-200 ease-[cubic-bezier(.2,.8,.2,1)] motion-reduce:transition-none ${
+            showBurnerSync
+              ? 'gap-px border-primary/20 bg-primary/10 p-px'
+              : 'gap-0 border-transparent bg-transparent p-0'
+          }`}
         >
           <Tooltip content={burnerSyncLabel} placement="bottom" nativeOverlay>
             <IconButton
+              ref={syncButtonRef}
               icon={burnerSyncIcon}
               label={burnerSyncLabel}
               showTooltip={TOOLTIP_SUPPRESSED}
               size="sm"
-              className={`!h-5 !w-5 rounded-md ${
+              aria-hidden={showBurnerSync ? undefined : true}
+              tabIndex={showBurnerSync ? undefined : -1}
+              disabled={!showBurnerSync}
+              className={`vf-burner-sync-icon-motion !h-5 overflow-hidden rounded-md transition-[background-color,color,width] duration-200 ease-[cubic-bezier(.2,.8,.2,1)] motion-reduce:transition-none ${
+                showBurnerSync
+                  ? '!w-5 opacity-100'
+                  : 'pointer-events-none !w-0 opacity-0'
+              } ${
                 burnerSyncStatus === 'syncing'
-                  ? 'animate-spin text-agent-shell-accent'
-                  : burnerSyncFailed
+                  ? 'vf-burner-sync-spin text-agent-shell-accent'
+                  : burnerSyncBlocked
                     ? 'bg-error/10 text-error hover:bg-error/15'
                     : 'text-agent-shell-accent hover:bg-agent-shell-accent/15'
               }`}
               onClick={(event) => {
                 event.stopPropagation()
-                if (syncFailureTimeoutRef.current) {
-                  clearTimeout(syncFailureTimeoutRef.current)
-                  syncFailureTimeoutRef.current = null
-                }
                 if (burnerActive) {
                   setBurnerSyncStatus('blocked')
 
@@ -197,18 +215,12 @@ export const HeaderActions = ({
                 }
                 setBurnerSyncStatus('syncing')
                 onSyncBurner?.()
-                syncFailureTimeoutRef.current = setTimeout(() => {
-                  syncFailureTimeoutRef.current = null
-                  setBurnerSyncStatus('failed')
-                }, SYNC_FAILURE_TIMEOUT_MS)
               }}
             />
           </Tooltip>
           {burnerButton}
         </div>
-      ) : (
-        burnerButton
-      )}
+      ) : null}
 
       {!hideCollapseToggle && (
         <Tooltip content={collapseLabel} placement="bottom" nativeOverlay>

--- a/src/features/terminal/components/TerminalPane/HeaderActions.tsx
+++ b/src/features/terminal/components/TerminalPane/HeaderActions.tsx
@@ -74,6 +74,7 @@ export const HeaderActions = ({
     useState<BurnerSyncStatus>('idle')
   const burnerButtonRef = useRef<HTMLButtonElement | null>(null)
   const syncButtonRef = useRef<HTMLButtonElement | null>(null)
+  const syncButtonHadFocusRef = useRef(false)
 
   const burnerLabel = burnerButtonLabel(
     burnerActive,
@@ -94,11 +95,13 @@ export const HeaderActions = ({
   }, [showBurnerSync])
 
   useEffect(() => {
-    if (
-      showBurnerSync ||
-      document.activeElement !== syncButtonRef.current ||
-      burnerButtonRef.current === null
-    ) {
+    if (showBurnerSync) {
+      return
+    }
+
+    const shouldRestoreFocus = syncButtonHadFocusRef.current
+    syncButtonHadFocusRef.current = false
+    if (!shouldRestoreFocus || burnerButtonRef.current === null) {
       return
     }
 
@@ -215,6 +218,16 @@ export const HeaderActions = ({
                 }
                 setBurnerSyncStatus('syncing')
                 onSyncBurner?.()
+              }}
+              onFocus={() => {
+                syncButtonHadFocusRef.current = true
+              }}
+              onBlur={(event) => {
+                if (event.currentTarget.disabled) {
+                  return
+                }
+
+                syncButtonHadFocusRef.current = false
               }}
             />
           </Tooltip>

--- a/src/index.css
+++ b/src/index.css
@@ -181,6 +181,23 @@
   }
 }
 
+.vf-burner-sync-icon-motion .material-symbols-outlined {
+  transform-origin: center;
+}
+
+.vf-burner-sync-spin .material-symbols-outlined {
+  animation: vfBurnerSyncSpin 480ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+@keyframes vfBurnerSyncSpin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 @utility glass-panel {
   /* Background lives on the Tailwind `bg-[…]/<alpha>` class on each consumer
      so the panel's opacity is explicit at the call site. We only contribute
@@ -256,6 +273,10 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .vf-burner-sync-icon-motion .material-symbols-outlined {
+    animation: none;
+  }
+
   .vf-liquid-wave-a,
   .vf-liquid-wave-b,
   .vf-liquid-slosh {


### PR DESCRIPTION
## Summary
- animate the burner sync button as a pill extension of the burner terminal button on show/hide
- use a restartable one-turn sync animation and remove the false timeout failure state
- keep both button tooltips while making same-surface native tooltip refreshes stable
- add the stripped demo at `docs/exploration/2026-07-06-burner-sync-pill-demo.html`

## Test plan
- `npm run test -- HeaderActions.test.tsx electron/native-overlay.test.ts Tooltip.test.tsx`
- `npx eslint electron/native-overlay.ts electron/native-overlay.test.ts src/features/terminal/components/TerminalPane/HeaderActions.tsx src/features/terminal/components/TerminalPane/HeaderActions.test.tsx`
- `npx prettier --check electron/native-overlay.ts electron/native-overlay.test.ts src/features/terminal/components/TerminalPane/HeaderActions.tsx src/features/terminal/components/TerminalPane/HeaderActions.test.tsx src/index.css docs/exploration/2026-07-06-burner-sync-pill-demo.html`
- `git diff --check`
- `codex review --base origin/main`
- `npm run test` (pre-push hook)
