### PR TITLE
fix(terminal): block Ghostty input behind overlays

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -83,7 +83,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 36       | 18   | 2026-07-05   |
 | [Module Boundaries](patterns/module-boundaries.md)                                                   | code-quality       | 17       | 3    | 2026-06-25   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 13       | 3    | 2026-06-15   |
-| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 34       | 9    | 2026-07-05   |
+| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 35       | 10   | 2026-07-07   |
 | [Verify Render Target](patterns/verify-render-target.md)                                             | code-quality       | 3        | 1    | 2026-07-01   |
 | [UI Visual Regression](patterns/ui-visual-regression.md)                                             | code-quality       | 27       | 17   | 2026-07-05   |
 | [Status Indicator Display](patterns/status-indicator-display.md)                                     | code-quality       | 3        | 0    | 2026-05-26   |

--- a/docs/reviews/patterns/keyboard-shortcut-guards.md
+++ b/docs/reviews/patterns/keyboard-shortcut-guards.md
@@ -2,8 +2,8 @@
 id: keyboard-shortcut-guards
 category: keyboard-shortcuts
 created: 2026-05-18
-last_updated: 2026-07-05
-ref_count: 9
+last_updated: 2026-07-07
+ref_count: 10
 ---
 
 # Keyboard Shortcut Guards
@@ -451,4 +451,18 @@ against three classes of false-fire:
 - **Fix:** Forwarded `shortcutKey` as the synthetic keyboard event key and added
   a focused regression assertion that both `key` and `code` are present in the
   renderer dispatch script.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 35. Native Ghostty shortcut refocus outlived overlay guards
+
+- **Source:** github-codex-connector | PR #670 round 1 | 2026-07-07
+- **Severity:** P2 / MEDIUM
+- **File:** `electron/ghostty-native-parent.ts`
+- **Finding:** The native Ghostty shortcut path checked the interactive overlay
+  guard before dispatching the synthetic key event into the renderer, but the
+  delayed post-dispatch refocus branch could still run after that renderer
+  shortcut opened a native overlay.
+- **Fix:** Rechecked `inputBlocked(win)` immediately before `addon.focus(currentSurface)`
+  in the async refocus branch and added regression coverage for an overlay opening
+  while shortcut dispatch is pending.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/electron/ghostty-native-parent.test.ts
+++ b/electron/ghostty-native-parent.test.ts
@@ -1519,6 +1519,88 @@ describe('ghostty native parent', () => {
     controller.dispose()
   })
 
