### PR TITLE
fix(ghostty): throttle PTY resize + layer hygiene for live drags

### DIFF
--- a/electron/ghostty-native-parent.test.ts
+++ b/electron/ghostty-native-parent.test.ts
@@ -1233,7 +1233,117 @@ describe('ghostty native parent', () => {
     controller.dispose()
   })
 
-  test('coalesces native resize bursts before resizing the PTY again', () => {
+  test('forwards a steady throttled resize stream during continuous drags', () => {
+    vi.useFakeTimers()
+    let controller: ReturnType<typeof setupGhosttyNativeParent> | null = null
+
+    try {
+      const callbacks: {
+        onResize?: (cols: number, rows: number) => void
+      } = {}
+      const surface = {}
+
+      const addon = {
+        create: vi.fn(
+          (
+            _bridge,
+            _handle,
+            _input,
+            resize,
+            _focus,
+            _shortcut,
+            _renamePane
+          ) => {
+            void _bridge
+            void _handle
+            void _input
+            void _focus
+            void _shortcut
+            void _renamePane
+            callbacks.onResize = resize
+
+            return surface
+          }
+        ),
+        setFrame: vi.fn(),
+        setFontFamily: vi.fn(),
+        write: vi.fn(),
+        focus: vi.fn(),
+        destroy: vi.fn(),
+      }
+
+      const sidecar = {
+        invoke: vi.fn(() => Promise.resolve(undefined)),
+        onEvent: vi.fn(() => vi.fn()),
+        shutdown: vi.fn(() => Promise.resolve()),
+      } as unknown as Sidecar
+
+      controller = setupGhosttyNativeParent({
+        sidecar,
+        platform: 'darwin',
+        env: { VITE_GHOSTTY_NATIVE_MACOS_PARENT: '1' },
+        addon,
+      })
+
+      handlers.get(GHOSTTY_NATIVE_UPDATE)?.(
+        { sender: {} },
+        {
+          sessionId: 'pty-1',
+          paneId: 'pane-1',
+          cwd: '/tmp',
+          visible: true,
+          parentHeight: 900,
+          bounds: { x: 10, y: 20, width: 300, height: 200 },
+        }
+      )
+
+      // Leading edge: the first resize forwards immediately.
+      callbacks.onResize?.(80, 24)
+      callbacks.onResize?.(81, 24)
+      callbacks.onResize?.(82, 24)
+
+      expect(sidecar.invoke).toHaveBeenCalledTimes(1)
+      expect(sidecar.invoke).toHaveBeenCalledWith('resize_pty', {
+        request: { sessionId: 'pty-1', cols: 80, rows: 24 },
+      })
+
+      // Trailing edge: one throttle window later the freshest size forwards.
+      vi.advanceTimersByTime(16)
+
+      expect(sidecar.invoke).toHaveBeenCalledTimes(2)
+      expect(sidecar.invoke).toHaveBeenLastCalledWith('resize_pty', {
+        request: { sessionId: 'pty-1', cols: 82, rows: 24 },
+      })
+
+      // Continuous motion keeps the stream flowing once per window — the
+      // reset-on-change starvation (zero forwards until drag end) is gone.
+      callbacks.onResize?.(83, 24)
+      vi.advanceTimersByTime(16)
+
+      expect(sidecar.invoke).toHaveBeenCalledTimes(3)
+      expect(sidecar.invoke).toHaveBeenLastCalledWith('resize_pty', {
+        request: { sessionId: 'pty-1', cols: 83, rows: 24 },
+      })
+
+      // Idle closes the window; nothing extra fires.
+      vi.advanceTimersByTime(200)
+
+      expect(sidecar.invoke).toHaveBeenCalledTimes(3)
+
+      // After idle the next change is leading-edge immediate again.
+      callbacks.onResize?.(90, 50)
+
+      expect(sidecar.invoke).toHaveBeenCalledTimes(4)
+      expect(sidecar.invoke).toHaveBeenLastCalledWith('resize_pty', {
+        request: { sessionId: 'pty-1', cols: 90, rows: 50 },
+      })
+    } finally {
+      controller?.dispose()
+      vi.useRealTimers()
+    }
+  })
+
+  test('drops a pending resize that reverts to the last forwarded size', () => {
     vi.useFakeTimers()
     let controller: ReturnType<typeof setupGhosttyNativeParent> | null = null
 
@@ -1299,25 +1409,13 @@ describe('ghostty native parent', () => {
 
       callbacks.onResize?.(80, 24)
       callbacks.onResize?.(81, 24)
-      callbacks.onResize?.(82, 24)
+      callbacks.onResize?.(80, 24)
+      vi.advanceTimersByTime(200)
 
       expect(sidecar.invoke).toHaveBeenCalledTimes(1)
       expect(sidecar.invoke).toHaveBeenCalledWith('resize_pty', {
         request: { sessionId: 'pty-1', cols: 80, rows: 24 },
       })
-
-      vi.advanceTimersByTime(200)
-
-      expect(sidecar.invoke).toHaveBeenCalledTimes(2)
-      expect(sidecar.invoke).toHaveBeenLastCalledWith('resize_pty', {
-        request: { sessionId: 'pty-1', cols: 82, rows: 24 },
-      })
-
-      callbacks.onResize?.(83, 24)
-      callbacks.onResize?.(82, 24)
-      vi.advanceTimersByTime(200)
-
-      expect(sidecar.invoke).toHaveBeenCalledTimes(2)
     } finally {
       controller?.dispose()
       vi.useRealTimers()

--- a/electron/ghostty-native-parent.ts
+++ b/electron/ghostty-native-parent.ts
@@ -121,6 +121,7 @@ interface GhosttyNativeSurfaceState {
   lastFontFamily: string | null
   lastResize: { cols: number; rows: number } | null
   resizeTimer: ReturnType<typeof setTimeout> | null
+  pendingResize: { cols: number; rows: number } | null
   lastShortcutDigits: string | null
 }
 
@@ -158,7 +159,19 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const require = createRequire(import.meta.url)
 const MAX_PENDING_CHUNKS = 64
 const MAX_SURFACES = 128
-const GHOSTTY_RESIZE_SETTLE_MS = 120
+// Leading+trailing throttle for PTY resize during live drags. Stock Ghostty
+// forwards every grid change with no timer (Surface.zig sizeCallback, dedupe
+// only); 16ms (~one frame) approximates that cadence while bounding bursts.
+// Env override is the tuning knob from the resize gray-band investigation.
+// An explicit 0 keeps a zero-delay window; empty/garbage/negative values
+// must fall back to the default (Number('') is 0, so guard before Number).
+const throttleMsRaw = process.env.GHOSTTY_RESIZE_THROTTLE_MS?.trim()
+const throttleMsOverride = throttleMsRaw ? Number(throttleMsRaw) : NaN
+
+const GHOSTTY_RESIZE_THROTTLE_MS =
+  Number.isFinite(throttleMsOverride) && throttleMsOverride >= 0
+    ? throttleMsOverride
+    : 16
 
 // Packaged macOS is the shipped Ghostty path. Dev and e2e still opt in with
 // VITE_GHOSTTY_NATIVE_MACOS_PARENT so ordinary local runs can keep the fallback.
@@ -805,6 +818,7 @@ export class GhosttyNativeParentController {
       lastFontFamily: null,
       lastResize: null,
       resizeTimer: null,
+      pendingResize: null,
       lastShortcutDigits: null,
     }
     this.surfaces.set(key, state)
@@ -1066,6 +1080,11 @@ export class GhosttyNativeParentController {
     }
   }
 
+  // Leading+trailing throttle: forward immediately when idle, then hold a
+  // throttle window that flushes the freshest size once per interval while a
+  // drag keeps producing changes. A reset-on-change debounce here starves the
+  // PTY of size updates for the whole drag, which is what let codex's gray
+  // composer rows stack up (see the resize gray-band investigation).
   private queuePtyResize(
     resizeState: GhosttyNativeSurfaceState,
     sessionId: string,
@@ -1081,29 +1100,44 @@ export class GhosttyNativeParentController {
       resizeState.lastResize?.cols === cols &&
       resizeState.lastResize.rows === rows
     ) {
-      this.clearPendingResize(resizeState)
-
-      return
-    }
-
-    if (resizeState.lastResize === null) {
-      this.forwardPtyResize(resizeState, sessionId, cols, rows)
+      resizeState.pendingResize = null
 
       return
     }
 
     if (resizeState.resizeTimer !== null) {
-      clearTimeout(resizeState.resizeTimer)
+      resizeState.pendingResize = { cols, rows }
+
+      return
     }
 
+    this.forwardPtyResize(resizeState, sessionId, cols, rows)
+    this.armResizeThrottle(resizeState, sessionId, canForward)
+  }
+
+  private armResizeThrottle(
+    resizeState: GhosttyNativeSurfaceState,
+    sessionId: string,
+    canForward: () => boolean
+  ): void {
     resizeState.resizeTimer = setTimeout(() => {
       resizeState.resizeTimer = null
-      if (!canForward()) {
+      const pending = resizeState.pendingResize
+      resizeState.pendingResize = null
+      if (pending === null || !canForward()) {
         return
       }
 
-      this.forwardPtyResize(resizeState, sessionId, cols, rows)
-    }, GHOSTTY_RESIZE_SETTLE_MS)
+      if (
+        resizeState.lastResize?.cols === pending.cols &&
+        resizeState.lastResize.rows === pending.rows
+      ) {
+        return
+      }
+
+      this.forwardPtyResize(resizeState, sessionId, pending.cols, pending.rows)
+      this.armResizeThrottle(resizeState, sessionId, canForward)
+    }, GHOSTTY_RESIZE_THROTTLE_MS)
   }
 
   private forwardPtyResize(
@@ -1127,6 +1161,7 @@ export class GhosttyNativeParentController {
       clearTimeout(resizeState.resizeTimer)
     }
     resizeState.resizeTimer = null
+    resizeState.pendingResize = null
   }
 
   private resetSurfaceScopedCaches(state: GhosttyNativeSurfaceState): void {

--- a/native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift
+++ b/native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift
@@ -295,6 +295,8 @@ private final class EmbeddedGhosttyChild {
         let view = TerminalView(frame: .zero)
         view.controller = controller
         view.configuration = TerminalSurfaceOptions(backend: .inMemory(session))
+        // Same stale-contents pinning as the primary terminalView.
+        view.layerContentsPlacement = .topLeft
         self.terminalView = view
     }
 
@@ -439,6 +441,10 @@ private final class EmbeddedGhosttySurface: NSObject {
         view.controller = controller
         view.configuration = TerminalSurfaceOptions(backend: .inMemory(session))
         view.autoresizingMask = [.width, .height]
+        // Ghostty.app pins stale surface contents to the top-left during live
+        // resize (kCAGravityTopLeft on IOSurfaceLayer) instead of letting the
+        // window server stretch the last frame across the new bounds.
+        view.layerContentsPlacement = .topLeft
 
         return view
     }()
@@ -483,18 +489,26 @@ private final class EmbeddedGhosttySurface: NSObject {
         let safeParentHeight = parentHeight.isFinite && parentHeight > 0 ? parentHeight : parentView.bounds.height
         let appKitY = safeParentHeight - y - safeHeight
 
+        // Direct layer writes (unlike AppKit-managed view geometry) pick up
+        // implicit ~0.25s animations, which smear the clip during drags —
+        // Ghostty.app nulls all layer actions. frame rides along so clip and
+        // geometry commit atomically. Clip unconditionally so a stale wider
+        // surface cannot bleed outside the pane between draws.
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
         container.layer?.cornerRadius = CGFloat(safeBottomCornerRadius)
         container.layer?.maskedCorners = [
             .layerMinXMinYCorner,
             .layerMaxXMinYCorner
         ]
-        container.layer?.masksToBounds = safeBottomCornerRadius > 0
+        container.layer?.masksToBounds = true
         container.frame = NSRect(
             x: x,
             y: appKitY,
             width: safeWidth,
             height: safeHeight
         )
+        CATransaction.commit()
         updateLiveResizePrediction(frame: container.frame)
         layoutChildren()
         container.isHidden = safeWidth <= 0 || safeHeight <= 0

--- a/tests/e2e/terminal/specs/keymap-bindings.spec.ts
+++ b/tests/e2e/terminal/specs/keymap-bindings.spec.ts
@@ -238,6 +238,49 @@ const hasElement = async (selector: string): Promise<boolean> =>
     selector
   )
 
+const waitForE2eBridge = async (): Promise<void> => {
+  await browser.waitUntil(
+    async () =>
+      browser.execute(() => typeof window.__VIMEFLOW_E2E__ !== 'undefined'),
+    {
+      timeout: 20_000,
+      interval: 250,
+      timeoutMsg: 'window.__VIMEFLOW_E2E__ missing',
+    }
+  )
+}
+
+const activePtySessionIds = async (): Promise<string[]> =>
+  browser.execute(() => window.__VIMEFLOW_E2E__?.getActiveSessionIds() ?? [])
+
+const isSplitViewDisplayed = async (): Promise<boolean> =>
+  browser.execute(() => {
+    const element = document.querySelector<HTMLElement>(
+      '[data-testid="split-view"]'
+    )
+    if (element === null) {
+      return false
+    }
+
+    const rect = element.getBoundingClientRect()
+    const style = window.getComputedStyle(element)
+
+    return (
+      rect.width > 0 &&
+      rect.height > 0 &&
+      style.display !== 'none' &&
+      style.visibility !== 'hidden'
+    )
+  })
+
+const waitForSplitViewDisplayed = async (): Promise<void> => {
+  await browser.waitUntil(async () => isSplitViewDisplayed(), {
+    timeout: 20_000,
+    interval: 250,
+    timeoutMsg: 'split-view did not become visible',
+  })
+}
+
 const activePaneIndex = async (): Promise<number> =>
   browser.execute(() => {
     const slots = Array.from(
@@ -323,16 +366,28 @@ describe('VIM-104 keymap + Vim mode keybindings', () => {
     await (
       await $('[data-testid="workspace-view"]')
     ).waitForDisplayed({ timeout: 20_000 })
+    await waitForE2eBridge()
 
     // Ensure a terminal session (and therefore a split-view) exists. The
     // app may launch with zero sessions depending on restore state.
-    const sv = await $('[data-testid="split-view"]')
-    if (!(await sv.isExisting())) {
+    if (
+      !(await isSplitViewDisplayed()) &&
+      (await activePtySessionIds()).length === 0
+    ) {
       await createNewSessionWithDefaults()
     }
-    await (
-      await $('[data-testid="split-view"]')
-    ).waitForDisplayed({ timeout: 20_000 })
+
+    await browser.waitUntil(
+      async () =>
+        (await activePtySessionIds()).length > 0 ||
+        (await isSplitViewDisplayed()),
+      {
+        timeout: 20_000,
+        interval: 250,
+        timeoutMsg: 'terminal session did not register',
+      }
+    )
+    await waitForSplitViewDisplayed()
   })
 
   it('Cmd+; opens the command palette', async () => {


### PR DESCRIPTION
## Summary
- `queuePtyResize` becomes a leading+trailing throttle (default 16ms, `GHOSTTY_RESIZE_THROTTLE_MS` override): the first size change forwards immediately and the freshest pending size flushes once per window while a drag continues, replacing the 120ms reset-on-change debounce that starved codex of resize signals for the whole drag. Stock Ghostty forwards every grid change with no timer (`Surface.zig` sizeCallback); codex's composer redraw and 75ms transcript-reflow debounce (`codex-rs/tui`) both depend on receiving that stream, and withholding it is what let reflowed full-width BCE composer rows stack into persistent gray bands.
- Ghostty.app presentation hygiene for the embedded bridge: pin stale surface contents top-left on the primary and secondary `TerminalView`s (`layerContentsPlacement`, mirroring `kCAGravityTopLeft` on IOSurfaceLayer), disable implicit CALayer actions around the per-frame clip writes (mirroring `actionForKey -> NSNull`), and clip the container unconditionally so a stale wider surface cannot bleed outside the pane.

## Test plan
- [x] `npx vitest run electron/ghostty-native-parent.test.ts` — 35 passed, including new throttle-cadence and revert-cancels-pending regression tests
- [x] Repo-wide `npm run lint`, `npm run format:check`, `npm run type-check`; full vitest suite green on pre-push (5370 passed)
- [x] `npm run ghostty:native-parent:build` clean
- [x] Manual feel-test (native Ghostty + codex): live narrow-drag reflows text continuously, composer stays a single box, no stacked gray bands, mid-drag skeleton matches stock Ghostty.app and heals on pause — verified against screen recordings at 19:55/20:20

Refs VIM-325