### PR TITLE
fix(ghostty): gate active pane state by visible session

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -100,7 +100,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Type Contract Safety](patterns/type-contract-safety.md)                                             | code-quality       | 16       | 10   | 2026-07-05   |
 | [String Construction Hygiene](patterns/string-construction-hygiene.md)                               | code-quality       | 2        | 1    | 2026-06-19   |
 | [Agent-State Guards](patterns/agent-state-guards.md)                                                 | correctness        | 15       | 10   | 2026-07-05   |
-| [React Prop Contracts](patterns/react-prop-contracts.md)                                             | react-patterns     | 8        | 6    | 2026-06-22   |
+| [React Prop Contracts](patterns/react-prop-contracts.md)                                             | react-patterns     | 9        | 6    | 2026-07-09   |
 | [Stale Retained Interactions](patterns/stale-retained-interactions.md)                               | react-patterns     | 10       | 9    | 2026-07-04   |
 | [Retained State Identity](patterns/retained-state-identity.md)                                       | react-patterns     | 5        | 4    | 2026-07-08   |
 | [Authoritative Completion Guard](patterns/authoritative-completion-guard.md)                         | correctness        | 7        | 4    | 2026-07-05   |

--- a/docs/reviews/patterns/react-prop-contracts.md
+++ b/docs/reviews/patterns/react-prop-contracts.md
@@ -2,7 +2,7 @@
 id: react-prop-contracts
 category: react-patterns
 created: 2026-06-15
-last_updated: 2026-06-22
+last_updated: 2026-07-09
 ref_count: 6
 ---
 
@@ -84,4 +84,13 @@ Components that wrap native HTML elements and forward `...rest` props must expli
 - **File:** `src/features/agent-status/components/QuotaUnavailableNotice.tsx` L30-34
 - **Finding:** The quota notice component hardcoded a tooltip string containing `sst/opencode#16017` while the URL lived in the agent registry. Updating the upstream issue link later could leave the tooltip stale even though the link opened the new destination.
 - **Fix:** Added `tooltipLabel` to `QuotaNotice`, populated it beside `trackUrl` in the registry, and made `QuotaUnavailableNotice` render that prop. Updated component and card tests to provide the co-located label.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 9. TerminalPane active prop mixed focus and visibility gates
+
+- **Source:** github-codex-connector | PR #676 round 1 | 2026-07-09
+- **Severity:** MEDIUM
+- **File:** `src/features/terminal/components/TerminalPane/index.tsx`
+- **Finding:** `TerminalPane` used one `isActive` prop for selected-pane focus/interactivity and for session-visible git metadata loading. After the selected-pane gate was tightened, visible inactive split panes stopped enabling branch, worktree, and status hooks.
+- **Fix:** Added a separate `isSessionVisible` prop for metadata hook enablement while keeping `isActive` as the selected-pane focus/body/chrome signal. `SplitView` now passes both gates, and a regression test covers visible inactive panes.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/src/features/terminal/components/SplitView/SplitView.test.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.test.tsx
@@ -204,7 +204,7 @@ const makeMockService = (): ITerminalService => ({
   setWorkspaceSessions: vi.fn(() => Promise.resolve(undefined)),
 })
 
-// Literal `isActive={false}` is stripped by the project's jsx-boolean-value
+// Literal `isSessionVisible={false}` is stripped by the project's jsx-boolean-value
 // autofix, which then breaks the required prop; a variable dodges the rule.
 const inactive = false
 
