### PR TITLE
fix: native overlay dialog input

### DIFF
--- a/electron/native-overlay.test.ts
+++ b/electron/native-overlay.test.ts
@@ -283,6 +283,52 @@ const dialogRequest = {
     actions: {
       selectIndex: 'command-palette:select-index',
       executeIndex: 'command-palette:execute-index',
+      setQuery: 'command-palette:set-query',
+    },
+  },
+} as const
+
+const newSessionDialogRequest = {
+  surfaceId: 'dialog-new-session',
+  kind: 'dialog',
+  anchorRect: { x: 0, y: 0, width: 900, height: 600 },
+  placement: 'top',
+  payload: {
+    kind: 'dialog',
+    dialog: 'new-session',
+    ariaLabel: 'New session',
+    name: 'scratch',
+    path: '/tmp',
+    nameEdited: false,
+    selectedLayoutId: 'single',
+    activeCommandPaneIndex: 0,
+    layouts: [
+      {
+        id: 'single',
+        label: 'Single',
+        capacity: 1,
+        cols: 'minmax(0,1fr)',
+        rows: 'minmax(0,1fr)',
+        areas: [['p0']],
+      },
+    ],
+    panes: [{ index: 0, areaName: 'p0', commandId: 'shell' }],
+    commands: [
+      {
+        id: 'shell',
+        label: 'Shell',
+        accentVar: '--color-agent-shell-accent',
+      },
+    ],
+    actions: {
+      focusName: 'new-session:focus-name',
+      resetName: 'new-session:reset-name',
+      browse: 'new-session:browse',
+      cancel: 'new-session:cancel',
+      create: 'new-session:create',
+      selectPanePrefix: 'new-session:select-pane:',
+      pickLayoutPrefix: 'new-session:pick-layout:',
+      pickCommandPrefix: 'new-session:pick-command:',
     },
   },
 } as const
@@ -705,6 +751,108 @@ describe('NativeOverlayController', () => {
         repeat: true,
       }
     )
