### PR TITLE
feat(diff): finding threads + agent outcome axis (VIM-304c)

### DIFF
--- a/src/features/diff/agentReplyThread.integration.test.tsx
+++ b/src/features/diff/agentReplyThread.integration.test.tsx
@@ -103,7 +103,7 @@ describe('inline agent Q&A thread (integration)', () => {
     render(<Harness />)
 
     // No agent reply yet.
-    expect(screen.queryByText('Agent reply')).not.toBeInTheDocument()
+    expect(screen.queryByText('Replied')).not.toBeInTheDocument()
 
     await emitReply({
       sessionId: 'pty-1',
@@ -114,8 +114,9 @@ describe('inline agent Q&A thread (integration)', () => {
       ],
     })
 
-    // The reply attached onto the dispatching owner and renders distinctly.
-    expect(screen.getByText('Agent reply')).toBeInTheDocument()
+    // The reply attached onto the dispatching owner and renders distinctly,
+    // carrying its outcome chip (VIM-304 PR-3: "reply" reads as "Replied").
+    expect(screen.getByText('Replied')).toBeInTheDocument()
     expect(screen.getByText('Because latency.')).toBeInTheDocument()
   })
 })

--- a/src/features/diff/components/ReviewCommentRow.test.tsx
+++ b/src/features/diff/components/ReviewCommentRow.test.tsx
@@ -303,6 +303,34 @@ describe('ReviewCommentRow', () => {
       screen.queryByRole('button', { name: 'Delete comment' })
     ).not.toBeInTheDocument()
   })
+
+  test.each([
+    ['reply', 'Replied'],
+    ['clarify', 'Awaiting you'],
+    ['resolved', 'Resolved'],
+    ['deferred', 'Deferred'],
+    ['rejected', 'Rejected'],
+  ] as const)(
+    'an agent turn with outcome %s renders its state chip',
+    (outcome, label) => {
+      render(
+        <ReviewCommentRow
+          comment={{
+            id: 'a',
+            text: 'x',
+            author: 'agent',
+            outcome,
+            createdAt: 1000,
+          }}
+          onEdit={vi.fn()}
+          onDelete={vi.fn()}
+        />
+      )
+
+      expect(screen.getByText(label)).toBeInTheDocument()
+      expect(screen.queryByText('Agent reply')).not.toBeInTheDocument()
+    }
+  )
 })
 
 const MINUTE = 60_000

--- a/src/features/diff/components/ReviewCommentRow.tsx
+++ b/src/features/diff/components/ReviewCommentRow.tsx
@@ -4,7 +4,7 @@ import {
   reviewCommentCategory,
   type ReviewComment,
 } from '../hooks/useFeedbackBatch'