@@ -214,7 +214,7 @@ describe('SplitView - single layout', () => {
       <SplitView
         session={makeSession('single', 1)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
       />
     )
 
@@ -232,7 +232,7 @@ describe('SplitView - single layout', () => {
       <SplitView
         session={makeSession('single', 1)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
       />
     )
 
@@ -252,7 +252,7 @@ describe('SplitView - single layout', () => {
           panes: [{ ...session.panes[0], status: 'completed' }],
         }}
         service={makeMockService()}
-        isActive
+        isSessionVisible
       />
     )
 
@@ -269,7 +269,7 @@ describe('SplitView - multi-pane layouts', () => {
       <SplitView
         session={makeSession('vsplit', 2)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
       />
     )
 
@@ -291,7 +291,7 @@ describe('SplitView - multi-pane layouts', () => {
       <SplitView
         session={makeSession('hsplit', 2)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
       />
     )
 
@@ -306,7 +306,7 @@ describe('SplitView - multi-pane layouts', () => {
       <SplitView
         session={makeSession('threeRight', 3)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
       />
     )
 
@@ -322,7 +322,7 @@ describe('SplitView - multi-pane layouts', () => {
       <SplitView
         session={makeSession('quad', 4)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
       />
     )
 
@@ -338,7 +338,7 @@ describe('SplitView - multi-pane layouts', () => {
       <SplitView
         session={makeSession('grid3x2', 6)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
       />
     )
 
@@ -355,7 +355,7 @@ describe('SplitView - multi-pane layouts', () => {
       <SplitView
         session={makeSession('single', 1)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
       />
     )
     expect(screen.queryAllByTestId('split-resize-handle')).toHaveLength(0)
@@ -365,7 +365,11 @@ describe('SplitView - multi-pane layouts', () => {
     const session = makeSession('vsplit', 2)
 
     const { rerender } = render(
-      <SplitView session={session} service={makeMockService()} isActive />
+      <SplitView
+        session={session}
+        service={makeMockService()}
+        isSessionVisible
+      />
     )
     expect(screen.getAllByTestId('split-resize-handle')).toHaveLength(1)
 
@@ -373,7 +377,7 @@ describe('SplitView - multi-pane layouts', () => {
       <SplitView
         session={session}
         service={makeMockService()}
-        isActive={inactive}
+        isSessionVisible={inactive}
       />
     )
     expect(screen.queryAllByTestId('split-resize-handle')).toHaveLength(0)
@@ -387,7 +391,7 @@ describe('SplitView - multi-pane layouts', () => {
       <SplitView
         session={makeSession('vsplit', 2)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
       />
     )
     const pristine = valueNow()
@@ -401,7 +405,7 @@ describe('SplitView - multi-pane layouts', () => {
       <SplitView
         session={makeSession('single', 1)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
       />
     )
 
@@ -409,7 +413,7 @@ describe('SplitView - multi-pane layouts', () => {
       <SplitView
         session={makeSession('vsplit', 2)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
       />
     )
     expect(valueNow()).toBe(resized)
@@ -423,7 +427,7 @@ describe('SplitView - multi-pane layouts', () => {
       <SplitView
         session={makeSession('vsplit', 2)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
       />
     )
     fireEvent.keyDown(screen.getByTestId('split-resize-handle'), {
@@ -435,7 +439,7 @@ describe('SplitView - multi-pane layouts', () => {
       <SplitView
         session={makeSession('vsplit', 2)}
         service={makeMockService()}
-        isActive={inactive}
+        isSessionVisible={inactive}
       />
     )
 
@@ -443,7 +447,7 @@ describe('SplitView - multi-pane layouts', () => {
       <SplitView
         session={makeSession('vsplit', 2)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
       />
     )
     expect(valueNow()).toBe(resized)
@@ -459,7 +463,7 @@ describe('SplitView - multi-pane layouts', () => {
       <SplitView
         session={makeSession('grid3x2', 6)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
       />
     )
     const defaultGridValues = handleValues()
@@ -469,7 +473,7 @@ describe('SplitView - multi-pane layouts', () => {
       <SplitView
         session={makeSession('vsplit', 2)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
       />
     )
 
@@ -481,7 +485,7 @@ describe('SplitView - multi-pane layouts', () => {
       <SplitView
         session={makeSession('grid3x2', 6)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
       />
     )
 
@@ -501,7 +505,7 @@ describe('SplitView - multi-pane layouts', () => {
           })),
         }}
         service={makeMockService()}
-        isActive
+        isSessionVisible
       />
     )
 
@@ -520,7 +524,13 @@ describe('SplitView - multi-pane layouts', () => {
       ],
     } satisfies Session
 
-    render(<SplitView session={session} service={makeMockService()} isActive />)
+    render(
+      <SplitView
+        session={session}
+        service={makeMockService()}
+        isSessionVisible
+      />
+    )
 
     const slots = screen.getAllByTestId('split-view-slot')
 
@@ -555,7 +565,7 @@ describe('SplitView - multi-pane layouts', () => {
       <SplitView
         session={makeSession('vsplit', 2, 1)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
       />
     )
 
@@ -571,6 +581,23 @@ describe('SplitView - multi-pane layouts', () => {
     expect(activeWrapper).not.toHaveAttribute('data-focused')
     expect(activeWrapper).toHaveStyle({ opacity: '1' })
   })
+
+  test('inactive sessions expose no active shell slot', () => {
+    render(
+      <SplitView
+        session={makeSession('vsplit', 2, 1)}
+        service={makeMockService()}
+        isSessionVisible={inactive}
+      />
+    )
+
+    for (const slot of screen.getAllByTestId('split-view-slot')) {
+      expect(slot).toHaveAttribute('data-pane-active', 'false')
+    }
+    for (const wrapper of screen.getAllByTestId('terminal-pane-wrapper')) {
+      expect(wrapper).not.toHaveAttribute('data-pane-active')
+    }
+  })
 })
 
 describe('SplitView - under-capacity', () => {
@@ -579,7 +606,7 @@ describe('SplitView - under-capacity', () => {
       <SplitView
         session={makeSession('quad', 2)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
       />
     )
 
@@ -607,7 +634,7 @@ describe('SplitView - under-capacity', () => {
       <SplitView
         session={makeSession('grid3x2', 5)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
         onAddPane={vi.fn()}
       />
     )
@@ -623,7 +650,7 @@ describe('SplitView - under-capacity', () => {
       <SplitView
         session={makeSession('threeRight', 1)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
       />
     )
 
@@ -635,7 +662,7 @@ describe('SplitView - under-capacity', () => {
       <SplitView
         session={makeSession('vsplit', 1)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
         onAddPane={vi.fn()}
       />
     )
@@ -656,7 +683,7 @@ describe('SplitView - under-capacity', () => {
       <SplitView
         session={makeSession('quad', 2)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
         onAddPane={vi.fn()}
       />
     )
@@ -673,7 +700,7 @@ describe('SplitView - under-capacity', () => {
       <SplitView
         session={makeSession('quad', 2)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
       />
     )
 
@@ -694,7 +721,7 @@ describe('SplitView - under-capacity', () => {
       <SplitView
         session={makeSession('vsplit', 1)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
         onAddPane={onAddPane}
       />
     )
@@ -710,7 +737,13 @@ describe('SplitView - over-capacity layout render', () => {
   test('single layout keeps an active second pane visible without throwing', () => {
     const session = makeSession('single', 2, 1)
 
-    render(<SplitView session={session} service={makeMockService()} isActive />)
+    render(
+      <SplitView
+        session={session}
+        service={makeMockService()}
+        isSessionVisible
+      />
+    )
 
     const slots = screen.getAllByTestId('split-view-slot')
 
@@ -728,7 +761,11 @@ describe('SplitView - no PTY lifecycle IPC', () => {
     const service = makeMockService()
 
     render(
-      <SplitView session={makeSession('quad', 4)} service={service} isActive />
+      <SplitView
+        session={makeSession('quad', 4)}
+        service={service}
+        isSessionVisible
+      />
     )
 
     expect(service.spawn).not.toHaveBeenCalled()
@@ -742,7 +779,7 @@ describe('SplitView - no PTY lifecycle IPC', () => {
       <SplitView
         session={makeSession('single', 1)}
         service={service}
-        isActive
+        isSessionVisible
       />
     )
 
@@ -759,7 +796,7 @@ describe('SplitView - imperative focus handle', () => {
         ref={ref}
         session={makeSession('single', 1)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
       />
     )
 
@@ -779,7 +816,7 @@ describe('SplitView - imperative focus handle', () => {
           panes: session.panes.map((pane) => ({ ...pane, active: false })),
         }}
         service={makeMockService()}
-        isActive
+        isSessionVisible
       />
     )
 
@@ -798,7 +835,7 @@ describe('SplitView - click-to-focus', () => {
       <SplitView
         session={session}
         service={makeMockService()}
-        isActive
+        isSessionVisible
         onSetActivePane={onSetActivePane}
       />
     )
@@ -816,7 +853,7 @@ describe('SplitView - click-to-focus', () => {
       <SplitView
         session={makeSession('vsplit', 2)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
       />
     )
 
@@ -830,7 +867,7 @@ describe('SplitView - click-to-focus', () => {
       <SplitView
         session={makeSession('vsplit', 2)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
       />
     )
 
@@ -868,7 +905,13 @@ describe('SplitView - click-to-focus', () => {
       ],
     } satisfies Session
 
-    render(<SplitView session={session} service={makeMockService()} isActive />)
+    render(
+      <SplitView
+        session={session}
+        service={makeMockService()}
+        isSessionVisible
+      />
+    )
 
     expect(screen.getByTestId('browser-pane-mock')).toBeInTheDocument()
     expect(screen.getAllByTestId('pane-shortcut-hint')[1]).toHaveTextContent(
@@ -883,7 +926,7 @@ describe('SplitView - click-to-focus', () => {
       <SplitView
         session={makeSession('vsplit', 2)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
       />
     )
 
@@ -911,7 +954,7 @@ describe('SplitView - close pane', () => {
       <SplitView
         session={makeSession('vsplit', 2)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
         onClosePane={onClosePane}
       />
     )
@@ -927,7 +970,7 @@ describe('SplitView - close pane', () => {
       <SplitView
         session={makeSession('single', 1)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
         onClosePane={vi.fn()}
       />
     )
@@ -1088,7 +1131,13 @@ describe('SplitView - over-capacity rescued active render', () => {
     const session = makeSession('vsplit', 3, 2)
     // 3 panes, vsplit capacity = 2, active at index 2 → must land at p1.
 
-    render(<SplitView session={session} service={makeMockService()} isActive />)
+    render(
+      <SplitView
+        session={session}
+        service={makeMockService()}
+        isSessionVisible
+      />
+    )
 
     const slots = screen.getAllByTestId('split-view-slot')
 
@@ -1146,7 +1195,7 @@ describe('SplitView - drag panes into slots (VIM-167)', () => {
       <SplitView
         session={makeSession('vsplit', 2)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
         onPanePlacementsChange={vi.fn()}
       />
     )
@@ -1179,7 +1228,7 @@ describe('SplitView - drag panes into slots (VIM-167)', () => {
       <SplitView
         session={browserSession}
         service={makeMockService()}
-        isActive
+        isSessionVisible
         onPanePlacementsChange={vi.fn()}
       />
     )
@@ -1201,7 +1250,7 @@ describe('SplitView - drag panes into slots (VIM-167)', () => {
       <SplitView
         session={makeSession('vsplit', 2)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
         onPanePlacementsChange={onPanePlacementsChange}
       />
     )
@@ -1234,7 +1283,7 @@ describe('SplitView - drag panes into slots (VIM-167)', () => {
       <SplitView
         session={makeSession('quad', 2)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
         onAddPane={vi.fn()}
         onPanePlacementsChange={onPanePlacementsChange}
       />
@@ -1323,7 +1372,7 @@ describe('SplitView - drag panes into slots (VIM-167)', () => {
       <SplitView
         session={browserSession}
         service={makeMockService()}
-        isActive
+        isSessionVisible
         layoutRegistry={registry}
         onPanePlacementsChange={onPanePlacementsChange}
       />
@@ -1352,7 +1401,7 @@ describe('SplitView - drag panes into slots (VIM-167)', () => {
       <SplitView
         session={makeSession('vsplit', 2)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
         onPanePlacementsChange={vi.fn()}
       />
     )
@@ -1375,7 +1424,7 @@ describe('SplitView - drag panes into slots (VIM-167)', () => {
       <SplitView
         session={makeSession('vsplit', 2)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
         onPanePlacementsChange={onPanePlacementsChange}
       />
     )
@@ -1394,7 +1443,7 @@ describe('SplitView - drag panes into slots (VIM-167)', () => {
       <SplitView
         session={makeSession('vsplit', 2)}
         service={makeMockService()}
-        isActive
+        isSessionVisible
       />
     )
 
@@ -1447,7 +1496,7 @@ describe('SplitView - drag panes into slots (VIM-167)', () => {
       <SplitView
         session={session}
         service={makeMockService()}
-        isActive
+        isSessionVisible
         onAddPane={vi.fn()}
         layoutRegistry={registry}
         onPanePlacementsChange={onPanePlacementsChange}
@@ -1519,7 +1568,7 @@ describe('SplitView - drag panes into slots (VIM-167)', () => {
       <SplitView
         session={session}
         service={makeMockService()}
-        isActive
+        isSessionVisible
         layoutRegistry={registry}
         onPanePlacementsChange={onPanePlacementsChange}
       />
@@ -1579,7 +1628,7 @@ describe('SplitView - drag panes into slots (VIM-167)', () => {
       <SplitView
         session={session}
         service={makeMockService()}
-        isActive
+        isSessionVisible
         onAddPane={vi.fn()}
         layoutRegistry={registry}
         onPanePlacementsChange={vi.fn()}

--- a/src/features/terminal/components/SplitView/SplitView.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.tsx
@@ -683,6 +683,7 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
                         runningBurnerPaneKeys={runningBurnerPaneKeys}
                         outOfSyncBurnerPaneKeys={outOfSyncBurnerPaneKeys}
                         isActive={isActive}
+                        isSessionVisible={isSessionVisible}
                         shortcutContext={nativeShortcutContext}
                         shortcutHint={
                           slotIndex < 9

--- a/src/features/terminal/components/SplitView/SplitView.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.tsx
@@ -58,7 +58,7 @@ const SLOT_FADE_TRANSITION = { duration: 0.08, ease: 'easeOut' } as const
 export interface SplitViewProps {
   session: Session
   service: ITerminalService
-  isActive: boolean
+  isSessionVisible: boolean
   onSessionCwdChange?: (sessionId: string, paneId: string, cwd: string) => void
   onPaneReady?: NotifyPaneReady
   onCommandSubmit?: (ptyId: string, command: string) => void
@@ -177,7 +177,7 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
     {
       session,
       service,
-      isActive,
+      isSessionVisible,
       onSessionCwdChange = undefined,
       onPaneReady = undefined,
       onCommandSubmit = undefined,
@@ -228,13 +228,13 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
     // Mount SplitDividers (and their useElasticContainer hooks) only once the
     // grid actually has a measured size. Sessions mount while hidden
     // (display:none → 0×0) and useElasticContainer hard-throws on a zero
-    // dimension at mount, so re-measure whenever `isActive` flips and the
+    // dimension at mount, so re-measure whenever `isSessionVisible` flips and the
     // session becomes visible.
     const [hasSize, setHasSize] = useState(false)
     useLayoutEffect(() => {
       const rect = outerDivRef.current?.getBoundingClientRect()
       setHasSize(Boolean(rect && rect.width > 0 && rect.height > 0))
-    }, [isActive])
+    }, [isSessionVisible])
 
     // VIM-167 drag-into-slot state: which pane is mid-drag, and which slot the
     // cursor is over (drives the valid-target highlight). Both reset on
@@ -319,8 +319,9 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
 
     const visibleShortcutPaneIdsKey = visibleShortcutPaneIds.join('\u0000')
 
-    const activePaneId =
-      session.panes.find((sessionPane) => sessionPane.active)?.id ?? null
+    const activePaneId = isSessionVisible
+      ? (session.panes.find((sessionPane) => sessionPane.active)?.id ?? null)
+      : null
 
     const nativeShortcutContext = useMemo<NativeGhosttyShortcutContext>(
       () => ({
@@ -547,6 +548,8 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
               const isBrowserPane = !isShellPane(pane)
               const mode = isBrowserPane ? 'browser' : paneMode(pane)
               const slotIndex = layout.definition.addOrder.indexOf(slotId)
+              // Only the visible session's selected pane is globally active.
+              const isActive = isSessionVisible && pane.active
 
               const closeHandler =
                 onClosePane && canClosePane(session) ? onClosePane : undefined
@@ -572,7 +575,7 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
                   data-testid="split-view-slot"
                   data-pane-id={pane.id}
                   data-pane-kind={pane.kind ?? 'shell'}
-                  data-pane-active={pane.active ? 'true' : 'false'}
+                  data-pane-active={isActive ? 'true' : 'false'}
                   data-pty-id={pane.ptyId}
                   data-mode={mode}
                   data-cwd={pane.cwd}
@@ -644,7 +647,7 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
                           key={pane.ptyId}
                           session={session}
                           pane={pane}
-                          isActive={isActive}
+                          isActive={isSessionVisible}
                           onClose={closeHandler}
                           onRequestActive={onSetActivePane}
                           onRequestFocus={onRequestFocus}
@@ -762,7 +765,7 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
                 })
               : null}
           </AnimatePresence>
-          {isActive && hasSize ? (
+          {isSessionVisible && hasSize ? (
             <SplitDividers
               layout={layout}
               containerRef={outerDivRef}

--- a/src/features/terminal/components/TerminalPane/index.test.tsx
+++ b/src/features/terminal/components/TerminalPane/index.test.tsx
@@ -4,6 +4,7 @@ import { createRef } from 'react'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import type { UseGitBranchReturn } from '../../../diff/hooks/useGitBranch'
 import type { UseGitStatusReturn } from '../../../diff/hooks/useGitStatus'
+import type { UseGitWorktreeReturn } from '../../../diff/hooks/useGitWorktree'
 import type { Session } from '../../../sessions/types'
 import type { BodyHandle, BodyProps } from './Body'
 import { TerminalPane, type TerminalPaneHandle } from './index'
@@ -13,6 +14,43 @@ vi.mock('./usePaneWidth', () => ({ usePaneWidth: vi.fn(() => null) }))
 
 const bodyPropsSpy = vi.hoisted(() => vi.fn())
 const focusTerminalSpy = vi.hoisted(() => vi.fn())
+
+const useGitBranchSpy = vi.hoisted(() =>
+  vi.fn((): UseGitBranchReturn => ({
+    branch: 'main',
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    idle: false,
+  }))
+)
+
+const useGitStatusSpy = vi.hoisted(() =>
+  vi.fn((): UseGitStatusReturn => ({
+    files: [
+      {
+        path: 'a.ts',
+        status: 'modified',
+        insertions: 10,
+        deletions: 3,
+        staged: false,
+      },
+    ],
+    filesCwd: '/home/user/repo',
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    idle: false,
+  }))
+)
+
+const useGitWorktreeSpy = vi.hoisted(() =>
+  vi.fn((): UseGitWorktreeReturn => ({
+    worktreeName: null,
+    loading: false,
+    error: null,
+  }))
+)
 
 vi.mock('./Body', async () => {
   const React = await import('react')
@@ -40,32 +78,15 @@ vi.mock('./Body', async () => {
 })
 
 vi.mock('../../../diff/hooks/useGitBranch', () => ({
-  useGitBranch: (): UseGitBranchReturn => ({
-    branch: 'main',
-    loading: false,
-    error: null,
-    refresh: vi.fn(),
-    idle: false,
-  }),
+  useGitBranch: useGitBranchSpy,
 }))
 
 vi.mock('../../../diff/hooks/useGitStatus', () => ({
-  useGitStatus: (): UseGitStatusReturn => ({
-    files: [
-      {
-        path: 'a.ts',
-        status: 'modified',
-        insertions: 10,
-        deletions: 3,
-        staged: false,
-      },
-    ],
-    filesCwd: '/home/user/repo',
-    loading: false,
-    error: null,
-    refresh: vi.fn(),
-    idle: false,
-  }),
+  useGitStatus: useGitStatusSpy,
+}))
+
+vi.mock('../../../diff/hooks/useGitWorktree', () => ({
+  useGitWorktree: useGitWorktreeSpy,
 }))
 
 const session: Session = {
@@ -116,6 +137,9 @@ describe('TerminalPane index', () => {
   beforeEach(() => {
     bodyPropsSpy.mockClear()
     focusTerminalSpy.mockClear()
+    useGitBranchSpy.mockClear()
+    useGitStatusSpy.mockClear()
+    useGitWorktreeSpy.mockClear()
     vi.mocked(usePaneWidth).mockReturnValue(null)
   })
 
@@ -344,6 +368,35 @@ describe('TerminalPane index', () => {
 
     expect(statusBar).toHaveTextContent('+10')
     expect(statusBar).toHaveTextContent('−3')
+  })
+
+  test('visible inactive panes still enable git metadata hooks', () => {
+    render(
+      <TerminalPane
+        {...baseProps}
+        pane={{ ...baseProps.pane, active: false }}
+        isActive={inactive}
+        isSessionVisible
+      />
+    )
+
+    expect(useGitBranchSpy).toHaveBeenCalledWith('/home/user/repo', {
+      enabled: true,
+    })
+
+    expect(useGitWorktreeSpy).toHaveBeenCalledWith('/home/user/repo', {
+      enabled: true,
+    })
+
+    expect(useGitStatusSpy).toHaveBeenCalledWith('/home/user/repo', {
+      enabled: true,
+    })
+
+    expect(screen.getByTestId('terminal-pane-wrapper')).toHaveStyle({
+      opacity: '0.78',
+    })
+
+    expect(focusTerminalSpy).not.toHaveBeenCalled()
   })
 
   test('the pane wrapper is a size container for responsive chrome', () => {

--- a/src/features/terminal/components/TerminalPane/index.test.tsx
+++ b/src/features/terminal/components/TerminalPane/index.test.tsx
@@ -16,40 +16,46 @@ const bodyPropsSpy = vi.hoisted(() => vi.fn())
 const focusTerminalSpy = vi.hoisted(() => vi.fn())
 
 const useGitBranchSpy = vi.hoisted(() =>
-  vi.fn((): UseGitBranchReturn => ({
-    branch: 'main',
-    loading: false,
-    error: null,
-    refresh: vi.fn(),
-    idle: false,
-  }))
+  vi.fn(
+    (): UseGitBranchReturn => ({
+      branch: 'main',
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+      idle: false,
+    })
+  )
 )
 
 const useGitStatusSpy = vi.hoisted(() =>
-  vi.fn((): UseGitStatusReturn => ({
-    files: [
-      {
-        path: 'a.ts',
-        status: 'modified',
-        insertions: 10,
-        deletions: 3,
-        staged: false,
-      },
-    ],
-    filesCwd: '/home/user/repo',
-    loading: false,
-    error: null,
-    refresh: vi.fn(),
-    idle: false,
-  }))
+  vi.fn(
+    (): UseGitStatusReturn => ({
+      files: [
+        {
+          path: 'a.ts',
+          status: 'modified',
+          insertions: 10,
+          deletions: 3,
+          staged: false,
+        },
+      ],
+      filesCwd: '/home/user/repo',
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+      idle: false,
+    })
+  )
 )
 
 const useGitWorktreeSpy = vi.hoisted(() =>
-  vi.fn((): UseGitWorktreeReturn => ({
-    worktreeName: null,
-    loading: false,
-    error: null,
-  }))
+  vi.fn(
+    (): UseGitWorktreeReturn => ({
+      worktreeName: null,
+      loading: false,
+      error: null,
+    })
+  )
 )
 
 vi.mock('./Body', async () => {

--- a/src/features/terminal/components/TerminalPane/index.test.tsx
+++ b/src/features/terminal/components/TerminalPane/index.test.tsx
@@ -110,6 +110,8 @@ const baseProps = {
   isActive: true,
 }
 
+const inactive = false
+
 describe('TerminalPane index', () => {
   beforeEach(() => {
     bodyPropsSpy.mockClear()
@@ -216,6 +218,7 @@ describe('TerminalPane index', () => {
       <TerminalPane
         {...baseProps}
         pane={{ ...baseProps.pane, active: false }}
+        isActive={inactive}
         onRequestActive={onRequestActive}
       />
     )
@@ -234,6 +237,7 @@ describe('TerminalPane index', () => {
       <TerminalPane
         {...baseProps}
         pane={{ ...baseProps.pane, active: false }}
+        isActive={inactive}
         onRequestActive={onRequestActive}
       />
     )
@@ -437,6 +441,7 @@ describe('TerminalPane index', () => {
       <TerminalPane
         {...baseProps}
         pane={{ ...baseProps.pane, active: false }}
+        isActive={inactive}
         onClose={onClose}
         onRequestActive={onRequestActive}
       />
@@ -457,6 +462,7 @@ describe('TerminalPane index', () => {
       <TerminalPane
         {...baseProps}
         pane={{ ...baseProps.pane, active: false }}
+        isActive={inactive}
         onRequestActive={onRequestActive}
       />
     )
@@ -482,6 +488,7 @@ describe('TerminalPane index', () => {
       <TerminalPane
         {...baseProps}
         pane={{ ...baseProps.pane, active: false }}
+        isActive={inactive}
       />
     )
 
@@ -515,6 +522,7 @@ describe('TerminalPane index', () => {
       <TerminalPane
         {...baseProps}
         pane={{ ...baseProps.pane, active: false }}
+        isActive={inactive}
       />
     )
 
@@ -549,7 +557,7 @@ describe('TerminalPane index', () => {
     )
   })
 
-  test('focuses on initial mount when pane.active=true', () => {
+  test('focuses on initial mount when active', () => {
     // A freshly-created pane (createSession, addPane, restored active pane on
     // app launch) mounts already active and never transitions false→true. The
     // rising-edge effect must therefore treat the first run as a focus event,
@@ -561,10 +569,26 @@ describe('TerminalPane index', () => {
     expect(focusTerminalSpy).toHaveBeenCalledOnce()
   })
 
-  test('does not focus on initial mount when pane.active=false', () => {
+  test('does not mark or focus a non-interactive restored pane', () => {
     render(
       <TerminalPane
         {...baseProps}
+        isActive={inactive}
+        pane={{ ...baseProps.pane, active: true }}
+      />
+    )
+
+    const wrapper = screen.getByTestId('terminal-pane-wrapper')
+    expect(wrapper).not.toHaveAttribute('data-pane-active')
+    expect(wrapper).toHaveStyle({ opacity: '0.78' })
+    expect(focusTerminalSpy).not.toHaveBeenCalled()
+  })
+
+  test('does not focus on initial mount when inactive', () => {
+    render(
+      <TerminalPane
+        {...baseProps}
+        isActive={inactive}
         pane={{ ...baseProps.pane, active: false }}
       />
     )
@@ -572,10 +596,11 @@ describe('TerminalPane index', () => {
     expect(focusTerminalSpy).not.toHaveBeenCalled()
   })
 
-  test('focuses when pane.active flips false to true', () => {
+  test('focuses when active flips false to true', () => {
     const { rerender } = render(
       <TerminalPane
         {...baseProps}
+        isActive={inactive}
         pane={{ ...baseProps.pane, active: false }}
       />
     )
@@ -588,10 +613,11 @@ describe('TerminalPane index', () => {
     expect(focusTerminalSpy).toHaveBeenCalledOnce()
   })
 
-  test('does not re-focus when pane.active stays true across renders', () => {
+  test('does not re-focus when active stays true across renders', () => {
     const { rerender } = render(
       <TerminalPane
         {...baseProps}
+        isActive={inactive}
         pane={{ ...baseProps.pane, active: false }}
       />
     )
@@ -611,6 +637,7 @@ describe('TerminalPane index', () => {
     const { rerender } = render(
       <TerminalPane
         {...baseProps}
+        isActive={inactive}
         pane={{ ...baseProps.pane, active: false }}
       />
     )
@@ -622,6 +649,7 @@ describe('TerminalPane index', () => {
     rerender(
       <TerminalPane
         {...baseProps}
+        isActive={inactive}
         pane={{ ...baseProps.pane, active: false }}
       />
     )
@@ -642,6 +670,7 @@ describe('TerminalPane index', () => {
       <TerminalPane
         ref={ref}
         {...baseProps}
+        isActive={inactive}
         pane={{ ...baseProps.pane, active: false }}
       />
     )

--- a/src/features/terminal/components/TerminalPane/index.tsx
+++ b/src/features/terminal/components/TerminalPane/index.tsx
@@ -130,7 +130,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
   ): ReactElement {
     const agent = agentForPane(pane)
     const bodyRef = useRef<TerminalBodyHandle>(null)
-    // Seeded `undefined` (NOT `pane.active`) so the first effect run can detect
+    // Seeded `undefined` so the first effect run can detect
     // initial mount distinctly from a stable `true → true` re-render. A pane
     // born active (createSession, addPane, restored on app launch) must focus
     // on first paint — otherwise its xterm stays unfocused with no transition
@@ -158,16 +158,14 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
       },
     }))
 
-    const isPaneActive = pane.active
-
     useEffect(() => {
       // Fire on `undefined → true` (initial mount active) AND `false → true`
       // (existing rising edge). Stable `true → true` re-renders are skipped.
-      if (pane.active && wasActiveRef.current !== true) {
+      if (isActive && wasActiveRef.current !== true) {
         bodyRef.current?.focusTerminal()
       }
-      wasActiveRef.current = pane.active
-    }, [pane.active])
+      wasActiveRef.current = isActive
+    }, [isActive])
 
     const { branch } = useGitBranch(pane.cwd, {
       enabled: isActive,
@@ -196,7 +194,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
 
     const handleContainerClick = useCallback(
       (event: MouseEvent<HTMLDivElement>): void => {
-        if (!pane.active) {
+        if (!isActive) {
           event.stopPropagation()
 
           return
@@ -204,7 +202,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
 
         bodyRef.current?.focusTerminal()
       },
-      [pane.active]
+      [isActive]
     )
 
     const handleContainerMouseDown = useCallback(
@@ -216,14 +214,14 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
           return
         }
 
-        if (!pane.active) {
+        if (!isActive) {
           requestPaneActive()
 
           return
         }
         bodyRef.current?.focusTerminal()
       },
-      [pane.active, requestPaneActive]
+      [isActive, requestPaneActive]
     )
 
     const handleToggleCollapse = useCallback((): void => {
@@ -291,7 +289,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
 
     const containerStyle = {
       boxShadow: 'none',
-      cursor: isPaneActive ? ('default' as const) : ('pointer' as const),
+      cursor: isActive ? ('default' as const) : ('pointer' as const),
     }
 
     return (
@@ -300,7 +298,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
         data-testid="terminal-pane-wrapper"
         data-session-id={session.id}
         data-mode={mode}
-        data-pane-active={isPaneActive || undefined}
+        data-pane-active={isActive || undefined}
         onMouseDown={handleContainerMouseDown}
         onClick={handleContainerClick}
         style={{
@@ -308,14 +306,14 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
           background: 'var(--color-surface-container-lowest)',
           borderRadius: TERMINAL_PANE_CORNER_RADIUS,
           transition: 'box-shadow 220ms ease, opacity 220ms ease',
-          opacity: isPaneActive ? 1 : 0.78,
+          opacity: isActive ? 1 : 0.78,
         }}
         className="@container/pane relative isolate flex h-full w-full flex-col overflow-hidden"
       >
         <Header
           agent={agent}
           session={session}
-          isActive={isPaneActive}
+          isActive={isActive}
           isCollapsed={isCollapsed}
           autoCollapsed={autoCollapsed}
           hideCollapseToggle={hideCollapseToggle}
@@ -367,7 +365,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
               paneId={pane.id}
               ptyId={pane.ptyId}
               cwd={pane.cwd}
-              active={isActive && pane.active}
+              active={isActive}
               service={service}
               restoredFrom={pane.restoreData}
               onCwdChange={onCwdChange}
@@ -386,7 +384,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
 
         {!isAwaitingRestart && !isCollapsed && (
           <PaneStatusBar
-            isActive={isPaneActive}
+            isActive={isActive}
             worktreeName={worktreeName}
             branch={branch}
             cwd={pane.cwd}

--- a/src/features/terminal/components/TerminalPane/index.tsx
+++ b/src/features/terminal/components/TerminalPane/index.tsx
@@ -52,7 +52,10 @@ export type TerminalPaneMode = 'attach' | 'spawn' | 'awaiting-restart'
 export interface TerminalPaneProps {
   session: Session
   pane: Pane
+  /** Selected-pane activity: drives focus, chrome emphasis, and body interactivity. */
   isActive: boolean
+  /** Session visibility: drives background metadata for panes mounted on screen. */
+  isSessionVisible?: boolean
   service: ITerminalService
   onPaneReady?: NotifyPaneReady
   mode?: TerminalPaneMode
@@ -104,6 +107,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
       session,
       pane,
       isActive,
+      isSessionVisible = isActive,
       service,
       onPaneReady = undefined,
       mode = 'spawn',
@@ -168,15 +172,15 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
     }, [isActive])
 
     const { branch } = useGitBranch(pane.cwd, {
-      enabled: isActive,
+      enabled: isSessionVisible,
     })
 
     const { worktreeName } = useGitWorktree(pane.cwd, {
-      enabled: isActive,
+      enabled: isSessionVisible,
     })
 
     const { files, filesCwd } = useGitStatus(pane.cwd, {
-      enabled: isActive,
+      enabled: isSessionVisible,
     })
 
     const isFresh = filesCwd === pane.cwd

--- a/src/features/workspace/components/TerminalZone.tsx
+++ b/src/features/workspace/components/TerminalZone.tsx
@@ -192,7 +192,7 @@ export const TerminalZone = forwardRef<TerminalZoneHandle, TerminalZoneProps>(
           ) : (
             // Render all sessions but hide inactive ones to keep PTY sessions alive.
             sessions.map((session) => {
-              const isActive = session.id === activeSessionId
+              const isSessionVisible = session.id === activeSessionId
 
               return (
                 <div
@@ -200,13 +200,17 @@ export const TerminalZone = forwardRef<TerminalZoneHandle, TerminalZoneProps>(
                   id={`session-panel-${session.id}`}
                   data-testid="terminal-pane"
                   data-session-id={session.id}
-                  className={`absolute inset-0 ${isActive ? '' : 'hidden'}`}
+                  className={`absolute inset-0 ${
+                    isSessionVisible ? '' : 'hidden'
+                  }`}
                 >
                   <SplitView
-                    ref={isActive ? setActiveSplitViewRefFn.current : null}
+                    ref={
+                      isSessionVisible ? setActiveSplitViewRefFn.current : null
+                    }
                     session={session}
                     service={service}
-                    isActive={isActive}
+                    isSessionVisible={isSessionVisible}
                     onSessionCwdChange={onSessionCwdChange}
                     onPaneReady={onPaneReady}
                     onCommandSubmit={onCommandSubmit}

--- a/tests/e2e/agent/specs/agent-runtime-regressions.spec.ts
+++ b/tests/e2e/agent/specs/agent-runtime-regressions.spec.ts
@@ -1,9 +1,9 @@
 import assert from 'node:assert/strict'
 import fs from 'node:fs'
-import os from 'node:os'
 import path from 'node:path'
 import { createNewSessionWithDefaults } from '../../shared/actions.js'
 import { waitForE2eBridge } from '../../shared/e2e-bridge.js'
+import { e2eTempRoot } from '../../shared/electron-app.js'
 import {
   pressEnterInActiveTerminal,
   typeInActiveTerminal,
@@ -374,7 +374,7 @@ describe('Agent runtime regressions', () => {
   })
 
   it('stores bridge files under app data and leaves project .vimeflow absent', async () => {
-    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'vimeflow-e2e-'))
+    const tempRoot = fs.mkdtempSync(path.join(e2eTempRoot(), 'vimeflow-e2e-'))
     const projectDir = path.join(tempRoot, 'Project With Spaces & Symbols')
     fs.mkdirSync(projectDir)
     const sessionId = `e2e_bridge_${Date.now()}`
@@ -549,10 +549,10 @@ describe('Agent runtime regressions', () => {
   it('renders seeded Codex and Kimi statuses in the sidebar card and status panel', async () => {
     const ptyId = await waitForVisiblePtyId()
     const codexHome = fs.mkdtempSync(
-      path.join(os.tmpdir(), 'vimeflow-codex-e2e-')
+      path.join(e2eTempRoot(), 'vimeflow-codex-e2e-')
     )
     const kimiHome = fs.mkdtempSync(
-      path.join(os.tmpdir(), 'vimeflow-kimi-e2e-')
+      path.join(e2eTempRoot(), 'vimeflow-kimi-e2e-')
     )
 
     const scenarios: AgentStatusScenario[] = [

--- a/tests/e2e/shared/electron-app.ts
+++ b/tests/e2e/shared/electron-app.ts
@@ -30,6 +30,13 @@ export const appEntryPoint = path.resolve(repoRoot, 'dist-electron/main.js')
 // E2E-only backend-method allowlist (electron/main.ts:isE2eRuntime).
 export const appArgs: string[] = ['--no-sandbox', '--vimeflow-e2e']
 
+export const e2eTempRoot = (): string => {
+  const root = process.env.RUNNER_TEMP ?? os.tmpdir()
+  fs.mkdirSync(root, { recursive: true })
+
+  return root
+}
+
 // Tracks the temp dirs created by injectFreshUserDataDir across all
 // sessions in this WDIO process so the exit-time safety net can clean up
 // anything afterSession missed (crash, kill -9, etc).
@@ -47,7 +54,7 @@ const activeUserDataDirs = new Set<string>()
 export const injectFreshUserDataDir = (
   capabilities: WebdriverIO.Capabilities
 ): void => {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vimeflow-e2e-'))
+  const dir = fs.mkdtempSync(path.join(e2eTempRoot(), 'vimeflow-e2e-'))
   activeUserDataDirs.add(dir)
   const electronOpts = capabilities['wdio:electronServiceOptions'] ?? {}
   // Strip any --user-data-dir already injected by a prior beforeSession


### PR DESCRIPTION
## Summary
- Gate SplitView's active shell markers and native shortcut context behind the visible session state.
- Pass the derived active state into TerminalPane so hidden restored sessions do not focus or expose active DOM markers.
- Rename SplitView's session visibility prop and add regression coverage for hidden restored active panes.

## Root Cause
TerminalZone keeps inactive sessions mounted but hidden to preserve PTYs. On restore, each session may still contain one pane with pane.active=true, so SplitView and TerminalPane were treating hidden sessions as globally active during startup.

## Validation
- npm test -- src/features/terminal/components/TerminalPane/index.test.tsx src/features/terminal/components/SplitView/SplitView.test.tsx src/features/workspace/components/TerminalZone.test.tsx
- npm run type-check
- npm run lint
- git push pre-push hook: npm test

Refs VIM-316