### PR TITLE
feat(diff): render delegated reviewer findings in the hunk (VIM-304 PR-2)

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -49,7 +49,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Imperative Animation Ownership](patterns/imperative-animation-ownership.md)                         | react-patterns     | 7        | 3    | 2026-06-17   |
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Fixed-Position Portals](patterns/fixed-position-portals.md)                                         | react-patterns     | 2        | 1    | 2026-06-22   |
-| [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 30       | 25   | 2026-07-05   |
+| [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 31       | 25   | 2026-07-09   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)                                             | cross-platform     | 14       | 12   | 2026-07-09   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                                                       | code-quality       | 7        | 0    | 2026-06-11   |
 | [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 26       | 21   | 2026-07-08   |
@@ -69,7 +69,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Fail-Closed Hooks](patterns/fail-closed-hooks.md)                                                   | security           | 5        | 3    | 2026-07-05   |
 | [Bridge Payload Minimization](patterns/bridge-payload-minimization.md)                               | security           | 4        | 4    | 2026-06-21   |
 | [IPC Sender Validation](patterns/ipc-sender-validation.md)                                           | security           | 1        | 1    | 2026-06-30   |
-| [IPC Resource Bounds](patterns/ipc-resource-bounds.md)                                               | security           | 8        | 2    | 2026-07-05   |
+| [IPC Resource Bounds](patterns/ipc-resource-bounds.md)                                               | security           | 9        | 2    | 2026-07-09   |
 | [Preflight Checks](patterns/preflight-checks.md)                                                     | error-handling     | 3        | 0    | 2026-05-31   |
 | [CSP Configuration](patterns/csp-configuration.md)                                                   | security           | 8        | 5    | 2026-05-16   |
 | [Network Request Hardening](patterns/network-request-hardening.md)                                   | security           | 1        | 1    | 2026-06-08   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -50,7 +50,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Motion Layout Projection](patterns/motion-layout-projection.md)                                     | react-patterns     | 1        | 0    | 2026-06-10   |
 | [Fixed-Position Portals](patterns/fixed-position-portals.md)                                         | react-patterns     | 2        | 1    | 2026-06-22   |
 | [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 30       | 25   | 2026-07-05   |
-| [Cross-Platform Paths](patterns/cross-platform-paths.md)                                             | cross-platform     | 12       | 12   | 2026-06-22   |
+| [Cross-Platform Paths](patterns/cross-platform-paths.md)                                             | cross-platform     | 14       | 12   | 2026-07-09   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                                                       | code-quality       | 7        | 0    | 2026-06-11   |
 | [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 26       | 21   | 2026-07-08   |
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
@@ -83,11 +83,11 @@ When appending findings to a pattern file, label the source so future readers ca
 | [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 36       | 18   | 2026-07-05   |
 | [Module Boundaries](patterns/module-boundaries.md)                                                   | code-quality       | 17       | 3    | 2026-06-25   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 13       | 3    | 2026-06-15   |
-| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 35       | 10   | 2026-07-07   |
+| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 36       | 10   | 2026-07-09   |
 | [Verify Render Target](patterns/verify-render-target.md)                                             | code-quality       | 3        | 1    | 2026-07-01   |
 | [UI Visual Regression](patterns/ui-visual-regression.md)                                             | code-quality       | 27       | 17   | 2026-07-05   |
 | [Status Indicator Display](patterns/status-indicator-display.md)                                     | code-quality       | 3        | 0    | 2026-05-26   |
-| [Parser Resilience](patterns/parser-resilience.md)                                                   | code-quality       | 19       | 9    | 2026-07-05   |
+| [Parser Resilience](patterns/parser-resilience.md)                                                   | code-quality       | 22       | 9    | 2026-07-09   |
 | [Persisted State Invariants](patterns/persisted-state-invariants.md)                                 | correctness        | 14       | 7    | 2026-06-23   |
 | [macOS Window Chrome](patterns/macos-window-chrome.md)                                               | cross-platform     | 9        | 2    | 2026-06-15   |
 | [Guard Branch Correctness](patterns/guard-branch-correctness.md)                                     | correctness        | 2        | 0    | 2026-06-19   |

--- a/docs/reviews/patterns/cross-platform-paths.md
+++ b/docs/reviews/patterns/cross-platform-paths.md
@@ -2,7 +2,7 @@
 id: cross-platform-paths
 category: cross-platform
 created: 2026-04-09
-last_updated: 2026-06-28
+last_updated: 2026-07-09
 ref_count: 12
 ---
 
@@ -132,4 +132,13 @@ consider using path libraries for cross-platform code.
 - **File:** `electron/ghostty-native-helper.ts`
 - **Finding:** The Swift Ghostty helper package path was hardcoded under `docs/exploration/2026-06-27-ghostty-native-macos-runtime`, so pruning exploratory documentation could silently break the development native-helper runtime.
 - **Fix:** Moved the Swift package to `native/ghostty-helper` and updated `helperPackageDir()` to resolve that product-owned native path.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 14. Delegated review prompts used repo-relative paths from descendant agent cwd
+
+- **Source:** github-codex-connector | PR #677 round 1 | 2026-07-09
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/diff/services/feedbackDispatch.ts`
+- **Finding:** The review-request payload listed only repo-relative paths, so an agent pane running from a descendant cwd such as `/repo/packages/app` could resolve `src/a.ts` under the descendant instead of the reviewed repository root.
+- **Fix:** Threaded the current repo root into `useRequestReview`, included an absolute prompt path beside the repo-relative path, and kept the stored review snapshot repo-relative so returned findings still place against the diff.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/ipc-resource-bounds.md
+++ b/docs/reviews/patterns/ipc-resource-bounds.md
@@ -2,7 +2,7 @@
 id: ipc-resource-bounds
 category: security
 created: 2026-07-05
-last_updated: 2026-07-05
+last_updated: 2026-07-09
 ref_count: 2
 ---
 
@@ -120,3 +120,12 @@ not become repeated unhandled main-process failures.
 - **Finding:** `Write` and `WriteSecondary` cast JS string byte lengths from `size_t` to `int` without checking `INT_MAX`, allowing oversized writes to wrap and be dropped with no visible error.
 - **Fix:** Reject oversized primary and secondary writes with JS-visible errors before passing lengths to the Swift bridge.
 - **Commit:** same commit as this entry
+
+### 9. Delegated reviewer findings need a display bound
+
+- **Source:** github-claude | PR #677 round 2 | 2026-07-09
+- **Severity:** MEDIUM
+- **File:** `src/features/diff/hooks/useAgentReview.ts`
+- **Finding:** A single valid `agent-review` event could contain an unbounded findings array, and every delegated reviewer finding was rendered as a diff annotation without a reviewer-specific ceiling. A malfunctioning or prompt-injected reviewer could flood the diff UI with thousands of rows.
+- **Fix:** Added a per-event reviewer finding cap and collapse overflow into one review-level note that reports how many findings were omitted. Regression coverage asserts only the capped number of annotations is rendered and the overflow note is retained.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/keyboard-shortcut-guards.md
+++ b/docs/reviews/patterns/keyboard-shortcut-guards.md
@@ -2,7 +2,7 @@
 id: keyboard-shortcut-guards
 category: keyboard-shortcuts
 created: 2026-05-18
-last_updated: 2026-07-07
+last_updated: 2026-07-09
 ref_count: 10
 ---
 
@@ -465,4 +465,13 @@ against three classes of false-fire:
 - **Fix:** Rechecked `inputBlocked(win)` immediately before `addon.focus(currentSurface)`
   in the async refocus branch and added regression coverage for an overlay opening
   while shortcut dispatch is pending.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 36. Independent popovers shared shortcut handlers
+
+- **Source:** github-claude | PR #677 round 1 | 2026-07-09
+- **Severity:** MEDIUM
+- **File:** `src/features/diff/Panel.tsx`
+- **Finding:** The Finish feedback popover and Request review popover were controlled by independent booleans, so mouse users could open both dialogs at the same toolbar anchor. Each dialog had document-level shortcut handling, making one shared keypress capable of submitting both actions.
+- **Fix:** Made the toolbar and keyboard entry points mutually exclusive: Finish cannot open while Request review is open, Request review cannot open while Finish is open, and a panel regression test asserts the Request review trigger disappears while Finish is active.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/parser-resilience.md
+++ b/docs/reviews/patterns/parser-resilience.md
@@ -2,7 +2,7 @@
 id: parser-resilience
 category: code-quality
 created: 2026-05-24
-last_updated: 2026-07-05
+last_updated: 2026-07-09
 ref_count: 11
 ---
 
@@ -311,3 +311,21 @@ true` and drop the chunk.
   closed/disabled malformed streams, and made addon string conversion fail
   explicitly on non-string or unreadable values.
 - **Commit:** same commit as this entry
+
+### 21. Reviewer range anchoring trusted only the start line
+
+- **Source:** github-codex-connector | PR #677 round 1 | 2026-07-09
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/diff/hooks/useAgentReview.ts`
+- **Finding:** Range findings were considered anchorable when `startLine` was inside a reviewed hunk, but `endLine` could still be outside that hunk or in another hunk. The UI could therefore attach reviewer text to lines that were not part of the reviewed diff.
+- **Fix:** Added a same-hunk range validator and used it for the downgrade decision, so ranges only anchor when both endpoints are present and inside the same reviewed hunk; otherwise they degrade to file-level.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 22. Null reviewer range end line bypassed graceful degradation
+
+- **Source:** github-claude | PR #677 round 1 | 2026-07-09
+- **Severity:** MEDIUM
+- **File:** `src/features/diff/hooks/useAgentReview.ts`
+- **Finding:** A `scope: "range"` finding with a valid `startLine` but `endLine: null` skipped file-level downgrade, failed range target construction, and fell through to a line annotation at line `0` with no file target. The reviewer finding then rendered nowhere.
+- **Fix:** Folded `endLine !== null` into the same target-in-hunk check used by the downgrade path and added regression coverage for missing and out-of-hunk range endpoints.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/resource-cleanup.md
+++ b/docs/reviews/patterns/resource-cleanup.md
@@ -2,7 +2,7 @@
 id: resource-cleanup
 category: react-patterns
 created: 2026-04-09
-last_updated: 2026-07-05
+last_updated: 2026-07-09
 ref_count: 25
 ---
 
@@ -308,3 +308,12 @@ causes listener accumulation and duplicate event handling.
 - **Finding:** Native Ghostty surfaces were cached only by session and pane id, while the callback closures captured the original `BrowserWindow`. macOS close/reopen could leave restored panes reusing a native surface bound to a destroyed window.
 - **Fix:** Track surface keys by owning `BrowserWindow.id`, register one `closed` handler per window, and destroy/evict every surface owned by that window before a later update can reuse the pane id. The surface creation path also destroys a stale owner-specific surface before reparenting.
 - **Commit:** same commit as this entry
+
+### 31. Owner-scoped review request stores must join pane pruning
+
+- **Source:** github-claude | PR #677 round 2 | 2026-07-09
+- **Severity:** MEDIUM
+- **File:** `src/features/diff/services/pendingReviewRequests.ts`
+- **Finding:** The delegated-review request store and review-level-note store were module singletons keyed by nonce and owner, but only successful `agent-review` replies cleared requests and no production path cleared review-level notes. Closing a pane could leave abandoned requests and stale notes retained for the app lifetime.
+- **Fix:** Added an owner-prune helper that deletes pending requests and review-level notes for owners no longer in the live pane set, then invoked it from the existing workspace pane-pruning effect. Regression tests cover pruning both requests and notes.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/src/features/diff/Panel.test.tsx
+++ b/src/features/diff/Panel.test.tsx
@@ -488,6 +488,104 @@ describe('Panel', () => {
     }
   })
 
+  test('hides Request review while the Finish popover is open', async (): Promise<void> => {
+    const user = userEvent.setup()
+
+    const annotation: DiffLineAnnotation<ReviewComment> = {
+      side: 'additions',
+      lineNumber: 5,
+      metadata: {
+        id: 'comment-1',
+        text: 'Needs review',
+        author: 'self',
+        createdAt: 1000,
+      },
+    }
+
+    const feedbackBatch: UseFeedbackBatchReturn = {
+      batch: new Map([
+        [makeBatchKey('/repo', 'src/foo.ts', false), [annotation]],
+      ]),
+      annotationsForFile: () => [annotation],
+      addAnnotation: () => 'ok',
+      addAnnotationForOwner: () => 'ok',
+      updateAnnotation: vi.fn(),
+      removeAnnotation: vi.fn(),
+      clearBatch: vi.fn(),
+      clearPending: vi.fn(),
+      markDispatched: vi.fn(),
+      totalAnnotations: () => 1,
+      pendingAnnotations: () => 1,
+    }
+
+    vi.spyOn(useGitStatusModule, 'useGitStatus').mockReturnValue({
+      files: [
+        {
+          path: 'src/foo.ts',
+          status: 'modified',
+          insertions: 1,
+          deletions: 0,
+          staged: false,
+        },
+      ],
+      filesCwd: '/repo',
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+      idle: false,
+    })
+
+    vi.spyOn(useFileDiffModule, 'useFileDiff').mockReturnValue(
+      fileDiffMock({
+        diff: {
+          filePath: 'src/foo.ts',
+          oldPath: 'src/foo.ts',
+          newPath: 'src/foo.ts',
+          hunks: [
+            {
+              id: 'h1',
+              header: '@@',
+              oldStart: 1,
+              oldLines: 0,
+              newStart: 1,
+              newLines: 1,
+              lines: [],
+            },
+          ],
+        },
+        loading: false,
+        error: null,
+        oldText: '',
+        newText: 'new',
+        rawDiff: '',
+      })
+    )
+
+    render(
+      <Panel
+        cwd="/repo"
+        feedbackBatch={feedbackBatch}
+        feedbackOwnerKey="sess:pane-1"
+      />
+    )
+
+    expect(
+      screen.getByRole('button', { name: /request review/i })
+    ).toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole('button', { name: /finish feedback \(1\)/i })
+    )
+
+    expect(
+      await screen.findByRole('dialog', { name: 'Finish feedback' })
+    ).toBeInTheDocument()
+
+    expect(
+      screen.queryByRole('button', { name: /request review/i })
+    ).not.toBeInTheDocument()
+  })
+
   test('keeps draft-only feedback discard available in the empty state', async (): Promise<void> => {
     const user = userEvent.setup()
     const clearBatch = vi.fn()

--- a/src/features/diff/Panel.tsx
+++ b/src/features/diff/Panel.tsx
@@ -66,12 +66,14 @@ import {
 import { useToolbarState } from './hooks/useToolbarState'
 import { useReviewTargetNavigation } from './hooks/useReviewTargetNavigation'
 import { useVisualSelection } from './hooks/useVisualSelection'
+import { useRequestReview } from './hooks/useRequestReview'
 import { Notifier } from './components/Notifier'
 import { PanelBody } from './components/PanelBody'
 import { DiffSearchButton } from './components/DiffSearchButton'
 import { DiffSearchPopup } from './components/DiffSearchPopup'
 import { ReviewCommentEditor } from './components/ReviewCommentEditor'
 import { ReviewCommentRow } from './components/ReviewCommentRow'
+import { ReviewLevelNotes } from './components/ReviewLevelNotes'
 import { DIFF_SEARCH_UNSAFE_CSS } from './search/diffSearchDom'
 import { DIFF_RANGE_BAR_UNSAFE_CSS } from './rangeBar/diffRangeBars'
 
@@ -889,6 +891,18 @@ export const Panel = ({
       )
     })()
   }, [buildFeedbackEntries, feedback, notifyInfo])
+
+  // Request review (VIM-304): the whole "arm a pending request, then dispatch or
+  // copy it" flow lives in useRequestReview so this component stays a renderer.
+  const review = useRequestReview({
+    fileDiff: activeResponse?.fileDiff,
+    ownerKey: feedbackOwnerKey,
+    cwd,
+    staged: selectedFileStaged,
+    writePty: feedbackDispatch?.writePty,
+    focusTerminal: feedbackDispatch?.focusTerminal,
+    notify: notifyInfo,
+  })
 
   // Single-flight staging flag — drops clicks while an IPC is in flight.
   const [staging, setStaging] = useState(false)
@@ -1927,6 +1941,7 @@ export const Panel = ({
         setFinishOpen(true)
       }
     },
+    onRequestReview: review.openPopover,
     onStageHunk: (): void => openKeyboardConfirm('stage-hunk'),
     onDiscardHunk: (): void => openKeyboardConfirm('discard-hunk'),
     onDiscardFile: (): void => openKeyboardConfirm('discard-file'),
@@ -2048,6 +2063,25 @@ export const Panel = ({
     onCopy: handleCopyFeedback,
   }
 
+  // The "Request review" affordance (VIM-304) — always available when a file
+  // diff is loaded, independent of pending comments (unlike Finish).
+  const onRequestReview = review.canRequest ? review.openPopover : undefined
+
+  const requestReview = {
+    open: review.open,
+    result: resolveCandidatePanes({
+      allPanes: feedbackDispatch?.candidates ?? [],
+      diffCwd: cwd,
+    }),
+    scopeLabel:
+      selectedFilePath !== null
+        ? `${selectedFilePath} (${selectedFileStaged ? 'staged' : 'unstaged'})`
+        : 'this file',
+    onSubmit: review.requestReview,
+    onCopy: review.copyReviewRequest,
+    onCancel: review.closePopover,
+  }
+
   // Loading state
   if (effectiveStatusLoading) {
     return (
@@ -2100,8 +2134,10 @@ export const Panel = ({
             feedbackCount: pendingFeedbackCount,
             onDiscardFeedback: feedback.clearPending,
             onFinishFeedback,
+            onRequestReview,
           }}
           finishFeedback={finishFeedback}
+          requestReview={requestReview}
           keyboardConfirm={null}
           onCancelKeyboardConfirm={cancelKeyboardConfirm}
           onConfirmKeyboardAction={confirmKeyboardAction}
@@ -2168,10 +2204,12 @@ export const Panel = ({
           feedbackCount: pendingFeedbackCount,
           onDiscardFeedback: feedback.clearPending,
           onFinishFeedback,
+          onRequestReview,
           onRefreshActiveFile:
             latestDiffStatus === 'ready' ? acceptLatestDiff : undefined,
         }}
         finishFeedback={finishFeedback}
+        requestReview={requestReview}
         keyboardConfirm={keyboardConfirm}
         renderSyncError={renderSyncError}
         notifyMessage={notifyMessage}
@@ -2331,6 +2369,7 @@ export const Panel = ({
               </div>
             </div>
           ) : null}
+          <ReviewLevelNotes ownerKey={feedbackOwnerKey} />
           <PanelBody
             scrollBodyRef={diffScrollBodyRef}
             diffError={diffError}

--- a/src/features/diff/Panel.tsx
+++ b/src/features/diff/Panel.tsx
@@ -899,6 +899,7 @@ export const Panel = ({
     ownerKey: feedbackOwnerKey,
     cwd,
     staged: selectedFileStaged,
+    repoRoot: response?.repoRoot ?? repoRootRef.current,
     writePty: feedbackDispatch?.writePty,
     focusTerminal: feedbackDispatch?.focusTerminal,
     notify: notifyInfo,
@@ -1937,11 +1938,15 @@ export const Panel = ({
     onUpdateFileComment: updateSelectedFileComment,
     onDeleteComment: deleteSelectedComment,
     onFinishReview: (): void => {
-      if (feedback.pendingAnnotations() > 0) {
+      if (feedback.pendingAnnotations() > 0 && !review.open) {
         setFinishOpen(true)
       }
     },
-    onRequestReview: review.openPopover,
+    onRequestReview: (): void => {
+      if (!finishOpen) {
+        review.openPopover()
+      }
+    },
     onStageHunk: (): void => openKeyboardConfirm('stage-hunk'),
     onDiscardHunk: (): void => openKeyboardConfirm('discard-hunk'),
     onDiscardFile: (): void => openKeyboardConfirm('discard-file'),
@@ -2048,7 +2053,12 @@ export const Panel = ({
   )
 
   const onFinishFeedback =
-    feedbackCount > 0 ? (): void => setFinishOpen(true) : undefined
+    feedbackCount > 0 && !review.open
+      ? (): void => {
+          review.closePopover()
+          setFinishOpen(true)
+        }
+      : undefined
 
   const finishFeedback = {
     open: finishOpen,
@@ -2065,7 +2075,13 @@ export const Panel = ({
 
   // The "Request review" affordance (VIM-304) — always available when a file
   // diff is loaded, independent of pending comments (unlike Finish).
-  const onRequestReview = review.canRequest ? review.openPopover : undefined
+  const onRequestReview =
+    review.canRequest && !finishOpen
+      ? (): void => {
+          setFinishOpen(false)
+          review.openPopover()
+        }
+      : undefined
 
   const requestReview = {
     open: review.open,

--- a/src/features/diff/components/Notifier.tsx
+++ b/src/features/diff/components/Notifier.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/Button'
 import { Popover } from '@/components/Popover'
 import { DiffChipToolbar, type DiffChipToolbarProps } from './toolbar'
 import { FinishFeedbackPopover } from './FinishFeedbackPopover'
+import { RequestReviewPopover } from './RequestReviewPopover'
 import type { PaneCandidate, ResolveResult } from '../services/activePanePicker'
 import {
   isFileAnnotationTarget,
@@ -19,6 +20,15 @@ interface FinishFeedbackState {
   onCopy: () => void
 }
 
+interface RequestReviewState {
+  open: boolean
+  result: ResolveResult
+  scopeLabel: string
+  onSubmit: (pane: PaneCandidate) => void
+  onCopy: () => void
+  onCancel: () => void
+}
+
 export interface KeyboardConfirmView {
   title: string
   body: string
@@ -33,6 +43,7 @@ interface DraftRecovery {
 interface NotifierProps {
   toolbarProps: DiffChipToolbarProps
   finishFeedback: FinishFeedbackState
+  requestReview?: RequestReviewState
   keyboardConfirm: KeyboardConfirmView | null
   renderSyncError?: string | null
   notifyMessage?: string | null
@@ -44,6 +55,7 @@ interface NotifierProps {
 export const Notifier = ({
   toolbarProps,
   finishFeedback,
+  requestReview = undefined,
   keyboardConfirm,
   renderSyncError = null,
   notifyMessage = null,
@@ -104,6 +116,18 @@ export const Notifier = ({
           onCancel={finishFeedback.onCancel}
           onSend={finishFeedback.onSend}
           onCopy={finishFeedback.onCopy}
+        />
+      ) : null}
+      {requestReview !== undefined &&
+      requestReview.open &&
+      toolbarShellRef.current !== null ? (
+        <RequestReviewPopover
+          anchor={toolbarShellRef.current}
+          result={requestReview.result}
+          scopeLabel={requestReview.scopeLabel}
+          onSubmit={requestReview.onSubmit}
+          onCopy={requestReview.onCopy}
+          onCancel={requestReview.onCancel}
         />
       ) : null}
       {keyboardConfirm !== null && toolbarShellRef.current !== null ? (

--- a/src/features/diff/components/RequestReviewPopover.test.tsx
+++ b/src/features/diff/components/RequestReviewPopover.test.tsx
@@ -1,0 +1,168 @@
+import { test, expect, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { RequestReviewPopover } from './RequestReviewPopover'
+import type { PaneCandidate, ResolveResult } from '../services/activePanePicker'
+
+const createAnchor = (): HTMLDivElement => {
+  const el = document.createElement('div')
+  document.body.appendChild(el)
+
+  return el
+}
+
+const makePane = (overrides: Partial<PaneCandidate> = {}): PaneCandidate => ({
+  paneId: 'pane-1',
+  ptyId: 'pty-1',
+  tabName: 'Tab 1',
+  agentLabel: 'Claude Code',
+  cwd: '/repo',
+  status: 'running',
+  isFocused: false,
+  ...overrides,
+})
+
+test('kind none shows no-agent copy; Copy and Dismiss fire their handlers', async () => {
+  const user = userEvent.setup()
+  const anchor = createAnchor()
+  const onCopy = vi.fn()
+  const onCancel = vi.fn()
+  const onSubmit = vi.fn()
+
+  render(
+    <RequestReviewPopover
+      anchor={anchor}
+      result={{ kind: 'none' } as ResolveResult}
+      scopeLabel="src/auth.ts (unstaged)"
+      onSubmit={onSubmit}
+      onCopy={onCopy}
+      onCancel={onCancel}
+    />
+  )
+
+  expect(
+    screen.getByRole('dialog', { name: 'Request review' })
+  ).toBeInTheDocument()
+
+  await user.click(screen.getByRole('button', { name: 'Copy (c)' }))
+  expect(onCopy).toHaveBeenCalledTimes(1)
+
+  await user.click(screen.getByRole('button', { name: 'Dismiss (n)' }))
+  expect(onCancel).toHaveBeenCalledTimes(1)
+  expect(onSubmit).not.toHaveBeenCalled()
+
+  anchor.remove()
+})
+
+test('kind one shows the scope label + pane, and Delegate submits the pane', async () => {
+  const user = userEvent.setup()
+  const anchor = createAnchor()
+  const onSubmit = vi.fn()
+  const onCancel = vi.fn()
+  const pane = makePane({ tabName: 'codex', agentLabel: 'Codex' })
+
+  render(
+    <RequestReviewPopover
+      anchor={anchor}
+      result={{ kind: 'one', pane } as ResolveResult}
+      scopeLabel="src/auth.ts (unstaged)"
+      onSubmit={onSubmit}
+      onCopy={vi.fn()}
+      onCancel={onCancel}
+    />
+  )
+
+  expect(
+    screen.getByText(
+      /Delegate a code review of src\/auth\.ts \(unstaged\) to codex \(Codex\)\?/
+    )
+  ).toBeInTheDocument()
+
+  await user.click(screen.getByRole('button', { name: 'Delegate (Y)' }))
+  expect(onSubmit).toHaveBeenCalledTimes(1)
+  expect(onSubmit).toHaveBeenCalledWith(pane)
+
+  await user.click(screen.getByRole('button', { name: 'Cancel (n)' }))
+  expect(onCancel).toHaveBeenCalledTimes(1)
+
+  anchor.remove()
+})
+
+test('kind one accepts Shift+Y to delegate and n to cancel', async () => {
+  const user = userEvent.setup()
+  const anchor = createAnchor()
+  const onSubmit = vi.fn()
+  const onCancel = vi.fn()
+  const pane = makePane()
+
+  render(
+    <RequestReviewPopover
+      anchor={anchor}
+      result={{ kind: 'one', pane } as ResolveResult}
+      scopeLabel="this file"
+      onSubmit={onSubmit}
+      onCopy={vi.fn()}
+      onCancel={onCancel}
+    />
+  )
+
+  fireEvent.keyDown(document, { key: 'Y', code: 'KeyY', shiftKey: true })
+  expect(onSubmit).toHaveBeenCalledWith(pane)
+
+  await user.keyboard('n')
+  expect(onCancel).toHaveBeenCalledTimes(1)
+
+  anchor.remove()
+})
+
+test('kind many shows copy-only (no picker) — review targets one bound agent', async () => {
+  const user = userEvent.setup()
+  const anchor = createAnchor()
+  const onCopy = vi.fn()
+  const onSubmit = vi.fn()
+
+  const paneA = makePane({ ptyId: 'pty-a', tabName: 'claude-a' })
+  const paneB = makePane({ ptyId: 'pty-b', tabName: 'codex-b' })
+
+  render(
+    <RequestReviewPopover
+      anchor={anchor}
+      result={{ kind: 'many', candidates: [paneA, paneB] } as ResolveResult}
+      scopeLabel="src/auth.ts (staged)"
+      onSubmit={onSubmit}
+      onCopy={onCopy}
+      onCancel={vi.fn()}
+    />
+  )
+
+  // No per-pane picker: multiple agents fall back to copy, not a chooser.
+  expect(screen.queryByRole('button', { name: 'Delegate' })).toBeNull()
+
+  await user.click(screen.getByRole('button', { name: 'Copy (c)' }))
+  expect(onCopy).toHaveBeenCalledTimes(1)
+  expect(onSubmit).not.toHaveBeenCalled()
+
+  anchor.remove()
+})
+
+test('the c key copies the review request', async () => {
+  const user = userEvent.setup()
+  const anchor = createAnchor()
+  const onCopy = vi.fn()
+
+  render(
+    <RequestReviewPopover
+      anchor={anchor}
+      result={{ kind: 'none' } as ResolveResult}
+      scopeLabel="this file"
+      onSubmit={vi.fn()}
+      onCopy={onCopy}
+      onCancel={vi.fn()}
+    />
+  )
+
+  await user.keyboard('c')
+  expect(onCopy).toHaveBeenCalledTimes(1)
+
+  anchor.remove()
+})

--- a/src/features/diff/components/RequestReviewPopover.tsx
+++ b/src/features/diff/components/RequestReviewPopover.tsx
@@ -1,0 +1,155 @@
+import { useEffect, type ReactElement } from 'react'
+import { Popover } from '@/components/Popover'
+import type { PaneCandidate, ResolveResult } from '../services/activePanePicker'
+
+const popoverGhostActionFocusClass =
+  'ring-0 focus:outline-none focus-visible:bg-surface-container-high focus-visible:text-on-surface focus-visible:outline-none focus-visible:ring-0'
+
+const popoverPrimaryActionFocusClass =
+  'ring-0 focus:outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface-container'
+
+interface RequestReviewPopoverProps {
+  anchor: HTMLElement
+  result: ResolveResult
+  /** What's being reviewed, e.g. "src/auth.ts (unstaged)". */
+  scopeLabel: string
+  /** Delegate the review to a specific agent pane (arms with session gating). */
+  onSubmit: (pane: PaneCandidate) => void
+  /** Copy the review-request prompt to the clipboard (you paste it; nonce-only). */
+  onCopy: () => void
+  onCancel: () => void
+}
+
+const isCapitalY = (event: KeyboardEvent): boolean =>
+  event.key === 'Y' ||
+  (event.shiftKey && (event.key.toLowerCase() === 'y' || event.code === 'KeyY'))
+
+/**
+ * The popover that opens from the diff toolbar's "Request review" button. It
+ * asks how to hand the current file's diff to a coding agent:
+ *  - Delegate — send the review straight to the single bound agent (shown only
+ *    when exactly one agent is the clear target).
+ *  - Copy — copy the request text to paste into whichever agent you want; this
+ *    is the fallback whenever there isn't one obvious agent to delegate to.
+ *  - Cancel / Dismiss.
+ *
+ * It only fires the matching callback; building the request and sending it lives
+ * in the Panel / useRequestReview layer, so this component stays a dumb chooser.
+ */
+export const RequestReviewPopover = ({
+  anchor,
+  result,
+  scopeLabel,
+  onSubmit,
+  onCopy,
+  onCancel,
+}: RequestReviewPopoverProps): ReactElement => {
+  const copyButton = (
+    <button
+      type="button"
+      aria-keyshortcuts="c"
+      onClick={(): void => onCopy()}
+      className={`rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface ${popoverGhostActionFocusClass}`}
+    >
+      Copy (c)
+    </button>
+  )
+
+  useEffect((): (() => void) => {
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.ctrlKey || event.metaKey || event.altKey) {
+        return
+      }
+
+      if (event.key === 'n') {
+        event.preventDefault()
+        event.stopPropagation()
+        onCancel()
+
+        return
+      }
+
+      if (event.key === 'c') {
+        event.preventDefault()
+        event.stopPropagation()
+        onCopy()
+
+        return
+      }
+
+      if (isCapitalY(event) && result.kind === 'one') {
+        event.preventDefault()
+        event.stopPropagation()
+        onSubmit(result.pane)
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown, { capture: true })
+
+    return (): void => {
+      document.removeEventListener('keydown', handleKeyDown, { capture: true })
+    }
+  }, [onCancel, onCopy, onSubmit, result])
+
+  return (
+    <Popover
+      anchor={anchor}
+      open
+      onOpenChange={(open): void => {
+        if (!open) {
+          onCancel()
+        }
+      }}
+      aria-label="Request review"
+      width={340}
+    >
+      {result.kind !== 'one' && (
+        <div className="flex flex-col gap-3 p-4">
+          <p className="text-sm text-on-surface">
+            Copy the review request and paste it into the coding agent you want
+            to review {scopeLabel}.
+          </p>
+          <div className="flex justify-end gap-2">
+            {copyButton}
+            <button
+              type="button"
+              aria-keyshortcuts="n"
+              onClick={(): void => onCancel()}
+              className={`rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface ${popoverGhostActionFocusClass}`}
+            >
+              Dismiss (n)
+            </button>
+          </div>
+        </div>
+      )}
+
+      {result.kind === 'one' && (
+        <div className="flex flex-col gap-3 p-4">
+          <p className="text-sm text-on-surface">
+            Delegate a code review of {scopeLabel} to {result.pane.tabName} (
+            {result.pane.agentLabel})?
+          </p>
+          <div className="flex justify-end gap-2">
+            {copyButton}
+            <button
+              type="button"
+              aria-keyshortcuts="n"
+              onClick={(): void => onCancel()}
+              className={`rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface ${popoverGhostActionFocusClass}`}
+            >
+              Cancel (n)
+            </button>
+            <button
+              type="button"
+              aria-keyshortcuts="Y"
+              onClick={(): void => onSubmit(result.pane)}
+              className={`rounded-md bg-primary px-3 py-1 text-xs text-on-primary hover:bg-primary/80 ${popoverPrimaryActionFocusClass}`}
+            >
+              Delegate (Y)
+            </button>
+          </div>
+        </div>
+      )}
+    </Popover>
+  )
+}

--- a/src/features/diff/components/ReviewCommentRow.test.tsx
+++ b/src/features/diff/components/ReviewCommentRow.test.tsx
@@ -21,6 +21,49 @@ describe('ReviewCommentRow', () => {
     expect(screen.getByText('Looks good to me')).toBeInTheDocument()
   })
 
+  test('a reviewer finding renders its reviewer name + category, read-only (VIM-304)', () => {
+    render(
+      <ReviewCommentRow
+        comment={{
+          id: 'r1',
+          text: 'Token compared with ==',
+          author: 'reviewer',
+          reviewer: 'codex',
+          category: 'bug',
+          createdAt: 3000,
+        }}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('codex')).toBeInTheDocument()
+    expect(screen.getByText('Bug')).toBeInTheDocument()
+    expect(screen.getByText('Token compared with ==')).toBeInTheDocument()
+    // Read-only: no edit/delete controls.
+    expect(
+      screen.queryByRole('button', { name: 'Edit comment' })
+    ).not.toBeInTheDocument()
+  })
+
+  test('a reviewer finding with no name falls back to "Reviewer"', () => {
+    render(
+      <ReviewCommentRow
+        comment={{
+          id: 'r2',
+          text: 'x',
+          author: 'reviewer',
+          category: 'suggestion',
+          createdAt: 3000,
+        }}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Reviewer')).toBeInTheDocument()
+  })
+
   test('clicking Edit button fires onEdit once', async () => {
     const user = userEvent.setup()
     const handleEdit = vi.fn()

--- a/src/features/diff/components/ReviewCommentRow.tsx
+++ b/src/features/diff/components/ReviewCommentRow.tsx
@@ -58,19 +58,36 @@ export const ReviewCommentRow = ({
   // user comment also shows "Sent <time ago>" (VIM-282).
   const { author, dispatchedAt } = comment
   const isAgent = author === 'agent'
+  const isReviewer = author === 'reviewer'
+  // Agent replies and delegated reviewer findings are agent output — read-only,
+  // never dispatched, rendered on an elevated card (VIM-256 / VIM-304).
+  const isAgentOutput = isAgent || isReviewer
   const isDispatched = dispatchedAt !== undefined
-  const readOnly = isAgent || isDispatched
+  const readOnly = isAgentOutput || isDispatched
   const categoryMeta = REVIEW_CATEGORY_META[reviewCommentCategory(comment)]
 
   return (
     <div
       className={`mx-2 my-1 flex items-start gap-2 rounded-md px-3 py-2 ${
-        isAgent ? 'bg-primary-container/15' : 'bg-surface-container-high/60'
+        isAgentOutput
+          ? 'bg-primary-container/15'
+          : 'bg-surface-container-high/60'
       }`}
     >
       <div className="min-w-0 flex-1">
         <div className="mb-1 flex flex-wrap items-center gap-1">
-          {isAgent ? (
+          {isReviewer ? (
+            <>
+              <span className="inline-flex items-center rounded bg-surface-container-highest/70 px-1.5 py-px text-[10px] font-medium text-primary">
+                {comment.reviewer ?? 'Reviewer'}
+              </span>
+              <span
+                className={`inline-flex items-center rounded bg-surface-container-highest/70 px-1.5 py-px text-[10px] font-medium ${categoryMeta.chip}`}
+              >
+                {categoryMeta.label}
+              </span>
+            </>
+          ) : isAgent ? (
             <span className="inline-flex items-center rounded bg-surface-container-highest/70 px-1.5 py-px text-[10px] font-medium text-success">
               Agent reply
             </span>

--- a/src/features/diff/components/ReviewLevelNotes.test.tsx
+++ b/src/features/diff/components/ReviewLevelNotes.test.tsx
@@ -1,0 +1,64 @@
+import { afterEach, expect, test } from 'vitest'
+import { act, render, screen } from '@testing-library/react'
+import { ReviewLevelNotes } from './ReviewLevelNotes'
+import {
+  addReviewLevelNote,
+  clearReviewLevelNotes,
+} from '../services/pendingReviewRequests'
+
+// ReviewLevelNotes has one job: show review comments that couldn't be pinned to
+// a diff line (an off-diff file, or a garbled review) so they aren't lost. The
+// first two tests are its resting/empty states (no comments, or no file active
+// at all); the last two are the actual job — showing those stray comments,
+// scoped to the active file.
+
+const note = (commentId: string, reviewer: string, text: string): void =>
+  addReviewLevelNote('owner', { commentId, reviewer, text, nonce: 'abc' })
+
+afterEach(() => {
+  // Wrap in act(): clearing emits to any still-mounted subscriber before
+  // testing-library's auto-cleanup unmounts it.
+  act(() => {
+    clearReviewLevelNotes('owner')
+    clearReviewLevelNotes('other')
+  })
+})
+
+test('shows nothing when the active file has no stray review comments', () => {
+  render(<ReviewLevelNotes ownerKey="owner" />)
+  expect(screen.queryByTestId('review-level-notes-panel')).toBeNull()
+})
+
+test('shows nothing when no file is active yet (undefined owner)', () => {
+  // Guard: before a file with a review is selected there is no owner to scope
+  // to, so the surface stays collapsed rather than showing another file's notes.
+  render(<ReviewLevelNotes ownerKey={undefined} />)
+  expect(screen.queryByTestId('review-level-notes-panel')).toBeNull()
+})
+
+test('lists each stray review comment (reviewer + text) for the active file', () => {
+  note('c1', 'codex', 'config.ts drifts from the schema')
+  note('c2', 'Reviewer', 'broken block')
+
+  render(<ReviewLevelNotes ownerKey="owner" />)
+
+  expect(screen.getByText('Review — 2 off-file')).toBeInTheDocument()
+  expect(screen.getByText('codex')).toBeInTheDocument()
+  expect(
+    screen.getByText('config.ts drifts from the schema')
+  ).toBeInTheDocument()
+  expect(screen.getByText('broken block')).toBeInTheDocument()
+})
+
+test('ignores notes belonging to a different owner', () => {
+  addReviewLevelNote('other', {
+    commentId: 'c1',
+    reviewer: 'codex',
+    text: 'not mine',
+    nonce: 'abc',
+  })
+
+  render(<ReviewLevelNotes ownerKey="owner" />)
+
+  expect(screen.queryByTestId('review-level-notes-panel')).toBeNull()
+})

--- a/src/features/diff/components/ReviewLevelNotes.tsx
+++ b/src/features/diff/components/ReviewLevelNotes.tsx
@@ -1,0 +1,60 @@
+import { useSyncExternalStore, type ReactElement } from 'react'
+import {
+  reviewLevelNotes,
+  subscribeReviewLevelNotes,
+} from '../services/pendingReviewRequests'
+
+interface ReviewLevelNotesProps {
+  /** The active file's review; comments for other files are not shown. */
+  ownerKey: string | undefined
+}
+
+/**
+ * A short list of review comments that don't line up with any line in the
+ * current diff — for example the reviewer commented on a file that isn't part
+ * of this review, or the reply came back garbled. We show them here instead of
+ * dropping them, so nothing the reviewer said is silently lost.
+ *
+ * Rendered inside the diff panel, just below the active file's own comments,
+ * and scoped to that file's review. Shows nothing when there are none.
+ */
+export const ReviewLevelNotes = ({
+  ownerKey,
+}: ReviewLevelNotesProps): ReactElement | null => {
+  const notes = useSyncExternalStore(subscribeReviewLevelNotes, () =>
+    reviewLevelNotes(ownerKey)
+  )
+
+  if (notes.length === 0) {
+    return null
+  }
+
+  return (
+    <div
+      data-testid="review-level-notes-panel"
+      className="flex max-h-56 shrink-0 flex-col gap-1 px-4 pb-3 pt-2"
+    >
+      <div className="px-2 text-xs font-medium text-on-surface-variant">
+        Review — {notes.length} off-file
+      </div>
+      <div
+        data-testid="review-level-notes-list"
+        className="flex min-h-0 flex-col gap-1 overflow-y-auto pr-1"
+      >
+        {notes.map((note) => (
+          <div
+            key={note.commentId}
+            className="flex flex-col gap-1 rounded-md bg-surface-container-high/70 px-3 py-2"
+          >
+            <span className="font-mono text-[0.625rem] font-semibold uppercase tracking-wide text-on-surface-variant">
+              {note.reviewer}
+            </span>
+            <span className="whitespace-pre-wrap text-xs leading-5 text-on-surface">
+              {note.text}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/features/diff/components/toolbar/DiffChipToolbar.test.tsx
+++ b/src/features/diff/components/toolbar/DiffChipToolbar.test.tsx
@@ -824,6 +824,32 @@ describe('DiffChipToolbar', () => {
     expect(onFinishFeedback).toHaveBeenCalledTimes(1)
   })
 
+  test('renders the Request review button even when feedbackCount is 0', () => {
+    renderToolbar({ feedbackCount: 0, onRequestReview: vi.fn<() => void>() })
+
+    const button = screen.getByRole('button', { name: /request review/i })
+    expect(button).toBeInTheDocument()
+    expect(button).toHaveAttribute('aria-keyshortcuts', '@')
+  })
+
+  test('omits the Request review button when onRequestReview is undefined', () => {
+    renderToolbar({ feedbackCount: 0, onRequestReview: undefined })
+
+    expect(
+      screen.queryByRole('button', { name: /request review/i })
+    ).not.toBeInTheDocument()
+  })
+
+  test('clicking Request review calls onRequestReview once', async () => {
+    const user = userEvent.setup()
+    const onRequestReview = vi.fn<() => void>()
+
+    renderToolbar({ feedbackCount: 0, onRequestReview })
+
+    await user.click(screen.getByRole('button', { name: /request review/i }))
+    expect(onRequestReview).toHaveBeenCalledTimes(1)
+  })
+
   test('clicking the Discard action calls onDiscardFeedback once', async () => {
     const user = userEvent.setup()
     const onDiscardFeedback = vi.fn<() => void>()

--- a/src/features/diff/components/toolbar/DiffChipToolbar.tsx
+++ b/src/features/diff/components/toolbar/DiffChipToolbar.tsx
@@ -199,6 +199,10 @@ export interface DiffChipToolbarProps {
   onFinishFeedback?: () => void
   onDiscardFeedback?: () => void
   onRefreshActiveFile?: () => void
+  // Request review (VIM-304) — delegate a code review of the active file to an
+  // agent. Unlike Finish, this is ALWAYS available (not gated on pending
+  // feedback): it opens the request-review popover. Omit to hide the button.
+  onRequestReview?: () => void
 }
 
 // Composed chip toolbar. Pure controlled component — all state lives in the
@@ -250,6 +254,7 @@ export const DiffChipToolbar = ({
   onFinishFeedback = undefined,
   onDiscardFeedback = undefined,
   onRefreshActiveFile = undefined,
+  onRequestReview = undefined,
 }: DiffChipToolbarProps): ReactElement => {
   // Discard All confirmation popover state. The trigger is the discard-all
   // button inside the tool-well; the confirm card renders on the shared Popover
@@ -495,7 +500,10 @@ export const DiffChipToolbar = ({
   const showActions = feedbackCount > 0
   const canDiscardFeedback = onDiscardFeedback !== undefined
   const canFinishFeedback = onFinishFeedback !== undefined
-  const showPinnedActions = onRefreshActiveFile !== undefined || showActions
+  const canRequestReview = onRequestReview !== undefined
+
+  const showPinnedActions =
+    onRefreshActiveFile !== undefined || canRequestReview || showActions
 
   const renderNativeOverflowMenu = (
     hiddenKeys: readonly string[]
@@ -752,6 +760,32 @@ export const DiffChipToolbar = ({
                     className="rounded border border-outline-variant/40 px-1 text-[0.625rem] leading-none text-on-surface-muted"
                   >
                     r
+                  </span>
+                </button>
+              </Tooltip>
+            ) : null}
+            {canRequestReview ? (
+              <Tooltip content="Request agent review" shortcut="@">
+                <button
+                  type="button"
+                  data-testid="diff-request-review"
+                  aria-label="request review"
+                  aria-keyshortcuts="@"
+                  onClick={onRequestReview}
+                  className="inline-flex h-7 items-center gap-1.5 rounded-md border border-outline-variant/60 bg-transparent px-3 font-mono text-[0.6875rem] font-medium text-on-surface transition-colors hover:border-primary/50 hover:bg-surface-container hover:text-primary"
+                >
+                  <span
+                    aria-hidden="true"
+                    className="material-symbols-outlined text-sm leading-none"
+                  >
+                    rate_review
+                  </span>
+                  Request review
+                  <span
+                    aria-hidden="true"
+                    className="rounded border border-outline-variant/40 px-1 text-[0.625rem] leading-none text-on-surface-muted"
+                  >
+                    @
                   </span>
                 </button>
               </Tooltip>

--- a/src/features/diff/hooks/useAgentReview.test.ts
+++ b/src/features/diff/hooks/useAgentReview.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import type { Mock } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import type { DiffLineAnnotation } from '@pierre/diffs'
+import { listen } from '@/lib/backend'
+import type { BackendApi } from '@/lib/backend'
+import type { AgentReviewEvent, AgentReviewFinding } from '@/bindings'
+import { useAgentReview } from './useAgentReview'
+import type { ReviewComment } from './useFeedbackBatch'
+import {
+  clearPendingReviewRequest,
+  clearReviewLevelNotes,
+  reviewLevelNotes,
+  setPendingReviewRequest,
+  type PendingReviewRequest,
+} from '../services/pendingReviewRequests'
+
+type AddForOwner = (
+  ownerKey: string,
+  cwd: string,
+  filePath: string,
+  staged: boolean,
+  annotation: DiffLineAnnotation<ReviewComment>
+) => 'ok' | 'cap-reached'
+
+type Cb = (payload: unknown) => void
+const listeners = new Map<string, Cb[]>()
+
+const listenImpl = (name: string, cb: Cb): Promise<() => void> => {
+  const existing = listeners.get(name) ?? []
+  existing.push(cb)
+  listeners.set(name, existing)
+
+  return Promise.resolve(() => {
+    const list = listeners.get(name) ?? []
+    const i = list.indexOf(cb)
+    if (i >= 0) {
+      list.splice(i, 1)
+    }
+  })
+}
+
+vi.mock('@/lib/backend', () => ({ listen: vi.fn() }))
+
+const emit = async (event: AgentReviewEvent): Promise<void> => {
+  await Promise.resolve()
+  for (const cb of listeners.get('agent-review') ?? []) {
+    cb(event)
+  }
+}
+
+const request = (
+  overrides: Partial<PendingReviewRequest> = {}
+): PendingReviewRequest => ({
+  nonce: 'abc',
+  ptyId: 'pty-1',
+  ownerKey: 'owner',
+  cwd: '/repo',
+  staged: false,
+  diffSnapshot: [
+    {
+      path: 'a.ts',
+      additions: [{ start: 40, end: 50 }],
+      deletions: [{ start: 5, end: 8 }],
+    },
+  ],
+  dispatchedAt: 1,
+  ...overrides,
+})
+
+const finding = (o: Partial<AgentReviewFinding> = {}): AgentReviewFinding => ({
+  scope: 'line',
+  path: 'a.ts',
+  side: 'additions',
+  line: 42,
+  startLine: null,
+  endLine: null,
+  category: 'bug',
+  text: 'x',
+  ...o,
+})
+
+const event = (o: Partial<AgentReviewEvent> = {}): AgentReviewEvent => ({
+  sessionId: 'pty-1',
+  nonce: 'abc',
+  reviewer: 'codex',
+  rawText: 'raw block',
+  findings: [],
+  ...o,
+})
+
+let addAnnotationForOwner: Mock<AddForOwner>
+let ids = 0
+
+const mount = (): void => {
+  renderHook(() =>
+    useAgentReview({
+      addAnnotationForOwner,
+      nextCommentId: () => `rev-${(ids += 1)}`,
+    })
+  )
+}
+
+beforeEach(() => {
+  listeners.clear()
+  ids = 0
+  window.vimeflow = {
+    invoke: vi.fn(),
+    listen: vi.fn(),
+  } as unknown as BackendApi
+  addAnnotationForOwner = vi.fn<AddForOwner>(() => 'ok')
+  vi.mocked(listen).mockClear()
+  vi.mocked(listen).mockImplementation(listenImpl as unknown as typeof listen)
+})
+
+afterEach(() => {
+  clearPendingReviewRequest('abc')
+  clearReviewLevelNotes('owner')
+  delete window.vimeflow
+})
+
+describe('useAgentReview', () => {
+  test('ignores an event with no pending request for the nonce', async () => {
+    mount()
+    await emit(event({ nonce: 'nope', findings: [finding()] }))
+    expect(addAnnotationForOwner).not.toHaveBeenCalled()
+  })
+
+  test('ignores an event whose session id is not the request pty', async () => {
+    setPendingReviewRequest(request())
+    mount()
+    await emit(event({ sessionId: 'other', findings: [finding()] }))
+    expect(addAnnotationForOwner).not.toHaveBeenCalled()
+  })
+
+  test('places a line finding on the dispatching owner with reviewer + category', async () => {
+    setPendingReviewRequest(request())
+    mount()
+    await emit(event({ findings: [finding({ line: 42 })] }))
+
+    expect(addAnnotationForOwner).toHaveBeenCalledTimes(1)
+
+    const [ownerKey, cwd, path, staged, annotation] =
+      addAnnotationForOwner.mock.calls[0]
+    expect(ownerKey).toBe('owner')
+    expect(cwd).toBe('/repo')
+    expect(path).toBe('a.ts')
+    expect(staged).toBe(false)
+    expect(annotation.lineNumber).toBe(42)
+    expect(annotation.side).toBe('additions')
+    expect(annotation.metadata.author).toBe('reviewer')
+    expect(annotation.metadata.reviewer).toBe('codex')
+    expect(annotation.metadata.category).toBe('bug')
+    expect(annotation.metadata.target).toBeUndefined()
+  })
+
+  test('places a range finding with a range target', async () => {
+    setPendingReviewRequest(request())
+    mount()
+    await emit(
+      event({
+        findings: [
+          finding({ scope: 'range', line: null, startLine: 41, endLine: 48 }),
+        ],
+      })
+    )
+
+    const annotation = addAnnotationForOwner.mock.calls[0][4]
+    expect(annotation.metadata.target).toEqual({
+      scope: 'range',
+      side: 'additions',
+      startLine: 41,
+      endLine: 48,
+    })
+  })
+
+  test('places a file finding as a file-scope note', async () => {
+    setPendingReviewRequest(request())
+    mount()
+    await emit(
+      event({
+        findings: [finding({ scope: 'file', side: null, line: null })],
+      })
+    )
+
+    const annotation = addAnnotationForOwner.mock.calls[0][4]
+    expect(annotation.metadata.target).toEqual({ scope: 'file' })
+    expect(annotation.lineNumber).toBe(0)
+  })
+
+  test('downgrades a line finding whose line is outside the hunks to file-level', async () => {
+    setPendingReviewRequest(request())
+    mount()
+    // line 999 is not in the additions range 40-50.
+    await emit(event({ findings: [finding({ line: 999 })] }))
+
+    const annotation = addAnnotationForOwner.mock.calls[0][4]
+    expect(annotation.metadata.target).toEqual({ scope: 'file' })
+  })
+
+  test('sends an off-snapshot path to the review-level surface, not the diff', async () => {
+    setPendingReviewRequest(request())
+    mount()
+    await emit(
+      event({ findings: [finding({ path: 'not-in-diff.ts', text: 'orphan' })] })
+    )
+
+    expect(addAnnotationForOwner).not.toHaveBeenCalled()
+    expect(reviewLevelNotes('owner').map((n) => n.text)).toEqual(['orphan'])
+  })
+
+  test('degrades a malformed event (findings:null) to one review-level note', async () => {
+    setPendingReviewRequest(request())
+    mount()
+    await emit(event({ findings: null, reviewer: null, rawText: 'broken' }))
+
+    expect(addAnnotationForOwner).not.toHaveBeenCalled()
+    const notes = reviewLevelNotes('owner')
+    expect(notes).toHaveLength(1)
+    expect(notes[0].text).toBe('broken')
+    expect(notes[0].reviewer).toBe('Reviewer') // fallback label
+  })
+
+  test('a clean review (empty findings) places nothing and clears the request', async () => {
+    setPendingReviewRequest(request())
+    mount()
+    await emit(event({ findings: [] }))
+    // replay: request already cleared → no-op
+    await emit(event({ findings: [finding()] }))
+
+    expect(addAnnotationForOwner).not.toHaveBeenCalled()
+  })
+
+  test('a replayed event after the request is cleared is a no-op', async () => {
+    setPendingReviewRequest(request())
+    mount()
+    const e = event({ findings: [finding()] })
+    await emit(e)
+    await emit(e)
+
+    expect(addAnnotationForOwner).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/features/diff/hooks/useAgentReview.test.ts
+++ b/src/features/diff/hooks/useAgentReview.test.ts
@@ -53,7 +53,6 @@ const request = (
   overrides: Partial<PendingReviewRequest> = {}
 ): PendingReviewRequest => ({
   nonce: 'abc',
-  ptyId: 'pty-1',
   ownerKey: 'owner',
   cwd: '/repo',
   staged: false,
@@ -126,11 +125,13 @@ describe('useAgentReview', () => {
     expect(addAnnotationForOwner).not.toHaveBeenCalled()
   })
 
-  test('ignores an event whose session id is not the request pty', async () => {
+  test('accepts a matching nonce from any session (the nonce is the whole gate)', async () => {
+    // No session/pty gating: whether the review was delegated to a pane or
+    // copied and pasted into some other agent, a matching nonce is enough.
     setPendingReviewRequest(request())
     mount()
-    await emit(event({ sessionId: 'other', findings: [finding()] }))
-    expect(addAnnotationForOwner).not.toHaveBeenCalled()
+    await emit(event({ sessionId: 'some-other-pane', findings: [finding()] }))
+    expect(addAnnotationForOwner).toHaveBeenCalledTimes(1)
   })
 
   test('places a line finding on the dispatching owner with reviewer + category', async () => {

--- a/src/features/diff/hooks/useAgentReview.test.ts
+++ b/src/features/diff/hooks/useAgentReview.test.ts
@@ -5,7 +5,7 @@ import type { DiffLineAnnotation } from '@pierre/diffs'
 import { listen } from '@/lib/backend'
 import type { BackendApi } from '@/lib/backend'
 import type { AgentReviewEvent, AgentReviewFinding } from '@/bindings'
-import { useAgentReview } from './useAgentReview'
+import { REVIEWER_FINDING_SOFT_CAP, useAgentReview } from './useAgentReview'
 import type { ReviewComment } from './useFeedbackBatch'
 import {
   clearPendingReviewRequest,
@@ -272,5 +272,26 @@ describe('useAgentReview', () => {
     await emit(e)
 
     expect(addAnnotationForOwner).toHaveBeenCalledTimes(1)
+  })
+
+  test('caps delegated reviewer findings and records one overflow note', async () => {
+    setPendingReviewRequest(request())
+    mount()
+    await emit(
+      event({
+        findings: Array.from(
+          { length: REVIEWER_FINDING_SOFT_CAP + 2 },
+          (_, index) => finding({ text: `finding ${index}` })
+        ),
+      })
+    )
+
+    expect(addAnnotationForOwner).toHaveBeenCalledTimes(
+      REVIEWER_FINDING_SOFT_CAP
+    )
+
+    expect(reviewLevelNotes('owner').map((note) => note.text)).toEqual([
+      `2 additional reviewer findings were omitted because this review exceeded the ${REVIEWER_FINDING_SOFT_CAP}-finding display limit.`,
+    ])
   })
 })

--- a/src/features/diff/hooks/useAgentReview.test.ts
+++ b/src/features/diff/hooks/useAgentReview.test.ts
@@ -175,6 +175,38 @@ describe('useAgentReview', () => {
     })
   })
 
+  test('downgrades a range finding with no end line to file-level', async () => {
+    setPendingReviewRequest(request())
+    mount()
+    await emit(
+      event({
+        findings: [
+          finding({ scope: 'range', line: null, startLine: 41, endLine: null }),
+        ],
+      })
+    )
+
+    const annotation = addAnnotationForOwner.mock.calls[0][4]
+    expect(annotation.lineNumber).toBe(0)
+    expect(annotation.metadata.target).toEqual({ scope: 'file' })
+  })
+
+  test('downgrades a range finding whose end line leaves the hunk', async () => {
+    setPendingReviewRequest(request())
+    mount()
+    await emit(
+      event({
+        findings: [
+          finding({ scope: 'range', line: null, startLine: 41, endLine: 999 }),
+        ],
+      })
+    )
+
+    const annotation = addAnnotationForOwner.mock.calls[0][4]
+    expect(annotation.lineNumber).toBe(0)
+    expect(annotation.metadata.target).toEqual({ scope: 'file' })
+  })
+
   test('places a file finding as a file-scope note', async () => {
     setPendingReviewRequest(request())
     mount()

--- a/src/features/diff/hooks/useAgentReview.ts
+++ b/src/features/diff/hooks/useAgentReview.ts
@@ -32,6 +32,19 @@ export interface UseAgentReviewOptions {
 const lineInRanges = (line: number, ranges: HunkRange[]): boolean =>
   ranges.some((range) => line >= range.start && line <= range.end)
 
+const rangeInSameHunk = (
+  startLine: number,
+  endLine: number,
+  ranges: HunkRange[]
+): boolean =>
+  ranges.some(
+    (range) =>
+      startLine >= range.start &&
+      startLine <= range.end &&
+      endLine >= range.start &&
+      endLine <= range.end
+  )
+
 const findFile = (
   snapshot: ReviewedFile[],
   path: string
@@ -157,10 +170,13 @@ export const useAgentReview = ({
         const ranges =
           finding.side === 'deletions' ? file.deletions : file.additions
 
-        const anchor =
-          finding.scope === 'range' ? finding.startLine : finding.line
-        const anchorInHunk = anchor !== null && lineInRanges(anchor, ranges)
-        const downgradeToFile = finding.scope !== 'file' && !anchorInHunk
+        const targetInHunk =
+          finding.scope === 'range'
+            ? finding.startLine !== null &&
+              finding.endLine !== null &&
+              rangeInSameHunk(finding.startLine, finding.endLine, ranges)
+            : finding.line !== null && lineInRanges(finding.line, ranges)
+        const downgradeToFile = finding.scope !== 'file' && !targetInHunk
 
         addAnnotationForOwner(
           ownerKey,

--- a/src/features/diff/hooks/useAgentReview.ts
+++ b/src/features/diff/hooks/useAgentReview.ts
@@ -1,0 +1,194 @@
+import { useEffect } from 'react'
+import { listen } from '@/lib/backend'
+import { isDesktop } from '@/lib/environment'
+import type { AgentReviewEvent, AgentReviewFinding } from '@/bindings'
+import type { AnnotationSide, DiffLineAnnotation } from '@pierre/diffs'
+import {
+  FILE_COMMENT_LINE_NUMBER,
+  type ReviewComment,
+  type ReviewCommentCategory,
+} from './useFeedbackBatch'
+import {
+  addReviewLevelNote,
+  clearPendingReviewRequest,
+  getPendingReviewRequest,
+  type HunkRange,
+  type ReviewedFile,
+} from '../services/pendingReviewRequests'
+
+export interface UseAgentReviewOptions {
+  /** Attach an annotation onto a specific feedback owner (the dispatching one). */
+  addAnnotationForOwner: (
+    ownerKey: string,
+    cwd: string,
+    filePath: string,
+    staged: boolean,
+    annotation: DiffLineAnnotation<ReviewComment>
+  ) => 'ok' | 'cap-reached'
+  /** Fresh unique id for each attached reviewer annotation. */
+  nextCommentId: () => string
+}
+
+const lineInRanges = (line: number, ranges: HunkRange[]): boolean =>
+  ranges.some((range) => line >= range.start && line <= range.end)
+
+const findFile = (
+  snapshot: ReviewedFile[],
+  path: string
+): ReviewedFile | undefined => snapshot.find((file) => file.path === path)
+
+/**
+ * Captures the backend `agent-review` event (VIM-304) and places a delegated
+ * reviewer's findings as `author: 'reviewer'` annotations on the review that
+ * requested them. Mounts once where all feedback owners are reachable
+ * (WorkspaceView).
+ *
+ * The gate — session id AND nonce must match the pending request — means a stray
+ * sentinel or a review we did not ask for cannot mutate the diff. Each finding resolves
+ * against the request's diff snapshot: line/range in a hunk → anchored; line/range
+ * out of range → file-level; path not in the snapshot → a review-level note
+ * (never dropped). A malformed event degrades to one review-level note. The
+ * request is cleared after processing so a replay is a no-op. It never throws.
+ */
+export const useAgentReview = ({
+  addAnnotationForOwner,
+  nextCommentId,
+}: UseAgentReviewOptions): void => {
+  useEffect(() => {
+    if (!isDesktop()) {
+      return undefined
+    }
+
+    let cancelled = false
+    let unlisten: (() => void) | undefined
+
+    const reviewerAnnotation = (
+      finding: AgentReviewFinding,
+      reviewer: string,
+      downgradeToFile: boolean
+    ): DiffLineAnnotation<ReviewComment> => {
+      const metadata: ReviewComment = {
+        id: nextCommentId(),
+        text: finding.text,
+        author: 'reviewer',
+        reviewer,
+        category: finding.category as ReviewCommentCategory,
+        createdAt: Date.now(),
+      }
+
+      // Native file scope, or a line/range whose anchor fell out of the diff.
+      if (finding.scope === 'file' || downgradeToFile) {
+        return {
+          side: 'additions',
+          lineNumber: FILE_COMMENT_LINE_NUMBER,
+          metadata: { ...metadata, target: { scope: 'file' } },
+        }
+      }
+
+      const side = (finding.side ?? 'additions') as AnnotationSide
+
+      if (
+        finding.scope === 'range' &&
+        finding.startLine !== null &&
+        finding.endLine !== null
+      ) {
+        return {
+          side,
+          lineNumber: finding.startLine,
+          metadata: {
+            ...metadata,
+            target: {
+              scope: 'range',
+              side,
+              startLine: finding.startLine,
+              endLine: finding.endLine,
+            },
+          },
+        }
+      }
+
+      return {
+        side,
+        lineNumber: finding.line ?? FILE_COMMENT_LINE_NUMBER,
+        metadata,
+      }
+    }
+
+    const handleReview = (event: AgentReviewEvent): void => {
+      const request = getPendingReviewRequest(event.nonce ?? '')
+      // Session + nonce gate: only a review we requested, on its pty, proceeds.
+      if (
+        request === undefined ||
+        event.nonce === null ||
+        event.sessionId !== request.ptyId
+      ) {
+        return
+      }
+
+      const reviewer = event.reviewer ?? 'Reviewer'
+      const { ownerKey, cwd, staged, diffSnapshot, nonce } = request
+
+      // Malformed marker, or a valid-but-empty clean review.
+      if (event.findings === null) {
+        addReviewLevelNote(ownerKey, {
+          commentId: nextCommentId(),
+          reviewer,
+          text: event.rawText,
+          nonce,
+        })
+        clearPendingReviewRequest(event.nonce)
+
+        return
+      }
+
+      for (const finding of event.findings) {
+        const file = findFile(diffSnapshot, finding.path)
+
+        // path not in the reviewed diff → no (path, staged) row to anchor under.
+        if (file === undefined) {
+          addReviewLevelNote(ownerKey, {
+            commentId: nextCommentId(),
+            reviewer,
+            text: finding.text,
+            nonce,
+          })
+          continue
+        }
+
+        const ranges =
+          finding.side === 'deletions' ? file.deletions : file.additions
+
+        const anchor =
+          finding.scope === 'range' ? finding.startLine : finding.line
+        const anchorInHunk = anchor !== null && lineInRanges(anchor, ranges)
+        const downgradeToFile = finding.scope !== 'file' && !anchorInHunk
+
+        addAnnotationForOwner(
+          ownerKey,
+          cwd,
+          finding.path,
+          staged,
+          reviewerAnnotation(finding, reviewer, downgradeToFile)
+        )
+      }
+
+      clearPendingReviewRequest(event.nonce)
+    }
+
+    const subscribe = async (): Promise<void> => {
+      const fn = await listen<AgentReviewEvent>('agent-review', handleReview)
+      if (cancelled) {
+        fn()
+      } else {
+        unlisten = fn
+      }
+    }
+
+    void subscribe()
+
+    return (): void => {
+      cancelled = true
+      unlisten?.()
+    }
+  }, [addAnnotationForOwner, nextCommentId])
+}

--- a/src/features/diff/hooks/useAgentReview.ts
+++ b/src/features/diff/hooks/useAgentReview.ts
@@ -43,7 +43,7 @@ const findFile = (
  * requested them. Mounts once where all feedback owners are reachable
  * (WorkspaceView).
  *
- * The gate — session id AND nonce must match the pending request — means a stray
+ * The gate — the event's nonce must match a request we minted — means a stray
  * sentinel or a review we did not ask for cannot mutate the diff. Each finding resolves
  * against the request's diff snapshot: line/range in a hunk → anchored; line/range
  * out of range → file-level; path not in the snapshot → a review-level note
@@ -116,12 +116,11 @@ export const useAgentReview = ({
 
     const handleReview = (event: AgentReviewEvent): void => {
       const request = getPendingReviewRequest(event.nonce ?? '')
-      // Session + nonce gate: only a review we requested, on its pty, proceeds.
-      if (
-        request === undefined ||
-        event.nonce === null ||
-        event.sessionId !== request.ptyId
-      ) {
+      // The nonce is the whole gate: we only act on a review whose nonce matches
+      // one we minted. It's random + unguessable, so this holds equally for a
+      // review we delegated to a pane and one you copied and pasted into any
+      // agent — no session check, and the copy path needs no pty id.
+      if (request === undefined || event.nonce === null) {
         return
       }
 

--- a/src/features/diff/hooks/useAgentReview.ts
+++ b/src/features/diff/hooks/useAgentReview.ts
@@ -16,6 +16,8 @@ import {
   type ReviewedFile,
 } from '../services/pendingReviewRequests'
 
+export const REVIEWER_FINDING_SOFT_CAP = 50
+
 export interface UseAgentReviewOptions {
   /** Attach an annotation onto a specific feedback owner (the dispatching one). */
   addAnnotationForOwner: (
@@ -153,7 +155,10 @@ export const useAgentReview = ({
         return
       }
 
-      for (const finding of event.findings) {
+      const findingsToPlace = event.findings.slice(0, REVIEWER_FINDING_SOFT_CAP)
+      const omittedCount = event.findings.length - findingsToPlace.length
+
+      for (const finding of findingsToPlace) {
         const file = findFile(diffSnapshot, finding.path)
 
         // path not in the reviewed diff → no (path, staged) row to anchor under.
@@ -185,6 +190,15 @@ export const useAgentReview = ({
           staged,
           reviewerAnnotation(finding, reviewer, downgradeToFile)
         )
+      }
+
+      if (omittedCount > 0) {
+        addReviewLevelNote(ownerKey, {
+          commentId: nextCommentId(),
+          reviewer,
+          text: `${omittedCount} additional reviewer findings were omitted because this review exceeded the ${REVIEWER_FINDING_SOFT_CAP}-finding display limit.`,
+          nonce,
+        })
       }
 
       clearPendingReviewRequest(event.nonce)

--- a/src/features/diff/hooks/useFeedbackBatch.test.ts
+++ b/src/features/diff/hooks/useFeedbackBatch.test.ts
@@ -905,6 +905,12 @@ describe('review annotation category + agent predicates (VIM-256)', () => {
     expect(isPendingReviewAnnotation(annotation({ author: 'self' }))).toBe(true)
   })
 
+  test('a delegated reviewer finding is never pending (VIM-304)', () => {
+    expect(isPendingReviewAnnotation(annotation({ author: 'reviewer' }))).toBe(
+      false
+    )
+  })
+
   test('reviewCommentCategory defaults an untagged comment to change', () => {
     expect(
       reviewCommentCategory({

--- a/src/features/diff/hooks/useFeedbackBatch.ts
+++ b/src/features/diff/hooks/useFeedbackBatch.ts
@@ -40,13 +40,20 @@ export interface ReviewComment {
   id: string
   text: string
   /**
-   * 'self' = a user comment; 'agent' = a coding-agent reply (VIM-256), which
-   * renders distinctly and is never dispatched or counted as pending.
+   * 'self' = a user comment; 'agent' = the primary coding-agent's reply
+   * (VIM-256); 'reviewer' = a delegated review agent's finding (VIM-304).
+   * Only 'self' comments are ever pending, dispatched, or counted at the cap;
+   * 'agent' and 'reviewer' render distinctly and read-only.
    */
-  author: 'self' | 'agent'
+  author: 'self' | 'agent' | 'reviewer'
   /**
-   * The user's category tag (VIM-256/253). Absent →
-   * DEFAULT_REVIEW_COMMENT_CATEGORY. Not set on agent replies.
+   * The delegated reviewer's self-reported name (VIM-304), set when
+   * `author === 'reviewer'`. The row renders it as the finding's identity.
+   */
+  reviewer?: string
+  /**
+   * The user's category tag (VIM-256/253), or the delegated finding's category
+   * (VIM-304). Absent → DEFAULT_REVIEW_COMMENT_CATEGORY. Not set on agent replies.
    */
   category?: ReviewCommentCategory
   createdAt: number
@@ -142,13 +149,13 @@ export const reviewCommentCategory = (
  * A comment is *pending* until it is dispatched to an agent. Pending comments
  * are the review the user is still assembling; dispatched ones stay in the hunk
  * as thread anchors but are never re-sent, counted as unfinished, or discarded.
- * Agent replies are never pending — they are the agent's output, not the user's
- * unsent feedback.
+ * Only the user's own not-yet-dispatched comments are pending — `agent` replies
+ * and `reviewer` findings are agent output, never the user's unsent feedback.
  */
 export const isPendingReviewAnnotation = (
   annotation: DiffLineAnnotation<ReviewComment>
 ): boolean =>
-  !isAgentReviewAnnotation(annotation) &&
+  annotation.metadata.author === 'self' &&
   annotation.metadata.dispatchedAt === undefined
 
 const countAnnotationsInBatch = (batch: FeedbackBatch): number => {
@@ -423,7 +430,7 @@ export const useFeedbackBatchStore = (
         optimisticBatchesRef.current.get(targetOwnerKey) ?? EMPTY_BATCH
 
       if (
-        annotation.metadata.author !== 'agent' &&
+        annotation.metadata.author === 'self' &&
         countPendingInBatch(optimisticBatch) >= SOFT_CAP
       ) {
         addAnnotationResultRef.current = 'cap-reached'
@@ -444,7 +451,7 @@ export const useFeedbackBatchStore = (
       setBatchesByOwner((prev) => {
         const currentBatch = prev.get(targetOwnerKey) ?? EMPTY_BATCH
         if (
-          annotation.metadata.author !== 'agent' &&
+          annotation.metadata.author === 'self' &&
           countPendingInBatch(currentBatch) >= SOFT_CAP
         ) {
           addAnnotationResultRef.current = 'cap-reached'

--- a/src/features/diff/hooks/useKeyboard.test.ts
+++ b/src/features/diff/hooks/useKeyboard.test.ts
@@ -83,6 +83,7 @@ const renderKeyboard = (
     onUpdateFileComment: vi.fn(),
     onDeleteComment: vi.fn(),
     onFinishReview: vi.fn(),
+    onRequestReview: vi.fn(),
     onStageHunk: vi.fn(),
     onDiscardHunk: vi.fn(),
     onDiscardFile: vi.fn(),
@@ -208,6 +209,14 @@ describe('useKeyboard', () => {
     dispatch('Y')
 
     expect(props.onFinishReview).toHaveBeenCalledOnce()
+  })
+
+  test('@ opens request review', () => {
+    const { props } = renderKeyboard()
+
+    dispatch('@')
+
+    expect(props.onRequestReview).toHaveBeenCalledOnce()
   })
 
   test('s, d, and D request keyboard confirmations for hunk/file actions', () => {
@@ -419,6 +428,7 @@ describe('useKeyboard', () => {
       onUpdateFileComment: vi.fn(),
       onDeleteComment: vi.fn(),
       onFinishReview: vi.fn(),
+      onRequestReview: vi.fn(),
       onStageHunk: vi.fn(),
       onDiscardHunk: vi.fn(),
       onDiscardFile: vi.fn(),

--- a/src/features/diff/hooks/useKeyboard.ts
+++ b/src/features/diff/hooks/useKeyboard.ts
@@ -28,6 +28,7 @@ export interface UseKeyboardOptions {
   onUpdateFileComment: () => void
   onDeleteComment: () => void
   onFinishReview: () => void
+  onRequestReview: () => void
   onStageHunk: () => void
   onDiscardHunk: () => void
   onDiscardFile: () => void
@@ -84,6 +85,7 @@ export const useKeyboard = (options: UseKeyboardOptions): void => {
     onUpdateFileComment,
     onDeleteComment,
     onFinishReview,
+    onRequestReview,
     onStageHunk,
     onDiscardHunk,
     onDiscardFile,
@@ -206,6 +208,7 @@ export const useKeyboard = (options: UseKeyboardOptions): void => {
         U: onUpdateFileComment,
         x: onDeleteComment,
         Y: onFinishReview,
+        '@': onRequestReview,
         s: onStageHunk,
         d: onDiscardHunk,
         D: onDiscardFile,
@@ -253,6 +256,7 @@ export const useKeyboard = (options: UseKeyboardOptions): void => {
     onUpdateFileComment,
     onDeleteComment,
     onFinishReview,
+    onRequestReview,
     onStageHunk,
     onDiscardHunk,
     onDiscardFile,

--- a/src/features/diff/hooks/useRequestReview.test.ts
+++ b/src/features/diff/hooks/useRequestReview.test.ts
@@ -115,6 +115,32 @@ test('requestReview records the pending request and dispatches to the pane', asy
   expect(result.current.open).toBe(false)
 })
 
+test('requestReview dispatches resolvable prompt paths without changing the stored snapshot', async () => {
+  const { result } = setup({ cwd: '/repo/packages/app', repoRoot: '/repo' })
+
+  await act(async () => {
+    result.current.requestReview(pane('pty-9'))
+    await Promise.resolve()
+  })
+
+  const request = getPendingReviewRequest('nonce-1')
+  expect(request?.diffSnapshot[0].path).toBe('src/a.ts')
+  expect(dispatchReviewRequest).toHaveBeenCalledWith(
+    'pty-9',
+    [
+      {
+        path: 'src/a.ts',
+        promptPath: '/repo/src/a.ts',
+        additions: [{ start: 40, end: 50 }],
+        deletions: [{ start: 5, end: 7 }],
+      },
+    ],
+    false,
+    'nonce-1',
+    writePty
+  )
+})
+
 test('copyReviewRequest records a request and copies the prompt', async () => {
   const { result } = setup()
 

--- a/src/features/diff/hooks/useRequestReview.test.ts
+++ b/src/features/diff/hooks/useRequestReview.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, expect, test, vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import type { FileDiff } from '../types'
+import type { PaneCandidate } from '../services/activePanePicker'
+import { useRequestReview } from './useRequestReview'
+import {
+  clearPendingReviewRequest,
+  getPendingReviewRequest,
+} from '../services/pendingReviewRequests'
+import {
+  dispatchReviewRequest,
+  formatReviewRequest,
+} from '../services/feedbackDispatch'
+import { writeClipboardText } from '@/lib/clipboard'
+
+vi.mock('../services/feedbackDispatch', () => ({
+  dispatchReviewRequest: vi.fn(() => Promise.resolve()),
+  formatReviewRequest: vi.fn(() => 'REVIEW_PROMPT'),
+  makeDispatchNonce: vi.fn(() => 'nonce-1'),
+}))
+
+vi.mock('@/lib/clipboard', () => ({
+  writeClipboardText: vi.fn(() => Promise.resolve(true)),
+}))
+
+const fileDiff: FileDiff = {
+  filePath: 'src/a.ts',
+  hunks: [
+    {
+      id: 'h1',
+      header: '@@',
+      oldStart: 5,
+      oldLines: 3,
+      newStart: 40,
+      newLines: 11,
+      lines: [],
+    },
+  ],
+}
+
+const pane = (ptyId = 'pty-1'): PaneCandidate => ({
+  paneId: 'p',
+  ptyId,
+  tabName: 't',
+  agentLabel: 'Codex',
+  cwd: '/repo',
+  status: 'running',
+  isFocused: false,
+})
+
+const writePty = vi.fn(() => Promise.resolve())
+const notify = vi.fn()
+
+const setup = (
+  over: Partial<Parameters<typeof useRequestReview>[0]> = {}
+): ReturnType<
+  typeof renderHook<ReturnType<typeof useRequestReview>, unknown>
+> =>
+  renderHook(() =>
+    useRequestReview({
+      fileDiff,
+      ownerKey: 'owner',
+      cwd: '/repo',
+      staged: false,
+      writePty,
+      notify,
+      ...over,
+    })
+  )
+
+afterEach(() => {
+  clearPendingReviewRequest('nonce-1')
+  vi.clearAllMocks()
+})
+
+test('canRequest is false without a fileDiff or owner, true otherwise', () => {
+  expect(setup({ fileDiff: undefined }).result.current.canRequest).toBe(false)
+  expect(setup({ ownerKey: undefined }).result.current.canRequest).toBe(false)
+  expect(setup().result.current.canRequest).toBe(true)
+})
+
+test('openPopover opens only when a review can be requested', () => {
+  const blocked = setup({ fileDiff: undefined })
+  act(() => blocked.result.current.openPopover())
+  expect(blocked.result.current.open).toBe(false)
+
+  const ok = setup()
+  act(() => ok.result.current.openPopover())
+  expect(ok.result.current.open).toBe(true)
+
+  act(() => ok.result.current.closePopover())
+  expect(ok.result.current.open).toBe(false)
+})
+
+test('requestReview records the pending request and dispatches to the pane', async () => {
+  const { result } = setup()
+
+  await act(async () => {
+    result.current.requestReview(pane('pty-9'))
+    await Promise.resolve()
+  })
+
+  const request = getPendingReviewRequest('nonce-1')
+  expect(request?.ownerKey).toBe('owner')
+  expect(request?.diffSnapshot[0].path).toBe('src/a.ts')
+
+  // The pane is used for dispatch directly, not stored on the request.
+  expect(dispatchReviewRequest).toHaveBeenCalledWith(
+    'pty-9',
+    request?.diffSnapshot,
+    false,
+    'nonce-1',
+    writePty
+  )
+  expect(result.current.open).toBe(false)
+})
+
+test('copyReviewRequest records a request and copies the prompt', async () => {
+  const { result } = setup()
+
+  await act(async () => {
+    result.current.copyReviewRequest()
+    await Promise.resolve()
+  })
+
+  const request = getPendingReviewRequest('nonce-1')
+  expect(request?.ownerKey).toBe('owner')
+  expect(formatReviewRequest).toHaveBeenCalledWith(
+    request?.diffSnapshot,
+    false,
+    'nonce-1'
+  )
+  expect(writeClipboardText).toHaveBeenCalledWith('REVIEW_PROMPT')
+  expect(notify).toHaveBeenCalledWith(
+    'Copied the review request — paste it into an agent.'
+  )
+})
+
+test('requestReview is a no-op when there is nothing to review', async () => {
+  const { result } = setup({ fileDiff: undefined })
+
+  await act(async () => {
+    result.current.requestReview(pane())
+    await Promise.resolve()
+  })
+
+  expect(dispatchReviewRequest).not.toHaveBeenCalled()
+  expect(getPendingReviewRequest('nonce-1')).toBeUndefined()
+})
+
+test('notifies when the pane dispatch throws', async () => {
+  vi.mocked(dispatchReviewRequest).mockRejectedValueOnce(new Error('gone'))
+  const { result } = setup()
+
+  await act(async () => {
+    result.current.requestReview(pane())
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+
+  expect(notify).toHaveBeenCalledWith(
+    'Terminal session ended; review request not sent.'
+  )
+})

--- a/src/features/diff/hooks/useRequestReview.ts
+++ b/src/features/diff/hooks/useRequestReview.ts
@@ -11,6 +11,7 @@ import {
   dispatchReviewRequest,
   formatReviewRequest,
   makeDispatchNonce,
+  type ReviewRequestFile,
 } from '../services/feedbackDispatch'
 
 export interface UseRequestReviewOptions {
@@ -30,6 +31,8 @@ export interface UseRequestReviewOptions {
   focusTerminal?: () => void
   /** Surface a one-line status message to the user. */
   notify: (message: string) => void
+  /** Git repo root used to include resolvable absolute file paths in prompts. */
+  repoRoot?: string
 }
 
 export interface RequestReviewController {
@@ -59,6 +62,7 @@ export const useRequestReview = ({
   writePty,
   focusTerminal,
   notify,
+  repoRoot = undefined,
 }: UseRequestReviewOptions): RequestReviewController => {
   const [open, setOpen] = useState(false)
 
@@ -71,12 +75,22 @@ export const useRequestReview = ({
   const arm = useCallback((): {
     nonce: string
     files: ReviewedFile[]
+    requestFiles: ReviewRequestFile[]
   } | null => {
     if (fileDiff === undefined || ownerKey === undefined) {
       return null
     }
 
     const files = buildDiffSnapshot(fileDiff)
+    const normalizedRepoRoot = repoRoot?.replace(/[\\/]+$/, '') ?? ''
+
+    const requestFiles =
+      normalizedRepoRoot.length > 0
+        ? files.map((file) => ({
+            ...file,
+            promptPath: `${normalizedRepoRoot}/${file.path}`,
+          }))
+        : files
     const nonce = makeDispatchNonce()
     setPendingReviewRequest({
       nonce,
@@ -87,8 +101,8 @@ export const useRequestReview = ({
       dispatchedAt: Date.now(),
     })
 
-    return { nonce, files }
-  }, [fileDiff, ownerKey, cwd, staged])
+    return { nonce, files, requestFiles }
+  }, [fileDiff, ownerKey, cwd, staged, repoRoot])
 
   const requestReview = useCallback(
     (pane: PaneCandidate): void => {
@@ -102,7 +116,7 @@ export const useRequestReview = ({
         try {
           await dispatchReviewRequest(
             pane.ptyId,
-            armed.files,
+            armed.requestFiles,
             staged,
             armed.nonce,
             writePty
@@ -127,7 +141,7 @@ export const useRequestReview = ({
 
     void (async (): Promise<void> => {
       const copied = await writeClipboardText(
-        formatReviewRequest(armed.files, staged, armed.nonce)
+        formatReviewRequest(armed.requestFiles, staged, armed.nonce)
       )
       notify(
         copied

--- a/src/features/diff/hooks/useRequestReview.ts
+++ b/src/features/diff/hooks/useRequestReview.ts
@@ -1,0 +1,156 @@
+import { useCallback, useState } from 'react'
+import { writeClipboardText } from '@/lib/clipboard'
+import type { FileDiff } from '../types'
+import type { PaneCandidate } from '../services/activePanePicker'
+import {
+  buildDiffSnapshot,
+  setPendingReviewRequest,
+  type ReviewedFile,
+} from '../services/pendingReviewRequests'
+import {
+  dispatchReviewRequest,
+  formatReviewRequest,
+  makeDispatchNonce,
+} from '../services/feedbackDispatch'
+
+export interface UseRequestReviewOptions {
+  /** The active file's parsed diff, or undefined when no diff is loaded. */
+  fileDiff: FileDiff | undefined
+  /** The feedback owner (sessionId:paneId) the findings route back to. */
+  ownerKey: string | undefined
+  cwd: string
+  /** The diff's staged axis; the reviewer inherits it. */
+  staged: boolean
+  /**
+   * Send bytes to an agent pane's pty (the delegate path). Undefined when no
+   * live agent is reachable — then only the copy path works.
+   */
+  writePty?: (ptyId: string, data: string) => Promise<void>
+  /** Refocus the terminal after a delegate dispatch. */
+  focusTerminal?: () => void
+  /** Surface a one-line status message to the user. */
+  notify: (message: string) => void
+}
+
+export interface RequestReviewController {
+  /** Whether the request-review popover is open. */
+  open: boolean
+  /** True when a review can be requested (a diff and an owner are present). */
+  canRequest: boolean
+  openPopover: () => void
+  closePopover: () => void
+  /** Delegate the review to a specific agent pane. */
+  requestReview: (pane: PaneCandidate) => void
+  /** Copy the review-request text so it can be pasted into any agent. */
+  copyReviewRequest: () => void
+}
+
+/**
+ * Owns the "Request review" flow (VIM-304): record a pending request (diff
+ * snapshot + nonce + owner), then either send it to an agent pane or copy it for
+ * a manual paste. Lifted out of the diff Panel so the component stays a thin
+ * renderer and this orchestration is unit-testable on its own.
+ */
+export const useRequestReview = ({
+  fileDiff,
+  ownerKey,
+  cwd,
+  staged,
+  writePty,
+  focusTerminal,
+  notify,
+}: UseRequestReviewOptions): RequestReviewController => {
+  const [open, setOpen] = useState(false)
+
+  const canRequest = fileDiff !== undefined && ownerKey !== undefined
+
+  // Record the pending request (snapshot + nonce) so the incoming agent-review
+  // event can be matched, routed, and placed. The nonce alone gates it, so the
+  // target pane isn't stored. Returns the dispatch inputs, or null when there's
+  // nothing to review.
+  const arm = useCallback((): {
+    nonce: string
+    files: ReviewedFile[]
+  } | null => {
+    if (fileDiff === undefined || ownerKey === undefined) {
+      return null
+    }
+
+    const files = buildDiffSnapshot(fileDiff)
+    const nonce = makeDispatchNonce()
+    setPendingReviewRequest({
+      nonce,
+      ownerKey,
+      cwd,
+      staged,
+      diffSnapshot: files,
+      dispatchedAt: Date.now(),
+    })
+
+    return { nonce, files }
+  }, [fileDiff, ownerKey, cwd, staged])
+
+  const requestReview = useCallback(
+    (pane: PaneCandidate): void => {
+      const armed = arm()
+      setOpen(false)
+      if (armed === null || writePty === undefined) {
+        return
+      }
+
+      void (async (): Promise<void> => {
+        try {
+          await dispatchReviewRequest(
+            pane.ptyId,
+            armed.files,
+            staged,
+            armed.nonce,
+            writePty
+          )
+          if (focusTerminal !== undefined) {
+            setTimeout(focusTerminal, 0)
+          }
+        } catch {
+          notify('Terminal session ended; review request not sent.')
+        }
+      })()
+    },
+    [arm, writePty, focusTerminal, staged, notify]
+  )
+
+  const copyReviewRequest = useCallback((): void => {
+    const armed = arm()
+    setOpen(false)
+    if (armed === null) {
+      return
+    }
+
+    void (async (): Promise<void> => {
+      const copied = await writeClipboardText(
+        formatReviewRequest(armed.files, staged, armed.nonce)
+      )
+      notify(
+        copied
+          ? 'Copied the review request — paste it into an agent.'
+          : 'Could not copy the review request.'
+      )
+    })()
+  }, [arm, staged, notify])
+
+  const openPopover = useCallback((): void => {
+    if (canRequest) {
+      setOpen(true)
+    }
+  }, [canRequest])
+
+  const closePopover = useCallback((): void => setOpen(false), [])
+
+  return {
+    open,
+    canRequest,
+    openPopover,
+    closePopover,
+    requestReview,
+    copyReviewRequest,
+  }
+}

--- a/src/features/diff/services/feedbackDispatch.test.ts
+++ b/src/features/diff/services/feedbackDispatch.test.ts
@@ -286,6 +286,27 @@ test('formatReviewRequest names the scope, coordinate convention, and block (VIM
   expect(payload).toContain('VIMEFLOW_REVIEW>>>')
 })
 
+test('formatReviewRequest can include absolute prompt paths while preserving JSON paths', () => {
+  const payload = formatReviewRequest(
+    [
+      {
+        path: 'src/auth.ts',
+        promptPath: '/repo/src/auth.ts',
+        additions: [{ start: 40, end: 50 }],
+        deletions: [],
+      },
+    ],
+    false,
+    'r3v13w'
+  )
+
+  expect(payload).toContain('> ─ src/auth.ts (/repo/src/auth.ts)')
+  expect(payload).toContain(
+    'use the repo-relative path before the parentheses as each finding path'
+  )
+  expect(payload).toContain('"path":"<file>"')
+})
+
 test('formatReviewRequest uses the staged label + singular wording', () => {
   const payload = formatReviewRequest([reviewedFiles[0]], true, 'n')
 

--- a/src/features/diff/services/feedbackDispatch.test.ts
+++ b/src/features/diff/services/feedbackDispatch.test.ts
@@ -7,8 +7,11 @@ import type {
 import {
   formatFeedbackPayload,
   dispatchFeedbackBatch,
+  formatReviewRequest,
+  dispatchReviewRequest,
   type DispatchEntry,
 } from './feedbackDispatch'
+import type { ReviewedFile } from './pendingReviewRequests'
 
 const makeAnnotation = (
   lineNumber: number,
@@ -264,4 +267,49 @@ test('strips terminal control characters so a crafted path/comment cannot break 
   // wrapper's own start/end sentinels — exactly two ESC bytes, one trailing CR.
   const sent = `\x1b[200~${body}\x1b[201~\r`
   expect((sent.match(/\x1b/g) ?? []).length).toBe(2)
+})
+
+const reviewedFiles: ReviewedFile[] = [
+  { path: 'src/auth.ts', additions: [{ start: 40, end: 50 }], deletions: [] },
+  { path: 'src/db.ts', additions: [], deletions: [{ start: 1, end: 3 }] },
+]
+
+test('formatReviewRequest names the scope, coordinate convention, and block (VIM-304)', () => {
+  const payload = formatReviewRequest(reviewedFiles, false, 'r3v13w')
+
+  expect(payload).toContain('unstaged diff of these 2 files')
+  expect(payload).toContain('> ─ src/auth.ts')
+  expect(payload).toContain('> ─ src/db.ts')
+  expect(payload).toContain('"additions" uses new-file lines')
+  expect(payload).toContain('<<<VIMEFLOW_REVIEW')
+  expect(payload).toContain('"nonce":"r3v13w"')
+  expect(payload).toContain('VIMEFLOW_REVIEW>>>')
+})
+
+test('formatReviewRequest uses the staged label + singular wording', () => {
+  const payload = formatReviewRequest([reviewedFiles[0]], true, 'n')
+
+  expect(payload).toContain('staged diff of these 1 file:')
+})
+
+test('dispatchReviewRequest calls writePty once with a paste-bracketed payload', async () => {
+  const writePty = vi.fn().mockResolvedValue(undefined)
+
+  await dispatchReviewRequest('pty-1', reviewedFiles, false, 'n', writePty)
+
+  expect(writePty).toHaveBeenCalledTimes(1)
+  const sent = writePty.mock.calls[0][1] as string
+  expect(sent.startsWith('\x1b[200~')).toBe(true)
+  expect(sent.endsWith('\x1b[201~\r')).toBe(true)
+})
+
+test('formatReviewRequest strips control chars from a crafted path', () => {
+  const payload = formatReviewRequest(
+    [{ path: 'src/ev\x1b[201~il.ts', additions: [], deletions: [] }],
+    false,
+    'n'
+  )
+
+  expect(payload).not.toContain('\x1b')
+  expect(payload).toContain('src/ev[201~il.ts')
 })

--- a/src/features/diff/services/feedbackDispatch.ts
+++ b/src/features/diff/services/feedbackDispatch.ts
@@ -139,23 +139,36 @@ export const dispatchFeedbackBatch = async (
   await writePty(ptyId, payload)
 }
 
+export interface ReviewRequestFile extends ReviewedFile {
+  promptPath?: string
+}
+
 // The "Request review" payload (VIM-304): instruct the primary agent to delegate
 // a code review of a specific diff scope and emit the self-anchoring
 // VIMEFLOW_REVIEW block, echoing the nonce. The findings self-anchor, so there
 // is no [#n] item list — only the scope (paths + staged mode) + the contract.
 export const formatReviewRequest = (
-  files: ReviewedFile[],
+  files: ReviewRequestFile[],
   staged: boolean,
   nonce: string
 ): string => {
   const mode = staged ? 'staged' : 'unstaged'
-  const fileLines = files.map((file) => `> ─ ${stripControls(file.path)}`)
+
+  const fileLines = files.map((file) => {
+    const path = stripControls(file.path)
+
+    const promptPath =
+      file.promptPath === undefined ? '' : stripControls(file.promptPath)
+
+    return promptPath.length > 0 ? `> ─ ${path} (${promptPath})` : `> ─ ${path}`
+  })
 
   return [
     `> Delegate a code review of the ${mode} diff of these ${files.length} file${files.length === 1 ? '' : 's'}:`,
     ...fileLines,
     '>',
     '> Anchor each finding with diff-side line numbers: "additions" uses new-file lines, "deletions" uses old-file lines.',
+    '> In the JSON block, use the repo-relative path before the parentheses as each finding path.',
     '> category is one of: "bug", "suggestion", "change", "question". scope is "line", "range", or "file".',
     '> When done, end your reply with this exact block — echo the nonce verbatim and self-report the reviewer name.',
     '> Also give a one-line overview in your normal reply (not in the block), especially if there is little to report.',

--- a/src/features/diff/services/feedbackDispatch.ts
+++ b/src/features/diff/services/feedbackDispatch.ts
@@ -5,6 +5,7 @@ import {
   type ReviewComment,
   type ReviewCommentCategory,
 } from '../hooks/useFeedbackBatch'
+import type { ReviewedFile } from './pendingReviewRequests'
 
 const PASTE_START = '\x1b[200~'
 const PASTE_END = '\x1b[201~'
@@ -133,6 +134,45 @@ export const dispatchFeedbackBatch = async (
   writePty: (ptyId: string, data: string) => Promise<void>
 ): Promise<void> => {
   const formatted = formatFeedbackPayload(entries, nonce)
+  const payload = `${PASTE_START}${formatted}${PASTE_END}\r`
+
+  await writePty(ptyId, payload)
+}
+
+// The "Request review" payload (VIM-304): instruct the primary agent to delegate
+// a code review of a specific diff scope and emit the self-anchoring
+// VIMEFLOW_REVIEW block, echoing the nonce. The findings self-anchor, so there
+// is no [#n] item list — only the scope (paths + staged mode) + the contract.
+export const formatReviewRequest = (
+  files: ReviewedFile[],
+  staged: boolean,
+  nonce: string
+): string => {
+  const mode = staged ? 'staged' : 'unstaged'
+  const fileLines = files.map((file) => `> ─ ${stripControls(file.path)}`)
+
+  return [
+    `> Delegate a code review of the ${mode} diff of these ${files.length} file${files.length === 1 ? '' : 's'}:`,
+    ...fileLines,
+    '>',
+    '> Anchor each finding with diff-side line numbers: "additions" uses new-file lines, "deletions" uses old-file lines.',
+    '> category is one of: "bug", "suggestion", "change", "question". scope is "line", "range", or "file".',
+    '> When done, end your reply with this exact block — echo the nonce verbatim and self-report the reviewer name.',
+    '> Also give a one-line overview in your normal reply (not in the block), especially if there is little to report.',
+    '> <<<VIMEFLOW_REVIEW',
+    `> {"v":1,"nonce":"${nonce}","reviewer":"<your name>","findings":[{"path":"<file>","scope":"line","side":"additions","line":1,"category":"bug","text":"..."}]}`,
+    '> VIMEFLOW_REVIEW>>>',
+  ].join('\n')
+}
+
+export const dispatchReviewRequest = async (
+  ptyId: string,
+  files: ReviewedFile[],
+  staged: boolean,
+  nonce: string,
+  writePty: (ptyId: string, data: string) => Promise<void>
+): Promise<void> => {
+  const formatted = formatReviewRequest(files, staged, nonce)
   const payload = `${PASTE_START}${formatted}${PASTE_END}\r`
 
   await writePty(ptyId, payload)

--- a/src/features/diff/services/pendingReviewRequests.test.ts
+++ b/src/features/diff/services/pendingReviewRequests.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from 'vitest'
 import {
   addReviewLevelNote,
+  buildDiffSnapshot,
   clearPendingReviewRequest,
   clearReviewLevelNotes,
   getPendingReviewRequest,
@@ -8,10 +9,10 @@ import {
   setPendingReviewRequest,
   type PendingReviewRequest,
 } from './pendingReviewRequests'
+import type { FileDiff } from '../types'
 
 const request = (nonce = 'abc'): PendingReviewRequest => ({
   nonce,
-  ptyId: 'pty-1',
   ownerKey: 'sess:pane',
   cwd: '/repo',
   staged: false,
@@ -30,14 +31,14 @@ afterEach(() => {
 describe('pendingReviewRequests', () => {
   test('set then get by nonce', () => {
     setPendingReviewRequest(request())
-    expect(getPendingReviewRequest('abc')?.ptyId).toBe('pty-1')
+    expect(getPendingReviewRequest('abc')?.ownerKey).toBe('sess:pane')
     expect(getPendingReviewRequest('abc')?.diffSnapshot[0].path).toBe('a.ts')
   })
 
   test('set replaces the prior request for the same nonce', () => {
     setPendingReviewRequest(request())
-    setPendingReviewRequest({ ...request(), ptyId: 'pty-2' })
-    expect(getPendingReviewRequest('abc')?.ptyId).toBe('pty-2')
+    setPendingReviewRequest({ ...request(), ownerKey: 'sess:pane2' })
+    expect(getPendingReviewRequest('abc')?.ownerKey).toBe('sess:pane2')
   })
 
   test('clear removes the request', () => {
@@ -62,12 +63,14 @@ describe('reviewLevelNotes', () => {
       text: 'first',
       nonce: 'abc',
     })
+
     addReviewLevelNote('owner', {
       commentId: 'c2',
       reviewer: 'codex',
       text: 'second',
       nonce: 'abc',
     })
+
     expect(reviewLevelNotes('owner').map((n) => n.text)).toEqual([
       'first',
       'second',
@@ -76,5 +79,45 @@ describe('reviewLevelNotes', () => {
 
   test('an owner with no notes reads as empty', () => {
     expect(reviewLevelNotes('nobody')).toEqual([])
+  })
+})
+
+describe('buildDiffSnapshot', () => {
+  test('maps hunks to additions/deletions line ranges', () => {
+    const fileDiff: FileDiff = {
+      filePath: 'src/a.ts',
+      hunks: [
+        {
+          id: 'h1',
+          header: '@@',
+          oldStart: 5,
+          oldLines: 3,
+          newStart: 40,
+          newLines: 11,
+          lines: [],
+        },
+        // pure-addition hunk (no old lines)
+        {
+          id: 'h2',
+          header: '@@',
+          oldStart: 20,
+          oldLines: 0,
+          newStart: 88,
+          newLines: 7,
+          lines: [],
+        },
+      ],
+    }
+
+    expect(buildDiffSnapshot(fileDiff)).toEqual([
+      {
+        path: 'src/a.ts',
+        additions: [
+          { start: 40, end: 50 },
+          { start: 88, end: 94 },
+        ],
+        deletions: [{ start: 5, end: 7 }],
+      },
+    ])
   })
 })

--- a/src/features/diff/services/pendingReviewRequests.test.ts
+++ b/src/features/diff/services/pendingReviewRequests.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, test } from 'vitest'
+import {
+  addReviewLevelNote,
+  clearPendingReviewRequest,
+  clearReviewLevelNotes,
+  getPendingReviewRequest,
+  reviewLevelNotes,
+  setPendingReviewRequest,
+  type PendingReviewRequest,
+} from './pendingReviewRequests'
+
+const request = (nonce = 'abc'): PendingReviewRequest => ({
+  nonce,
+  ptyId: 'pty-1',
+  ownerKey: 'sess:pane',
+  cwd: '/repo',
+  staged: false,
+  diffSnapshot: [
+    { path: 'a.ts', additions: [{ start: 1, end: 10 }], deletions: [] },
+  ],
+  dispatchedAt: 1,
+})
+
+afterEach(() => {
+  clearPendingReviewRequest('abc')
+  clearPendingReviewRequest('xyz')
+  clearReviewLevelNotes('owner')
+})
+
+describe('pendingReviewRequests', () => {
+  test('set then get by nonce', () => {
+    setPendingReviewRequest(request())
+    expect(getPendingReviewRequest('abc')?.ptyId).toBe('pty-1')
+    expect(getPendingReviewRequest('abc')?.diffSnapshot[0].path).toBe('a.ts')
+  })
+
+  test('set replaces the prior request for the same nonce', () => {
+    setPendingReviewRequest(request())
+    setPendingReviewRequest({ ...request(), ptyId: 'pty-2' })
+    expect(getPendingReviewRequest('abc')?.ptyId).toBe('pty-2')
+  })
+
+  test('clear removes the request', () => {
+    setPendingReviewRequest(request())
+    clearPendingReviewRequest('abc')
+    expect(getPendingReviewRequest('abc')).toBeUndefined()
+  })
+
+  test('two requests can be in flight under different nonces', () => {
+    setPendingReviewRequest(request('abc'))
+    setPendingReviewRequest(request('xyz'))
+    expect(getPendingReviewRequest('abc')?.nonce).toBe('abc')
+    expect(getPendingReviewRequest('xyz')?.nonce).toBe('xyz')
+  })
+})
+
+describe('reviewLevelNotes', () => {
+  test('add then read notes per owner, in order', () => {
+    addReviewLevelNote('owner', {
+      commentId: 'c1',
+      reviewer: 'codex',
+      text: 'first',
+      nonce: 'abc',
+    })
+    addReviewLevelNote('owner', {
+      commentId: 'c2',
+      reviewer: 'codex',
+      text: 'second',
+      nonce: 'abc',
+    })
+    expect(reviewLevelNotes('owner').map((n) => n.text)).toEqual([
+      'first',
+      'second',
+    ])
+  })
+
+  test('an owner with no notes reads as empty', () => {
+    expect(reviewLevelNotes('nobody')).toEqual([])
+  })
+})

--- a/src/features/diff/services/pendingReviewRequests.test.ts
+++ b/src/features/diff/services/pendingReviewRequests.test.ts
@@ -5,6 +5,7 @@ import {
   clearPendingReviewRequest,
   clearReviewLevelNotes,
   getPendingReviewRequest,
+  prunePendingReviewRequestOwners,
   reviewLevelNotes,
   setPendingReviewRequest,
   type PendingReviewRequest,
@@ -25,7 +26,10 @@ const request = (nonce = 'abc'): PendingReviewRequest => ({
 afterEach(() => {
   clearPendingReviewRequest('abc')
   clearPendingReviewRequest('xyz')
+  clearPendingReviewRequest('stale')
   clearReviewLevelNotes('owner')
+  clearReviewLevelNotes('sess:pane')
+  clearReviewLevelNotes('stale-owner')
 })
 
 describe('pendingReviewRequests', () => {
@@ -53,6 +57,16 @@ describe('pendingReviewRequests', () => {
     expect(getPendingReviewRequest('abc')?.nonce).toBe('abc')
     expect(getPendingReviewRequest('xyz')?.nonce).toBe('xyz')
   })
+
+  test('prunePendingReviewRequestOwners removes requests for closed owners', () => {
+    setPendingReviewRequest(request('abc'))
+    setPendingReviewRequest({ ...request('stale'), ownerKey: 'stale-owner' })
+
+    prunePendingReviewRequestOwners(new Set(['sess:pane']))
+
+    expect(getPendingReviewRequest('abc')?.ownerKey).toBe('sess:pane')
+    expect(getPendingReviewRequest('stale')).toBeUndefined()
+  })
 })
 
 describe('reviewLevelNotes', () => {
@@ -79,6 +93,27 @@ describe('reviewLevelNotes', () => {
 
   test('an owner with no notes reads as empty', () => {
     expect(reviewLevelNotes('nobody')).toEqual([])
+  })
+
+  test('prunePendingReviewRequestOwners removes notes for closed owners', () => {
+    addReviewLevelNote('sess:pane', {
+      commentId: 'c1',
+      reviewer: 'codex',
+      text: 'live',
+      nonce: 'abc',
+    })
+
+    addReviewLevelNote('stale-owner', {
+      commentId: 'c2',
+      reviewer: 'codex',
+      text: 'stale',
+      nonce: 'stale',
+    })
+
+    prunePendingReviewRequestOwners(new Set(['sess:pane']))
+
+    expect(reviewLevelNotes('sess:pane').map((n) => n.text)).toEqual(['live'])
+    expect(reviewLevelNotes('stale-owner')).toEqual([])
   })
 })
 

--- a/src/features/diff/services/pendingReviewRequests.ts
+++ b/src/features/diff/services/pendingReviewRequests.ts
@@ -144,3 +144,25 @@ export const clearReviewLevelNotes = (ownerKey: string): void => {
   reviewLevelByOwner.delete(ownerKey)
   emitNotes()
 }
+
+export const prunePendingReviewRequestOwners = (
+  liveOwnerKeys: ReadonlySet<string>
+): void => {
+  for (const [nonce, request] of store) {
+    if (!liveOwnerKeys.has(request.ownerKey)) {
+      store.delete(nonce)
+    }
+  }
+
+  let notesChanged = false
+  for (const ownerKey of reviewLevelByOwner.keys()) {
+    if (!liveOwnerKeys.has(ownerKey)) {
+      reviewLevelByOwner.delete(ownerKey)
+      notesChanged = true
+    }
+  }
+
+  if (notesChanged) {
+    emitNotes()
+  }
+}

--- a/src/features/diff/services/pendingReviewRequests.ts
+++ b/src/features/diff/services/pendingReviewRequests.ts
@@ -5,6 +5,7 @@
  * compatible with VIM-297). Not persisted — the placed reviewer annotations
  * persist via the feedback store (VIM-282); this is just the routing + snapshot.
  */
+import type { FileDiff } from '../types'
 
 /** A diff-side line range (inclusive) from the reviewed hunks. */
 export interface HunkRange {
@@ -19,9 +20,40 @@ export interface ReviewedFile {
   deletions: HunkRange[]
 }
 
+/**
+ * Build the diff snapshot handed to the reviewer, from a parsed file diff — the
+ * new-file line span of each hunk (additions) and the old-file span
+ * (deletions). This is both the payload the review is scoped to and the
+ * placement resolver: a finding's line anchors only if it falls in one of these
+ * ranges (else it degrades to file-level). Returns an array because a snapshot
+ * is a list of files; today a review always covers exactly the one active file.
+ */
+export const buildDiffSnapshot = (fileDiff: FileDiff): ReviewedFile[] => [
+  {
+    path: fileDiff.filePath,
+    additions: fileDiff.hunks
+      .filter((hunk) => hunk.newLines > 0)
+      .map((hunk) => ({
+        start: hunk.newStart,
+        end: hunk.newStart + hunk.newLines - 1,
+      })),
+    deletions: fileDiff.hunks
+      .filter((hunk) => hunk.oldLines > 0)
+      .map((hunk) => ({
+        start: hunk.oldStart,
+        end: hunk.oldStart + hunk.oldLines - 1,
+      })),
+  },
+]
+
 export interface PendingReviewRequest {
+  /**
+   * The per-dispatch random token. It is the whole gate: an incoming
+   * `agent-review` is accepted only if its nonce matches one we minted, so it
+   * works the same whether the review was delegated to a pane or copied and
+   * pasted into any agent (the nonce is unguessable — no session check needed).
+   */
   nonce: string
-  ptyId: string
   /** The feedback owner (sessionId:paneId) at dispatch — findings route here. */
   ownerKey: string
   cwd: string
@@ -54,9 +86,10 @@ export const clearPendingReviewRequest = (nonce: string): void => {
 }
 
 /**
- * Unplaceable findings (path not in the reviewed diff) and malformed reviewer
- * notes have no `(path, staged)` row; they live here, grouped by owner, for the
- * review-level surface (never dropped — the spec's "keep it visible").
+ * Findings that cannot be anchored (path not in the reviewed diff) and
+ * malformed reviewer notes have no `(path, staged)` row; they live here,
+ * grouped by owner, for the review-level surface (never dropped — the spec's
+ * "keep it visible").
  */
 export interface ReviewLevelNote {
   commentId: string
@@ -67,6 +100,28 @@ export interface ReviewLevelNote {
 
 const reviewLevelByOwner = new Map<string, ReviewLevelNote[]>()
 
+// Stable empty reference — `useSyncExternalStore` compares snapshots by identity,
+// so a fresh `[]` each read would loop forever.
+const EMPTY_NOTES: readonly ReviewLevelNote[] = []
+
+const noteListeners = new Set<() => void>()
+
+const emitNotes = (): void => {
+  for (const listener of noteListeners) {
+    listener()
+  }
+}
+
+export const subscribeReviewLevelNotes = (
+  listener: () => void
+): (() => void) => {
+  noteListeners.add(listener)
+
+  return (): void => {
+    noteListeners.delete(listener)
+  }
+}
+
 export const addReviewLevelNote = (
   ownerKey: string,
   note: ReviewLevelNote
@@ -75,11 +130,17 @@ export const addReviewLevelNote = (
     ...(reviewLevelByOwner.get(ownerKey) ?? []),
     note,
   ])
+  emitNotes()
 }
 
-export const reviewLevelNotes = (ownerKey: string): ReviewLevelNote[] =>
-  reviewLevelByOwner.get(ownerKey) ?? []
+export const reviewLevelNotes = (
+  ownerKey: string | undefined
+): readonly ReviewLevelNote[] =>
+  ownerKey === undefined
+    ? EMPTY_NOTES
+    : (reviewLevelByOwner.get(ownerKey) ?? EMPTY_NOTES)
 
 export const clearReviewLevelNotes = (ownerKey: string): void => {
   reviewLevelByOwner.delete(ownerKey)
+  emitNotes()
 }

--- a/src/features/diff/services/pendingReviewRequests.ts
+++ b/src/features/diff/services/pendingReviewRequests.ts
@@ -1,0 +1,85 @@
+/**
+ * Correlation state for a dispatched "Request review" (VIM-304), parallel to
+ * `pendingReviews` (the reply-correlation store). Keyed by the per-dispatch
+ * nonce so multiple review requests can be in flight on one pty (forward-
+ * compatible with VIM-297). Not persisted — the placed reviewer annotations
+ * persist via the feedback store (VIM-282); this is just the routing + snapshot.
+ */
+
+/** A diff-side line range (inclusive) from the reviewed hunks. */
+export interface HunkRange {
+  start: number
+  end: number
+}
+
+/** One reviewed file's hunk line ranges, per side, captured at dispatch. */
+export interface ReviewedFile {
+  path: string
+  additions: HunkRange[]
+  deletions: HunkRange[]
+}
+
+export interface PendingReviewRequest {
+  nonce: string
+  ptyId: string
+  /** The feedback owner (sessionId:paneId) at dispatch — findings route here. */
+  ownerKey: string
+  cwd: string
+  /** The invoked diff view's staged axis; findings inherit it. */
+  staged: boolean
+  /**
+   * The diff the reviewer was given, captured at dispatch. Both the scope named
+   * in the dispatch instruction AND the placement resolver — a finding resolves
+   * against exactly what the reviewer saw, immune to edits after dispatch.
+   */
+  diffSnapshot: ReviewedFile[]
+  dispatchedAt: number
+}
+
+// ponytail: module-singleton keyed by nonce. One entry per in-flight request.
+const store = new Map<string, PendingReviewRequest>()
+
+export const setPendingReviewRequest = (
+  request: PendingReviewRequest
+): void => {
+  store.set(request.nonce, request)
+}
+
+export const getPendingReviewRequest = (
+  nonce: string
+): PendingReviewRequest | undefined => store.get(nonce)
+
+export const clearPendingReviewRequest = (nonce: string): void => {
+  store.delete(nonce)
+}
+
+/**
+ * Unplaceable findings (path not in the reviewed diff) and malformed reviewer
+ * notes have no `(path, staged)` row; they live here, grouped by owner, for the
+ * review-level surface (never dropped — the spec's "keep it visible").
+ */
+export interface ReviewLevelNote {
+  commentId: string
+  reviewer: string
+  text: string
+  nonce: string
+}
+
+const reviewLevelByOwner = new Map<string, ReviewLevelNote[]>()
+
+export const addReviewLevelNote = (
+  ownerKey: string,
+  note: ReviewLevelNote
+): void => {
+  reviewLevelByOwner.set(ownerKey, [
+    ...(reviewLevelByOwner.get(ownerKey) ?? []),
+    note,
+  ])
+}
+
+export const reviewLevelNotes = (ownerKey: string): ReviewLevelNote[] =>
+  reviewLevelByOwner.get(ownerKey) ?? []
+
+export const clearReviewLevelNotes = (ownerKey: string): void => {
+  reviewLevelByOwner.delete(ownerKey)
+}

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -92,6 +92,7 @@ import { useGitStatus } from '../diff/hooks/useGitStatus'
 import { useFeedbackBatchStore } from '../diff/hooks/useFeedbackBatch'
 import { useAgentReply } from '../diff/hooks/useAgentReply'
 import { useAgentReview } from '../diff/hooks/useAgentReview'
+import { prunePendingReviewRequestOwners } from '../diff/services/pendingReviewRequests'
 import type { PaneCandidate } from '../diff/services/activePanePicker'
 import { sumLines } from '../diff/utils/sumLines'
 import { findActivePane } from '../sessions/utils/activeSessionPane'
@@ -1976,6 +1977,7 @@ const WorkspaceViewContent = (): ReactElement => {
 
   useLayoutEffect(() => {
     pruneFeedbackOwners(livePaneKeys)
+    prunePendingReviewRequestOwners(livePaneKeys)
   }, [livePaneKeys, pruneFeedbackOwners])
 
   // Capture agent replies (VIM-249): the single subscription point, mounted

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -91,6 +91,7 @@ import { useAgentStatusHotLoading } from '../agent-status/hooks/useAgentStatusHo
 import { useGitStatus } from '../diff/hooks/useGitStatus'
 import { useFeedbackBatchStore } from '../diff/hooks/useFeedbackBatch'
 import { useAgentReply } from '../diff/hooks/useAgentReply'
+import { useAgentReview } from '../diff/hooks/useAgentReview'
 import type { PaneCandidate } from '../diff/services/activePanePicker'
 import { sumLines } from '../diff/utils/sumLines'
 import { findActivePane } from '../sessions/utils/activeSessionPane'
@@ -161,6 +162,11 @@ let agentReplyCommentSeq = 0
 
 const nextAgentReplyCommentId = (): string =>
   `agent-reply-${(agentReplyCommentSeq += 1)}`
+
+let agentReviewCommentSeq = 0
+
+const nextAgentReviewCommentId = (): string =>
+  `agent-review-${(agentReviewCommentSeq += 1)}`
 
 const sameSelectedDiffFile = (
   left: SelectedDiffFile | null,
@@ -1978,6 +1984,13 @@ const WorkspaceViewContent = (): ReactElement => {
   useAgentReply({
     addAnnotationForOwner: feedbackBatch.addAnnotationForOwner,
     nextCommentId: nextAgentReplyCommentId,
+  })
+
+  // Capture delegated review findings (VIM-304): the same single subscription
+  // point, placing reviewer findings onto the owner that requested the review.
+  useAgentReview({
+    addAnnotationForOwner: feedbackBatch.addAnnotationForOwner,
+    nextCommentId: nextAgentReviewCommentId,
   })
 
   useLayoutEffect(() => {


### PR DESCRIPTION
## What

PR-2 of the VIM-304 delegated-review series (frontend). A **"Request review"** affordance lets you hand the active file's diff to a coding agent; the agent's `VIMEFLOW_REVIEW` findings (captured by PR-1's backend) then render as first-class **reviewer** comments in the hunk — anchored to a line/range, degrading to file-level, and finally to a review-level notes panel, so nothing is ever silently dropped.

Depends on PR-1 (#673, backend capture — merged). Threads (main agent posting into a finding) are PR-3.

## Changes

- **`useFeedbackBatch.ts`** — `ReviewComment.author` extended to `'self' | 'agent' | 'reviewer'` (+ `reviewer?` name); corrected the pending predicate to `author === 'self' && dispatchedAt === undefined` so reviewer comments never count as the user's pending feedback.
- **`pendingReviewRequests.ts`** (new) — nonce-keyed pending-request store carrying a `diffSnapshot` (each hunk's line ranges per side, captured at dispatch) + a review-level notes store for unanchorable findings. `buildDiffSnapshot(fileDiff)` is the placement resolver.
- **`useRequestReview.ts`** (new) — owns the arm → dispatch/copy flow so `Panel` stays a renderer.
- **`useAgentReview.ts`** (new) — `listen('agent-review')`, resolve each finding against the snapshot, place via `addAnnotationForOwner` (line → range → file → review-level fallback), degrade `findings:null` to a reviewer note. Mounted in `WorkspaceView` beside `useAgentReply`.
- **`RequestReviewPopover` / `ReviewLevelNotes`** (new) + a reviewer-variant `ReviewCommentRow` + an always-visible **Request review** toolbar button (`@` shortcut).

## Decisions taken during review (diverge from VIM-309's written scope)

- **Nonce-only gate.** The incoming `agent-review` is gated by the random, unguessable nonce alone — no `sessionId === ptyId` check. This makes the **copy → paste into any agent** path work with no pty id, and let me drop the now-vestigial `ptyId` from the store. (VIM-309 originally spec'd session+nonce.)
- **Single bound agent, else copy.** The Request-review popover delegates only to the one clear agent; multiple agents fall back to copy rather than a picker.
- **`@` shortcut** (not `k`, which is vim up-motion in the diff).

## Testing

Full frontend suite green: **4894 passed / 3 skipped**, lint + type-check + prettier clean.

Part of VIM-304 (VIM-309).

🤖 Generated with [Claude Code](https://claude.com/claude-code)