-import { REVIEW_CATEGORY_META } from '../reviewCategoryMeta'
+import { AGENT_OUTCOME_META, REVIEW_CATEGORY_META } from '../reviewCategoryMeta'
 
 interface ReviewCommentRowProps {
   comment: ReviewComment
@@ -88,9 +88,19 @@ export const ReviewCommentRow = ({
               </span>
             </>
           ) : isAgent ? (
-            <span className="inline-flex items-center rounded bg-surface-container-highest/70 px-1.5 py-px text-[10px] font-medium text-success">
-              Agent reply
-            </span>
+            // An outcome-carrying turn (VIM-304 PR-3) shows its state chip;
+            // a plain reply keeps the legacy "Agent reply" treatment.
+            comment.outcome !== undefined ? (
+              <span
+                className={`inline-flex items-center rounded bg-surface-container-highest/70 px-1.5 py-px text-[10px] font-medium ${AGENT_OUTCOME_META[comment.outcome].chip}`}
+              >
+                {AGENT_OUTCOME_META[comment.outcome].label}
+              </span>
+            ) : (
+              <span className="inline-flex items-center rounded bg-surface-container-highest/70 px-1.5 py-px text-[10px] font-medium text-success">
+                Agent reply
+              </span>
+            )
           ) : (
             <span
               className={`inline-flex items-center rounded bg-surface-container-highest/70 px-1.5 py-px text-[10px] font-medium ${categoryMeta.chip}`}

--- a/src/features/diff/components/ReviewLevelNotes.test.tsx
+++ b/src/features/diff/components/ReviewLevelNotes.test.tsx
@@ -15,6 +15,21 @@ import {
 const note = (commentId: string, reviewer: string, text: string): void =>
   addReviewLevelNote('owner', { commentId, reviewer, text, nonce: 'abc' })
 
+test('a main-agent turn on a review-level finding shows its outcome chip', () => {
+  addReviewLevelNote('owner', {
+    commentId: 'c9',
+    reviewer: 'Agent',
+    text: 'Filed as VIM-999.',
+    nonce: 'abc',
+    outcome: 'deferred',
+  })
+
+  render(<ReviewLevelNotes ownerKey="owner" />)
+
+  expect(screen.getByText('Deferred')).toBeInTheDocument()
+  expect(screen.getByText('Filed as VIM-999.')).toBeInTheDocument()
+})
+
 afterEach(() => {
   // Wrap in act(): clearing emits to any still-mounted subscriber before
   // testing-library's auto-cleanup unmounts it.

--- a/src/features/diff/components/ReviewLevelNotes.tsx
+++ b/src/features/diff/components/ReviewLevelNotes.tsx
@@ -3,6 +3,7 @@ import {
   reviewLevelNotes,
   subscribeReviewLevelNotes,
 } from '../services/pendingReviewRequests'
+import { AGENT_OUTCOME_META } from '../reviewCategoryMeta'
 
 interface ReviewLevelNotesProps {
   /** The active file's review; comments for other files are not shown. */
@@ -46,8 +47,17 @@ export const ReviewLevelNotes = ({
             key={note.commentId}
             className="flex flex-col gap-1 rounded-md bg-surface-container-high/70 px-3 py-2"
           >
-            <span className="font-mono text-[0.625rem] font-semibold uppercase tracking-wide text-on-surface-variant">
-              {note.reviewer}
+            <span className="flex items-center gap-1.5">
+              <span className="font-mono text-[0.625rem] font-semibold uppercase tracking-wide text-on-surface-variant">
+                {note.reviewer}
+              </span>
+              {note.outcome !== undefined ? (
+                <span
+                  className={`inline-flex items-center rounded bg-surface-container-highest/70 px-1.5 py-px text-[10px] font-medium ${AGENT_OUTCOME_META[note.outcome].chip}`}
+                >
+                  {AGENT_OUTCOME_META[note.outcome].label}
+                </span>
+              ) : null}
             </span>
             <span className="whitespace-pre-wrap text-xs leading-5 text-on-surface">
               {note.text}

--- a/src/features/diff/hooks/useAgentReply.test.ts
+++ b/src/features/diff/hooks/useAgentReply.test.ts
@@ -13,6 +13,14 @@ import {
   type PendingReview,
   type PendingReviewHandle,
 } from '../services/pendingReviews'
+import {
+  clearFindingThreadRecord,
+  clearReviewLevelNotes,
+  getFindingThreadRecord,
+  reviewLevelNotes,
+  setFindingThreadRecord,
+  type FindingThreadRecord,
+} from '../services/pendingReviewRequests'
 
 type AddForOwner = (
   ownerKey: string,
@@ -104,7 +112,23 @@ beforeEach(() => {
 
 afterEach(() => {
   clearPendingReview('pty-1')
+  clearFindingThreadRecord('pty-1', 'rev')
+  clearReviewLevelNotes('owner-r')
   delete window.vimeflow
+})
+
+const findingRecord = (
+  overrides: Partial<FindingThreadRecord> = {}
+): FindingThreadRecord => ({
+  ptyId: 'pty-1',
+  nonce: 'rev',
+  ownerKey: 'owner-r',
+  byOrdinal: new Map([
+    [1, { kind: 'anchored', commentId: 'rev-1', handle: handle() }],
+    [2, { kind: 'reviewLevel', commentId: 'rev-2' }],
+  ]),
+  seenReplies: new Set(),
+  ...overrides,
 })
 
 describe('useAgentReply', () => {
@@ -135,6 +159,8 @@ describe('useAgentReply', () => {
     expect(annotation.metadata.author).toBe('agent')
     expect(annotation.metadata.text).toBe('Because latency.')
     expect(annotation.lineNumber).toBe(5)
+    // The agent turn carries its outcome (VIM-304 PR-3).
+    expect(annotation.metadata.outcome).toBe('reply')
   })
 
   test('ignores an event whose nonce does not match (superseded dispatch)', async () => {
@@ -305,5 +331,146 @@ describe('useAgentReply', () => {
     await emit(reply) // replay — record was cleared, so nothing happens
 
     expect(addAnnotationForOwner).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('finding-thread replies (VIM-304 PR-3)', () => {
+  test('attaches a target:finding turn at the anchored finding with its outcome', async () => {
+    setFindingThreadRecord(findingRecord())
+    mount()
+    await emit(
+      event({
+        nonce: 'rev',
+        replies: [
+          { id: 1, status: 'resolved', target: 'finding', text: 'Fixed it.' },
+        ],
+      })
+    )
+
+    expect(addAnnotationForOwner).toHaveBeenCalledTimes(1)
+
+    const [ownerKey, cwd, filePath, staged, annotation] =
+      addAnnotationForOwner.mock.calls[0]
+    expect(ownerKey).toBe('owner-r')
+    expect(cwd).toBe('/repo')
+    expect(filePath).toBe('a.ts')
+    expect(staged).toBe(false)
+    expect(annotation.lineNumber).toBe(5)
+    expect(annotation.side).toBe('additions')
+    expect(annotation.metadata.author).toBe('agent')
+    expect(annotation.metadata.outcome).toBe('resolved')
+    expect(annotation.metadata.text).toBe('Fixed it.')
+  })
+
+  test('gates on session: the same nonce from another pty is ignored', async () => {
+    setFindingThreadRecord(findingRecord())
+    mount()
+    await emit(
+      event({
+        sessionId: 'pty-2',
+        nonce: 'rev',
+        replies: [
+          { id: 1, status: 'resolved', target: 'finding', text: 'Fixed it.' },
+        ],
+      })
+    )
+
+    expect(addAnnotationForOwner).not.toHaveBeenCalled()
+  })
+
+  test('a reviewLevel-target turn lands as a review-level note with outcome', async () => {
+    setFindingThreadRecord(findingRecord())
+    mount()
+    await emit(
+      event({
+        nonce: 'rev',
+        replies: [
+          {
+            id: 2,
+            status: 'deferred',
+            target: 'finding',
+            text: 'Filed as VIM-999.',
+          },
+        ],
+      })
+    )
+
+    expect(addAnnotationForOwner).not.toHaveBeenCalled()
+    const notes = reviewLevelNotes('owner-r')
+    expect(notes).toHaveLength(1)
+    expect(notes[0].text).toBe('Filed as VIM-999.')
+    expect(notes[0].outcome).toBe('deferred')
+  })
+
+  test('an unknown ordinal is skipped without touching the thread', async () => {
+    setFindingThreadRecord(findingRecord())
+    mount()
+    await emit(
+      event({
+        nonce: 'rev',
+        replies: [{ id: 99, status: 'resolved', target: 'finding', text: 'x' }],
+      })
+    )
+
+    expect(addAnnotationForOwner).not.toHaveBeenCalled()
+    expect(reviewLevelNotes('owner-r')).toHaveLength(0)
+  })
+
+  test('an exact duplicate turn attaches once; a new turn on the same finding attaches', async () => {
+    setFindingThreadRecord(findingRecord())
+    mount()
+
+    const turn = event({
+      nonce: 'rev',
+      replies: [
+        { id: 1, status: 'clarify', target: 'finding', text: 'Which env?' },
+      ],
+    })
+    await emit(turn)
+    await emit(turn) // replay of the same turn — no duplicate
+
+    expect(addAnnotationForOwner).toHaveBeenCalledTimes(1)
+    expect(addAnnotationForOwner.mock.calls[0][4].metadata.outcome).toBe(
+      'clarify'
+    )
+
+    // The thread lives on: a later different turn attaches.
+    await emit(
+      event({
+        nonce: 'rev',
+        replies: [
+          { id: 1, status: 'resolved', target: 'finding', text: 'Done.' },
+        ],
+      })
+    )
+
+    expect(addAnnotationForOwner).toHaveBeenCalledTimes(2)
+    expect(getFindingThreadRecord('pty-1', 'rev')).toBeDefined()
+  })
+
+  test('a malformed marker with a review nonce degrades to one review-level note', async () => {
+    setFindingThreadRecord(findingRecord())
+    mount()
+    await emit(event({ nonce: 'rev', replies: null, rawText: 'garbled block' }))
+
+    expect(addAnnotationForOwner).not.toHaveBeenCalled()
+    const notes = reviewLevelNotes('owner-r')
+    expect(notes).toHaveLength(1)
+    expect(notes[0].text).toBe('garbled block')
+    // The record is NOT consumed — the thread can still continue.
+    expect(getFindingThreadRecord('pty-1', 'rev')).toBeDefined()
+  })
+
+  test('target:comment replies never resolve against the finding space', async () => {
+    setFindingThreadRecord(findingRecord())
+    mount()
+    await emit(
+      event({
+        nonce: 'rev',
+        replies: [{ id: 1, status: 'reply', target: 'comment', text: 'x' }],
+      })
+    )
+
+    expect(addAnnotationForOwner).not.toHaveBeenCalled()
   })
 })

--- a/src/features/diff/hooks/useAgentReply.ts
+++ b/src/features/diff/hooks/useAgentReply.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 import { listen } from '@/lib/backend'
 import { isDesktop } from '@/lib/environment'
-import type { AgentReplyEvent } from '@/bindings'
+import type { AgentReplyEvent, AgentReplyStatus } from '@/bindings'
 import type { DiffLineAnnotation } from '@pierre/diffs'
 import type { ReviewComment } from './useFeedbackBatch'
 import {
@@ -10,6 +10,14 @@ import {
   setPendingReview,
   type PendingReviewHandle,
 } from '../services/pendingReviews'
+import {
+  addReviewLevelNote,
+  getFindingThreadRecord,
+  type FindingThreadRecord,
+} from '../services/pendingReviewRequests'
+
+/** Identity label for a main-agent turn shown on the review-level surface. */
+const AGENT_REVIEW_LEVEL_LABEL = 'Agent'
 
 export interface UseAgentReplyOptions {
   /** Attach an annotation onto a specific feedback owner (the dispatching one). */
@@ -51,7 +59,8 @@ export const useAgentReply = ({
     const attachAgentNote = (
       ownerKey: string,
       handle: PendingReviewHandle,
-      text: string
+      text: string,
+      outcome?: AgentReplyStatus
     ): 'ok' | 'cap-reached' =>
       addAnnotationForOwner(
         ownerKey,
@@ -69,18 +78,88 @@ export const useAgentReply = ({
             // Inherit the original comment's scope so a file-level reply stays
             // file-scoped and a range reply keeps its span (VIM-249).
             ...(handle.target === undefined ? {} : { target: handle.target }),
+            ...(outcome === undefined ? {} : { outcome }),
           },
         }
       )
 
+    // A turn posted into a delegated finding's thread (VIM-304 PR-3). The
+    // record is never consumed — threads are multi-turn — so an exact
+    // duplicate turn is the replay no-op instead.
+    const handleFindingTurns = (
+      record: FindingThreadRecord,
+      event: AgentReplyEvent
+    ): void => {
+      // Malformed marker: degrade to one review-level note; the living thread
+      // record survives one garbled turn.
+      if (event.replies === null) {
+        addReviewLevelNote(record.ownerKey, {
+          commentId: nextCommentId(),
+          reviewer: AGENT_REVIEW_LEVEL_LABEL,
+          text: event.rawText,
+          nonce: record.nonce,
+        })
+
+        return
+      }
+
+      for (const reply of event.replies) {
+        if (reply.target !== 'finding') {
+          continue
+        }
+
+        const target = record.byOrdinal.get(reply.id)
+        if (target === undefined) {
+          continue
+        }
+
+        const turnKey = `${reply.id}\u0000${reply.status}\u0000${reply.text}`
+        if (record.seenReplies.has(turnKey)) {
+          continue
+        }
+
+        if (target.kind === 'anchored') {
+          const result = attachAgentNote(
+            record.ownerKey,
+            target.handle,
+            reply.text,
+            reply.status
+          )
+          if (result === 'ok') {
+            record.seenReplies.add(turnKey)
+          }
+          continue
+        }
+
+        addReviewLevelNote(record.ownerKey, {
+          commentId: nextCommentId(),
+          reviewer: AGENT_REVIEW_LEVEL_LABEL,
+          text: reply.text,
+          nonce: record.nonce,
+          outcome: reply.status,
+        })
+        record.seenReplies.add(turnKey)
+      }
+    }
+
     const handleReply = (event: AgentReplyEvent): void => {
+      if (event.nonce === null) {
+        return
+      }
+
+      // The nonce names the dispatch a turn answers: a review nonce resolves
+      // against the finding-thread record (same session + nonce gate), a
+      // feedback nonce against the pending [#n] handles below.
+      const record = getFindingThreadRecord(event.sessionId, event.nonce)
+      if (record !== undefined) {
+        handleFindingTurns(record, event)
+
+        return
+      }
+
       const pending = getPendingReview(event.sessionId)
       // Session + nonce gate: only a reply to the current dispatch proceeds.
-      if (
-        pending === undefined ||
-        event.nonce === null ||
-        event.nonce !== pending.nonce
-      ) {
+      if (event.nonce !== pending?.nonce) {
         return
       }
 
@@ -95,7 +174,12 @@ export const useAgentReply = ({
             continue
           }
 
-          const result = attachAgentNote(pending.ownerKey, handle, reply.text)
+          const result = attachAgentNote(
+            pending.ownerKey,
+            handle,
+            reply.text,
+            reply.status
+          )
           if (result === 'ok') {
             pending.byHandle.delete(reply.id) // consume so a replay can't re-attach
           }

--- a/src/features/diff/hooks/useAgentReview.test.ts
+++ b/src/features/diff/hooks/useAgentReview.test.ts
@@ -8,8 +8,10 @@ import type { AgentReviewEvent, AgentReviewFinding } from '@/bindings'
 import { REVIEWER_FINDING_SOFT_CAP, useAgentReview } from './useAgentReview'
 import type { ReviewComment } from './useFeedbackBatch'
 import {
+  clearFindingThreadRecord,
   clearPendingReviewRequest,
   clearReviewLevelNotes,
+  getFindingThreadRecord,
   reviewLevelNotes,
   setPendingReviewRequest,
   type PendingReviewRequest,
@@ -115,6 +117,7 @@ beforeEach(() => {
 afterEach(() => {
   clearPendingReviewRequest('abc')
   clearReviewLevelNotes('owner')
+  clearFindingThreadRecord('pty-1', 'abc')
   delete window.vimeflow
 })
 
@@ -293,5 +296,85 @@ describe('useAgentReview', () => {
     expect(reviewLevelNotes('owner').map((note) => note.text)).toEqual([
       `2 additional reviewer findings were omitted because this review exceeded the ${REVIEWER_FINDING_SOFT_CAP}-finding display limit.`,
     ])
+  })
+})
+
+describe('finding-thread transition (VIM-304 PR-3)', () => {
+  test('transitions the processed request into a record keyed (ptyId, nonce)', async () => {
+    setPendingReviewRequest(request())
+    mount()
+    await emit(
+      event({
+        findings: [
+          finding(), // line 42, in-hunk → anchored, ordinal 1
+          finding({ path: 'other.ts' }), // off-snapshot → review-level, ordinal 2
+        ],
+      })
+    )
+
+    const record = getFindingThreadRecord('pty-1', 'abc')
+    expect(record?.ownerKey).toBe('owner')
+
+    const anchored = record?.byOrdinal.get(1)
+    expect(anchored?.kind).toBe('anchored')
+    if (anchored?.kind === 'anchored') {
+      // The record's commentId is the placed annotation's id, so a later
+      // reply addresses the exact comment the finding rendered as.
+      const placed = addAnnotationForOwner.mock.calls[0][4]
+      expect(anchored.commentId).toBe(placed.metadata.id)
+      expect(anchored.handle).toEqual({
+        cwd: '/repo',
+        filePath: 'a.ts',
+        staged: false,
+        lineNumber: 42,
+        side: 'additions',
+        target: undefined,
+      })
+    }
+
+    const reviewLevel = record?.byOrdinal.get(2)
+    expect(reviewLevel?.kind).toBe('reviewLevel')
+    if (reviewLevel?.kind === 'reviewLevel') {
+      expect(reviewLevel.commentId).toBe(reviewLevelNotes('owner')[0].commentId)
+    }
+  })
+
+  test('an anchored range finding carries its range target into the handle', async () => {
+    setPendingReviewRequest(request())
+    mount()
+    await emit(
+      event({
+        findings: [
+          finding({ scope: 'range', line: null, startLine: 41, endLine: 44 }),
+        ],
+      })
+    )
+
+    const target = getFindingThreadRecord('pty-1', 'abc')?.byOrdinal.get(1)
+    expect(target?.kind).toBe('anchored')
+    if (target?.kind === 'anchored') {
+      expect(target.handle.target).toEqual({
+        scope: 'range',
+        side: 'additions',
+        startLine: 41,
+        endLine: 44,
+      })
+    }
+  })
+
+  test('a malformed event (findings: null) leaves no finding-thread record', async () => {
+    setPendingReviewRequest(request())
+    mount()
+    await emit(event({ findings: null }))
+
+    expect(getFindingThreadRecord('pty-1', 'abc')).toBeUndefined()
+  })
+
+  test('a clean review (empty findings) leaves no record', async () => {
+    setPendingReviewRequest(request())
+    mount()
+    await emit(event({ findings: [] }))
+
+    expect(getFindingThreadRecord('pty-1', 'abc')).toBeUndefined()
   })
 })

--- a/src/features/diff/hooks/useAgentReview.ts
+++ b/src/features/diff/hooks/useAgentReview.ts
@@ -12,6 +12,8 @@ import {
   addReviewLevelNote,
   clearPendingReviewRequest,
   getPendingReviewRequest,
+  setFindingThreadRecord,
+  type FindingThreadTarget,
   type HunkRange,
   type ReviewedFile,
 } from '../services/pendingReviewRequests'
@@ -158,17 +160,25 @@ export const useAgentReview = ({
       const findingsToPlace = event.findings.slice(0, REVIEWER_FINDING_SOFT_CAP)
       const omittedCount = event.findings.length - findingsToPlace.length
 
-      for (const finding of findingsToPlace) {
+      // Each placed finding becomes a thread root the main agent can post into
+      // (VIM-304 PR-3): its 1-based block ordinal maps to where it landed.
+      // Cap-omitted findings have no entry — they were never placed.
+      const byOrdinal = new Map<number, FindingThreadTarget>()
+
+      for (const [index, finding] of findingsToPlace.entries()) {
+        const ordinal = index + 1
         const file = findFile(diffSnapshot, finding.path)
 
         // path not in the reviewed diff → no (path, staged) row to anchor under.
         if (file === undefined) {
+          const commentId = nextCommentId()
           addReviewLevelNote(ownerKey, {
-            commentId: nextCommentId(),
+            commentId,
             reviewer,
             text: finding.text,
             nonce,
           })
+          byOrdinal.set(ordinal, { kind: 'reviewLevel', commentId })
           continue
         }
 
@@ -183,13 +193,24 @@ export const useAgentReview = ({
             : finding.line !== null && lineInRanges(finding.line, ranges)
         const downgradeToFile = finding.scope !== 'file' && !targetInHunk
 
-        addAnnotationForOwner(
-          ownerKey,
-          cwd,
-          finding.path,
-          staged,
-          reviewerAnnotation(finding, reviewer, downgradeToFile)
+        const annotation = reviewerAnnotation(
+          finding,
+          reviewer,
+          downgradeToFile
         )
+        addAnnotationForOwner(ownerKey, cwd, finding.path, staged, annotation)
+        byOrdinal.set(ordinal, {
+          kind: 'anchored',
+          commentId: annotation.metadata.id,
+          handle: {
+            cwd,
+            filePath: finding.path,
+            staged,
+            lineNumber: annotation.lineNumber,
+            side: annotation.side,
+            target: annotation.metadata.target,
+          },
+        })
       }
 
       if (omittedCount > 0) {
@@ -201,6 +222,18 @@ export const useAgentReview = ({
         })
       }
 
+      // Transition (not merely clear): the request becomes the finding-thread
+      // record so `target:'finding'` replies can resolve; a replayed
+      // `agent-review` still finds no pending request and is a no-op.
+      if (byOrdinal.size > 0) {
+        setFindingThreadRecord({
+          ptyId: event.sessionId,
+          nonce,
+          ownerKey,
+          byOrdinal,
+          seenReplies: new Set(),
+        })
+      }
       clearPendingReviewRequest(event.nonce)
     }
 

--- a/src/features/diff/hooks/useFeedbackBatch.ts
+++ b/src/features/diff/hooks/useFeedbackBatch.ts
@@ -13,6 +13,7 @@
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { AnnotationSide, DiffLineAnnotation } from '@pierre/diffs'
+import type { AgentReplyStatus } from '@/bindings'
 
 /**
  * The user's one-axis tag on a review comment (VIM-256/253). It is the
@@ -56,6 +57,13 @@ export interface ReviewComment {
    * (VIM-304). Absent → DEFAULT_REVIEW_COMMENT_CATEGORY. Not set on agent replies.
    */
   category?: ReviewCommentCategory
+  /**
+   * The outcome axis of an agent turn (VIM-304 PR-3), set when
+   * `author === 'agent'`: reply / clarify / resolved / deferred / rejected.
+   * The user/reviewer raise (category = intent); the main agent responds
+   * (outcome). A thread's rollup status derives from the latest agent turn.
+   */
+  outcome?: AgentReplyStatus
   createdAt: number
   /**
    * When set, the comment has been dispatched to an agent and now stays in the

--- a/src/features/diff/reviewCategoryMeta.ts
+++ b/src/features/diff/reviewCategoryMeta.ts
@@ -1,3 +1,4 @@
+import type { AgentReplyStatus } from '@/bindings'
 import type { ReviewCommentCategory } from './hooks/useFeedbackBatch'
 
 /**
@@ -13,4 +14,20 @@ export const REVIEW_CATEGORY_META: Record<
   change: { label: 'Change', chip: 'text-tertiary' },
   bug: { label: 'Bug', chip: 'text-error' },
   suggestion: { label: 'Suggestion', chip: 'text-secondary' },
+}
+
+/**
+ * The UI face of an agent turn's outcome (VIM-304 PR-3) — the state chip on an
+ * `author: 'agent'` row. `clarify` reads as "Awaiting you": the thread is
+ * waiting on the user. A thread's rollup derives from its latest agent turn.
+ */
+export const AGENT_OUTCOME_META: Record<
+  AgentReplyStatus,
+  { label: string; chip: string }
+> = {
+  reply: { label: 'Replied', chip: 'text-success' },
+  clarify: { label: 'Awaiting you', chip: 'text-primary' },
+  resolved: { label: 'Resolved', chip: 'text-success' },
+  deferred: { label: 'Deferred', chip: 'text-secondary' },
+  rejected: { label: 'Rejected', chip: 'text-error' },
 }

--- a/src/features/diff/services/feedbackDispatch.test.ts
+++ b/src/features/diff/services/feedbackDispatch.test.ts
@@ -224,6 +224,32 @@ test('the footer instructs the agent to emit the reply block with the nonce', ()
   expect(payload).toContain('VIMEFLOW_REPLY>>>')
 })
 
+test('the footer teaches the outcome vocabulary, not the legacy literals', () => {
+  const payload = formatFeedbackPayload(
+    [
+      {
+        filePath: 'src/a.ts',
+        staged: false,
+        annotations: [makeAnnotation(5, 'additions', 'Why?', 'question')],
+      },
+    ],
+    'n0nc3'
+  )
+
+  for (const outcome of [
+    '"reply"',
+    '"clarify"',
+    '"resolved"',
+    '"deferred"',
+    '"rejected"',
+  ]) {
+    expect(payload).toContain(outcome)
+  }
+  expect(payload).toContain('"status":"reply"')
+  expect(payload).not.toContain('"answered"')
+  expect(payload).not.toContain('"skipped"')
+})
+
 test('dispatchFeedbackBatch calls writePty once with paste-bracketed payload', async () => {
   const writePty = vi.fn().mockResolvedValue(undefined)
 

--- a/src/features/diff/services/feedbackDispatch.ts
+++ b/src/features/diff/services/feedbackDispatch.ts
@@ -114,9 +114,9 @@ export const formatFeedbackPayload = (
     ...blocks,
     '> ―',
     '> When done, end your reply with this exact block, echoing the nonce verbatim.',
-    '> status is one of: "answered" (a question), "changed" (you edited files), "skipped".',
+    '> status is one of: "reply" (answers a question), "clarify" (you need the user to answer — the thread awaits them), "resolved" (you made the change), "deferred" (punted for later; cite the issue # in text), "rejected" (declined).',
     '> <<<VIMEFLOW_REPLY',
-    `> {"v":1,"nonce":"${nonce}","replies":[{"id":1,"status":"answered","text":"..."}]}`,
+    `> {"v":1,"nonce":"${nonce}","replies":[{"id":1,"status":"reply","text":"..."}]}`,
     '> VIMEFLOW_REPLY>>>',
   ].join('\n')
 }

--- a/src/features/diff/services/pendingReviewRequests.test.ts
+++ b/src/features/diff/services/pendingReviewRequests.test.ts
@@ -2,12 +2,16 @@ import { afterEach, describe, expect, test } from 'vitest'
 import {
   addReviewLevelNote,
   buildDiffSnapshot,
+  clearFindingThreadRecord,
   clearPendingReviewRequest,
   clearReviewLevelNotes,
+  getFindingThreadRecord,
   getPendingReviewRequest,
   prunePendingReviewRequestOwners,
   reviewLevelNotes,
+  setFindingThreadRecord,
   setPendingReviewRequest,
+  type FindingThreadRecord,
   type PendingReviewRequest,
 } from './pendingReviewRequests'
 import type { FileDiff } from '../types'
@@ -30,6 +34,35 @@ afterEach(() => {
   clearReviewLevelNotes('owner')
   clearReviewLevelNotes('sess:pane')
   clearReviewLevelNotes('stale-owner')
+  clearFindingThreadRecord('pty-1', 'abc')
+  clearFindingThreadRecord('pty-1', 'stale')
+})
+
+const threadRecord = (
+  overrides: Partial<FindingThreadRecord> = {}
+): FindingThreadRecord => ({
+  ptyId: 'pty-1',
+  nonce: 'abc',
+  ownerKey: 'sess:pane',
+  byOrdinal: new Map([
+    [
+      1,
+      {
+        kind: 'anchored',
+        commentId: 'rev-1',
+        handle: {
+          cwd: '/repo',
+          filePath: 'a.ts',
+          staged: false,
+          lineNumber: 42,
+          side: 'additions',
+          target: undefined,
+        },
+      },
+    ],
+  ]),
+  seenReplies: new Set(),
+  ...overrides,
 })
 
 describe('pendingReviewRequests', () => {
@@ -66,6 +99,38 @@ describe('pendingReviewRequests', () => {
 
     expect(getPendingReviewRequest('abc')?.ownerKey).toBe('sess:pane')
     expect(getPendingReviewRequest('stale')).toBeUndefined()
+  })
+})
+
+describe('findingThreadRecords', () => {
+  test('set then get keyed by (ptyId, nonce)', () => {
+    setFindingThreadRecord(threadRecord())
+
+    expect(getFindingThreadRecord('pty-1', 'abc')?.ownerKey).toBe('sess:pane')
+    expect(getFindingThreadRecord('pty-1', 'abc')?.byOrdinal.get(1)?.kind).toBe(
+      'anchored'
+    )
+    // The pty is part of the key — the same nonce on another pty is no match.
+    expect(getFindingThreadRecord('pty-2', 'abc')).toBeUndefined()
+  })
+
+  test('clear removes the record', () => {
+    setFindingThreadRecord(threadRecord())
+    clearFindingThreadRecord('pty-1', 'abc')
+
+    expect(getFindingThreadRecord('pty-1', 'abc')).toBeUndefined()
+  })
+
+  test('prunePendingReviewRequestOwners removes records for closed owners', () => {
+    setFindingThreadRecord(threadRecord())
+    setFindingThreadRecord(
+      threadRecord({ nonce: 'stale', ownerKey: 'stale-owner' })
+    )
+
+    prunePendingReviewRequestOwners(new Set(['sess:pane']))
+
+    expect(getFindingThreadRecord('pty-1', 'abc')?.nonce).toBe('abc')
+    expect(getFindingThreadRecord('pty-1', 'stale')).toBeUndefined()
   })
 })
 

--- a/src/features/diff/services/pendingReviewRequests.ts
+++ b/src/features/diff/services/pendingReviewRequests.ts
@@ -5,6 +5,7 @@
  * compatible with VIM-297). Not persisted — the placed reviewer annotations
  * persist via the feedback store (VIM-282); this is just the routing + snapshot.
  */
+import type { AgentReplyStatus } from '@/bindings'
 import type { FileDiff } from '../types'
 import type { PendingReviewHandle } from './pendingReviews'
 
@@ -97,6 +98,12 @@ export interface ReviewLevelNote {
   reviewer: string
   text: string
   nonce: string
+  /**
+   * Set when the note is a main-agent turn on a review-level finding thread
+   * (VIM-304 PR-3) — the outcome axis, rendered as the same state chip the
+   * anchored agent turns get.
+   */
+  outcome?: AgentReplyStatus
 }
 
 const reviewLevelByOwner = new Map<string, ReviewLevelNote[]>()

--- a/src/features/diff/services/pendingReviewRequests.ts
+++ b/src/features/diff/services/pendingReviewRequests.ts
@@ -6,6 +6,7 @@
  * persist via the feedback store (VIM-282); this is just the routing + snapshot.
  */
 import type { FileDiff } from '../types'
+import type { PendingReviewHandle } from './pendingReviews'
 
 /** A diff-side line range (inclusive) from the reviewed hunks. */
 export interface HunkRange {
@@ -145,12 +146,73 @@ export const clearReviewLevelNotes = (ownerKey: string): void => {
   emitNotes()
 }
 
+/**
+ * Where one placed finding landed (VIM-304 PR-3): an anchored hunk annotation
+ * (with the placement handle a later agent reply re-uses so the turn renders
+ * co-located with the finding) or a review-level note. Either way the stable
+ * `commentId` names the finding's thread root.
+ */
+export type FindingThreadTarget =
+  | { kind: 'anchored'; commentId: string; handle: PendingReviewHandle }
+  | { kind: 'reviewLevel'; commentId: string }
+
+/**
+ * A processed review request, transitioned (not cleared) so its findings stay
+ * addressable as thread roots: `target:'finding'` replies resolve
+ * `(sessionId, nonce, ordinal)` against this — the same session + nonce gate
+ * as the reply path. Ordinals are the finding's 1-based index in the review
+ * block, which the emitting agent knows. The record lives for the thread's
+ * life; a replayed `agent-review` finds no pending request and is a no-op.
+ */
+export interface FindingThreadRecord {
+  ptyId: string
+  nonce: string
+  /** The feedback owner (sessionId:paneId) the review routed to. */
+  ownerKey: string
+  /** 1-based block ordinal → where that finding landed. */
+  byOrdinal: Map<number, FindingThreadTarget>
+  /**
+   * Replay guard for a living thread: the record is never consumed (threads
+   * are multi-turn), so an exact duplicate turn (ordinal + outcome + text)
+   * attaches once and re-emissions are no-ops.
+   */
+  seenReplies: Set<string>
+}
+
+const threadKey = (ptyId: string, nonce: string): string =>
+  `${ptyId}\u0000${nonce}`
+
+const findingThreads = new Map<string, FindingThreadRecord>()
+
+export const setFindingThreadRecord = (record: FindingThreadRecord): void => {
+  findingThreads.set(threadKey(record.ptyId, record.nonce), record)
+}
+
+export const getFindingThreadRecord = (
+  ptyId: string,
+  nonce: string
+): FindingThreadRecord | undefined =>
+  findingThreads.get(threadKey(ptyId, nonce))
+
+export const clearFindingThreadRecord = (
+  ptyId: string,
+  nonce: string
+): void => {
+  findingThreads.delete(threadKey(ptyId, nonce))
+}
+
 export const prunePendingReviewRequestOwners = (
   liveOwnerKeys: ReadonlySet<string>
 ): void => {
   for (const [nonce, request] of store) {
     if (!liveOwnerKeys.has(request.ownerKey)) {
       store.delete(nonce)
+    }
+  }
+
+  for (const [key, record] of findingThreads) {
+    if (!liveOwnerKeys.has(record.ownerKey)) {
+      findingThreads.delete(key)
     }
   }
 


### PR DESCRIPTION
## Summary
- **Finding-thread record (Task 15):** a processed review request now *transitions* into a record keyed `(ptyId, nonce)` instead of being cleared — each placed finding's 1-based block ordinal maps to where it landed (anchored placement handle + stable `commentId`, or a review-level note), pruned with its owner. Replayed `agent-review` events stay no-ops.
- **Unified reply target (Task 16):** `useAgentReply` resolves a turn by its nonce space — a review nonce resolves `(sessionId, nonce, ordinal)` against the finding-thread record under the same session + nonce gate as the `[#n]` path, attaching an `author:'agent'` annotation carrying the turn's `outcome` at the finding (anchored or review-level). Records are never consumed (threads are multi-turn); exact duplicate turns are replay no-ops. Comment-path replies now carry their `outcome` too, and the reply-block prompt teaches the migrated vocabulary (`reply` / `clarify` / `resolved` / `deferred` / `rejected`) so the agent-facing schema matches the parser shipped in #679.
- **Outcome chips (Task 17):** `author:'agent'` turns render their state chip (Replied / Awaiting you / Resolved / Deferred / Rejected); review-level agent turns get the same chip on the off-file surface; outcome-less replies keep the legacy "Agent reply" treatment.

Completes the frontend half of VIM-310 (PR-3b); the backend half (outcome enum + `target` discriminator) shipped as #679. Spec §4 / plan Tasks 15–17 in `docs/superpowers/{specs,plans}/2026-07-07-delegated-review-hunk-comments*`. Multi-turn thread rendering and the user's outbound reply dispatch remain VIM-298 / VIM-297.

Closes VIM-310. Part of VIM-304.

## Test plan
- [x] `npx vitest run src/features/diff src/features/workspace` — 1439 passed (15 new: record transition, union resolution + gates + replay guard, outcome chips)
- [x] Repo-wide `npm run lint`, `npm run format:check`, `npm run type-check` — green
- [x] `cargo test -p vimeflow agent::` — 695 passed
- [x] Full vitest suite green on pre-push