### PR TITLE
fix(workspace): render dock tooltips above Ghostty

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -111,6 +111,6 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Vite HMR Static Dependencies](patterns/vite-hmr-static-deps.md)                                     | code-quality       | 3        | 2    | 2026-06-18   |
 | [Custom Pane Layout Preservation](patterns/custom-pane-layout-preservation.md)                       | correctness        | 13       | 5    | 2026-06-22   |
 | [Pane Slot Identity](patterns/pane-slot-identity.md)                                                 | correctness        | 3        | 1    | 2026-06-22   |
-| [Transient UI Side Effects](patterns/transient-ui-side-effects.md)                                   | react-patterns     | 17       | 9    | 2026-07-05   |
+| [Transient UI Side Effects](patterns/transient-ui-side-effects.md)                                   | react-patterns     | 18       | 9    | 2026-07-07   |
 | [Async Global State Mutation](patterns/async-global-state-mutation.md)                               | backend            | 1        | 0    | 2026-06-19   |
 | [Boolean Sentinel Consistency](patterns/boolean-sentinel-consistency.md)                             | code-quality       | 2        | 1    | 2026-06-22   |

--- a/docs/reviews/patterns/transient-ui-side-effects.md
+++ b/docs/reviews/patterns/transient-ui-side-effects.md
@@ -2,7 +2,7 @@
 id: transient-ui-side-effects
 category: react-patterns
 created: 2026-06-20
-last_updated: 2026-07-05
+last_updated: 2026-07-07
 ref_count: 9
 ---
 
@@ -248,4 +248,19 @@ to persistent state through a separate, explicit path.
 - **Fix:** Exposed Dialog's actual accepted native-active state and disabled
   Browse only while that state is active. Added a regression that rejects the
   native dialog open and expects the local Browse button to stay enabled.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 18. Native tooltip shortcut arrays retriggered overlay lifetime effects
+
+- **Source:** github-claude | PR #671 round 1 | 2026-07-07
+- **Severity:** HIGH
+- **File:** `src/components/Tooltip.tsx`
+- **Finding:** Native tooltip requests depended on the raw `shortcut` prop.
+  Callers that passed inline chord arrays allocated a new array on each render,
+  so an unchanged shortcut could still recreate the native request callback and
+  make the open/close effect tear down and reopen the visible overlay.
+- **Fix:** Formatted shortcuts once into a primitive string and used that value
+  in the native payload and effect dependencies. Added regression coverage that
+  rerenders an open native tooltip with a fresh inline shortcut array without
+  closing or reopening the overlay.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/electron/native-overlay.test.ts
+++ b/electron/native-overlay.test.ts
@@ -256,6 +256,7 @@ const tooltipRequest = {
   payload: {
     kind: 'tooltip',
     text: 'collapse status',
+    shortcut: '⌘0',
     maxWidth: 320,
   },
 } as const

