### PR TITLE
fix: coalesce native Ghostty resize PTY updates

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -61,7 +61,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 95       | 90   | 2026-07-05   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 100      | 89   | 2026-07-07   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |
-| [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 90       | 83   | 2026-07-05   |
+| [Async Race Conditions](patterns/async-race-conditions.md)                                           | react-patterns     | 91       | 84   | 2026-07-08   |
 | [Canonical Path Dedupe](patterns/canonical-path-dedupe.md)                                           | correctness        | 2        | 0    | 2026-06-14   |
 | [Tokio Blocking On Async](patterns/tokio-blocking-on-async.md)                                       | backend            | 4        | 2    | 2026-06-14   |
 | [Command Injection](patterns/command-injection.md)                                                   | security           | 8        | 3    | 2026-06-16   |

--- a/docs/reviews/patterns/async-race-conditions.md
+++ b/docs/reviews/patterns/async-race-conditions.md
@@ -2,8 +2,8 @@
 id: async-race-conditions
 category: react-patterns
 created: 2026-04-09
-last_updated: 2026-07-05
-ref_count: 83
+last_updated: 2026-07-08
+ref_count: 84
 ---
 
 # Async Race Conditions
@@ -983,4 +983,19 @@ prevent showing previous data.
 - **File:** `src/components/Menu.tsx`, `src/components/Tooltip.tsx`
 - **Finding:** Native-overlay Menu and Tooltip resize effects could resolve an accepted `openNativeOverlay` request after the surface was dismissed, leaving stale native sessions alive after renderer cleanup.
 - **Fix:** Mirror the initial-open cancellation guard in resize resync effects: when the effect has been disposed and the pending request is accepted, close the native overlay by `surfaceId` and skip state updates. Added regression tests for menu and tooltip stale resize requests.
+- **Commit:** same commit as this entry
+
+### 91. Native Ghostty reparent left a stale resize debounce
+
+- **Source:** github-claude | PR #674 round 1 | 2026-07-08
+- **Severity:** MEDIUM
+- **File:** `electron/ghostty-native-parent.ts`
+- **Finding:** The native Ghostty reparent path destroyed the old surface but
+  left any pending primary resize debounce alive on the retained pane state.
+  That stale timer could later forward the old grid size after the pane had
+  been attached to a different BrowserWindow.
+- **Fix:** Clear pending primary resize state when destroying the old surface
+  during reparenting. Added a regression test that queues a resize, reparents
+  the pane, advances the debounce timer, and asserts only the original resize
+  reached the sidecar.
 - **Commit:** same commit as this entry

--- a/electron/ghostty-native-parent.test.ts
+++ b/electron/ghostty-native-parent.test.ts
@@ -592,8 +592,17 @@ describe('ghostty native parent', () => {
         destroy: vi.fn(),
       }
 
+      const invoke = vi.fn()
+
       const sidecar = {
-        invoke: vi.fn(<T>(): Promise<T> => Promise.resolve(undefined as T)),
+        invoke: <T>(
+          method: string,
+          args?: Record<string, unknown>
+        ): Promise<T> => {
+          invoke(method, args)
+
+          return Promise.resolve(undefined as T)
+        },
         onEvent: vi.fn(() => vi.fn()),
         shutdown: vi.fn(() => Promise.resolve()),
       } satisfies Sidecar
@@ -646,8 +655,8 @@ describe('ghostty native parent', () => {
 
       expect(addon.destroy).toHaveBeenCalledWith(firstSurface)
       expect(addon.create).toHaveBeenCalledTimes(2)
-      expect(sidecar.invoke).toHaveBeenCalledTimes(1)
-      expect(sidecar.invoke).toHaveBeenCalledWith('resize_pty', {
+      expect(invoke).toHaveBeenCalledTimes(1)
+      expect(invoke).toHaveBeenCalledWith('resize_pty', {
         request: {
           sessionId: 'pty-1',
           cols: 80,

--- a/electron/ghostty-native-parent.test.ts
+++ b/electron/ghostty-native-parent.test.ts
@@ -978,6 +978,96 @@ describe('ghostty native parent', () => {
     controller.dispose()
   })
 
+  test('coalesces native resize bursts before resizing the PTY again', () => {
+    vi.useFakeTimers()
+    let controller: ReturnType<typeof setupGhosttyNativeParent> | null = null
+
+    try {
+      const callbacks: {
+        onResize?: (cols: number, rows: number) => void
+      } = {}
+      const surface = {}
+
+      const addon = {
+        create: vi.fn(
+          (
+            _bridge,
+            _handle,
+            _input,
+            resize,
+            _focus,
+            _shortcut,
+            _renamePane
+          ) => {
+            void _bridge
+            void _handle
+            void _input
+            void _focus
+            void _shortcut
+            void _renamePane
+            callbacks.onResize = resize
+
+            return surface
+          }
+        ),
+        setFrame: vi.fn(),
+        write: vi.fn(),
+        focus: vi.fn(),
+        destroy: vi.fn(),
+      }
+
+      const sidecar = {
+        invoke: vi.fn(() => Promise.resolve(undefined)),
+        onEvent: vi.fn(() => vi.fn()),
+        shutdown: vi.fn(() => Promise.resolve()),
+      } as unknown as Sidecar
+
+      controller = setupGhosttyNativeParent({
+        sidecar,
+        platform: 'darwin',
+        env: { VITE_GHOSTTY_NATIVE_MACOS_PARENT: '1' },
+        addon,
+      })
+
+      handlers.get(GHOSTTY_NATIVE_UPDATE)?.(
+        { sender: {} },
+        {
+          sessionId: 'pty-1',
+          paneId: 'pane-1',
+          cwd: '/tmp',
+          visible: true,
+          parentHeight: 900,
+          bounds: { x: 10, y: 20, width: 300, height: 200 },
+        }
+      )
+
+      callbacks.onResize?.(80, 24)
+      callbacks.onResize?.(81, 24)
+      callbacks.onResize?.(82, 24)
+
+      expect(sidecar.invoke).toHaveBeenCalledTimes(1)
+      expect(sidecar.invoke).toHaveBeenCalledWith('resize_pty', {
+        request: { sessionId: 'pty-1', cols: 80, rows: 24 },
+      })
+
+      vi.advanceTimersByTime(200)
+
+      expect(sidecar.invoke).toHaveBeenCalledTimes(2)
+      expect(sidecar.invoke).toHaveBeenLastCalledWith('resize_pty', {
+        request: { sessionId: 'pty-1', cols: 82, rows: 24 },
+      })
+
+      callbacks.onResize?.(83, 24)
+      callbacks.onResize?.(82, 24)
+      vi.advanceTimersByTime(200)
+
+      expect(sidecar.invoke).toHaveBeenCalledTimes(2)
+    } finally {
+      controller?.dispose()
+      vi.useRealTimers()
+    }
+  })
+
   test('drops native Ghostty input while an interactive overlay is active', () => {
     const callbacks: {
       onInput?: (data: string) => void

--- a/electron/ghostty-native-parent.test.ts
+++ b/electron/ghostty-native-parent.test.ts
@@ -574,6 +574,93 @@ describe('ghostty native parent', () => {
     controller.dispose()
   })
 
+  test('clears pending primary resize when moving a surface between windows', () => {
+    vi.useFakeTimers()
+
+    try {
+      const firstSurface = {}
+      const secondSurface = {}
+
+      const addon = {
+        create: vi
+          .fn()
+          .mockReturnValueOnce(firstSurface)
+          .mockReturnValueOnce(secondSurface),
+        setFrame: vi.fn(),
+        write: vi.fn(),
+        focus: vi.fn(),
+        destroy: vi.fn(),
+      }
+
+      const sidecar = {
+        invoke: vi.fn(<T>(): Promise<T> => Promise.resolve(undefined as T)),
+        onEvent: vi.fn(() => vi.fn()),
+        shutdown: vi.fn(() => Promise.resolve()),
+      } satisfies Sidecar
+
+      const controller = setupGhosttyNativeParent({
+        sidecar,
+        platform: 'darwin',
+        env: { VITE_GHOSTTY_NATIVE_MACOS_PARENT: '1' },
+        addon,
+      })
+      const update = handlers.get(GHOSTTY_NATIVE_UPDATE)
+
+      update?.(
+        { sender: {} },
+        {
+          sessionId: 'pty-1',
+          paneId: 'pane-1',
+          cwd: '/tmp',
+          visible: true,
+          parentHeight: 900,
+          bounds: { x: 10, y: 20, width: 300, height: 200 },
+        }
+      )
+
+      const firstResize = addon.create.mock.calls[0]?.[3] as
+        | ((cols: number, rows: number) => void)
+        | undefined
+
+      if (firstResize === undefined) {
+        throw new Error('expected native resize callback')
+      }
+
+      firstResize(80, 24)
+      firstResize(100, 30)
+
+      browserWindowState.id = 2
+      update?.(
+        { sender: {} },
+        {
+          sessionId: 'pty-1',
+          paneId: 'pane-1',
+          cwd: '/tmp',
+          visible: true,
+          parentHeight: 900,
+          bounds: { x: 10, y: 20, width: 300, height: 200 },
+        }
+      )
+
+      vi.advanceTimersByTime(120)
+
+      expect(addon.destroy).toHaveBeenCalledWith(firstSurface)
+      expect(addon.create).toHaveBeenCalledTimes(2)
+      expect(sidecar.invoke).toHaveBeenCalledTimes(1)
+      expect(sidecar.invoke).toHaveBeenCalledWith('resize_pty', {
+        request: {
+          sessionId: 'pty-1',
+          cols: 80,
+          rows: 24,
+        },
+      })
+
+      controller.dispose()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   test('caps renderer-created pane state before allocating unbounded surfaces', () => {
     const addon = {
       create: vi.fn(),

--- a/electron/ghostty-native-parent.ts
+++ b/electron/ghostty-native-parent.ts
@@ -844,6 +844,7 @@ export class GhosttyNativeParentController {
     const key = this.paneKey(state.pane)
     if (state.surface) {
       addon.destroy(state.surface)
+      this.clearPendingResize(state)
       if (state.ownerWindowId !== null) {
         this.surfaceKeysByWindowId.get(state.ownerWindowId)?.delete(key)
       }

--- a/electron/ghostty-native-parent.ts
+++ b/electron/ghostty-native-parent.ts
@@ -117,6 +117,7 @@ interface GhosttyNativeSurfaceState {
   lastBackgroundColor: string | null
   lastForegroundColor: string | null
   lastResize: { cols: number; rows: number } | null
+  resizeTimer: ReturnType<typeof setTimeout> | null
   lastShortcutDigits: string | null
 }
 
@@ -146,6 +147,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const require = createRequire(import.meta.url)
 const MAX_PENDING_CHUNKS = 64
 const MAX_SURFACES = 128
+const GHOSTTY_RESIZE_SETTLE_MS = 120
 
 // Packaged macOS is the shipped Ghostty path. Dev and e2e still opt in with
 // VITE_GHOSTTY_NATIVE_MACOS_PARENT so ordinary local runs can keep the fallback.
@@ -822,6 +824,7 @@ export class GhosttyNativeParentController {
       lastBackgroundColor: null,
       lastForegroundColor: null,
       lastResize: null,
+      resizeTimer: null,
       lastShortcutDigits: null,
     }
     this.surfaces.set(key, state)
@@ -879,18 +882,14 @@ export class GhosttyNativeParentController {
           return
         }
 
-        if (state.lastResize?.cols === cols && state.lastResize.rows === rows) {
-          return
-        }
-
-        state.lastResize = { cols, rows }
-        this.invokeSidecar('resize_pty', {
-          request: {
-            sessionId: state.pane.sessionId,
-            cols,
-            rows,
-          },
-        })
+        this.queuePtyResize(
+          state,
+          state.pane.sessionId,
+          cols,
+          rows,
+          () =>
+            !win.isDestroyed() && this.surfaces.has(this.paneKey(state.pane))
+        )
       },
       () => {
         if (win.isDestroyed() || !this.surfaces.has(this.paneKey(state.pane))) {
@@ -1076,6 +1075,69 @@ export class GhosttyNativeParentController {
     }
   }
 
+  private queuePtyResize(
+    resizeState: GhosttyNativeSurfaceState,
+    sessionId: string,
+    cols: number,
+    rows: number,
+    canForward: () => boolean
+  ): void {
+    if (cols <= 0 || rows <= 0) {
+      return
+    }
+
+    if (
+      resizeState.lastResize?.cols === cols &&
+      resizeState.lastResize.rows === rows
+    ) {
+      this.clearPendingResize(resizeState)
+
+      return
+    }
+
+    if (resizeState.lastResize === null) {
+      this.forwardPtyResize(resizeState, sessionId, cols, rows)
+
+      return
+    }
+
+    if (resizeState.resizeTimer !== null) {
+      clearTimeout(resizeState.resizeTimer)
+    }
+
+    resizeState.resizeTimer = setTimeout(() => {
+      resizeState.resizeTimer = null
+      if (!canForward()) {
+        return
+      }
+
+      this.forwardPtyResize(resizeState, sessionId, cols, rows)
+    }, GHOSTTY_RESIZE_SETTLE_MS)
+  }
+
+  private forwardPtyResize(
+    resizeState: GhosttyNativeSurfaceState,
+    sessionId: string,
+    cols: number,
+    rows: number
+  ): void {
+    resizeState.lastResize = { cols, rows }
+    this.invokeSidecar('resize_pty', {
+      request: {
+        sessionId,
+        cols,
+        rows,
+      },
+    })
+  }
+
+  private clearPendingResize(resizeState: GhosttyNativeSurfaceState): void {
+    if (resizeState.resizeTimer !== null) {
+      clearTimeout(resizeState.resizeTimer)
+    }
+    resizeState.resizeTimer = null
+  }
+
   private invokeSidecar(
     command: Parameters<Sidecar['invoke']>[0],
     payload: Parameters<Sidecar['invoke']>[1]
@@ -1152,6 +1214,7 @@ export class GhosttyNativeParentController {
     if (state.surface && addon) {
       addon.destroy(state.surface)
     }
+    this.clearPendingResize(state)
     this.surfaces.delete(key)
 
     if (state.ownerWindowId !== null) {


### PR DESCRIPTION
## Summary
- Coalesce native Ghostty PTY resize IPC after the first grid size so transient AppKit relayout grids do not spam Codex with intermediate terminal sizes.
- Skip pending resize dispatches when the surface returns to the last-sent grid, and clear pending timers when surfaces are destroyed.
- Add regression coverage for resize bursts and returning to the previous grid before the debounce fires.

Refs VIM-307

## Test plan
- [x] `npx vitest run electron/ghostty-native-parent.test.ts`
- [x] `npx eslint electron/ghostty-native-parent.ts electron/ghostty-native-parent.test.ts`
- [x] `npm run type-check -- --pretty false`
- [x] `git diff --check origin/main...HEAD`
- [x] pre-push hook: `npm test` (385 files, 4,846 passed, 3 skipped)