+  test('does not refocus when an overlay opens during shortcut dispatch', async () => {
+    const callbacks: {
+      onShortcut?: (
+        key: string,
+        code: string,
+        control: boolean,
+        meta: boolean,
+        alt: boolean,
+        shift: boolean,
+        repeat: boolean
+      ) => void
+    } = {}
+    const surface = { id: 'surface-1' }
+    let overlayOpen = false
+    let resolveDispatch: (value: unknown) => void = () => {
+      throw new Error('Shortcut dispatch resolver was not initialized')
+    }
+
+    const pendingDispatch = new Promise<unknown>((resolve) => {
+      resolveDispatch = resolve
+    })
+
+    const addon = {
+      create: vi.fn(
+        (_bridge, _handle, _input, _resize, _focus, shortcut, _renamePane) => {
+          void _renamePane
+          callbacks.onShortcut = shortcut
+
+          return surface
+        }
+      ),
+      setFrame: vi.fn(),
+      write: vi.fn(),
+      focus: vi.fn(),
+      destroy: vi.fn(),
+    }
+
+    const sidecar = {
+      invoke: vi.fn(() => Promise.resolve(undefined)),
+      onEvent: vi.fn(() => vi.fn()),
+      shutdown: vi.fn(() => Promise.resolve()),
+    } as unknown as Sidecar
+    const inputBlocked = vi.fn(() => overlayOpen)
+
+    const controller = setupGhosttyNativeParent({
+      sidecar,
+      platform: 'darwin',
+      env: { VITE_GHOSTTY_NATIVE_MACOS_PARENT: '1' },
+      addon,
+      inputBlocked,
+    })
+
+    handlers.get(GHOSTTY_NATIVE_UPDATE)?.(
+      { sender: {} },
+      {
+        sessionId: 'pty-1',
+        paneId: 'pane-1',
+        cwd: '/tmp',
+        visible: true,
+        parentHeight: 900,
+        bounds: { x: 10, y: 20, width: 300, height: 200 },
+      }
+    )
+
+    webContentsExecuteJavaScript.mockReturnValueOnce(pendingDispatch)
+    callbacks.onShortcut?.('n', 'KeyN', false, true, false, false, false)
+
+    expect(webContentsExecuteJavaScript).toHaveBeenCalledOnce()
+    overlayOpen = true
+
+    resolveDispatch({ activeGhosttyPane: true, dockHasFocus: false })
+    await pendingDispatch
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0)
+    })
+
+    expect(inputBlocked).toHaveBeenCalledTimes(2)
+    expect(addon.focus).not.toHaveBeenCalled()
+
+    controller.dispose()
+  })
+
   test('opens command palette directly from native Ghostty shortcut', () => {
     const callbacks: {
       onShortcut?: (

--- a/electron/ghostty-native-parent.test.ts
+++ b/electron/ghostty-native-parent.test.ts
@@ -978,6 +978,84 @@ describe('ghostty native parent', () => {
     controller.dispose()
   })
 
+  test('drops native Ghostty input while an interactive overlay is active', () => {
+    const callbacks: {
+      onInput?: (data: string) => void
+      onFocus?: () => void
+      onShortcut?: (
+        key: string,
+        code: string,
+        control: boolean,
+        meta: boolean,
+        alt: boolean,
+        shift: boolean,
+        repeat: boolean
+      ) => void
+      onRenamePane?: () => void
+    } = {}
+    const surface = {}
+
+    const addon = {
+      create: vi.fn(
+        (_bridge, _handle, input, _resize, focus, shortcut, renamePane) => {
+          void _resize
+          callbacks.onInput = input
+          callbacks.onFocus = focus
+          callbacks.onShortcut = shortcut
+          callbacks.onRenamePane = renamePane
+
+          return surface
+        }
+      ),
+      setFrame: vi.fn(),
+      write: vi.fn(),
+      focus: vi.fn(),
+      destroy: vi.fn(),
+    }
+
+    const sidecar = {
+      invoke: vi.fn(() => Promise.resolve(undefined)),
+      onEvent: vi.fn(() => vi.fn()),
+      shutdown: vi.fn(() => Promise.resolve()),
+    } as unknown as Sidecar
+
+    const inputBlocked = vi.fn(() => true)
+
+    const controller = setupGhosttyNativeParent({
+      sidecar,
+      platform: 'darwin',
+      env: { VITE_GHOSTTY_NATIVE_MACOS_PARENT: '1' },
+      addon,
+      inputBlocked,
+    })
+
+    handlers.get(GHOSTTY_NATIVE_UPDATE)?.(
+      { sender: {} },
+      {
+        sessionId: 'pty-1',
+        paneId: 'pane-1',
+        cwd: '/tmp',
+        visible: true,
+        parentHeight: 900,
+        bounds: { x: 10, y: 20, width: 300, height: 200 },
+      }
+    )
+
+    callbacks.onInput?.('secret')
+    callbacks.onFocus?.()
+    callbacks.onShortcut?.('n', 'KeyN', false, true, false, false, false)
+    callbacks.onRenamePane?.()
+
+    expect(inputBlocked).toHaveBeenCalled()
+    expect(sidecar.invoke).not.toHaveBeenCalled()
+    expect(webContentsSend).not.toHaveBeenCalled()
+    expect(webContentsFocus).not.toHaveBeenCalled()
+    expect(webContentsExecuteJavaScript).not.toHaveBeenCalled()
+    expect(addon.focus).not.toHaveBeenCalled()
+
+    controller.dispose()
+  })
+
   test('attaches secondary child and routes input plus resize to its PTY', () => {
     const callbacks: {
       onInput?: (data: string) => void

--- a/electron/ghostty-native-parent.ts
+++ b/electron/ghostty-native-parent.ts
@@ -103,6 +103,7 @@ interface GhosttyNativeParentDeps {
   packaged?: boolean
   resourcesPath?: string
   addon?: GhosttyNativeParentAddon
+  inputBlocked?: (win: BrowserWindow) => boolean
 }
 
 interface GhosttyNativeSurfaceState {
@@ -330,6 +331,8 @@ export class GhosttyNativeParentController {
 
   private readonly nativeParentDir: string
 
+  private readonly inputBlocked: (win: BrowserWindow) => boolean
+
   private addon: GhosttyNativeParentAddon | null
 
   private addonLoadFailed = false
@@ -350,6 +353,7 @@ export class GhosttyNativeParentController {
       deps.resourcesPath ?? process.resourcesPath
     )
     this.addon = deps.addon ?? null
+    this.inputBlocked = deps.inputBlocked ?? ((): boolean => false)
   }
 
   registerIpc(): void {
@@ -587,6 +591,10 @@ export class GhosttyNativeParentController {
           return
         }
 
+        if (this.inputBlocked(win)) {
+          return
+        }
+
         this.invokeSidecar('write_pty', {
           request: {
             sessionId: payload.secondarySessionId,
@@ -621,6 +629,10 @@ export class GhosttyNativeParentController {
       },
       () => {
         if (win.isDestroyed() || !this.surfaces.has(this.paneKey(state.pane))) {
+          return
+        }
+
+        if (this.inputBlocked(win)) {
           return
         }
 
@@ -846,6 +858,10 @@ export class GhosttyNativeParentController {
           return
         }
 
+        if (this.inputBlocked(win)) {
+          return
+        }
+
         win.webContents.send(BACKEND_EVENT, {
           event: 'ghostty-native-input',
           payload: { ...state.pane, data },
@@ -881,6 +897,10 @@ export class GhosttyNativeParentController {
           return
         }
 
+        if (this.inputBlocked(win)) {
+          return
+        }
+
         win.webContents.send(BACKEND_EVENT, {
           event: 'ghostty-native-focus',
           payload: state.pane,
@@ -888,6 +908,10 @@ export class GhosttyNativeParentController {
       },
       (shortcutKey, code, control, meta, alt, shift, repeat) => {
         if (win.isDestroyed() || !this.surfaces.has(this.paneKey(state.pane))) {
+          return
+        }
+
+        if (this.inputBlocked(win)) {
           return
         }
 
@@ -918,6 +942,10 @@ export class GhosttyNativeParentController {
       },
       () => {
         if (win.isDestroyed() || !this.surfaces.has(this.paneKey(state.pane))) {
+          return
+        }
+
+        if (this.inputBlocked(win)) {
           return
         }
 

--- a/electron/ghostty-native-parent.ts
+++ b/electron/ghostty-native-parent.ts
@@ -1052,7 +1052,7 @@ export class GhosttyNativeParentController {
         const currentSurface =
           currentState === state ? currentState.surface : null
 
-        if (currentSurface) {
+        if (currentSurface && !this.inputBlocked(win)) {
           addon.focus(currentSurface)
         }
       }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -459,6 +459,9 @@ const setupApp = async (): Promise<void> => {
     ghosttyNativeController = setupGhosttyNativeParent({
       sidecar: spawnedSidecar,
       packaged: app.isPackaged,
+      inputBlocked: (win) =>
+        nativeOverlayController?.hasActiveInteractiveOverlaySurface(win) ===
+        true,
     })
   } else if (ghosttyNativeHelperEnabled) {
     ghosttyNativeController = setupGhosttyNativeHelper({

--- a/electron/native-overlay.test.ts
+++ b/electron/native-overlay.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
+import type { BrowserWindow } from 'electron'
 import {
   NATIVE_OVERLAY_ACTION,
   NATIVE_OVERLAY_ACTION_RESULT,
@@ -835,6 +836,47 @@ describe('NativeOverlayController', () => {
     await expect(openPromise).resolves.toEqual({ accepted: true })
     expect(overlayWindow.showInactive).toHaveBeenCalledOnce()
     expect(overlayWindow.webContents.focus).not.toHaveBeenCalled()
+  })
+
+  test('reports active interactive overlay surfaces but ignores passive tooltips', async () => {
+    const ownerWindow = electronMock.owner as unknown as BrowserWindow
+
+    expect(controller.hasActiveInteractiveOverlaySurface(ownerWindow)).toBe(
+      false
+    )
+
+    const tooltipOpenPromise = handler(NATIVE_OVERLAY_OPEN)(
+      { sender: electronMock.owner.webContents },
+      tooltipRequest
+    )
+    const tooltipWindow = finishOverlayLoad(1)
+    await acknowledgeOverlayReady(tooltipWindow, tooltipRequest.surfaceId)
+    await tooltipOpenPromise
+
+    expect(controller.hasActiveInteractiveOverlaySurface(ownerWindow)).toBe(
+      false
+    )
+
+    const dialogOpenPromise = handler(NATIVE_OVERLAY_OPEN)(
+      { sender: electronMock.owner.webContents },
+      dialogRequest
+    )
+    const dialogWindow = finishOverlayLoad()
+    await acknowledgeOverlayReady(dialogWindow, dialogRequest.surfaceId)
+    await dialogOpenPromise
+
+    expect(controller.hasActiveInteractiveOverlaySurface(ownerWindow)).toBe(
+      true
+    )
+
+    handler(NATIVE_OVERLAY_CLOSE)(
+      { sender: electronMock.owner.webContents },
+      { surfaceId: dialogRequest.surfaceId, reason: 'renderer' }
+    )
+
+    expect(controller.hasActiveInteractiveOverlaySurface(ownerWindow)).toBe(
+      false
+    )
   })
 
   test('does not hide a newer active overlay when an older render times out', async () => {

--- a/electron/native-overlay.ts
+++ b/electron/native-overlay.ts
@@ -763,6 +763,14 @@ export class NativeOverlayController {
     this.surfaces.clear()
   }
 
+  hasActiveInteractiveOverlaySurface(parent: BrowserWindow): boolean {
+    const record = this.overlays.get(parent.id)
+
+    return (
+      record?.activeSurfaceId !== null && record?.activeSurfaceId !== undefined
+    )
+  }
+
   private readonly handleOpen = async (
     event: IpcMainInvokeEvent,
     payload: unknown


### PR DESCRIPTION
## Summary
- block native Ghostty input/focus/shortcut/rename callbacks while an interactive native overlay surface is active
- expose native overlay interactive-surface state for the Ghostty parent controller
- add focused coverage for active overlay detection and blocked Ghostty callbacks

## Test plan
- npx vitest run electron/ghostty-native-parent.test.ts electron/native-overlay.test.ts
- npx eslint electron/native-overlay.ts electron/native-overlay.test.ts electron/main.ts electron/ghostty-native-parent.ts electron/ghostty-native-parent.test.ts
- npx tsc -p electron/tsconfig.json --noEmit
- npm test (pre-push hook)

Refs VIM-301