--- a/electron/native-overlay.ts
+++ b/electron/native-overlay.ts
@@ -113,6 +113,7 @@ interface NativeOverlayMenuPayload {
 interface NativeOverlayTooltipPayload {
   kind: 'tooltip'
   text: string
+  shortcut?: string
   maxWidth?: number
 }
 
@@ -489,6 +490,7 @@ const isTooltipPayload = (
   isRecord(value) &&
   value.kind === 'tooltip' &&
   isString(value.text) &&
+  (value.shortcut === undefined || isString(value.shortcut)) &&
   (value.maxWidth === undefined || isFiniteNumber(value.maxWidth))
 
 const isCommandPaletteItem = (

--- a/src/components/NativeOverlayHost.test.tsx
+++ b/src/components/NativeOverlayHost.test.tsx
@@ -150,6 +150,16 @@ const tooltipRequest: NativeOverlayRequest = {
   },
 }
 
+const shortcutTooltipRequest: NativeOverlayRequest = {
+  ...tooltipRequest,
+  surfaceId: 'tooltip-2',
+  payload: {
+    kind: 'tooltip',
+    text: 'Diff Viewer',
+    shortcut: '⌘G',
+  },
+}
+
 const commandPaletteRequest: NativeOverlayRequest = {
   surfaceId: 'dialog-1',
   kind: 'dialog',
@@ -407,6 +417,19 @@ describe('NativeOverlayHost', () => {
     bridge.emitClear()
 
     expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+  })
+
+  test('renders a shortcut chip for native overlay tooltip requests', async () => {
+    const bridge = installNativeOverlayHostBridge()
+    render(<NativeOverlayHost mode="tooltip" />)
+
+    bridge.emitRender(shortcutTooltipRequest)
+
+    const tooltip = await screen.findByRole('tooltip')
+    expect(tooltip).toHaveTextContent('Diff Viewer')
+    expect(
+      within(tooltip).getByTestId('native-overlay-tooltip-shortcut')
+    ).toHaveTextContent('⌘G')
   })
 
   test('renders command palette dialog requests on the menu layer', async () => {

--- a/src/components/NativeOverlayHost.tsx
+++ b/src/components/NativeOverlayHost.tsx
@@ -1048,7 +1048,19 @@ export const NativeOverlayHost = ({
         className={OVERLAY_TOOLTIP_CLASSES}
         style={tooltipStyleForRequest(request)}
       >
-        {request.payload.text}
+        {request.payload.shortcut === undefined ? (
+          request.payload.text
+        ) : (
+          <span className="flex items-center gap-3">
+            <span className="min-w-0 flex-1">{request.payload.text}</span>
+            <kbd
+              data-testid="native-overlay-tooltip-shortcut"
+              className={OVERLAY_MENU_SHORTCUT_CLASSES}
+            >
+              {request.payload.shortcut}
+            </kbd>
+          </span>
+        )}
       </div>
     )
   }

--- a/src/components/SegmentedControl.test.tsx
+++ b/src/components/SegmentedControl.test.tsx
@@ -1,12 +1,66 @@
-import { render, screen, within } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, test, vi } from 'vitest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { __resetNativeOverlayForTest } from '@/components/base/floating/nativeOverlay'
 import { SegmentedControl } from './SegmentedControl'
+
+let restorePlatform: (() => void) | null = null
+
+const setNavigatorPlatform = (platform: string): void => {
+  restorePlatform?.()
+  const original = Object.getOwnPropertyDescriptor(window.navigator, 'platform')
+
+  Object.defineProperty(window.navigator, 'platform', {
+    configurable: true,
+    value: platform,
+  })
+
+  restorePlatform = (): void => {
+    if (original === undefined) {
+      delete (window.navigator as unknown as { platform?: string }).platform
+
+      return
+    }
+
+    Object.defineProperty(window.navigator, 'platform', original)
+  }
+}
+
+const installNativeOverlayBridge = (): {
+  open: ReturnType<typeof vi.fn>
+  close: ReturnType<typeof vi.fn>
+} => {
+  const open = vi.fn().mockResolvedValue({ accepted: true })
+  const close = vi.fn().mockResolvedValue(undefined)
+
+  window.vimeflow = {
+    invoke: <T,>(): Promise<T> => Promise.resolve(null as T),
+    listen: vi.fn(() => Promise.resolve(vi.fn())),
+    nativeOverlay: {
+      open,
+      close,
+      actionResult: vi.fn(() => Promise.resolve()),
+      resume: vi.fn(() => Promise.resolve()),
+      onAction: vi.fn(() => vi.fn()),
+      onClose: vi.fn(() => vi.fn()),
+    },
+  }
+
+  return { open, close }
+}
 
 const OPTIONS = [
   { value: 'split', label: 'Split' },
   { value: 'unified', label: 'Unified' },
 ] as const
+
+afterEach(() => {
+  restorePlatform?.()
+  restorePlatform = null
+  vi.unstubAllEnvs()
+  __resetNativeOverlayForTest()
+  delete window.vimeflow
+})
 
 describe('SegmentedControl', () => {
   test('renders options as pressed buttons inside a named group', () => {
@@ -199,6 +253,45 @@ describe('SegmentedControl', () => {
         name: 'Reduce panes to switch to Unified',
       })
     ).toBeInTheDocument()
+  })
+
+  test('can route option tooltips through native overlay', async () => {
+    vi.stubEnv('VITE_NATIVE_OVERLAY', '1')
+    setNavigatorPlatform('MacIntel')
+    const nativeBridge = installNativeOverlayBridge()
+    const user = userEvent.setup()
+
+    render(
+      <SegmentedControl
+        aria-label="Dock tab"
+        variant="dock"
+        value="editor"
+        options={[
+          {
+            value: 'diff',
+            label: 'Diff Viewer',
+            tooltip: 'Diff Viewer',
+            shortcut: ['Mod', 'G'] as const,
+          },
+          { value: 'editor', label: 'Editor' },
+        ]}
+        onChange={vi.fn()}
+        nativeOverlayTooltips
+      />
+    )
+
+    await user.hover(screen.getByRole('button', { name: 'Diff Viewer' }))
+
+    await waitFor(() => expect(nativeBridge.open).toHaveBeenCalledOnce())
+    expect(nativeBridge.open.mock.calls[0][0]).toMatchObject({
+      kind: 'tooltip',
+      payload: {
+        kind: 'tooltip',
+        text: 'Diff Viewer',
+        shortcut: '⌘G',
+      },
+    })
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
   })
 
   test('arrow-key navigation skips a disabled option', async () => {

--- a/src/components/SegmentedControl.tsx
+++ b/src/components/SegmentedControl.tsx
@@ -148,6 +148,7 @@ interface SegmentedControlProps<
   showActiveThumb?: boolean
   thumbTestId?: string
   style?: CSSProperties
+  nativeOverlayTooltips?: boolean
 }
 
 const keyToOffset = (key: string): number | 'first' | 'last' | null => {
@@ -228,6 +229,7 @@ export const SegmentedControl = <T extends string | number>({
   showActiveThumb = variant === 'sidebar',
   thumbTestId = undefined,
   style = undefined,
+  nativeOverlayTooltips = false,
 }: SegmentedControlProps<T>): ReactElement => {
   const activeIndex = options.findIndex((option) => option.value === value)
   const focusIndex = Math.max(0, activeIndex)
@@ -353,6 +355,7 @@ export const SegmentedControl = <T extends string | number>({
             content={option.tooltip}
             shortcut={option.shortcut}
             placement="bottom"
+            nativeOverlay={nativeOverlayTooltips}
           >
             {button}
           </Tooltip>

--- a/src/components/Tooltip.test.tsx
+++ b/src/components/Tooltip.test.tsx
@@ -1,4 +1,4 @@
-import { createRef } from 'react'
+import { createRef, type ReactElement } from 'react'
 import { act, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, test, vi } from 'vitest'
@@ -428,6 +428,38 @@ describe('Tooltip', () => {
       },
     })
     expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+  })
+
+  test('keeps native shortcut tooltip open across equal inline shortcut rerenders', async () => {
+    vi.stubEnv('VITE_NATIVE_OVERLAY', '1')
+    setNavigatorPlatform('MacIntel')
+    const nativeBridge = installNativeOverlayBridge()
+    const user = userEvent.setup()
+
+    const renderShortcutTooltip = (): ReactElement => (
+      <Tooltip
+        content="Collapse panel"
+        delayMs={0}
+        shortcut={['Mod', '0']}
+        nativeOverlay
+      >
+        <button type="button">trigger</button>
+      </Tooltip>
+    )
+
+    const { rerender } = render(renderShortcutTooltip())
+
+    await user.hover(screen.getByRole('button', { name: 'trigger' }))
+    await waitFor(() => expect(nativeBridge.open).toHaveBeenCalledOnce())
+
+    rerender(renderShortcutTooltip())
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(nativeBridge.open).toHaveBeenCalledOnce()
+    expect(nativeBridge.close).not.toHaveBeenCalled()
   })
 
   test('resyncs native tooltip anchor geometry after resize', async () => {

--- a/src/components/Tooltip.test.tsx
+++ b/src/components/Tooltip.test.tsx
@@ -399,6 +399,37 @@ describe('Tooltip', () => {
     })
   })
 
+  test('sends shortcut chips through native tooltip overlay', async () => {
+    vi.stubEnv('VITE_NATIVE_OVERLAY', '1')
+    setNavigatorPlatform('MacIntel')
+    const nativeBridge = installNativeOverlayBridge()
+    const user = userEvent.setup()
+
+    render(
+      <Tooltip
+        content="Open diff"
+        delayMs={0}
+        shortcut={['Mod', 'G']}
+        nativeOverlay
+      >
+        <button type="button">trigger</button>
+      </Tooltip>
+    )
+
+    await user.hover(screen.getByRole('button', { name: 'trigger' }))
+
+    await waitFor(() => expect(nativeBridge.open).toHaveBeenCalledOnce())
+    expect(nativeBridge.open.mock.calls[0][0]).toMatchObject({
+      kind: 'tooltip',
+      payload: {
+        kind: 'tooltip',
+        text: 'Open diff',
+        shortcut: '⌘G',
+      },
+    })
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+  })
+
   test('resyncs native tooltip anchor geometry after resize', async () => {
     vi.stubEnv('VITE_NATIVE_OVERLAY', '1')
     setNavigatorPlatform('MacIntel')

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -4,6 +4,7 @@ import {
   useCallback,
   useEffect,
   useId,
+  useMemo,
   useState,
   type ReactElement,
   type ReactNode,
@@ -137,6 +138,11 @@ export const Tooltip = ({
   const transport = selectFloatingTransport(nativeOverlay)
   const nativeTooltipText = typeof content === 'string' ? content : null
 
+  const formattedShortcut = useMemo(
+    () => (shortcut === undefined ? undefined : formatShortcut(shortcut)),
+    [shortcut]
+  )
+
   const nativeUnsupportedReason =
     nativeTooltipText === null
       ? 'tooltip native overlay only supports plain text'
@@ -208,9 +214,6 @@ export const Tooltip = ({
 
     const rect = reference.getBoundingClientRect()
 
-    const nativeShortcut =
-      shortcut === undefined ? undefined : formatShortcut(shortcut)
-
     return openNativeOverlay(
       {
         surfaceId: nativeSurfaceId,
@@ -225,7 +228,9 @@ export const Tooltip = ({
         payload: {
           kind: 'tooltip',
           text: nativeTooltipText,
-          ...(nativeShortcut === undefined ? {} : { shortcut: nativeShortcut }),
+          ...(formattedShortcut === undefined
+            ? {}
+            : { shortcut: formattedShortcut }),
           maxWidth,
         },
         theme: nativeOverlayThemeSnapshot(),
@@ -236,12 +241,12 @@ export const Tooltip = ({
       }
     )
   }, [
+    formattedShortcut,
     maxWidth,
     nativeSurfaceId,
     nativeTooltipText,
     placement,
     refs.reference,
-    shortcut,
   ])
 
   useEffect(() => {
@@ -386,7 +391,7 @@ export const Tooltip = ({
         <div className="flex items-center gap-3">
           <span className="min-w-0 flex-1">{content}</span>
           <kbd data-testid="tooltip-shortcut" className={SHORTCUT_CHIP_CLASSES}>
-            {formatShortcut(shortcut)}
+            {formattedShortcut}
           </kbd>
         </div>
       ) : (

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -144,9 +144,7 @@ export const Tooltip = ({
         ? 'interactive tooltip native overlay is not in v0'
         : bare
           ? 'bare tooltip native overlay is not in v0'
-          : shortcut !== undefined
-            ? 'shortcut tooltip native overlay is not in v0'
-            : null
+          : null
 
   const canUseNativeOverlay =
     open && transport === 'native-overlay' && nativeUnsupportedReason === null
@@ -210,6 +208,9 @@ export const Tooltip = ({
 
     const rect = reference.getBoundingClientRect()
 
+    const nativeShortcut =
+      shortcut === undefined ? undefined : formatShortcut(shortcut)
+
     return openNativeOverlay(
       {
         surfaceId: nativeSurfaceId,
@@ -224,6 +225,7 @@ export const Tooltip = ({
         payload: {
           kind: 'tooltip',
           text: nativeTooltipText,
+          ...(nativeShortcut === undefined ? {} : { shortcut: nativeShortcut }),
           maxWidth,
         },
         theme: nativeOverlayThemeSnapshot(),
@@ -233,7 +235,14 @@ export const Tooltip = ({
         onClose: () => setOpen(false),
       }
     )
-  }, [maxWidth, nativeSurfaceId, nativeTooltipText, placement, refs.reference])
+  }, [
+    maxWidth,
+    nativeSurfaceId,
+    nativeTooltipText,
+    placement,
+    refs.reference,
+    shortcut,
+  ])
 
   useEffect(() => {
     if (!canUseNativeOverlay || nativeTooltipText === null) {

--- a/src/components/base/floating/nativeOverlay.ts
+++ b/src/components/base/floating/nativeOverlay.ts
@@ -94,6 +94,7 @@ export interface NativeOverlayMenuPayload {
 export interface NativeOverlayTooltipPayload {
   kind: 'tooltip'
   text: string
+  shortcut?: string
   maxWidth?: number
 }
 

--- a/src/features/diff/components/toolbar/DiffChipToolbar.test.tsx
+++ b/src/features/diff/components/toolbar/DiffChipToolbar.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, within } from '@testing-library/react'
+import { act, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import type { BaseDiffOptions, DiffsThemeNames } from '@pierre/diffs'
@@ -7,6 +7,7 @@ import { DiffChipToolbar, type DiffChipToolbarProps } from './DiffChipToolbar'
 // Capture the ResizeObserver callback so the test can flush PriorityPlus
 // measurements deterministically — same pattern as PriorityPlus.test.tsx.
 let resizeCallback: ResizeObserverCallback | null = null
+let restorePlatform: (() => void) | null = null
 
 class TestResizeObserver implements ResizeObserver {
   constructor(callback: ResizeObserverCallback) {
@@ -20,6 +21,77 @@ class TestResizeObserver implements ResizeObserver {
   }
   disconnect(): void {
     // No-op.
+  }
+}
+
+const setNavigatorPlatform = (platform: string): void => {
+  restorePlatform?.()
+  const original = Object.getOwnPropertyDescriptor(window.navigator, 'platform')
+
+  Object.defineProperty(window.navigator, 'platform', {
+    configurable: true,
+    value: platform,
+  })
+
+  restorePlatform = (): void => {
+    if (original === undefined) {
+      delete (window.navigator as unknown as { platform?: string }).platform
+
+      return
+    }
+
+    Object.defineProperty(window.navigator, 'platform', original)
+  }
+}
+
+const installNativeOverlayBridge = (): {
+  open: ReturnType<typeof vi.fn>
+  action: (event: unknown) => void
+} => {
+  const open = vi.fn().mockResolvedValue({ accepted: true })
+  let actionListener: ((event: unknown) => void) | null = null
+
+  window.vimeflow = {
+    invoke: <T,>(): Promise<T> => Promise.resolve(null as T),
+    listen: vi.fn(() => Promise.resolve(vi.fn())),
+    nativeOverlay: {
+      open,
+      close: vi.fn(() => Promise.resolve()),
+      actionResult: vi.fn(() => Promise.resolve()),
+      resume: vi.fn(() => Promise.resolve()),
+      onAction: vi.fn((callback: (event: unknown) => void) => {
+        actionListener = callback
+
+        return vi.fn()
+      }),
+      onClose: vi.fn(() => vi.fn()),
+    },
+  }
+
+  return {
+    open,
+    action: (event): void => {
+      actionListener?.(event)
+    },
+  }
+}
+
+interface NativeMenuItemForTest {
+  id?: string
+  label?: string
+}
+
+interface NativeMenuSectionForTest {
+  label?: string
+  items: NativeMenuItemForTest[]
+}
+
+interface NativeMenuRequestForTest {
+  surfaceId: string
+  kind: string
+  placement: string
+  payload: {
+    sections?: NativeMenuSectionForTest[]
   }
 }
 
@@ -157,6 +229,10 @@ describe('DiffChipToolbar', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals()
+    vi.unstubAllEnvs()
+    restorePlatform?.()
+    restorePlatform = null
+    delete window.vimeflow
     resizeCallback = null
   })
 
@@ -827,5 +903,74 @@ describe('DiffChipToolbar', () => {
     expect(
       screen.getByRole('button', { name: /previous file/i })
     ).toBeInTheDocument()
+  })
+
+  test('overflow controls use a native overlay menu when native overlay is active', async () => {
+    vi.stubEnv('VITE_NATIVE_OVERLAY', '1')
+    setNavigatorPlatform('MacIntel')
+    const nativeBridge = installNativeOverlayBridge()
+    const user = userEvent.setup()
+    const onStage = vi.fn<() => Promise<void>>().mockResolvedValue(undefined)
+
+    renderToolbar({
+      onStage,
+      onDiscard: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+      onPrevHunk: vi.fn<() => void>(),
+      onNextHunk: vi.fn<() => void>(),
+      totalHunks: 3,
+      focusedHunkIndex: 1,
+    })
+
+    const layouts: ItemLayout[] = []
+    for (let index = 0; index < 9; index += 1) {
+      layouts.push({
+        offsetTop: index === 0 ? 0 : 30,
+        offsetHeight: 24,
+        offsetLeft: index * 72,
+        offsetWidth: 60,
+      })
+    }
+
+    stubLayout(priorityPlusRoot(), layouts, 600)
+    fireResize()
+
+    await user.click(
+      screen.getByRole('button', { name: /show 7 more controls/i })
+    )
+
+    await waitFor(() => expect(nativeBridge.open).toHaveBeenCalledOnce())
+    expect(
+      screen.queryByRole('dialog', { name: 'More controls' })
+    ).not.toBeInTheDocument()
+
+    const request = nativeBridge.open.mock
+      .calls[0][0] as NativeMenuRequestForTest
+    expect(request.kind).toBe('menu')
+    expect(request.placement).toBe('bottom-end')
+    expect(request.payload.sections?.map((section) => section.label)).toEqual([
+      'Diff view',
+      'File 2/9',
+      'Changes',
+      'Hunks 2/3',
+      'Highlight',
+      'Theme',
+      'Indicators',
+      'Overflow',
+      'View options',
+    ])
+
+    const stage = request.payload.sections
+      ?.find((section) => section.label === 'Changes')
+      ?.items.find((item) => item.label === 'Stage hunk')
+    expect(stage?.id).toBeDefined()
+
+    act(() => {
+      nativeBridge.action({
+        surfaceId: request.surfaceId,
+        actionId: stage?.id,
+      })
+    })
+
+    await waitFor(() => expect(onStage).toHaveBeenCalledOnce())
   })
 })

--- a/src/features/diff/components/toolbar/DiffChipToolbar.test.tsx
+++ b/src/features/diff/components/toolbar/DiffChipToolbar.test.tsx
@@ -8,6 +8,7 @@ import { DiffChipToolbar, type DiffChipToolbarProps } from './DiffChipToolbar'
 // measurements deterministically — same pattern as PriorityPlus.test.tsx.
 let resizeCallback: ResizeObserverCallback | null = null
 let restorePlatform: (() => void) | null = null
+let nativeOverlayActionListener: ((event: unknown) => void) | null = null
 
 class TestResizeObserver implements ResizeObserver {
   constructor(callback: ResizeObserverCallback) {
@@ -49,7 +50,6 @@ const installNativeOverlayBridge = (): {
   action: (event: unknown) => void
 } => {
   const open = vi.fn().mockResolvedValue({ accepted: true })
-  let actionListener: ((event: unknown) => void) | null = null
 
   window.vimeflow = {
     invoke: <T,>(): Promise<T> => Promise.resolve(null as T),
@@ -60,7 +60,7 @@ const installNativeOverlayBridge = (): {
       actionResult: vi.fn(() => Promise.resolve()),
       resume: vi.fn(() => Promise.resolve()),
       onAction: vi.fn((callback: (event: unknown) => void) => {
-        actionListener = callback
+        nativeOverlayActionListener = callback
 
         return vi.fn()
       }),
@@ -71,7 +71,7 @@ const installNativeOverlayBridge = (): {
   return {
     open,
     action: (event): void => {
-      actionListener?.(event)
+      nativeOverlayActionListener?.(event)
     },
   }
 }
@@ -79,6 +79,7 @@ const installNativeOverlayBridge = (): {
 interface NativeMenuItemForTest {
   id?: string
   label?: string
+  disabled?: boolean
 }
 
 interface NativeMenuSectionForTest {
@@ -972,5 +973,66 @@ describe('DiffChipToolbar', () => {
     })
 
     await waitFor(() => expect(onStage).toHaveBeenCalledOnce())
+  })
+
+  test('native overflow discard-all row preserves confirmation', async () => {
+    vi.stubEnv('VITE_NATIVE_OVERLAY', '1')
+    setNavigatorPlatform('MacIntel')
+    const nativeBridge = installNativeOverlayBridge()
+    const user = userEvent.setup()
+
+    const onDiscardAll = vi
+      .fn<() => Promise<void>>()
+      .mockResolvedValue(undefined)
+
+    renderToolbar({
+      onDiscardAll,
+      selectedFileName: 'src/App.tsx',
+    })
+
+    const layouts: ItemLayout[] = []
+    for (let index = 0; index < 9; index += 1) {
+      layouts.push({
+        offsetTop: index === 0 ? 0 : 30,
+        offsetHeight: 24,
+        offsetLeft: index * 72,
+        offsetWidth: 60,
+      })
+    }
+
+    stubLayout(priorityPlusRoot(), layouts, 600)
+    fireResize()
+
+    await user.click(
+      screen.getByRole('button', { name: /show 7 more controls/i })
+    )
+
+    await waitFor(() => expect(nativeBridge.open).toHaveBeenCalledOnce())
+
+    const request = nativeBridge.open.mock
+      .calls[0][0] as NativeMenuRequestForTest
+
+    const discardAll = request.payload.sections
+      ?.find((section) => section.label === 'Changes')
+      ?.items.find((item) => item.label === 'Discard all changes')
+
+    expect(discardAll?.id).toBeDefined()
+    expect(discardAll?.disabled).not.toBe(true)
+
+    act(() => {
+      nativeBridge.action({
+        surfaceId: request.surfaceId,
+        actionId: discardAll?.id,
+      })
+    })
+
+    expect(onDiscardAll).not.toHaveBeenCalled()
+    expect(
+      await screen.findByText(/discard all changes to "src\/App\.tsx"/i)
+    ).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /^discard$/i }))
+
+    await waitFor(() => expect(onDiscardAll).toHaveBeenCalledOnce())
   })
 })

--- a/src/features/diff/components/toolbar/DiffChipToolbar.tsx
+++ b/src/features/diff/components/toolbar/DiffChipToolbar.tsx
@@ -6,9 +6,14 @@ import { IconButton } from '@/components/IconButton'
 import { Popover } from '@/components/Popover'
 import { TOOLTIP_SUPPRESSED } from '@/lib/constants'
 import { Dropdown, type DropdownOption } from '@/components/Dropdown'
+import { Menu } from '@/components/Menu'
 import { PriorityPlus } from './PriorityPlus'
 import { Segmented } from './Segmented'
-import { ViewSettingsDropdown } from './ViewSettingsDropdown'
+import {
+  ViewSettingsDropdown,
+  VIEW_INDICATOR_OPTIONS,
+  VIEW_OVERFLOW_OPTIONS,
+} from './ViewSettingsDropdown'
 import { FilePill } from './FilePill'
 import { ChangeStepper } from './ChangeStepper'
 import {
@@ -111,6 +116,15 @@ const LINE_DIFF_OPTIONS: readonly DropdownOption<LineDiffType>[] = [
     label: 'None',
     description: 'Show line-level changes only',
   },
+]
+
+const DIFF_STYLE_OPTIONS: readonly {
+  value: DiffStyle
+  label: string
+  icon: string
+}[] = [
+  { value: 'split', label: 'Split', icon: 'vertical_split' },
+  { value: 'unified', label: 'Unified', icon: 'view_headline' },
 ]
 
 export interface DiffChipToolbarProps {
@@ -466,6 +480,221 @@ export const DiffChipToolbar = ({
   const canFinishFeedback = onFinishFeedback !== undefined
   const showPinnedActions = onRefreshActiveFile !== undefined || showActions
 
+  const renderNativeOverflowMenu = (
+    hiddenKeys: readonly string[]
+  ): ReactNode => {
+    const hidden = new Set(hiddenKeys)
+    const sections: ReactNode[] = []
+
+    if (hidden.has('diff-style')) {
+      sections.push(
+        <Menu.Section key="diff-style" label="Diff view">
+          {DIFF_STYLE_OPTIONS.map((option) => (
+            <Menu.Checkbox
+              key={option.value}
+              icon={option.icon}
+              checked={diffStyle === option.value}
+              onChange={(): void => onDiffStyleChange(option.value)}
+            >
+              {option.label}
+            </Menu.Checkbox>
+          ))}
+        </Menu.Section>
+      )
+    }
+
+    if (hidden.has('file-nav')) {
+      sections.push(
+        <Menu.Section key="file-nav" label={`File ${fileCounterText}`}>
+          <Menu.Row
+            label="Previous file"
+            disabled={!fileNavEnabled}
+            nativeOverlayIcon="chevron_left"
+            onSelect={onPrevFile}
+          >
+            <span>Previous file</span>
+            <kbd>p</kbd>
+          </Menu.Row>
+          <Menu.Row
+            label="Next file"
+            disabled={!fileNavEnabled}
+            nativeOverlayIcon="chevron_right"
+            onSelect={onNextFile}
+          >
+            <span>Next file</span>
+            <kbd>n</kbd>
+          </Menu.Row>
+        </Menu.Section>
+      )
+    }
+
+    if (hidden.has('tool-well')) {
+      sections.push(
+        <Menu.Section key="tool-well" label="Changes">
+          <Menu.Row
+            label="Stage hunk"
+            disabled={onStage === undefined || staging}
+            nativeOverlayIcon="add_box"
+            onSelect={(): Promise<void> | undefined => onStage?.()}
+          >
+            <span>Stage hunk</span>
+            <kbd>s</kbd>
+          </Menu.Row>
+          {diffMode === 'staged' ? (
+            <Menu.Row
+              label="Unstage"
+              disabled={onUnstage === undefined || staging}
+              nativeOverlayIcon="indeterminate_check_box"
+              onSelect={(): Promise<void> | undefined => onUnstage?.()}
+            >
+              <span>Unstage</span>
+              <kbd>s</kbd>
+            </Menu.Row>
+          ) : null}
+          <Menu.Row
+            label="Discard hunk"
+            disabled={onDiscard === undefined || staging}
+            nativeOverlayIcon="backspace"
+            onSelect={(): Promise<void> | undefined => onDiscard?.()}
+          >
+            <span>Discard hunk</span>
+            <kbd>d</kbd>
+          </Menu.Row>
+          {onDiscardAll !== undefined ? (
+            <Menu.Row
+              label="Discard all changes"
+              disabled
+              nativeOverlayIcon="delete_sweep"
+              nativeOverlayDetail="Confirmation required"
+            >
+              <span>Discard all changes</span>
+            </Menu.Row>
+          ) : null}
+        </Menu.Section>
+      )
+    }
+
+    if (hidden.has('change-stepper')) {
+      sections.push(
+        <Menu.Section key="change-stepper" label={`Hunks ${hunkCounterText}`}>
+          <Menu.Row
+            label="Previous change"
+            disabled={!hunkNavEnabled}
+            nativeOverlayIcon="keyboard_arrow_up"
+            onSelect={onPrevHunk}
+          >
+            <span>Previous change</span>
+            <kbd>[</kbd>
+          </Menu.Row>
+          <Menu.Row
+            label="Next change"
+            disabled={!hunkNavEnabled}
+            nativeOverlayIcon="keyboard_arrow_down"
+            onSelect={onNextHunk}
+          >
+            <span>Next change</span>
+            <kbd>]</kbd>
+          </Menu.Row>
+        </Menu.Section>
+      )
+    }
+
+    if (hidden.has('highlight')) {
+      sections.push(
+        <Menu.Section key="highlight" label="Highlight">
+          {LINE_DIFF_OPTIONS.map((option) => (
+            <Menu.Checkbox
+              key={option.value}
+              icon="format_ink_highlighter"
+              checked={lineDiffType === option.value}
+              onChange={(): void => onLineDiffTypeChange(option.value)}
+            >
+              {option.label}
+            </Menu.Checkbox>
+          ))}
+        </Menu.Section>
+      )
+    }
+
+    if (hidden.has('theme')) {
+      sections.push(
+        <Menu.Section key="theme" label="Theme">
+          {THEME_OPTIONS.map((option) => (
+            <Menu.Checkbox
+              key={option.value}
+              icon="palette"
+              checked={theme === option.value}
+              onChange={(): void => onThemeChange(option.value)}
+            >
+              {option.label}
+            </Menu.Checkbox>
+          ))}
+        </Menu.Section>
+      )
+    }
+
+    if (hidden.has('view-settings')) {
+      sections.push(
+        <Menu.Section key="view-format" label="Indicators">
+          {VIEW_INDICATOR_OPTIONS.map((option) => (
+            <Menu.Checkbox
+              key={option.value}
+              icon="flag"
+              checked={diffIndicators === option.value}
+              onChange={(): void => onDiffIndicatorsChange(option.value)}
+            >
+              {option.label}
+            </Menu.Checkbox>
+          ))}
+        </Menu.Section>,
+        <Menu.Section key="view-overflow" label="Overflow">
+          {VIEW_OVERFLOW_OPTIONS.map((option) => (
+            <Menu.Checkbox
+              key={option.value}
+              icon="wrap_text"
+              checked={overflow === option.value}
+              onChange={(): void => onOverflowChange(option.value)}
+            >
+              {option.label}
+            </Menu.Checkbox>
+          ))}
+        </Menu.Section>,
+        <Menu.Section key="view-options" label="View options">
+          <Menu.Checkbox
+            icon="123"
+            checked={!disableLineNumbers}
+            onChange={(next): void => onDisableLineNumbersChange(!next)}
+          >
+            Line numbers
+          </Menu.Checkbox>
+          <Menu.Checkbox
+            icon="format_paint"
+            checked={!disableBackground}
+            onChange={(next): void => onDisableBackgroundChange(!next)}
+          >
+            Background tint
+          </Menu.Checkbox>
+          <Menu.Checkbox
+            icon="description"
+            checked={!disableFileHeader}
+            onChange={(next): void => onDisableFileHeaderChange(!next)}
+          >
+            File header
+          </Menu.Checkbox>
+          <Menu.Checkbox
+            icon="push_pin"
+            checked={stickyHeader}
+            onChange={onStickyHeaderChange}
+          >
+            Sticky header
+          </Menu.Checkbox>
+        </Menu.Section>
+      )
+    }
+
+    return sections.length === 0 ? null : sections
+  }
+
   return (
     <div
       role="toolbar"
@@ -476,6 +705,7 @@ export const DiffChipToolbar = ({
         <PriorityPlus
           maxRows={1}
           remeasureKey={`${selectedFileName ?? ''}|${fileCounterText}|${hunkCounterText}|${theme}|${lineDiffType}|${diffMode}`}
+          renderNativeOverflowMenu={renderNativeOverflowMenu}
         >
           {chips}
         </PriorityPlus>

--- a/src/features/diff/components/toolbar/DiffChipToolbar.tsx
+++ b/src/features/diff/components/toolbar/DiffChipToolbar.tsx
@@ -259,6 +259,27 @@ export const DiffChipToolbar = ({
   const [discardAllAnchor, setDiscardAllAnchor] =
     useState<HTMLButtonElement | null>(null)
 
+  const [toolbarAnchor, setToolbarAnchor] = useState<HTMLDivElement | null>(
+    null
+  )
+
+  const discardAllPopoverAnchor =
+    discardAllAnchor !== null && discardAllAnchor.offsetParent !== null
+      ? discardAllAnchor
+      : toolbarAnchor
+
+  const openDiscardAllConfirmation = (): void => {
+    if (!staging) {
+      setDiscardAllOpen(true)
+    }
+  }
+
+  const toggleDiscardAllConfirmation = (): void => {
+    if (!staging) {
+      setDiscardAllOpen((prev) => !prev)
+    }
+  }
+
   // Counter copy: `1/N` when there is at least one hunk, `0/0` otherwise.
   // Shows the current focused index as `focusedHunkIndex + 1` so the counter
   // is consistent with PR3 once prev/next start mutating the index.
@@ -315,14 +336,10 @@ export const DiffChipToolbar = ({
                 ? WELL_DISABLED_BUTTON_CLASSES
                 : WELL_DANGER_BUTTON_CLASSES
             }
-            onClick={(): void => {
-              if (!staging) {
-                setDiscardAllOpen((prev) => !prev)
-              }
-            }}
+            onClick={toggleDiscardAllConfirmation}
           />
           <Popover
-            anchor={discardAllAnchor}
+            anchor={discardAllPopoverAnchor}
             open={discardAllOpen}
             onOpenChange={setDiscardAllOpen}
             placement="bottom-end"
@@ -563,9 +580,10 @@ export const DiffChipToolbar = ({
           {onDiscardAll !== undefined ? (
             <Menu.Row
               label="Discard all changes"
-              disabled
+              disabled={staging}
               nativeOverlayIcon="delete_sweep"
               nativeOverlayDetail="Confirmation required"
+              onSelect={openDiscardAllConfirmation}
             >
               <span>Discard all changes</span>
             </Menu.Row>
@@ -697,6 +715,7 @@ export const DiffChipToolbar = ({
 
   return (
     <div
+      ref={setToolbarAnchor}
       role="toolbar"
       aria-label="Diff toolbar"
       className="flex min-h-[46px] items-center px-3 bg-surface-container-lowest border-b border-outline-variant/45"

--- a/src/features/diff/components/toolbar/PriorityPlus.tsx
+++ b/src/features/diff/components/toolbar/PriorityPlus.tsx
@@ -7,6 +7,7 @@ import {
   type ReactNode,
 } from 'react'
 import { IconButton } from '@/components/IconButton'
+import { Menu, isNativeOverlayMenuTransportActive } from '@/components/Menu'
 import { Popover } from '@/components/Popover'
 import { Tooltip } from '@/components/Tooltip'
 import { TOOLTIP_SUPPRESSED } from '@/lib/constants'
@@ -23,6 +24,7 @@ interface PriorityPlusProps {
   children: readonly ReactNode[]
   maxRows?: number
   gap?: string
+  renderNativeOverflowMenu?: (hiddenKeys: readonly string[]) => ReactNode
   // Bump to force a re-measure when a child's rendered WIDTH changes without a
   // change in child count or container size (e.g. the file pill swapping a
   // short filename for a long one). PriorityPlus otherwise only re-measures on
@@ -60,6 +62,7 @@ export const PriorityPlus = ({
   children,
   maxRows = 1,
   gap = 'gap-x-3 gap-y-2',
+  renderNativeOverflowMenu = undefined,
   remeasureKey = undefined,
 }: PriorityPlusProps): ReactElement => {
   const containerRef = useRef<HTMLDivElement>(null)
@@ -176,8 +179,14 @@ export const PriorityPlus = ({
 
   // Drop separators from the tray — a 1px vertical hairline is meaningless in
   // the vertical `…` menu and would inflate the "N more controls" count.
-  const hiddenItems = showOverflow
-    ? children.slice(overflowFrom).filter((child) => !isSeparatorElement(child))
+  const hiddenEntries = showOverflow
+    ? children
+        .slice(overflowFrom)
+        .map((child, index) => ({
+          item: child,
+          key: stableItemKey(child, overflowFrom + index),
+        }))
+        .filter(({ item }) => !isSeparatorElement(item))
     : []
 
   return (
@@ -213,8 +222,11 @@ export const PriorityPlus = ({
           </div>
         )
       })}
-      {hiddenItems.length > 0 ? (
-        <OverflowMenu hiddenItems={hiddenItems} />
+      {hiddenEntries.length > 0 ? (
+        <OverflowMenu
+          hiddenEntries={hiddenEntries}
+          renderNativeOverflowMenu={renderNativeOverflowMenu}
+        />
       ) : null}
     </div>
   )
@@ -235,23 +247,54 @@ const stableItemKey = (item: ReactNode, index: number): string => {
 // items are arbitrary stateful controls the user operates inside the tray,
 // so this is a dialog-shaped Popover, not a selectable menu.
 const OverflowMenu = ({
-  hiddenItems,
+  hiddenEntries,
+  renderNativeOverflowMenu = undefined,
 }: {
-  hiddenItems: readonly ReactNode[]
+  hiddenEntries: readonly { key: string; item: ReactNode }[]
+  renderNativeOverflowMenu?: (hiddenKeys: readonly string[]) => ReactNode
 }): ReactElement => {
   const [open, setOpen] = useState(false)
   const [anchor, setAnchor] = useState<HTMLButtonElement | null>(null)
 
-  return (
-    <>
-      <Tooltip
-        content={`Show ${hiddenItems.length} more controls`}
+  const label = `Show ${hiddenEntries.length} more controls`
+
+  const nativeMenu = renderNativeOverflowMenu?.(
+    hiddenEntries.map((entry) => entry.key)
+  )
+
+  if (
+    nativeMenu !== undefined &&
+    nativeMenu !== null &&
+    isNativeOverlayMenuTransportActive(true)
+  ) {
+    return (
+      <Menu
+        trigger={
+          <IconButton
+            ref={setAnchor}
+            icon="more_horiz"
+            label={label}
+            size="lg"
+            showTooltip={TOOLTIP_SUPPRESSED}
+            className="rounded-full"
+          />
+        }
+        placement="bottom-end"
+        aria-label="More controls"
         nativeOverlay
       >
+        {nativeMenu}
+      </Menu>
+    )
+  }
+
+  return (
+    <>
+      <Tooltip content={label} nativeOverlay>
         <IconButton
           ref={setAnchor}
           icon="more_horiz"
-          label={`Show ${hiddenItems.length} more controls`}
+          label={label}
           size="lg"
           showTooltip={TOOLTIP_SUPPRESSED} // outer Tooltip already supplies the label
           onClick={(): void => setOpen((previous) => !previous)}
@@ -266,12 +309,12 @@ const OverflowMenu = ({
         anchor={anchor}
         open={open}
         onOpenChange={setOpen}
-        placement="bottom-start"
+        placement="bottom-end"
         aria-label="More controls"
       >
         <div className="flex flex-col gap-2 p-3 max-w-[320px]">
-          {hiddenItems.map((item, index) => (
-            <div key={stableItemKey(item, index)}>{item}</div>
+          {hiddenEntries.map(({ key, item }) => (
+            <div key={key}>{item}</div>
           ))}
         </div>
       </Popover>

--- a/src/features/diff/components/toolbar/PriorityPlus.tsx
+++ b/src/features/diff/components/toolbar/PriorityPlus.tsx
@@ -244,7 +244,10 @@ const OverflowMenu = ({
 
   return (
     <>
-      <Tooltip content={`Show ${hiddenItems.length} more controls`}>
+      <Tooltip
+        content={`Show ${hiddenItems.length} more controls`}
+        nativeOverlay
+      >
         <IconButton
           ref={setAnchor}
           icon="more_horiz"
@@ -263,7 +266,7 @@ const OverflowMenu = ({
         anchor={anchor}
         open={open}
         onOpenChange={setOpen}
-        placement="bottom-end"
+        placement="bottom-start"
         aria-label="More controls"
       >
         <div className="flex flex-col gap-2 p-3 max-w-[320px]">

--- a/src/features/diff/components/toolbar/ViewSettingsDropdown.tsx
+++ b/src/features/diff/components/toolbar/ViewSettingsDropdown.tsx
@@ -12,13 +12,18 @@ type Overflow = NonNullable<BaseDiffOptions['overflow']>
 // Hardcoded enum lists for the nested sub-dropdowns. Mirrors the same
 // constants that DiffChipToolbar.tsx used to host before consolidation —
 // they moved here because ViewSettingsDropdown is now the only consumer.
-const INDICATOR_OPTIONS: readonly DropdownOption<DiffIndicators>[] = [
-  { value: 'classic', label: 'classic', description: 'Plus and minus glyphs' },
-  { value: 'bars', label: 'bars', description: 'Colored gutter bars' },
-  { value: 'none', label: 'none', description: 'No indicator column' },
-]
+export const VIEW_INDICATOR_OPTIONS: readonly DropdownOption<DiffIndicators>[] =
+  [
+    {
+      value: 'classic',
+      label: 'classic',
+      description: 'Plus and minus glyphs',
+    },
+    { value: 'bars', label: 'bars', description: 'Colored gutter bars' },
+    { value: 'none', label: 'none', description: 'No indicator column' },
+  ]
 
-const OVERFLOW_OPTIONS: readonly DropdownOption<Overflow>[] = [
+export const VIEW_OVERFLOW_OPTIONS: readonly DropdownOption<Overflow>[] = [
   {
     value: 'scroll',
     label: 'scroll',
@@ -85,14 +90,14 @@ export const ViewSettingsDropdown = ({
         label="Indicators"
         icon="flag"
         value={diffIndicators}
-        options={INDICATOR_OPTIONS}
+        options={VIEW_INDICATOR_OPTIONS}
         onChange={onDiffIndicatorsChange}
       />
       <Menu.Submenu
         label="Overflow"
         icon="wrap_text"
         value={overflow}
-        options={OVERFLOW_OPTIONS}
+        options={VIEW_OVERFLOW_OPTIONS}
         onChange={onOverflowChange}
       />
     </Menu.Section>

--- a/src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.test.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.test.tsx
@@ -1,8 +1,58 @@
-import { render, screen, within } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, test, vi } from 'vitest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
 import { SINGLE_PANE_FOCUS_LABEL } from '../../layout-registry'
 import { LayoutSwitcher } from './LayoutSwitcher'
+
+let restorePlatform: (() => void) | null = null
+
+const setNavigatorPlatform = (platform: string): void => {
+  restorePlatform?.()
+  const original = Object.getOwnPropertyDescriptor(window.navigator, 'platform')
+
+  Object.defineProperty(window.navigator, 'platform', {
+    configurable: true,
+    value: platform,
+  })
+
+  restorePlatform = (): void => {
+    if (original === undefined) {
+      delete (window.navigator as unknown as { platform?: string }).platform
+
+      return
+    }
+
+    Object.defineProperty(window.navigator, 'platform', original)
+  }
+}
+
+const installNativeOverlayBridge = (): {
+  open: ReturnType<typeof vi.fn>
+} => {
+  const open = vi.fn().mockResolvedValue({ accepted: true })
+
+  window.vimeflow = {
+    invoke: <T,>(): Promise<T> => Promise.resolve(null as T),
+    listen: vi.fn(() => Promise.resolve(vi.fn())),
+    nativeOverlay: {
+      open,
+      close: vi.fn(() => Promise.resolve()),
+      actionResult: vi.fn(() => Promise.resolve()),
+      resume: vi.fn(() => Promise.resolve()),
+      onAction: vi.fn(() => vi.fn()),
+      onClose: vi.fn(() => vi.fn()),
+    },
+  }
+
+  return { open }
+}
+
+afterEach(() => {
+  restorePlatform?.()
+  restorePlatform = null
+  vi.unstubAllEnvs()
+  delete window.vimeflow
+})
 
 describe('LayoutSwitcher', () => {
   test('renders 6 buttons (one per LayoutId)', () => {
@@ -242,5 +292,32 @@ describe('LayoutSwitcher', () => {
     expect(within(focusTip).getByTestId('tooltip-shortcut')).toHaveTextContent(
       'Z'
     )
+  })
+
+  test('can route layout pill tooltips through native overlay', async () => {
+    vi.stubEnv('VITE_NATIVE_OVERLAY', '1')
+    setNavigatorPlatform('MacIntel')
+    const nativeBridge = installNativeOverlayBridge()
+    const user = userEvent.setup()
+
+    render(
+      <LayoutSwitcher
+        activeLayoutId="single"
+        onPick={vi.fn()}
+        nativeOverlayTooltips
+      />
+    )
+
+    await user.hover(screen.getByRole('button', { name: 'Quad' }))
+
+    await waitFor(() => expect(nativeBridge.open).toHaveBeenCalledOnce())
+    expect(nativeBridge.open.mock.calls[0][0]).toMatchObject({
+      kind: 'tooltip',
+      payload: {
+        kind: 'tooltip',
+        text: 'Quad',
+      },
+    })
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
   })
 })

--- a/src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.tsx
@@ -39,6 +39,7 @@ export interface LayoutSwitcherProps {
    * toggle. Generic layout pickers keep the plain layout name.
    */
   labelSingleAsFocusAction?: boolean
+  nativeOverlayTooltips?: boolean
 }
 
 export const LayoutSwitcher = ({
@@ -52,6 +53,7 @@ export const LayoutSwitcher = ({
   trailing = undefined,
   vertical = false,
   labelSingleAsFocusAction = false,
+  nativeOverlayTooltips = false,
 }: LayoutSwitcherProps): ReactElement => {
   const layoutIds = useMemo(() => layouts.map((layout) => layout.id), [layouts])
 
@@ -124,6 +126,7 @@ export const LayoutSwitcher = ({
         })}
         onChange={onPick}
         skipActiveReselect
+        nativeOverlayTooltips={nativeOverlayTooltips}
         // Vertical mode fills the column as a grouped list: each row is a
         // full-width glyph + name. Horizontal mode keeps the compact icon pill.
         buttonClassName={

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -3038,6 +3038,7 @@ const WorkspaceViewContent = (): ReactElement => {
               blockedLayoutIds={blockedLayoutIds}
               onPick={handlePickLayout}
               labelSingleAsFocusAction
+              nativeOverlayTooltips
               trailing={
                 <LayoutDisplayMenu
                   activeLayoutId={activeSession.layout}

--- a/src/features/workspace/components/DockTab.tsx
+++ b/src/features/workspace/components/DockTab.tsx
@@ -152,6 +152,7 @@ export const DockTab = ({
         options={DOCK_TAB_OPTIONS}
         onChange={onTabChange}
         buttonClassName={compactActions ? 'w-[30px] px-0' : 'gap-1.5'}
+        nativeOverlayTooltips
         renderOption={(option, active) => (
           <>
             <span className={tabIconClass(active)} aria-hidden="true">
@@ -170,6 +171,7 @@ export const DockTab = ({
             content="More dock actions"
             placement="bottom"
             disabled={actionsOpen}
+            nativeOverlay
           >
             <IconButton
               ref={triggerRef}
@@ -209,6 +211,7 @@ export const DockTab = ({
                   content="Collapse panel"
                   shortcut={['Mod', '0']}
                   placement="bottom"
+                  nativeOverlay
                 >
                   <IconButton
                     icon="minimize"
@@ -231,6 +234,7 @@ export const DockTab = ({
               content="Collapse panel"
               shortcut={['Mod', '0']}
               placement="bottom"
+              nativeOverlay
             >
               <IconButton
                 icon="minimize"

--- a/tests/e2e/core/specs/native-overlay-layering.spec.ts
+++ b/tests/e2e/core/specs/native-overlay-layering.spec.ts
@@ -468,12 +468,21 @@ describe('NativeOverlay BrowserWindow layering', () => {
     }
 
     const paneRect = await waitForRealNativeGhosttyPane()
-    const trigger = await $('button[aria-label="Configure displayed layouts"]')
     await waitForLayoutDisplayAnchor()
     const before = captureScreen()
     const mapping = await mapViewportToScreenPixels()
 
-    await trigger.click()
+    const clicked = await browser.execute(() => {
+      const button = document.querySelector<HTMLElement>(
+        'button[aria-label="Configure displayed layouts"]'
+      )
+      button?.click()
+
+      return button !== null
+    })
+    if (!clicked) {
+      throw new Error('layout display trigger unavailable')
+    }
     await waitForOverlayMenu()
 
     await waitForOverlayPaint(before, mapping, paneRect)


### PR DESCRIPTION
## Summary
- Route dock tab tooltip surfaces through the native overlay layer so they appear above Ghostty.
- Preserve shortcut chips in native tooltip payloads and overlay rendering.
- Add focused coverage for tooltip payloads, overlay host rendering, and segmented-control native tooltip opt-in.

## Test plan
- npx vitest run src/components/Tooltip.test.tsx src/components/NativeOverlayHost.test.tsx src/components/SegmentedControl.test.tsx src/features/workspace/components/DockTab.test.tsx electron/native-overlay.test.ts
- npx eslint src/components/Tooltip.tsx src/components/Tooltip.test.tsx src/components/base/floating/nativeOverlay.ts src/components/NativeOverlayHost.tsx src/components/NativeOverlayHost.test.tsx src/components/SegmentedControl.tsx src/components/SegmentedControl.test.tsx src/features/workspace/components/DockTab.tsx src/features/workspace/components/DockTab.test.tsx electron/native-overlay.ts electron/native-overlay.test.ts
- npx tsc -p electron/tsconfig.json --noEmit && npx tsc --noEmit
- npm test via pre-push hook: 385 files passed, 4,841 passed, 3 skipped

Refs VIM-305