### PR TITLE
fix(ghostty): reattach burner secondary after surface recreation

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -57,7 +57,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 8        | 2    | 2026-06-19   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 4        | 0    | 2026-06-21   |
 | [Testing Gaps](patterns/testing-gaps.md)                                                             | testing            | 87       | 41   | 2026-07-04   |
-| [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 10       | 5    | 2026-07-05   |
+| [Terminal Input Handling](patterns/terminal-input-handling.md)                                       | terminal           | 11       | 5    | 2026-07-08   |
 | [Documentation Accuracy](patterns/documentation-accuracy.md)                                         | code-quality       | 95       | 90   | 2026-07-05   |
 | [Accessibility](patterns/accessibility.md)                                                           | a11y               | 100      | 89   | 2026-07-07   |
 | [Event Identity Guard](patterns/event-identity-guard.md)                                             | backend            | 1        | 0    | 2026-06-11   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -52,7 +52,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 30       | 25   | 2026-07-05   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)                                             | cross-platform     | 12       | 12   | 2026-06-22   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                                                       | code-quality       | 7        | 0    | 2026-06-11   |
-| [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 25       | 21   | 2026-07-05   |
+| [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 26       | 21   | 2026-07-08   |
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 8        | 2    | 2026-06-19   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 4        | 0    | 2026-06-21   |
@@ -102,7 +102,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Agent-State Guards](patterns/agent-state-guards.md)                                                 | correctness        | 15       | 10   | 2026-07-05   |
 | [React Prop Contracts](patterns/react-prop-contracts.md)                                             | react-patterns     | 8        | 6    | 2026-06-22   |
 | [Stale Retained Interactions](patterns/stale-retained-interactions.md)                               | react-patterns     | 10       | 9    | 2026-07-04   |
-| [Retained State Identity](patterns/retained-state-identity.md)                                       | react-patterns     | 4        | 4    | 2026-07-05   |
+| [Retained State Identity](patterns/retained-state-identity.md)                                       | react-patterns     | 5        | 4    | 2026-07-08   |
 | [Authoritative Completion Guard](patterns/authoritative-completion-guard.md)                         | correctness        | 7        | 4    | 2026-07-05   |
 | [Equality Guard Completeness](patterns/equality-guard-completeness.md)                               | correctness        | 2        | 0    | 2026-06-17   |
 | [Resizable Layout Bounds](patterns/resizable-layout-bounds.md)                                       | correctness        | 3        | 2    | 2026-06-18   |

--- a/docs/reviews/patterns/derived-state-consistency.md
+++ b/docs/reviews/patterns/derived-state-consistency.md
@@ -2,7 +2,7 @@
 id: derived-state-consistency
 category: code-quality
 created: 2026-06-07
-last_updated: 2026-07-05
+last_updated: 2026-07-08
 ref_count: 21
 ---
 
@@ -335,3 +335,12 @@ base data is technically "correct."
   is the active pane. Extended the inactive-pane restart test to assert the
   active session metadata remains unchanged.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 26. Preserved native surface caches skipped replay on recreation
+
+- **Source:** github-codex-connector | PR #675 round 1 | 2026-07-08
+- **Severity:** P2 / MEDIUM
+- **File:** `electron/ghostty-native-parent.ts`
+- **Finding:** Destroying a primary Ghostty surface while preserving its burner secondary left `lastBackgroundColor`, `lastForegroundColor`, and `lastShortcutDigits` populated. Recreating the native surface with the same theme and shortcut context then skipped the setter calls needed to initialize the new surface.
+- **Fix:** Reset the surface-scoped visual and shortcut caches whenever a native surface is torn down, including preserved-secondary destroys and window reparenting destroys. Added a regression test proving the same colors and shortcut digits are replayed onto the recreated surface.
+- **Commit:** same commit as this entry

--- a/docs/reviews/patterns/retained-state-identity.md
+++ b/docs/reviews/patterns/retained-state-identity.md
@@ -2,7 +2,7 @@
 id: retained-state-identity
 category: react-patterns
 created: 2026-06-15
-last_updated: 2026-07-05
+last_updated: 2026-07-08
 ref_count: 4
 ---
 
@@ -54,4 +54,13 @@ When a React component renders retained (stale) content while fresh data for a n
 - **File:** `src/features/diff/hooks/useDiffRangeBars.ts`
 - **Finding:** The diff range-bar hook retained Pierre's last rendered shadow-DOM container but repainted whenever selected-file annotations changed. During file navigation, new-file spans could be combined with the previous file's retained container before Pierre posted the new file's render callback.
 - **Fix:** Passed the selected-file key into the hook, stored that key with the retained container, invalidated the container on file-key changes, and skipped repaint unless the stored container key still matches the active file key. Added a regression test that changes file keys with different spans and verifies the previous file host is not repainted.
+- **Commit:** same commit as this entry
+
+### 5. Preserved native secondary reattached stale session before replacement
+
+- **Source:** github-claude | PR #675 round 1 | 2026-07-08
+- **Severity:** MEDIUM
+- **File:** `electron/ghostty-native-parent.ts`
+- **Finding:** `attachSecondary()` recreated the primary Ghostty surface before replacing preserved secondary state. When a primary surface was destroyed with `preserveSecondary` and the next attach targeted a different burner session, surface recreation briefly reattached the old secondary before removing it and attaching the requested one.
+- **Fix:** Replaced mismatched secondary state before calling `getOrCreateSurface()`, so the auto-reattach path sees the requested secondary identity. Added a regression test proving a preserved old burner is not reattached during the replacement attach.
 - **Commit:** same commit as this entry

--- a/docs/reviews/patterns/terminal-input-handling.md
+++ b/docs/reviews/patterns/terminal-input-handling.md
@@ -2,7 +2,7 @@
 id: terminal-input-handling
 category: terminal
 created: 2026-04-09
-last_updated: 2026-07-05
+last_updated: 2026-07-08
 ref_count: 5
 ---
 
@@ -105,4 +105,13 @@ double execution, and paste failures.
 - **File:** `native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift`, `native/ghostty-parent/ghostty_native_parent.cc`
 - **Finding:** Native Ghostty input and write paths crossed Swift/C++ bridge APIs with `Int32`/`int` length parameters but did not guard oversized byte buffers before conversion.
 - **Fix:** Drop input buffers larger than `Int32.max` before the Swift callback conversion and throw JS-visible errors before narrowing primary or secondary write strings beyond `INT_MAX`.
+- **Commit:** same commit as this entry
+
+### 11. Secondary Ghostty resize was gated as interactive input
+
+- **Source:** github-codex-connector | PR #675 round 1 | 2026-07-08
+- **Severity:** P2 / MEDIUM
+- **File:** `electron/ghostty-native-parent.ts`
+- **Finding:** The native secondary Ghostty resize callback returned early when an interactive overlay was active. Burner PTYs could keep stale cols/rows if the split or popup layout changed while a menu or dialog was open.
+- **Fix:** Kept overlay gating on secondary input and focus callbacks, but let secondary resize callbacks continue when the owner window and secondary state are live. Added a regression test covering blocked input/focus with resize still forwarded to `resize_pty`.
 - **Commit:** same commit as this entry

--- a/electron/ghostty-native-parent.test.ts
+++ b/electron/ghostty-native-parent.test.ts
@@ -430,6 +430,96 @@ describe('ghostty native parent', () => {
     controller.dispose()
   })
 
+  test('replays surface-scoped state after preserving secondary on destroy', () => {
+    const firstSurface = { id: 'surface-1' }
+    const secondSurface = { id: 'surface-2' }
+    let createCount = 0
+
+    const addon = {
+      create: vi.fn(() => {
+        const surface = createCount === 0 ? firstSurface : secondSurface
+        createCount += 1
+
+        return surface
+      }),
+      addSecondary: vi.fn(),
+      setFrame: vi.fn(),
+      setBackgroundColor: vi.fn(),
+      setForegroundColor: vi.fn(),
+      setShortcutDigits: vi.fn(),
+      write: vi.fn(),
+      focus: vi.fn(),
+      destroy: vi.fn(),
+    }
+
+    const sidecar = {
+      invoke: <T>(): Promise<T> => Promise.resolve(undefined as T),
+      onEvent: vi.fn(() => vi.fn()),
+      shutdown: vi.fn(() => Promise.resolve()),
+    } satisfies Sidecar
+
+    const controller = setupGhosttyNativeParent({
+      sidecar,
+      platform: 'darwin',
+      env: { VITE_GHOSTTY_NATIVE_MACOS_PARENT: '1' },
+      addon,
+    })
+
+    handlers.get(GHOSTTY_NATIVE_SECONDARY_ATTACH)?.(
+      { sender: {} },
+      {
+        sessionId: 'pty-1',
+        paneId: 'pane-1',
+        secondarySessionId: 'burner-pty',
+      }
+    )
+
+    const updatePayload = {
+      sessionId: 'pty-1',
+      paneId: 'pane-1',
+      cwd: '/tmp',
+      backgroundColor: '#fffcf0',
+      foregroundColor: '#100f0f',
+      visible: true,
+      parentHeight: 900,
+      bounds: { x: 10, y: 20, width: 300, height: 200 },
+      shortcutContext: {
+        paneIds: ['pane-1', 'pane-2', 'pane-3'],
+        activePaneId: 'pane-1',
+      },
+    }
+
+    handlers.get(GHOSTTY_NATIVE_UPDATE)?.({ sender: {} }, updatePayload)
+
+    handlers.get(GHOSTTY_NATIVE_DESTROY)?.(
+      {},
+      { sessionId: 'pty-1', paneId: 'pane-1' }
+    )
+
+    handlers.get(GHOSTTY_NATIVE_UPDATE)?.({ sender: {} }, updatePayload)
+
+    expect(addon.destroy).toHaveBeenCalledWith(firstSurface)
+    expect(addon.setBackgroundColor).toHaveBeenNthCalledWith(
+      2,
+      secondSurface,
+      '#fffcf0'
+    )
+
+    expect(addon.setForegroundColor).toHaveBeenNthCalledWith(
+      2,
+      secondSurface,
+      '#100f0f'
+    )
+
+    expect(addon.setShortcutDigits).toHaveBeenNthCalledWith(
+      2,
+      secondSurface,
+      '23'
+    )
+
+    controller.dispose()
+  })
+
   test('flushes pending data once when the parented surface is created', () => {
     const surface = {}
 
@@ -1613,6 +1703,83 @@ describe('ghostty native parent', () => {
     expect(sidecar.invoke).toHaveBeenCalledWith('write_pty', {
       request: { sessionId: 'burner-pty', data: 'b' },
     })
+
+    controller.dispose()
+  })
+
+  test('does not reattach stale secondary before replacing it', () => {
+    const firstSurface = { id: 'surface-1' }
+    const secondSurface = { id: 'surface-2' }
+    let createCount = 0
+
+    const addon = {
+      create: vi.fn(() => {
+        const surface = createCount === 0 ? firstSurface : secondSurface
+        createCount += 1
+
+        return surface
+      }),
+      addSecondary: vi.fn(),
+      removeSecondary: vi.fn(),
+      setFrame: vi.fn(),
+      write: vi.fn(),
+      focus: vi.fn(),
+      destroy: vi.fn(),
+    }
+
+    const sidecar = {
+      invoke: vi.fn(() => Promise.resolve(undefined)),
+      onEvent: vi.fn(() => vi.fn()),
+      shutdown: vi.fn(() => Promise.resolve()),
+    } as unknown as Sidecar
+
+    const controller = setupGhosttyNativeParent({
+      sidecar,
+      platform: 'darwin',
+      env: { VITE_GHOSTTY_NATIVE_MACOS_PARENT: '1' },
+      addon,
+    })
+
+    handlers.get(GHOSTTY_NATIVE_SECONDARY_ATTACH)?.(
+      { sender: {} },
+      {
+        sessionId: 'host-pty',
+        paneId: 'pane-1',
+        secondarySessionId: 'old-burner-pty',
+      }
+    )
+
+    handlers.get(GHOSTTY_NATIVE_DESTROY)?.(
+      {},
+      { sessionId: 'host-pty', paneId: 'pane-1' }
+    )
+
+    handlers.get(GHOSTTY_NATIVE_SECONDARY_ATTACH)?.(
+      { sender: {} },
+      {
+        sessionId: 'host-pty',
+        paneId: 'pane-1',
+        secondarySessionId: 'new-burner-pty',
+      }
+    )
+
+    expect(addon.addSecondary).toHaveBeenCalledTimes(2)
+    expect(addon.addSecondary).toHaveBeenNthCalledWith(
+      1,
+      firstSurface,
+      expect.any(Function),
+      expect.any(Function),
+      expect.any(Function)
+    )
+
+    expect(addon.addSecondary).toHaveBeenNthCalledWith(
+      2,
+      secondSurface,
+      expect.any(Function),
+      expect.any(Function),
+      expect.any(Function)
+    )
+    expect(addon.removeSecondary).not.toHaveBeenCalled()
 
     controller.dispose()
   })

--- a/electron/ghostty-native-parent.test.ts
+++ b/electron/ghostty-native-parent.test.ts
@@ -1443,6 +1443,122 @@ describe('ghostty native parent', () => {
     controller.dispose()
   })
 
+  test('reattaches secondary child after primary surface recreation', () => {
+    const callbacks: {
+      onInput?: (data: string) => void
+      onResize?: (cols: number, rows: number) => void
+      onFocus?: () => void
+    }[] = []
+    const firstSurface = { id: 'surface-1' }
+    const secondSurface = { id: 'surface-2' }
+
+    const addon = {
+      create: vi.fn(() =>
+        callbacks.length === 0 ? firstSurface : secondSurface
+      ),
+      addSecondary: vi.fn((_surface, input, resize, focus) => {
+        callbacks.push({
+          onInput: input,
+          onResize: resize,
+          onFocus: focus,
+        })
+      }),
+      setSecondaryVisible: vi.fn(),
+      removeSecondary: vi.fn(),
+      setFrame: vi.fn(),
+      write: vi.fn(),
+      writeSecondary: vi.fn(),
+      focus: vi.fn(),
+      destroy: vi.fn(),
+    }
+
+    const sidecar = {
+      invoke: vi.fn(() => Promise.resolve(undefined)),
+      onEvent: vi.fn(() => vi.fn()),
+      shutdown: vi.fn(() => Promise.resolve()),
+    } as unknown as Sidecar
+
+    const controller = setupGhosttyNativeParent({
+      sidecar,
+      platform: 'darwin',
+      env: { VITE_GHOSTTY_NATIVE_MACOS_PARENT: '1' },
+      addon,
+    })
+
+    handlers.get(GHOSTTY_NATIVE_SECONDARY_ATTACH)?.(
+      { sender: {} },
+      {
+        sessionId: 'host-pty',
+        paneId: 'pane-1',
+        secondarySessionId: 'burner-pty',
+      }
+    )
+
+    handlers.get(GHOSTTY_NATIVE_SECONDARY_VISIBLE)?.(
+      {},
+      {
+        sessionId: 'host-pty',
+        paneId: 'pane-1',
+        secondarySessionId: 'burner-pty',
+        visible: false,
+      }
+    )
+
+    handlers.get(GHOSTTY_NATIVE_DESTROY)?.(
+      {},
+      { sessionId: 'host-pty', paneId: 'pane-1' }
+    )
+
+    handlers.get(GHOSTTY_NATIVE_SECONDARY_DATA)?.(
+      {},
+      {
+        sessionId: 'host-pty',
+        paneId: 'pane-1',
+        secondarySessionId: 'burner-pty',
+        data: 'after-destroy',
+      }
+    )
+
+    handlers.get(GHOSTTY_NATIVE_UPDATE)?.(
+      { sender: {} },
+      {
+        sessionId: 'host-pty',
+        paneId: 'pane-1',
+        cwd: '/tmp',
+        visible: true,
+        parentHeight: 900,
+        bounds: { x: 10, y: 20, width: 300, height: 200 },
+      }
+    )
+
+    expect(addon.destroy).toHaveBeenCalledWith(firstSurface)
+    expect(addon.create).toHaveBeenCalledTimes(2)
+    expect(addon.addSecondary).toHaveBeenNthCalledWith(
+      2,
+      secondSurface,
+      expect.any(Function),
+      expect.any(Function),
+      expect.any(Function)
+    )
+
+    expect(addon.setSecondaryVisible).toHaveBeenLastCalledWith(
+      secondSurface,
+      false
+    )
+
+    expect(addon.writeSecondary).toHaveBeenCalledWith(
+      secondSurface,
+      'after-destroy'
+    )
+
+    callbacks[1]?.onInput?.('b')
+    expect(sidecar.invoke).toHaveBeenCalledWith('write_pty', {
+      request: { sessionId: 'burner-pty', data: 'b' },
+    })
+
+    controller.dispose()
+  })
+
   test('forwards native app shortcuts into the app renderer', async () => {
     const callbacks: {
       onShortcut?: (

--- a/electron/ghostty-native-parent.test.ts
+++ b/electron/ghostty-native-parent.test.ts
@@ -1318,6 +1318,64 @@ describe('ghostty native parent', () => {
     controller.dispose()
   })
 
+  test('keeps secondary resize active while overlay blocks input', () => {
+    const callbacks: {
+      onInput?: (data: string) => void
+      onResize?: (cols: number, rows: number) => void
+      onFocus?: () => void
+    } = {}
+    const surface = {}
+
+    const addon = {
+      create: vi.fn(() => surface),
+      addSecondary: vi.fn((_surface, input, resize, focus) => {
+        callbacks.onInput = input
+        callbacks.onResize = resize
+        callbacks.onFocus = focus
+      }),
+      setFrame: vi.fn(),
+      write: vi.fn(),
+      writeSecondary: vi.fn(),
+      focus: vi.fn(),
+      destroy: vi.fn(),
+    }
+
+    const sidecar = {
+      invoke: vi.fn(() => Promise.resolve(undefined)),
+      onEvent: vi.fn(() => vi.fn()),
+      shutdown: vi.fn(() => Promise.resolve()),
+    } as unknown as Sidecar
+
+    const controller = setupGhosttyNativeParent({
+      sidecar,
+      platform: 'darwin',
+      env: { VITE_GHOSTTY_NATIVE_MACOS_PARENT: '1' },
+      addon,
+      inputBlocked: vi.fn(() => true),
+    })
+
+    handlers.get(GHOSTTY_NATIVE_SECONDARY_ATTACH)?.(
+      { sender: {} },
+      {
+        sessionId: 'host-pty',
+        paneId: 'pane-1',
+        secondarySessionId: 'burner-pty',
+      }
+    )
+
+    callbacks.onInput?.('blocked')
+    callbacks.onResize?.(100, 30)
+    callbacks.onFocus?.()
+
+    expect(sidecar.invoke).toHaveBeenCalledOnce()
+    expect(sidecar.invoke).toHaveBeenCalledWith('resize_pty', {
+      request: { sessionId: 'burner-pty', cols: 100, rows: 30 },
+    })
+    expect(webContentsSend).not.toHaveBeenCalled()
+
+    controller.dispose()
+  })
+
   test('buffers capped secondary output until the child is attached', () => {
     const surface = {}
 

--- a/electron/ghostty-native-parent.ts
+++ b/electron/ghostty-native-parent.ts
@@ -590,8 +590,8 @@ export class GhosttyNativeParentController {
     }
 
     const state = this.getOrCreatePaneState(payload)
-    this.getOrCreateSurface(addon, win, state)
     this.replaceSecondaryIfNeeded(addon, state, payload.secondarySessionId)
+    this.getOrCreateSurface(addon, win, state)
 
     const secondary = this.ensureSecondaryState(
       state,
@@ -815,6 +815,7 @@ export class GhosttyNativeParentController {
     if (state.surface) {
       addon.destroy(state.surface)
       this.clearPendingResize(state)
+      this.resetSurfaceScopedCaches(state)
       if (state.ownerWindowId !== null) {
         this.surfaceKeysByWindowId.get(state.ownerWindowId)?.delete(key)
       }
@@ -1118,6 +1119,12 @@ export class GhosttyNativeParentController {
     resizeState.resizeTimer = null
   }
 
+  private resetSurfaceScopedCaches(state: GhosttyNativeSurfaceState): void {
+    state.lastBackgroundColor = null
+    state.lastForegroundColor = null
+    state.lastShortcutDigits = null
+  }
+
   private invokeSidecar(
     command: Parameters<Sidecar['invoke']>[0],
     payload: Parameters<Sidecar['invoke']>[1]
@@ -1291,6 +1298,7 @@ export class GhosttyNativeParentController {
       addon.destroy(state.surface)
     }
     this.clearPendingResize(state)
+    this.resetSurfaceScopedCaches(state)
 
     if (state.ownerWindowId !== null) {
       const keys = this.surfaceKeysByWindowId.get(state.ownerWindowId)

--- a/electron/ghostty-native-parent.ts
+++ b/electron/ghostty-native-parent.ts
@@ -1201,7 +1201,7 @@ export class GhosttyNativeParentController {
       },
       onResize: (cols, rows): void => {
         const win = ownerWindow()
-        if (!win || !state.secondary || this.inputBlocked(win)) {
+        if (!win || !state.secondary) {
           return
         }
 

--- a/electron/ghostty-native-parent.ts
+++ b/electron/ghostty-native-parent.ts
@@ -109,6 +109,7 @@ interface GhosttyNativeParentDeps {
 interface GhosttyNativeSurfaceState {
   pane: GhosttyNativePaneRequest
   surface: GhosttyNativeSurface | null
+  ownerWindow: BrowserWindow | null
   ownerWindowId: number | null
   pendingData: string[]
   secondary: GhosttyNativeSecondaryState | null
@@ -121,9 +122,17 @@ interface GhosttyNativeSurfaceState {
   lastShortcutDigits: string | null
 }
 
+interface GhosttyNativeSecondaryCallbacks {
+  onInput: (data: string) => void
+  onResize: (cols: number, rows: number) => void
+  onFocus: () => void
+}
+
 interface GhosttyNativeSecondaryState {
   sessionId: string
   attached: boolean
+  visible: boolean
+  callbacks: GhosttyNativeSecondaryCallbacks | null
   pendingData: string[]
   lastResize: { cols: number; rows: number } | null
 }
@@ -555,7 +564,9 @@ export class GhosttyNativeParentController {
       return { enabled: false }
     }
 
-    this.destroySurface(this.paneKey(payload), addon)
+    this.destroySurface(this.paneKey(payload), addon, {
+      preserveSecondary: true,
+    })
 
     return { enabled: true }
   }
@@ -579,75 +590,18 @@ export class GhosttyNativeParentController {
     }
 
     const state = this.getOrCreatePaneState(payload)
-    const surface = this.getOrCreateSurface(addon, win, state)
+    this.getOrCreateSurface(addon, win, state)
     this.replaceSecondaryIfNeeded(addon, state, payload.secondarySessionId)
 
-    addon.addSecondary(
-      surface,
-      (data) => {
-        if (
-          win.isDestroyed() ||
-          !this.surfaces.has(this.paneKey(state.pane)) ||
-          state.secondary?.sessionId !== payload.secondarySessionId
-        ) {
-          return
-        }
-
-        if (this.inputBlocked(win)) {
-          return
-        }
-
-        this.invokeSidecar('write_pty', {
-          request: {
-            sessionId: payload.secondarySessionId,
-            data,
-          },
-        })
-      },
-      (cols, rows) => {
-        if (
-          win.isDestroyed() ||
-          !this.surfaces.has(this.paneKey(state.pane)) ||
-          state.secondary?.sessionId !== payload.secondarySessionId
-        ) {
-          return
-        }
-
-        if (
-          state.secondary.lastResize?.cols === cols &&
-          state.secondary.lastResize.rows === rows
-        ) {
-          return
-        }
-
-        state.secondary.lastResize = { cols, rows }
-        this.invokeSidecar('resize_pty', {
-          request: {
-            sessionId: payload.secondarySessionId,
-            cols,
-            rows,
-          },
-        })
-      },
-      () => {
-        if (win.isDestroyed() || !this.surfaces.has(this.paneKey(state.pane))) {
-          return
-        }
-
-        if (this.inputBlocked(win)) {
-          return
-        }
-
-        win.webContents.send(BACKEND_EVENT, {
-          event: 'ghostty-native-focus',
-          payload: state.pane,
-        })
-      }
+    const secondary = this.ensureSecondaryState(
+      state,
+      payload.secondarySessionId
     )
-    if (state.secondary) {
-      state.secondary.attached = true
-    }
-    this.flushPendingSecondaryData(addon, state)
+    secondary.callbacks = this.createSecondaryCallbacks(
+      state,
+      payload.secondarySessionId
+    )
+    this.attachSecondaryToSurface(addon, state, secondary)
 
     return { enabled: true }
   }
@@ -676,6 +630,9 @@ export class GhosttyNativeParentController {
       state,
       payload.secondarySessionId
     )
+    if (state.surface && !secondary.attached) {
+      this.attachSecondaryToSurface(addon, state, secondary)
+    }
 
     if (!state.surface || !secondary.attached) {
       secondary.pendingData.push(payload.data)
@@ -709,6 +666,9 @@ export class GhosttyNativeParentController {
       state?.surface &&
       state.secondary?.sessionId === payload.secondarySessionId
     ) {
+      if (!state.secondary.attached) {
+        this.attachSecondaryToSurface(addon, state, state.secondary)
+      }
       addon.focusSecondary(state.surface)
     }
 
@@ -722,18 +682,21 @@ export class GhosttyNativeParentController {
       return { enabled: false }
     }
 
-    const addon = this.getOptionalAddon()
-    if (!addon?.removeSecondary) {
-      return { enabled: false }
+    const state = this.getExistingPaneState(payload)
+    if (state?.secondary?.sessionId !== payload.secondarySessionId) {
+      return { enabled: true }
     }
 
-    const state = this.getExistingPaneState(payload)
-    if (
-      state?.surface &&
-      state.secondary?.sessionId === payload.secondarySessionId
-    ) {
-      addon.removeSecondary(state.surface)
-      state.secondary = null
+    if (state.surface) {
+      const removeSecondary = this.getOptionalAddon()?.removeSecondary
+      if (!removeSecondary) {
+        return { enabled: false }
+      }
+      removeSecondary(state.surface)
+    }
+    state.secondary = null
+    if (!state.surface) {
+      this.surfaces.delete(this.paneKey(payload))
     }
 
     return { enabled: true }
@@ -752,10 +715,16 @@ export class GhosttyNativeParentController {
     }
 
     const state = this.getExistingPaneState(payload)
+    if (state?.secondary?.sessionId === payload.secondarySessionId) {
+      state.secondary.visible = payload.visible
+    }
     if (
       state?.surface &&
       state.secondary?.sessionId === payload.secondarySessionId
     ) {
+      if (!state.secondary.attached) {
+        this.attachSecondaryToSurface(addon, state, state.secondary)
+      }
       addon.setSecondaryVisible(state.surface, payload.visible)
     }
 
@@ -818,6 +787,7 @@ export class GhosttyNativeParentController {
         paneId: payload.paneId,
       },
       surface: null,
+      ownerWindow: null,
       ownerWindowId: null,
       pendingData: [],
       secondary: null,
@@ -849,7 +819,12 @@ export class GhosttyNativeParentController {
         this.surfaceKeysByWindowId.get(state.ownerWindowId)?.delete(key)
       }
       state.surface = null
+      state.ownerWindow = null
       state.ownerWindowId = null
+      if (state.secondary) {
+        state.secondary.attached = false
+        state.secondary.lastResize = null
+      }
     }
 
     this.registerWindowCleanup(win)
@@ -959,8 +934,12 @@ export class GhosttyNativeParentController {
         })
       }
     )
+    state.ownerWindow = win
     state.ownerWindowId = win.id
     this.surfaceKeysByWindowId.get(win.id)?.add(key)
+    if (state.secondary) {
+      this.attachSecondaryToSurface(addon, state, state.secondary)
+    }
 
     return state.surface
   }
@@ -1164,6 +1143,8 @@ export class GhosttyNativeParentController {
     state.secondary = {
       sessionId: secondarySessionId,
       attached: false,
+      visible: true,
+      callbacks: null,
       pendingData: [],
       lastResize: null,
     }
@@ -1186,6 +1167,99 @@ export class GhosttyNativeParentController {
     this.ensureSecondaryState(state, secondarySessionId)
   }
 
+  private createSecondaryCallbacks(
+    state: GhosttyNativeSurfaceState,
+    secondarySessionId: string
+  ): GhosttyNativeSecondaryCallbacks {
+    const ownerWindow = (): BrowserWindow | null => {
+      const win = state.ownerWindow
+      if (
+        !win ||
+        win.isDestroyed() ||
+        !this.surfaces.has(this.paneKey(state.pane)) ||
+        state.secondary?.sessionId !== secondarySessionId
+      ) {
+        return null
+      }
+
+      return win
+    }
+
+    return {
+      onInput: (data): void => {
+        const win = ownerWindow()
+        if (!win || this.inputBlocked(win)) {
+          return
+        }
+
+        this.invokeSidecar('write_pty', {
+          request: {
+            sessionId: secondarySessionId,
+            data,
+          },
+        })
+      },
+      onResize: (cols, rows): void => {
+        const win = ownerWindow()
+        if (!win || !state.secondary || this.inputBlocked(win)) {
+          return
+        }
+
+        if (
+          state.secondary.lastResize?.cols === cols &&
+          state.secondary.lastResize.rows === rows
+        ) {
+          return
+        }
+
+        state.secondary.lastResize = { cols, rows }
+        this.invokeSidecar('resize_pty', {
+          request: {
+            sessionId: secondarySessionId,
+            cols,
+            rows,
+          },
+        })
+      },
+      onFocus: (): void => {
+        const win = ownerWindow()
+        if (!win || this.inputBlocked(win)) {
+          return
+        }
+
+        win.webContents.send(BACKEND_EVENT, {
+          event: 'ghostty-native-focus',
+          payload: state.pane,
+        })
+      },
+    }
+  }
+
+  private attachSecondaryToSurface(
+    addon: GhosttyNativeParentAddon,
+    state: GhosttyNativeSurfaceState,
+    secondary: GhosttyNativeSecondaryState
+  ): void {
+    if (
+      !state.surface ||
+      secondary.attached ||
+      !secondary.callbacks ||
+      !addon.addSecondary
+    ) {
+      return
+    }
+
+    addon.addSecondary(
+      state.surface,
+      secondary.callbacks.onInput,
+      secondary.callbacks.onResize,
+      secondary.callbacks.onFocus
+    )
+    secondary.attached = true
+    addon.setSecondaryVisible?.(state.surface, secondary.visible)
+    this.flushPendingSecondaryData(addon, state)
+  }
+
   private flushPendingSecondaryData(
     addon: GhosttyNativeParentAddon,
     state: GhosttyNativeSurfaceState
@@ -1205,7 +1279,8 @@ export class GhosttyNativeParentController {
 
   private destroySurface(
     key: string,
-    addon: GhosttyNativeParentAddon | null = this.getOptionalAddon()
+    addon: GhosttyNativeParentAddon | null = this.getOptionalAddon(),
+    options: { preserveSecondary?: boolean } = {}
   ): void {
     const state = this.surfaces.get(key)
     if (!state) {
@@ -1216,12 +1291,22 @@ export class GhosttyNativeParentController {
       addon.destroy(state.surface)
     }
     this.clearPendingResize(state)
-    this.surfaces.delete(key)
 
     if (state.ownerWindowId !== null) {
       const keys = this.surfaceKeysByWindowId.get(state.ownerWindowId)
       keys?.delete(key)
     }
+    state.surface = null
+    state.ownerWindow = null
+    state.ownerWindowId = null
+    if (options.preserveSecondary && state.secondary) {
+      state.secondary.attached = false
+      state.secondary.lastResize = null
+
+      return
+    }
+
+    this.surfaces.delete(key)
   }
 }
 


### PR DESCRIPTION
## Summary
- Preserve burner secondary state when Ghostty recreates the native primary surface.
- Reattach the secondary child on the new surface while preserving visibility and queued output.
- Add regression coverage for the destroy/recreate path.

Closes VIM-311

## Test plan
- [x] npm test -- electron/ghostty-native-parent.test.ts
- [x] npm run type-check
- [x] npm run lint