+  })
+
+  test('relays owner dialog text keys to the non-focusable dialog layer', async () => {
+    const openPromise = handler(NATIVE_OVERLAY_OPEN)(
+      { sender: electronMock.owner.webContents },
+      dialogRequest
+    )
+    const menuWindow = finishOverlayLoad()
+    await acknowledgeOverlayReady(menuWindow, dialogRequest.surfaceId)
+    await openPromise
+
+    menuWindow.webContents.send.mockClear()
+    const event = { preventDefault: vi.fn() }
+
+    electronMock.owner.webContents.emit('before-input-event', event, {
+      type: 'keyDown',
+      key: 'o',
+      code: 'KeyO',
+      isAutoRepeat: false,
+      isComposing: false,
+      shift: false,
+      control: false,
+      alt: false,
+      meta: false,
+      location: 0,
+      modifiers: [],
+    })
+
+    expect(event.preventDefault).toHaveBeenCalledOnce()
+    expect(menuWindow.webContents.send).toHaveBeenCalledWith(
+      NATIVE_OVERLAY_KEYDOWN,
+      {
+        surfaceId: dialogRequest.surfaceId,
+        key: 'o',
+        code: 'KeyO',
+        altKey: false,
+        ctrlKey: false,
+        metaKey: false,
+        shiftKey: false,
+        repeat: false,
+      }
+    )
+  })
+
+  test('leaves dialog Tab key events for owner renderer completion', async () => {
+    const openPromise = handler(NATIVE_OVERLAY_OPEN)(
+      { sender: electronMock.owner.webContents },
+      dialogRequest
+    )
+    const menuWindow = finishOverlayLoad()
+    await acknowledgeOverlayReady(menuWindow, dialogRequest.surfaceId)
+    await openPromise
+
+    menuWindow.webContents.send.mockClear()
+    const event = { preventDefault: vi.fn() }
+
+    electronMock.owner.webContents.emit('before-input-event', event, {
+      type: 'keyDown',
+      key: 'Tab',
+      code: 'Tab',
+      isAutoRepeat: false,
+      isComposing: false,
+      shift: false,
+      control: false,
+      alt: false,
+      meta: false,
+      location: 0,
+      modifiers: [],
+    })
+
+    expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(menuWindow.webContents.send).not.toHaveBeenCalled()
+  })
+
+  test('leaves new session dialog text keys in the owner renderer', async () => {
+    const openPromise = handler(NATIVE_OVERLAY_OPEN)(
+      { sender: electronMock.owner.webContents },
+      newSessionDialogRequest
+    )
+    const menuWindow = finishOverlayLoad()
+    await acknowledgeOverlayReady(menuWindow, newSessionDialogRequest.surfaceId)
+    await openPromise
+
+    menuWindow.webContents.send.mockClear()
+    const event = { preventDefault: vi.fn() }
+
+    electronMock.owner.webContents.emit('before-input-event', event, {
+      type: 'keyDown',
+      key: 'x',
+      code: 'KeyX',
+      isAutoRepeat: false,
+      isComposing: false,
+      shift: false,
+      control: false,
+      alt: false,
+      meta: false,
+      location: 0,
+      modifiers: [],
+    })
+
+    expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(menuWindow.webContents.send).not.toHaveBeenCalled()
   })
 
   test('dispatches command palette shortcut instead of menu key forwarding', async () => {
@@ -1442,10 +1590,17 @@ describe('NativeOverlayController', () => {
       }
     )
 
-    expect(overlayWindow.hide).not.toHaveBeenCalled()
+    expect(overlayWindow.hide).toHaveBeenCalledOnce()
     expect(overlayWindow.webContents.executeJavaScript).toHaveBeenCalledOnce()
     expect(overlayWindow.setAlwaysOnTop).toHaveBeenLastCalledWith(false)
     expect(overlayWindow.setIgnoreMouseEvents).toHaveBeenLastCalledWith(true)
+
+    electronMock.owner.webContents.send.mockClear()
+    electronMock.owner.emit('blur')
+    expect(electronMock.owner.webContents.send).not.toHaveBeenCalledWith(
+      NATIVE_OVERLAY_CLOSED,
+      { surfaceId: request.surfaceId, reason: 'outside' }
+    )
 
     handler(NATIVE_OVERLAY_RESUME)(
       { sender: electronMock.owner.webContents },

--- a/electron/native-overlay.ts
+++ b/electron/native-overlay.ts
@@ -129,6 +129,7 @@ interface NativeOverlayCommandPaletteItem {
 interface NativeOverlayCommandPaletteActions {
   selectIndex: string
   executeIndex: string
+  setQuery: string
 }
 
 interface NativeOverlayCommandPaletteDialogPayload {
@@ -228,6 +229,7 @@ interface NativeOverlayActionEvent {
   suspendOnSelect?: boolean
   feedback?: 'copy'
   index?: number
+  query?: string
 }
 
 interface NativeOverlayActionResultEvent {
@@ -281,6 +283,7 @@ interface NativeOverlaySurface {
   owner: WebContents
   parentId: number
   kind: NativeOverlayKind
+  dialog?: NativeOverlayDialogPayload['dialog']
 }
 
 interface NativeOverlayControllerOptions {
@@ -337,6 +340,12 @@ const MENU_KEY_MAP: Readonly<Partial<Record<string, string>>> = {
   Space: ' ',
   Tab: 'Tab',
   Up: 'ArrowUp',
+}
+
+const DIALOG_KEY_MAP: Readonly<Partial<Record<string, string>>> = {
+  ...MENU_KEY_MAP,
+  Backspace: 'Backspace',
+  Delete: 'Delete',
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -512,7 +521,10 @@ const isCommandPaletteItem = (
 const isCommandPaletteActions = (
   value: unknown
 ): value is NativeOverlayCommandPaletteActions =>
-  isRecord(value) && isString(value.selectIndex) && isString(value.executeIndex)
+  isRecord(value) &&
+  isString(value.selectIndex) &&
+  isString(value.executeIndex) &&
+  isString(value.setQuery)
 
 const isStringMatrix = (
   value: unknown
@@ -673,7 +685,8 @@ const isActionEvent = (value: unknown): value is NativeOverlayActionEvent =>
   (value.suspendOnSelect === undefined ||
     typeof value.suspendOnSelect === 'boolean') &&
   (value.feedback === undefined || value.feedback === 'copy') &&
-  (value.index === undefined || isFiniteNumber(value.index))
+  (value.index === undefined || isFiniteNumber(value.index)) &&
+  (value.query === undefined || typeof value.query === 'string')
 
 const isActionResultEvent = (
   value: unknown
@@ -712,12 +725,54 @@ const menuKeyboardEventFromInput = (
   }
 }
 
+const dialogKeyboardEventFromInput = (
+  surfaceId: string,
+  input: Input
+): NativeOverlayKeyboardEvent | null => {
+  if (input.type !== 'keyDown') {
+    return null
+  }
+
+  // Keep Tab in the owner renderer for command-palette completion.
+  if (input.key === 'Tab' || input.code === 'Tab') {
+    return null
+  }
+
+  const mapped = DIALOG_KEY_MAP[input.key] ?? DIALOG_KEY_MAP[input.code]
+
+  const printable =
+    mapped === undefined &&
+    !input.alt &&
+    !input.control &&
+    !input.meta &&
+    input.key.length === 1
+      ? input.key
+      : undefined
+  const key = mapped ?? printable
+
+  if (key === undefined) {
+    return null
+  }
+
+  return {
+    surfaceId,
+    key,
+    code: input.code,
+    altKey: input.alt,
+    ctrlKey: input.control,
+    metaKey: input.meta,
+    shiftKey: input.shift,
+    repeat: input.isAutoRepeat,
+  }
+}
+
 export class NativeOverlayController {
   private readonly menuOverlayUrl: string
   private readonly tooltipOverlayUrl: string
   private readonly platform: NodeJS.Platform
   private readonly overlays = new Map<number, NativeOverlayRecord>()
   private readonly surfaces = new Map<string, NativeOverlaySurface>()
+  private readonly suspendedSurfaceIds = new Set<string>()
   private readonly pendingReady = new Map<string, (ready: boolean) => void>()
   private registeredIpc: IpcMainLike | null = null
 
@@ -756,6 +811,7 @@ export class NativeOverlayController {
       resolve(false)
     }
     this.pendingReady.clear()
+    this.suspendedSurfaceIds.clear()
 
     for (const record of [...this.overlays.values()]) {
       this.destroyOverlayRecord(record, 'owner-closed', false)
@@ -833,10 +889,14 @@ export class NativeOverlayController {
     record.menu.window.setAlwaysOnTop(true, 'screen-saver')
     record.menu.window.moveTop()
     record.activeSurfaceId = payload.surfaceId
+
+    const dialog =
+      payload.payload.kind === 'dialog' ? payload.payload.dialog : undefined
     this.surfaces.set(payload.surfaceId, {
       owner,
       parentId: parent.id,
       kind: payload.kind,
+      ...(dialog === undefined ? {} : { dialog }),
     })
 
     const readyPromise = this.waitForReady(payload.surfaceId)
@@ -1118,7 +1178,10 @@ export class NativeOverlayController {
         return
       }
 
-      if (record.activeSurfaceId !== null) {
+      if (
+        record.activeSurfaceId !== null &&
+        !this.suspendedSurfaceIds.has(record.activeSurfaceId)
+      ) {
         this.closeSurface(record.activeSurfaceId, 'outside', true, false)
       }
 
@@ -1144,11 +1207,16 @@ export class NativeOverlayController {
         return
       }
 
-      if (surface?.kind !== 'menu') {
+      const isKeyboardDialog =
+        surface?.kind === 'dialog' && surface.dialog === 'command-palette'
+      if (surface?.kind !== 'menu' && !isKeyboardDialog) {
         return
       }
 
-      const keyEvent = menuKeyboardEventFromInput(surfaceId, input)
+      const keyEvent =
+        surface.kind === 'dialog'
+          ? dialogKeyboardEventFromInput(surfaceId, input)
+          : menuKeyboardEventFromInput(surfaceId, input)
       if (keyEvent === null) {
         return
       }
@@ -1293,6 +1361,7 @@ export class NativeOverlayController {
         : record?.activeSurfaceId === surfaceId
 
     this.surfaces.delete(surfaceId)
+    this.suspendedSurfaceIds.delete(surfaceId)
     this.resolvePendingReady(surfaceId, false)
 
     if (record && isActiveSurface) {
@@ -1341,9 +1410,11 @@ export class NativeOverlayController {
     }
 
     const overlayWindow = record.menu.window
+    this.suspendedSurfaceIds.add(surfaceId)
     resetOverlayCursor(overlayWindow)
     overlayWindow.setAlwaysOnTop(false)
     overlayWindow.setIgnoreMouseEvents(true)
+    overlayWindow.hide()
   }
 
   private resumeSurface(surfaceId: string): void {
@@ -1362,6 +1433,7 @@ export class NativeOverlayController {
 
     record.syncBounds()
     const overlayWindow = record.menu.window
+    this.suspendedSurfaceIds.delete(surfaceId)
     overlayWindow.setIgnoreMouseEvents(false)
     overlayWindow.showInactive()
     overlayWindow.setAlwaysOnTop(true, 'screen-saver')

--- a/src/components/Dialog.test.tsx
+++ b/src/components/Dialog.test.tsx
@@ -22,6 +22,7 @@ const nativeDialogPayload: NativeOverlayCommandPaletteDialogPayload = {
   actions: {
     selectIndex: 'command-palette:select-index',
     executeIndex: 'command-palette:execute-index',
+    setQuery: 'command-palette:set-query',
   },
 }
 

--- a/src/components/NativeOverlayHost.test.tsx
+++ b/src/components/NativeOverlayHost.test.tsx
@@ -7,7 +7,10 @@ import {
 } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, test, vi } from 'vitest'
-import type { NativeOverlayRequest } from '@/components/base/floating/nativeOverlay'
+import type {
+  NativeOverlayCommandPaletteDialogPayload,
+  NativeOverlayRequest,
+} from '@/components/base/floating/nativeOverlay'
 import { NativeOverlayHost } from './NativeOverlayHost'
 
 const request: NativeOverlayRequest = {
@@ -160,7 +163,9 @@ const shortcutTooltipRequest: NativeOverlayRequest = {
   },
 }
 
-const commandPaletteRequest: NativeOverlayRequest = {
+const commandPaletteRequest: NativeOverlayRequest & {
+  payload: NativeOverlayCommandPaletteDialogPayload
+} = {
   surfaceId: 'dialog-1',
   kind: 'dialog',
   anchorRect: { x: 0, y: 0, width: 900, height: 600 },
@@ -184,6 +189,7 @@ const commandPaletteRequest: NativeOverlayRequest = {
     actions: {
       selectIndex: 'command-palette:select-index',
       executeIndex: 'command-palette:execute-index',
+      setQuery: 'command-palette:set-query',
     },
   },
 }
@@ -443,7 +449,7 @@ describe('NativeOverlayHost', () => {
       name: 'Command palette',
     })
     expect(dialog).toBeInTheDocument()
-    expect(dialog).toHaveClass('bg-scrim/40')
+    expect(dialog).toHaveClass('bg-scrim/60')
     expect(screen.getByRole('combobox')).toHaveValue(':')
     expect(screen.getByRole('combobox')).toHaveAttribute('readonly')
     expect(screen.getByRole('option', { name: /:help/i })).toHaveAttribute(
@@ -461,6 +467,219 @@ describe('NativeOverlayHost', () => {
     })
 
     expect(screen.getByRole('dialog', { name: 'Command palette' })).toBe(dialog)
+  })
+
+  test('forwards command palette typed query and keyboard actions', async () => {
+    const bridge = installNativeOverlayHostBridge()
+    render(<NativeOverlayHost />)
+
+    bridge.emitRender(commandPaletteRequest)
+
+    await screen.findByRole('dialog', {
+      name: 'Command palette',
+    })
+
+    bridge.emitKeyDown({
+      surfaceId: 'dialog-1',
+      key: 'o',
+      code: 'KeyO',
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      repeat: false,
+    })
+
+    expect(bridge.action).toHaveBeenCalledWith({
+      surfaceId: 'dialog-1',
+      actionId: 'command-palette:set-query',
+      closeOnSelect: false,
+      query: ':o',
+    })
+
+    bridge.emitKeyDown({
+      surfaceId: 'dialog-1',
+      key: 'p',
+      code: 'KeyP',
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      repeat: false,
+    })
+
+    expect(bridge.action).toHaveBeenCalledWith({
+      surfaceId: 'dialog-1',
+      actionId: 'command-palette:set-query',
+      closeOnSelect: false,
+      query: ':op',
+    })
+
+    bridge.emitRender({
+      ...commandPaletteRequest,
+      payload: {
+        ...commandPaletteRequest.payload,
+        query: ':o',
+      },
+    })
+
+    bridge.emitKeyDown({
+      surfaceId: 'dialog-1',
+      key: 'Backspace',
+      code: 'Backspace',
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      repeat: false,
+    })
+
+    expect(bridge.action).toHaveBeenCalledWith({
+      surfaceId: 'dialog-1',
+      actionId: 'command-palette:set-query',
+      closeOnSelect: false,
+      query: ':o',
+    })
+
+    bridge.emitKeyDown({
+      surfaceId: 'dialog-1',
+      key: 'Enter',
+      code: 'Enter',
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      repeat: false,
+    })
+
+    expect(bridge.action).toHaveBeenCalledWith({
+      surfaceId: 'dialog-1',
+      actionId: 'command-palette:execute-index',
+      closeOnSelect: false,
+      index: 0,
+    })
+  })
+
+  test('does not execute a stale command palette selection', async () => {
+    const bridge = installNativeOverlayHostBridge()
+    render(<NativeOverlayHost />)
+
+    bridge.emitRender({
+      ...commandPaletteRequest,
+      payload: {
+        ...commandPaletteRequest.payload,
+        selectedIndex: 1,
+        results: [
+          ...commandPaletteRequest.payload.results,
+          {
+            id: 'open',
+            label: ':open',
+            description: 'Open file',
+            icon: 'folder_open',
+          },
+        ],
+      },
+    })
+
+    await screen.findByRole('dialog', {
+      name: 'Command palette',
+    })
+
+    bridge.emitRender({
+      ...commandPaletteRequest,
+      payload: {
+        ...commandPaletteRequest.payload,
+        selectedIndex: 1,
+        results: commandPaletteRequest.payload.results,
+      },
+    })
+
+    bridge.action.mockClear()
+    bridge.emitKeyDown({
+      surfaceId: 'dialog-1',
+      key: 'Enter',
+      code: 'Enter',
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      repeat: false,
+    })
+
+    expect(bridge.action).not.toHaveBeenCalled()
+  })
+
+  test('resets optimistic command palette selection on query edits', async () => {
+    const bridge = installNativeOverlayHostBridge()
+    render(<NativeOverlayHost />)
+
+    bridge.emitRender({
+      ...commandPaletteRequest,
+      payload: {
+        ...commandPaletteRequest.payload,
+        results: [
+          ...commandPaletteRequest.payload.results,
+          {
+            id: 'open',
+            label: ':open',
+            description: 'Open file',
+            icon: 'folder_open',
+          },
+        ],
+      },
+    })
+
+    await screen.findByRole('dialog', {
+      name: 'Command palette',
+    })
+
+    bridge.emitKeyDown({
+      surfaceId: 'dialog-1',
+      key: 'ArrowDown',
+      code: 'ArrowDown',
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      repeat: false,
+    })
+
+    bridge.action.mockClear()
+    bridge.emitKeyDown({
+      surfaceId: 'dialog-1',
+      key: 'o',
+      code: 'KeyO',
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      repeat: false,
+    })
+
+    expect(bridge.action).toHaveBeenCalledWith({
+      surfaceId: 'dialog-1',
+      actionId: 'command-palette:set-query',
+      closeOnSelect: false,
+      query: ':o',
+    })
+
+    bridge.emitKeyDown({
+      surfaceId: 'dialog-1',
+      key: 'Enter',
+      code: 'Enter',
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      repeat: false,
+    })
+
+    expect(bridge.action).toHaveBeenCalledWith({
+      surfaceId: 'dialog-1',
+      actionId: 'command-palette:execute-index',
+      closeOnSelect: false,
+      index: 0,
+    })
   })
 
   test('renders new session dialog requests and dispatches actions', async () => {
@@ -542,6 +761,7 @@ describe('NativeOverlayHost', () => {
           actions: {
             selectIndex: 'command-palette:select-index',
             executeIndex: 'command-palette:execute-index',
+            setQuery: 'command-palette:set-query',
           },
         },
       })

--- a/src/components/NativeOverlayHost.tsx
+++ b/src/components/NativeOverlayHost.tsx
@@ -4,6 +4,7 @@ import {
   useRef,
   useState,
   type CSSProperties,
+  type KeyboardEvent,
   type ReactElement,
 } from 'react'
 import { IconButton } from '@/components/IconButton'
@@ -31,6 +32,7 @@ interface NativeOverlayHostBridge {
     suspendOnSelect?: boolean
     feedback?: 'copy'
     index?: number
+    query?: string
   }) => Promise<unknown>
   close: (request: { surfaceId: string; reason: 'outside' }) => Promise<unknown>
   onRender: (callback: (payload: unknown) => void) => () => void
@@ -169,10 +171,10 @@ const OVERLAY_TOOLTIP_CLASSES =
 
 const OVERLAY_DIALOG_BACKDROP_CLASSES =
   'fixed inset-0 flex items-start justify-center pt-[15vh] backdrop-blur-sm ' +
-  'bg-scrim/40'
+  'bg-scrim/60'
 
 const OVERLAY_COMMAND_PALETTE_CLASSES =
-  'w-full max-w-2xl mx-4 bg-surface-container/90 glass-panel rounded-2xl ' +
+  'w-full max-w-2xl mx-4 bg-surface-container-high/95 glass-panel rounded-2xl ' +
   'border border-outline-variant/30 shadow-2xl overflow-hidden'
 
 const OVERLAY_COMMAND_PALETTE_INPUT_CLASSES =
@@ -326,7 +328,9 @@ const dispatchNativeOverlayKeyDown = (
     document.activeElement instanceof HTMLElement &&
     document.activeElement !== document.body
       ? document.activeElement
-      : (document.querySelector<HTMLElement>('[role="menu"]') ?? document.body)
+      : (document.querySelector<HTMLElement>('[role="menu"]') ??
+        document.querySelector<HTMLElement>('[role="dialog"]') ??
+        document.body)
 
   target.dispatchEvent(
     new KeyboardEvent('keydown', {
@@ -400,6 +404,10 @@ const NativeOverlayCommandPalette = ({
   const rowRefs = useRef(new Map<string, HTMLDivElement>())
   const payload = request.payload
   const selectedIndex = payload.selectedIndex
+  const localQueryRef = useRef(payload.query)
+  const pendingQueryRef = useRef<string | null>(null)
+  const localSelectedIndexRef = useRef(selectedIndex)
+  const pendingSelectedIndexRef = useRef<number | null>(null)
 
   const selectedCommand =
     selectedIndex >= 0 && selectedIndex < payload.results.length
@@ -414,6 +422,24 @@ const NativeOverlayCommandPalette = ({
 
   const showArgumentPlaceholder =
     payload.argumentPlaceholder !== undefined && payload.query.endsWith(' ')
+
+  useEffect(() => {
+    if (pendingQueryRef.current === payload.query) {
+      pendingQueryRef.current = null
+    }
+    if (pendingQueryRef.current === null) {
+      localQueryRef.current = payload.query
+    }
+  }, [payload.query])
+
+  useEffect(() => {
+    if (pendingSelectedIndexRef.current === selectedIndex) {
+      pendingSelectedIndexRef.current = null
+    }
+    if (pendingSelectedIndexRef.current === null) {
+      localSelectedIndexRef.current = selectedIndex
+    }
+  }, [selectedIndex])
 
   useEffect(() => {
     if (selectedCommand === undefined) {
@@ -439,7 +465,7 @@ const NativeOverlayCommandPalette = ({
 
   const dispatchAction = (
     actionId: string,
-    options: { index?: number } = {}
+    options: { index?: number; query?: string } = {}
   ): void => {
     void nativeOverlayHostBridge()?.action({
       surfaceId: request.surfaceId,
@@ -449,12 +475,88 @@ const NativeOverlayCommandPalette = ({
     })
   }
 
+  const dispatchQuery = (query: string): void => {
+    localQueryRef.current = query
+    pendingQueryRef.current = query
+    localSelectedIndexRef.current = 0
+    pendingSelectedIndexRef.current = 0
+    dispatchAction(payload.actions.setQuery, { query })
+  }
+
+  const dispatchSelectedIndex = (index: number): void => {
+    localSelectedIndexRef.current = index
+    pendingSelectedIndexRef.current = index
+    dispatchAction(payload.actions.selectIndex, { index })
+  }
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
+    if (event.metaKey || event.ctrlKey || event.altKey) {
+      return
+    }
+
+    switch (event.key) {
+      case 'Escape':
+        event.preventDefault()
+        close()
+
+        return
+      case 'ArrowUp':
+      case 'ArrowDown': {
+        if (payload.results.length === 0) {
+          return
+        }
+
+        event.preventDefault()
+        const offset = event.key === 'ArrowUp' ? -1 : 1
+        const localSelectedIndex = localSelectedIndexRef.current
+
+        const current =
+          localSelectedIndex >= 0 && localSelectedIndex < payload.results.length
+            ? localSelectedIndex
+            : 0
+        dispatchSelectedIndex(
+          (current + offset + payload.results.length) % payload.results.length
+        )
+
+        return
+      }
+      case 'Enter':
+        if (
+          localSelectedIndexRef.current >= 0 &&
+          localSelectedIndexRef.current < payload.results.length
+        ) {
+          event.preventDefault()
+          dispatchAction(payload.actions.executeIndex, {
+            index: localSelectedIndexRef.current,
+          })
+        }
+
+        return
+      case 'Backspace':
+        event.preventDefault()
+        if (localQueryRef.current === ':') {
+          close()
+
+          return
+        }
+        dispatchQuery(localQueryRef.current.slice(0, -1))
+
+        return
+      default:
+        if (event.key.length === 1) {
+          event.preventDefault()
+          dispatchQuery(`${localQueryRef.current}${event.key}`)
+        }
+    }
+  }
+
   return (
     <div
       role="dialog"
       aria-modal="true"
       aria-label={payload.ariaLabel}
       className={OVERLAY_DIALOG_BACKDROP_CLASSES}
+      onKeyDown={handleKeyDown}
       onMouseDown={(event): void => {
         if (event.target === event.currentTarget) {
           event.preventDefault()

--- a/src/components/base/floating/nativeOverlay.ts
+++ b/src/components/base/floating/nativeOverlay.ts
@@ -110,6 +110,7 @@ export interface NativeOverlayCommandPaletteItem {
 export interface NativeOverlayCommandPaletteActions {
   selectIndex: string
   executeIndex: string
+  setQuery: string
 }
 
 export interface NativeOverlayCommandPaletteDialogPayload {
@@ -217,6 +218,7 @@ export interface NativeOverlayActionEvent {
   suspendOnSelect?: boolean
   feedback?: 'copy'
   index?: number
+  query?: string
 }
 
 export interface NativeOverlayActionResultEvent {
@@ -312,7 +314,8 @@ const isActionEvent = (value: unknown): value is NativeOverlayActionEvent =>
   (value.suspendOnSelect === undefined ||
     typeof value.suspendOnSelect === 'boolean') &&
   (value.feedback === undefined || value.feedback === 'copy') &&
-  (value.index === undefined || typeof value.index === 'number')
+  (value.index === undefined || typeof value.index === 'number') &&
+  (value.query === undefined || typeof value.query === 'string')
 
 const isCloseEvent = (value: unknown): value is NativeOverlayCloseEvent =>
   isRecord(value) &&

--- a/src/features/command-palette/CommandPalette.test.tsx
+++ b/src/features/command-palette/CommandPalette.test.tsx
@@ -22,6 +22,7 @@ interface CommandPaletteNativeRequest {
     actions: {
       selectIndex: string
       executeIndex: string
+      setQuery: string
     }
   }
 }
@@ -221,7 +222,7 @@ describe('CommandPalette', () => {
     setNavigatorPlatform('MacIntel')
     const nativeBridge = installNativeOverlayBridge()
 
-    const { selectIndex, executeAt } = renderPalette({
+    const { setQuery, selectIndex, executeAt } = renderPalette({
       state: { isOpen: true, query: ':he' },
       filteredResults: [sampleCommand],
       clampedSelectedIndex: 0,
@@ -264,10 +265,17 @@ describe('CommandPalette', () => {
         actionId: request.payload.actions.executeIndex,
         index: 0,
       })
+
+      nativeBridge.action({
+        surfaceId: request.surfaceId,
+        actionId: request.payload.actions.setQuery,
+        query: ':open',
+      })
     })
 
     expect(selectIndex).toHaveBeenCalledWith(0)
     expect(executeAt).toHaveBeenCalledWith(0)
+    expect(setQuery).toHaveBeenCalledWith(':open')
   })
 
   test('does not reopen the native overlay on unrelated parent rerenders', async () => {

--- a/src/features/command-palette/CommandPalette.tsx
+++ b/src/features/command-palette/CommandPalette.tsx
@@ -59,6 +59,7 @@ const DIALOG_CLOSE_ON_ESCAPE = false
 
 const NATIVE_ACTION_SELECT_INDEX = 'command-palette:select-index'
 const NATIVE_ACTION_EXECUTE_INDEX = 'command-palette:execute-index'
+const NATIVE_ACTION_SET_QUERY = 'command-palette:set-query'
 
 export const CommandPalette = ({
   state,
@@ -107,6 +108,7 @@ export const CommandPalette = ({
         actions: {
           selectIndex: NATIVE_ACTION_SELECT_INDEX,
           executeIndex: NATIVE_ACTION_EXECUTE_INDEX,
+          setQuery: NATIVE_ACTION_SET_QUERY,
         },
       }
     }, [
@@ -120,6 +122,17 @@ export const CommandPalette = ({
   const nativeOverlayActions = useMemo(
     (): ReadonlyMap<string, NativeOverlayActionHandler> =>
       new Map([
+        [
+          NATIVE_ACTION_SET_QUERY,
+          {
+            retainSession: true,
+            run: (event): void => {
+              if (event?.query !== undefined) {
+                setQuery(event.query)
+              }
+            },
+          },
+        ],
         [
           NATIVE_ACTION_SELECT_INDEX,
           {
@@ -143,7 +156,7 @@ export const CommandPalette = ({
           },
         ],
       ]),
-    [executeAt, selectIndex]
+    [executeAt, selectIndex, setQuery]
   )
 
   const handleOpenChange = useCallback(


### PR DESCRIPTION
## Summary
- Fix native overlay command palette typing and keyboard navigation from Ghostty owner-window key events
- Suspend the native overlay while the New Session directory picker is open so the macOS selector remains usable
- Reduce native overlay transparency for command palette/readability without changing the dialog flow

## Validation
- npm run lint
- npm run type-check
- npm test -- electron/native-overlay.test.ts src/components/NativeOverlayHost.test.tsx src/features/command-palette/CommandPalette.test.tsx src/components/Dialog.test.tsx
- npm test


Refs VIM-323