### PR TITLE
feat(diff): per-comment dispatch (VIM-297)

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -52,7 +52,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 31       | 25   | 2026-07-09   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)                                             | cross-platform     | 14       | 12   | 2026-07-09   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                                                       | code-quality       | 7        | 0    | 2026-06-11   |
-| [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 29       | 22   | 2026-07-09   |
+| [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 30       | 23   | 2026-07-11   |
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 8        | 2    | 2026-06-19   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 4        | 0    | 2026-06-21   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -101,7 +101,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [String Construction Hygiene](patterns/string-construction-hygiene.md)                               | code-quality       | 2        | 1    | 2026-06-19   |
 | [Agent-State Guards](patterns/agent-state-guards.md)                                                 | correctness        | 15       | 10   | 2026-07-05   |
 | [React Prop Contracts](patterns/react-prop-contracts.md)                                             | react-patterns     | 11       | 6    | 2026-07-09   |
-| [Stale Retained Interactions](patterns/stale-retained-interactions.md)                               | react-patterns     | 10       | 9    | 2026-07-04   |
+| [Stale Retained Interactions](patterns/stale-retained-interactions.md)                               | react-patterns     | 11       | 9    | 2026-07-11   |
 | [Retained State Identity](patterns/retained-state-identity.md)                                       | react-patterns     | 5        | 4    | 2026-07-08   |
 | [Authoritative Completion Guard](patterns/authoritative-completion-guard.md)                         | correctness        | 7        | 4    | 2026-07-05   |
 | [Equality Guard Completeness](patterns/equality-guard-completeness.md)                               | correctness        | 2        | 0    | 2026-06-17   |

--- a/docs/reviews/patterns/derived-state-consistency.md
+++ b/docs/reviews/patterns/derived-state-consistency.md
@@ -2,8 +2,8 @@
 id: derived-state-consistency
 category: code-quality
 created: 2026-06-07
-last_updated: 2026-07-09
-ref_count: 22
+last_updated: 2026-07-11
+ref_count: 23
 ---
 
 # Derived State Consistency
@@ -385,4 +385,19 @@ base data is technically "correct."
 - **Fix:** Retain the latest pre-load broadcast as the load base and overlay any
   pending local patch before rendering or saving. Added regression coverage for
   a broadcast arriving between a local pre-load edit and the load resolution.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 30. Request-review gates ignored single-comment Finish popovers
+
+- **Source:** github-claude | PR #684 round 1 | 2026-07-11
+- **Severity:** MEDIUM
+- **File:** `src/features/diff/Panel.tsx`
+- **Finding:** The Finish feedback popover's rendered open state was expanded
+  from `finishOpen` to `finishOpen || sendNowCommentId !== null`, but the
+  Request-review shortcut and toolbar gates still checked only `finishOpen`.
+  Opening "Send comment now" could therefore leave Request-review enabled and
+  allow two confirmation popovers to render at once.
+- **Fix:** Derived a single `isFinishPopoverOpen` value and reused it for the
+  Finish popover state plus both Request-review entry gates, so the shortcut
+  and toolbar share the same exclusivity contract.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/stale-retained-interactions.md
+++ b/docs/reviews/patterns/stale-retained-interactions.md
@@ -2,7 +2,7 @@
 id: stale-retained-interactions
 category: react-patterns
 created: 2026-06-15
-last_updated: 2026-07-04
+last_updated: 2026-07-11
 ref_count: 9
 ---
 
@@ -107,4 +107,13 @@ When a React component renders retained or stale content while fresh data for a 
 - **File:** `src/features/diff/Panel.tsx`
 - **Finding:** New-comment entry points cleared draft text when switching to a different annotation target, but left the independently retained comment category unchanged. A user could abandon a Question, Bug, or Suggestion draft, open another blank comment on a different line or file, and dispatch the unrelated comment with the stale intent category.
 - **Fix:** Mirrored the target-identity reset for comment category in the line, file, and body add-comment paths. When a new annotation target differs from the current draft target, the draft text is cleared and the category returns to the default together.
+- **Commit:** same commit as this entry
+
+### 11. Single-comment send cleared unrelated review drafts
+
+- **Source:** github-codex-connector | PR #684 round 1 | 2026-07-11
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/diff/Panel.tsx`
+- **Finding:** The single-comment send-now flow dispatched only the addressed pending row, but still called the whole-batch `markDispatched` path that cleared the owner draft. Sending one existing pending comment could silently discard an unsaved draft for another comment in the same review owner.
+- **Fix:** Added a dispatch option that reserves whole-draft clearing for full-batch sends. Single-comment sends now clear only an editor draft whose `editId` matches the dispatched comment, and preserve unrelated drafts. Added hook regression coverage for both cases.
 - **Commit:** same commit as this entry

--- a/docs/superpowers/plans/2026-07-11-vim-297-per-comment-dispatch.md
+++ b/docs/superpowers/plans/2026-07-11-vim-297-per-comment-dispatch.md
@@ -1,0 +1,35 @@
+# Per-comment dispatch (VIM-297) — Implementation Plan
+
+**Goal:** send a single pending review comment to the agent immediately, without dispatching the rest of the pending batch — the foundation for threaded Q&A (VIM-298).
+
+**Architecture:** one PR, three tasks. The load-bearing change is re-keying `pendingReviews` from `ptyId` (one in-flight dispatch per pty, replaced on send) to `(ptyId, nonce)` — the same keying the finding-thread record already uses — so concurrent dispatches on one pty each correlate their own `agent-reply` independently. Single-send then _reuses_ the batch path end-to-end: `buildFeedbackEntries` gains an id filter, `handleSendFeedback` gains an optional target id, and the existing `FinishFeedbackPopover` renders scoped to one comment. No new dispatch machinery, no new popover.
+
+## Task 1: nonce-keyed pending store + reply resolution
+
+**Files:** `src/features/diff/services/pendingReviews.ts` (+test), `src/features/diff/hooks/useAgentReply.ts` (+test), `src/features/workspace/WorkspaceView.tsx`.
+
+- [ ] Failing tests — store: two records on the same pty under different nonces coexist; `get(ptyId, nonce)` / `clear(ptyId, nonce)`; `prunePendingReviewOwners` removes records for closed owners (new — the ptyId-keyed store never pruned). Reply: two concurrent dispatches each get their own reply attached by nonce (the acceptance case); a reply whose nonce matches no record is ignored (replaces the "superseded dispatch" semantics — nothing is clobbered anymore).
+- [ ] Implement: key `${ptyId}\u0000${nonce}` (mirror `findingThreads`); `getPendingReview(ptyId, nonce)`; `useAgentReply` comment path resolves by `(event.sessionId, event.nonce)` — the explicit nonce equality check dissolves into the key; clear by `(sessionId, nonce)`. Wire `prunePendingReviewOwners` in WorkspaceView beside `prunePendingReviewRequestOwners`.
+- [ ] Green + commit.
+
+## Task 2: single-comment dispatch through the batch path
+
+**Files:** `src/features/diff/Panel.tsx`.
+
+- [ ] `buildFeedbackEntries(onlyCommentId?)`: when given, filter each batch's pending annotations to that id (handles/`markDispatched`/`setPendingReview` all derive from the filtered entries, so they scope automatically).
+- [ ] `handleSendFeedback(pane, onlyCommentId?)`: thread the filter through; everything else (nonce mint, dispatch, record, markDispatched-subset, focus) is unchanged.
+- [ ] Send-now popover state: `sendNowCommentId: string | null`; `finishFeedback` renders the existing popover with `open: finishOpen || sendNowCommentId !== null`, `commentCount`/`fileCount` scoped to 1 when single-sending, `onSend` bound to the id, `onCancel` clearing it.
+- [ ] Behavior test at the row/popover seam (Panel test harness if tractable, else popover + row unit coverage): single send marks only that id dispatched; the rest stay pending and still dispatch on Finish.
+- [ ] Green + commit.
+
+## Task 3: Send-now affordance on the comment row
+
+**Files:** `src/features/diff/components/ReviewCommentRow.tsx` (+test), `src/features/diff/components/PanelBody.tsx`, `src/features/diff/Panel.tsx` (render sites).
+
+- [ ] Failing tests: a pending `self` comment row with `onSendNow` renders a "Send comment now" button that fires it; dispatched / agent / reviewer rows never render it.
+- [ ] Implement: optional `onSendNow?: () => void` prop → send IconButton beside edit/delete (read-only rows excluded by the existing `readOnly` gate); thread from both render sites with `() => setSendNowCommentId(comment.id)`.
+- [ ] Full gate: repo-wide lint + format + type-check, `npx vitest run src/features/diff src/features/workspace`. Green + commit.
+
+**PR:** `feat(diff): per-comment dispatch (VIM-297)`, branch `feature/vim-297`, `Closes VIM-297`, `Part of VIM-284`, auto-review/auto-approve.
+
+**Out of scope:** the reply affordance on agent rows and thread-grouped rendering (VIM-298, which builds on this); TTL/GC for abandoned dispatch records beyond owner-pruning (records are consumed when their replies land; abandoned ones fall with their owner).

--- a/src/features/diff/Panel.test.tsx
+++ b/src/features/diff/Panel.test.tsx
@@ -5989,12 +5989,16 @@ describe('Panel', () => {
       // VIM-249: a pending review is recorded for this pty, keyed by [#n], so an
       // agent reply can be correlated back. The path is the repo-relative batch
       // key, not the absolute prompt path.
-      const pending = getPendingReview('pty-1')
+      // The record is keyed by the minted nonce (VIM-297) — read it from the
+      // dispatched payload, proving the stored record matches what the agent
+      // will echo back.
+      const nonce = /"nonce":"(\w+)"/.exec(payload as string)?.[1] ?? ''
+      const pending = getPendingReview('pty-1', nonce)
       expect(pending?.ownerKey).toBe('sess:pane-1')
       expect(pending?.byHandle.get(1)?.filePath).toBe('src/foo.ts')
       expect(pending?.byHandle.get(1)?.lineNumber).toBe(1)
 
-      clearPendingReview('pty-1') // module singleton — don't leak into other tests
+      clearPendingReview('pty-1', nonce) // module singleton — don't leak into other tests
     })
 
     test('preserves the comment draft and shows a notification when the feedback cap is reached', async (): Promise<void> => {

--- a/src/features/diff/Panel.test.tsx
+++ b/src/features/diff/Panel.test.tsx
@@ -6001,6 +6001,98 @@ describe('Panel', () => {
       clearPendingReview('pty-1', nonce) // module singleton — don't leak into other tests
     })
 
+    test('Send now dispatches only the addressed comment; the rest stay pending (VIM-297)', async (): Promise<void> => {
+      const user = userEvent.setup()
+      const writePty = vi.fn().mockResolvedValue(undefined)
+      const focusTerminal = vi.fn()
+
+      const candidate: PaneCandidate = {
+        paneId: 'pane-1',
+        ptyId: 'pty-1',
+        tabName: 'Tab 1',
+        agentLabel: 'Claude Code',
+        cwd: '/repo',
+        status: 'running',
+        isFocused: true,
+      }
+
+      render(
+        <Panel
+          cwd="/repo"
+          selectedFile={{ path: 'src/foo.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+          feedbackOwnerKey="sess:pane-1"
+          feedbackDispatch={{
+            candidates: [candidate],
+            writePty,
+            focusTerminal,
+          }}
+        />
+      )
+
+      setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
+
+      const gutterSlot = screen.getByTestId('gutter-utility-slot')
+
+      const addButton = within(gutterSlot).getByRole('button', {
+        name: 'Add comment on this line',
+      })
+
+      await user.click(addButton)
+      const first = screen.getByRole('dialog', { name: /Comment on line/ })
+      await user.type(
+        within(first).getByPlaceholderText('Request change'),
+        'First note'
+      )
+      await user.keyboard('{Enter}')
+
+      await user.click(addButton)
+      const second = screen.getByRole('dialog', { name: /Comment on line/ })
+      await user.type(
+        within(second).getByPlaceholderText('Request change'),
+        'Second note'
+      )
+      await user.keyboard('{Enter}')
+
+      expect(
+        await screen.findByRole('button', { name: /finish feedback \(2\)/i })
+      ).toBeInTheDocument()
+
+      const sendButtons = screen.getAllByRole('button', {
+        name: 'Send comment now',
+      })
+      expect(sendButtons).toHaveLength(2)
+      await user.click(sendButtons[0])
+
+      const popover = await screen.findByRole('dialog', {
+        name: 'Finish feedback',
+      })
+      expect(popover).toHaveTextContent(/Send 1 comment/)
+
+      await user.keyboard('Y')
+
+      await waitFor(() => expect(writePty).toHaveBeenCalledTimes(1))
+      const [, payload] = writePty.mock.calls[0]
+      expect(payload as string).toContain('First note')
+      expect(payload as string).not.toContain('Second note')
+      expect(payload as string).toContain('[#1')
+      expect(payload as string).not.toContain('[#2')
+
+      // The other comment is untouched and still dispatches on Finish.
+      expect(
+        await screen.findByRole('button', { name: /finish feedback \(1\)/i })
+      ).toBeInTheDocument()
+      expect(screen.getByText('Second note')).toBeInTheDocument()
+
+      // Its correlation record covers exactly the one dispatched handle.
+      const nonce = /"nonce":"(\w+)"/.exec(payload as string)?.[1] ?? ''
+      const pending = getPendingReview('pty-1', nonce)
+      expect(pending?.byHandle.size).toBe(1)
+      expect(pending?.byHandle.get(1)?.lineNumber).toBe(1)
+
+      clearPendingReview('pty-1', nonce)
+    })
+
     test('preserves the comment draft and shows a notification when the feedback cap is reached', async (): Promise<void> => {
       const user = userEvent.setup()
       const addAnnotationSpy = vi.fn().mockReturnValue('cap-reached')

--- a/src/features/diff/Panel.tsx
+++ b/src/features/diff/Panel.tsx
@@ -1943,6 +1943,8 @@ export const Panel = ({
     closeCommentEditor()
   }, [cancelVisualSelection, closeCommentEditor])
 
+  const isFinishPopoverOpen = finishOpen || sendNowCommentId !== null
+
   useKeyboard({
     enabled: true,
     rootRef: diffRootRef,
@@ -1977,7 +1979,7 @@ export const Panel = ({
       }
     },
     onRequestReview: (): void => {
-      if (!finishOpen) {
+      if (!isFinishPopoverOpen) {
         review.openPopover()
       }
     },
@@ -2096,7 +2098,7 @@ export const Panel = ({
       : undefined
 
   const finishFeedback = {
-    open: finishOpen || sendNowCommentId !== null,
+    open: isFinishPopoverOpen,
     result: resolveCandidatePanes({
       allPanes: feedbackDispatch?.candidates ?? [],
       diffCwd: cwd,
@@ -2116,7 +2118,7 @@ export const Panel = ({
   // The "Request review" affordance (VIM-304) — always available when a file
   // diff is loaded, independent of pending comments (unlike Finish).
   const onRequestReview =
-    review.canRequest && !finishOpen
+    review.canRequest && !isFinishPopoverOpen
       ? (): void => {
           setFinishOpen(false)
           review.openPopover()

--- a/src/features/diff/Panel.tsx
+++ b/src/features/diff/Panel.tsx
@@ -720,6 +720,9 @@ export const Panel = ({
 
   // Finish feedback popover open state.
   const [finishOpen, setFinishOpen] = useState(false)
+  // The comment being single-sent (VIM-297); scopes the Finish popover +
+  // dispatch to exactly that comment. null = whole-batch behavior.
+  const [sendNowCommentId, setSendNowCommentId] = useState<string | null>(null)
 
   const [keyboardConfirmAction, setKeyboardConfirmAction] =
     useState<KeyboardConfirmAction | null>(null)
@@ -740,77 +743,97 @@ export const Panel = ({
 
   const sendingFeedbackRef = useRef(false)
 
-  const buildFeedbackEntries = useCallback((): {
-    entries: DispatchEntry[]
-    handles: Map<number, PendingReviewHandle>
-  } => {
-    // git reports file paths relative to the repo TOPLEVEL, but the target
-    // agent runs in the pane's cwd (possibly a repo subdirectory). Join the
-    // toplevel (`response.repoRoot`) so the dispatched reference is an
-    // absolute path the agent can resolve regardless of its cwd. Falls back to
-    // the repo-relative path if the root is unavailable (not in a git repo).
-    // Prefer the per-batch cwd root; fall back to the current diff's root, then
-    // the last-known root when `response` is transiently null (file-switch
-    // loading/error) so an in-flight batch keeps absolute paths.
-    const repoRoot = response?.repoRoot ?? repoRootRef.current
-    const entries: DispatchEntry[] = []
-    // [#n] → the comment it addressed. The path fields are the annotation BATCH
-    // KEY (repo-relative), NOT the absolute prompt path, so an agent reply
-    // (VIM-249) attaches back onto the same batch the comment lives in.
-    const handles = new Map<number, PendingReviewHandle>()
-    let handle = 0
+  const buildFeedbackEntries = useCallback(
+    (
+      onlyCommentId?: string
+    ): {
+      entries: DispatchEntry[]
+      handles: Map<number, PendingReviewHandle>
+    } => {
+      // git reports file paths relative to the repo TOPLEVEL, but the target
+      // agent runs in the pane's cwd (possibly a repo subdirectory). Join the
+      // toplevel (`response.repoRoot`) so the dispatched reference is an
+      // absolute path the agent can resolve regardless of its cwd. Falls back to
+      // the repo-relative path if the root is unavailable (not in a git repo).
+      // Prefer the per-batch cwd root; fall back to the current diff's root, then
+      // the last-known root when `response` is transiently null (file-switch
+      // loading/error) so an in-flight batch keeps absolute paths.
+      const repoRoot = response?.repoRoot ?? repoRootRef.current
+      const entries: DispatchEntry[] = []
+      // [#n] → the comment it addressed. The path fields are the annotation BATCH
+      // KEY (repo-relative), NOT the absolute prompt path, so an agent reply
+      // (VIM-249) attaches back onto the same batch the comment lives in.
+      const handles = new Map<number, PendingReviewHandle>()
+      let handle = 0
 
-    for (const [key, annotations] of feedback.batch) {
-      // Only dispatch comments that have not been sent yet; already-dispatched
-      // thread anchors stay in the hunk but are never re-sent (VIM-282).
-      const pending = annotations.filter(isPendingReviewAnnotation)
-      if (pending.length === 0) {
-        continue
+      for (const [key, annotations] of feedback.batch) {
+        // Only dispatch comments that have not been sent yet; already-dispatched
+        // thread anchors stay in the hunk but are never re-sent (VIM-282).
+        const pending = annotations
+          .filter(isPendingReviewAnnotation)
+          // Single-send (VIM-297): scope the whole path to one comment.
+          .filter(
+            (annotation) =>
+              onlyCommentId === undefined ||
+              annotation.metadata.id === onlyCommentId
+          )
+        if (pending.length === 0) {
+          continue
+        }
+
+        const { cwd: entryCwd, filePath: relPath, staged } = parseBatchKey(key)
+
+        const entryRepoRoot = repoRootRef.repoRootForCwd?.(entryCwd)
+
+        const resolvedRepoRoot =
+          entryRepoRoot && entryRepoRoot.length > 0 ? entryRepoRoot : repoRoot
+
+        const filePath = resolvedRepoRoot
+          ? `${resolvedRepoRoot}/${relPath}`
+          : relPath
+        entries.push({ filePath, staged, annotations: pending })
+
+        // Number handles in the SAME nested order formatFeedbackPayload assigns
+        // [#n], so handle N maps to the Nth dispatched comment.
+        for (const annotation of pending) {
+          handle += 1
+          handles.set(handle, {
+            cwd: entryCwd,
+            filePath: relPath,
+            staged,
+            lineNumber: annotation.lineNumber,
+            side: annotation.side,
+            target: annotation.metadata.target,
+          })
+        }
       }
 
-      const { cwd: entryCwd, filePath: relPath, staged } = parseBatchKey(key)
-
-      const entryRepoRoot = repoRootRef.repoRootForCwd?.(entryCwd)
-
-      const resolvedRepoRoot =
-        entryRepoRoot && entryRepoRoot.length > 0 ? entryRepoRoot : repoRoot
-
-      const filePath = resolvedRepoRoot
-        ? `${resolvedRepoRoot}/${relPath}`
-        : relPath
-      entries.push({ filePath, staged, annotations: pending })
-
-      // Number handles in the SAME nested order formatFeedbackPayload assigns
-      // [#n], so handle N maps to the Nth dispatched comment.
-      for (const annotation of pending) {
-        handle += 1
-        handles.set(handle, {
-          cwd: entryCwd,
-          filePath: relPath,
-          staged,
-          lineNumber: annotation.lineNumber,
-          side: annotation.side,
-          target: annotation.metadata.target,
-        })
-      }
-    }
-
-    return { entries, handles }
-  }, [feedback.batch, repoRootRef, response])
+      return { entries, handles }
+    },
+    [feedback.batch, repoRootRef, response]
+  )
 
   const handleSendFeedback = useCallback(
-    (pane: PaneCandidate): void => {
+    (pane: PaneCandidate, onlyCommentId?: string): void => {
       if (sendingFeedbackRef.current) {
         return
       }
       sendingFeedbackRef.current = true
       void (async (): Promise<void> => {
-        const { entries, handles } = buildFeedbackEntries()
+        const { entries, handles } = buildFeedbackEntries(onlyCommentId)
         // Per-dispatch correlation token the agent echoes in its reply block
         // (VIM-249), recorded below so a reply can be matched to this send.
         const nonce = makeDispatchNonce()
 
         try {
+          // The addressed comment can vanish between opening the popover and
+          // confirming (edit/delete) — never dispatch an empty payload.
+          if (entries.length === 0) {
+            setFinishOpen(false)
+            setSendNowCommentId(null)
+
+            return
+          }
           if (feedbackDispatch) {
             await dispatchFeedbackBatch(
               pane.paneId,
@@ -845,6 +868,7 @@ export const Panel = ({
             )
           )
           setFinishOpen(false)
+          setSendNowCommentId(null)
           const focusTerminal = feedbackDispatch?.focusTerminal
           if (focusTerminal !== undefined) {
             setTimeout(focusTerminal, 0)
@@ -869,29 +893,36 @@ export const Panel = ({
   // running to send to (comments are otherwise trapped in the batch). It uses
   // the same resolved paths as the send path so pasted feedback works from an
   // agent cwd below the repo root.
-  const handleCopyFeedback = useCallback((): void => {
-    const { entries } = buildFeedbackEntries()
+  const handleCopyFeedback = useCallback(
+    (onlyCommentId?: string): void => {
+      const { entries } = buildFeedbackEntries(onlyCommentId)
 
-    if (entries.length === 0) {
-      return
-    }
+      if (entries.length === 0) {
+        return
+      }
 
-    const count = feedback.pendingAnnotations()
-    setFinishOpen(false)
-
-    void (async (): Promise<void> => {
-      // Clipboard copy has no agent to reply, so the nonce is a throwaway that
-      // just satisfies the payload signature.
-      const copied = await writeClipboardText(
-        formatFeedbackPayload(entries, makeDispatchNonce())
+      const count = entries.reduce(
+        (sum, entry) => sum + entry.annotations.length,
+        0
       )
-      notifyInfo(
-        copied
-          ? `Copied ${count} comment${count === 1 ? '' : 's'} to the clipboard.`
-          : 'Could not copy comments to the clipboard.'
-      )
-    })()
-  }, [buildFeedbackEntries, feedback, notifyInfo])
+      setFinishOpen(false)
+      setSendNowCommentId(null)
+
+      void (async (): Promise<void> => {
+        // Clipboard copy has no agent to reply, so the nonce is a throwaway that
+        // just satisfies the payload signature.
+        const copied = await writeClipboardText(
+          formatFeedbackPayload(entries, makeDispatchNonce())
+        )
+        notifyInfo(
+          copied
+            ? `Copied ${count} comment${count === 1 ? '' : 's'} to the clipboard.`
+            : 'Could not copy comments to the clipboard.'
+        )
+      })()
+    },
+    [buildFeedbackEntries, notifyInfo]
+  )
 
   // Request review (VIM-304): the whole "arm a pending request, then dispatch or
   // copy it" flow lives in useRequestReview so this component stays a renderer.
@@ -1940,6 +1971,7 @@ export const Panel = ({
     onDeleteComment: deleteSelectedComment,
     onFinishReview: (): void => {
       if (feedback.pendingAnnotations() > 0 && !review.open) {
+        setSendNowCommentId(null)
         setFinishOpen(true)
       }
     },
@@ -2057,21 +2089,27 @@ export const Panel = ({
     feedbackCount > 0 && !review.open
       ? (): void => {
           review.closePopover()
+          setSendNowCommentId(null)
           setFinishOpen(true)
         }
       : undefined
 
   const finishFeedback = {
-    open: finishOpen,
+    open: finishOpen || sendNowCommentId !== null,
     result: resolveCandidatePanes({
       allPanes: feedbackDispatch?.candidates ?? [],
       diffCwd: cwd,
     }),
-    commentCount: feedbackCount,
-    fileCount: pendingFileCount,
-    onCancel: (): void => setFinishOpen(false),
-    onSend: handleSendFeedback,
-    onCopy: handleCopyFeedback,
+    // Single-send (VIM-297) reuses the popover scoped to one comment.
+    commentCount: sendNowCommentId !== null ? 1 : feedbackCount,
+    fileCount: sendNowCommentId !== null ? 1 : pendingFileCount,
+    onCancel: (): void => {
+      setFinishOpen(false)
+      setSendNowCommentId(null)
+    },
+    onSend: (pane: PaneCandidate): void =>
+      handleSendFeedback(pane, sendNowCommentId ?? undefined),
+    onCopy: (): void => handleCopyFeedback(sendNowCommentId ?? undefined),
   }
 
   // The "Request review" affordance (VIM-304) — always available when a file
@@ -2359,6 +2397,10 @@ export const Panel = ({
                     comment={annotation.metadata}
                     editShortcut="Shift+U"
                     deleteShortcut={null}
+                    onSendNow={(): void => {
+                      setFinishOpen(false)
+                      setSendNowCommentId(annotation.metadata.id)
+                    }}
                     onEdit={(): void => {
                       setFileCommentAnchorPoint(null)
                       setAnnotationTarget({
@@ -2407,6 +2449,10 @@ export const Panel = ({
             onAddComment={handleBodyAddComment}
             onEditComment={handleBodyEditComment}
             onDeleteComment={removeFeedbackAnnotation}
+            onSendComment={(id: string): void => {
+              setFinishOpen(false)
+              setSendNowCommentId(id)
+            }}
             onCommentTextChange={(text): void => {
               setCommentDraftText(text, false)
             }}

--- a/src/features/diff/Panel.tsx
+++ b/src/features/diff/Panel.tsx
@@ -820,8 +820,9 @@ export const Panel = ({
               feedbackDispatch.writePty
             )
             // Record the pending review so an agent-reply for this pty can be
-            // correlated back to these comments (VIM-249). Keyed by pty; a new
-            // dispatch replaces it. Only when there's an owner to attach onto.
+            // correlated back to these comments (VIM-249). Keyed by (pty,
+            // nonce) so concurrent dispatches coexist (VIM-297). Only when
+            // there's an owner to attach onto.
             if (feedbackOwnerKey !== undefined && handles.size > 0) {
               setPendingReview({
                 ptyId: pane.ptyId,

--- a/src/features/diff/Panel.tsx
+++ b/src/features/diff/Panel.tsx
@@ -865,7 +865,8 @@ export const Panel = ({
               entries.flatMap((entry) =>
                 entry.annotations.map((annotation) => annotation.metadata.id)
               )
-            )
+            ),
+            { clearDraftForWholeBatch: onlyCommentId === undefined }
           )
           setFinishOpen(false)
           setSendNowCommentId(null)

--- a/src/features/diff/agentReplyThread.integration.test.tsx
+++ b/src/features/diff/agentReplyThread.integration.test.tsx
@@ -74,7 +74,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-  clearPendingReview('pty-1')
+  clearPendingReview('pty-1', 'abc')
   delete window.vimeflow
 })
 

--- a/src/features/diff/components/PanelBody.tsx
+++ b/src/features/diff/components/PanelBody.tsx
@@ -154,6 +154,8 @@ interface PanelBodyProps {
   onAddComment: (lineNumber: number, side: AnnotationSide) => void
   onEditComment: (annotation: DiffLineAnnotation<ReviewComment>) => void
   onDeleteComment: (id: string) => void
+  /** Dispatch one pending comment to the agent now (VIM-297). */
+  onSendComment?: (id: string) => void
   onCommentTextChange: (text: string) => void
   onCommentCategoryChange: (category: ReviewCommentCategory) => void
   onConfirmComment: (text: string, category: ReviewCommentCategory) => void
@@ -180,6 +182,7 @@ export const PanelBody = ({
   onAddComment,
   onEditComment,
   onDeleteComment,
+  onSendComment = undefined,
   onCommentTextChange,
   onCommentCategoryChange,
   onConfirmComment,
@@ -260,6 +263,11 @@ export const PanelBody = ({
                 <ReviewCommentRow
                   comment={annotation.metadata}
                   targetLabel={annotationTargetLabel(annotation)}
+                  onSendNow={
+                    onSendComment === undefined
+                      ? undefined
+                      : (): void => onSendComment(annotation.metadata.id)
+                  }
                   onEdit={(): void => onEditComment(annotation)}
                   onDelete={(): void => onDeleteComment(annotation.metadata.id)}
                 />

--- a/src/features/diff/components/ReviewCommentRow.test.tsx
+++ b/src/features/diff/components/ReviewCommentRow.test.tsx
@@ -331,6 +331,82 @@ describe('ReviewCommentRow', () => {
       expect(screen.queryByText('Agent reply')).not.toBeInTheDocument()
     }
   )
+
+  test('a pending self comment with onSendNow renders the send button', async () => {
+    const user = userEvent.setup()
+    const onSendNow = vi.fn()
+    render(
+      <ReviewCommentRow
+        comment={{ id: 's', text: 'x', author: 'self', createdAt: 1000 }}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onSendNow={onSendNow}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Send comment now' }))
+    expect(onSendNow).toHaveBeenCalledOnce()
+  })
+
+  test('send-now is absent when omitted and on dispatched rows', () => {
+    const { rerender } = render(
+      <ReviewCommentRow
+        comment={{ id: 's', text: 'x', author: 'self', createdAt: 1000 }}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    )
+    expect(
+      screen.queryByRole('button', { name: 'Send comment now' })
+    ).not.toBeInTheDocument()
+
+    // Dispatched rows are read-only thread anchors — never re-sendable.
+    rerender(
+      <ReviewCommentRow
+        comment={{
+          id: 's',
+          text: 'x',
+          author: 'self',
+          createdAt: 1000,
+          dispatchedAt: 2000,
+        }}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onSendNow={vi.fn()}
+      />
+    )
+
+    expect(
+      screen.queryByRole('button', { name: 'Send comment now' })
+    ).not.toBeInTheDocument()
+  })
+
+  test('agent and reviewer rows never render send-now', () => {
+    const { rerender } = render(
+      <ReviewCommentRow
+        comment={{ id: 'a', text: 'x', author: 'agent', createdAt: 1000 }}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onSendNow={vi.fn()}
+      />
+    )
+    expect(
+      screen.queryByRole('button', { name: 'Send comment now' })
+    ).not.toBeInTheDocument()
+
+    rerender(
+      <ReviewCommentRow
+        comment={{ id: 'r', text: 'x', author: 'reviewer', createdAt: 1000 }}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onSendNow={vi.fn()}
+      />
+    )
+
+    expect(
+      screen.queryByRole('button', { name: 'Send comment now' })
+    ).not.toBeInTheDocument()
+  })
 })
 
 const MINUTE = 60_000

--- a/src/features/diff/components/ReviewCommentRow.tsx
+++ b/src/features/diff/components/ReviewCommentRow.tsx
@@ -10,6 +10,9 @@ interface ReviewCommentRowProps {
   comment: ReviewComment
   editShortcut?: 'u' | 'Shift+U'
   deleteShortcut?: 'x' | null
+  /** Dispatch just this comment to the agent now (VIM-297). Omitted → hidden;
+   * read-only rows (dispatched anchors, agent/reviewer output) never show it. */
+  onSendNow?: () => void
   /** Range/line reference shown above the text (e.g. "lines R4-R6"); the diff
    * itself shows the code, so this only names the span. Omitted for plain line
    * comments. */
@@ -50,6 +53,7 @@ export const ReviewCommentRow = ({
   editShortcut = 'u',
   deleteShortcut = 'x',
   targetLabel = undefined,
+  onSendNow = undefined,
   onEdit,
   onDelete,
 }: ReviewCommentRowProps): ReactElement => {
@@ -125,6 +129,14 @@ export const ReviewCommentRow = ({
       </div>
       {readOnly ? null : (
         <div className="flex shrink-0 items-center gap-1">
+          {onSendNow !== undefined ? (
+            <IconButton
+              icon="send"
+              label="Send comment now"
+              size="sm"
+              onClick={(): void => onSendNow()}
+            />
+          ) : null}
           <IconButton
             icon="edit"
             label="Edit comment"

--- a/src/features/diff/hooks/useAgentReply.test.ts
+++ b/src/features/diff/hooks/useAgentReply.test.ts
@@ -111,7 +111,8 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-  clearPendingReview('pty-1')
+  clearPendingReview('pty-1', 'abc')
+  clearPendingReview('pty-1', 'xyz')
   clearFindingThreadRecord('pty-1', 'rev')
   clearReviewLevelNotes('owner-r')
   delete window.vimeflow
@@ -163,10 +164,10 @@ describe('useAgentReply', () => {
     expect(annotation.metadata.outcome).toBe('reply')
   })
 
-  test('ignores an event whose nonce does not match (superseded dispatch)', async () => {
+  test('ignores an event whose nonce matches no in-flight dispatch', async () => {
     setPendingReview(pending(new Map([[1, handle()]])))
     mount()
-    // A late reply for the old dispatch — its #1 collides but the nonce differs.
+    // Its #1 collides with a pending handle, but the nonce names no record.
     await emit(
       event({
         nonce: 'stale',
@@ -175,6 +176,37 @@ describe('useAgentReply', () => {
     )
 
     expect(addAnnotationForOwner).not.toHaveBeenCalled()
+  })
+
+  test('two concurrent dispatches each correlate their own reply (VIM-297)', async () => {
+    setPendingReview(pending(new Map([[1, handle({ lineNumber: 5 })]])))
+    setPendingReview({
+      ...pending(new Map([[1, handle({ lineNumber: 9 })]])),
+      nonce: 'xyz',
+    })
+    mount()
+
+    // The SECOND dispatch's reply arrives first — it must hit its own record,
+    // not clobber or shadow the first dispatch's correlation.
+    await emit(
+      event({
+        nonce: 'xyz',
+        replies: [{ id: 1, status: 'reply', target: 'comment', text: 'B' }],
+      })
+    )
+
+    await emit(
+      event({
+        nonce: 'abc',
+        replies: [{ id: 1, status: 'resolved', target: 'comment', text: 'A' }],
+      })
+    )
+
+    expect(addAnnotationForOwner).toHaveBeenCalledTimes(2)
+    expect(addAnnotationForOwner.mock.calls[0][4].lineNumber).toBe(9)
+    expect(addAnnotationForOwner.mock.calls[0][4].metadata.text).toBe('B')
+    expect(addAnnotationForOwner.mock.calls[1][4].lineNumber).toBe(5)
+    expect(addAnnotationForOwner.mock.calls[1][4].metadata.text).toBe('A')
   })
 
   test('ignores an event with no pending record for the session', async () => {

--- a/src/features/diff/hooks/useAgentReply.ts
+++ b/src/features/diff/hooks/useAgentReply.ts
@@ -157,9 +157,10 @@ export const useAgentReply = ({
         return
       }
 
-      const pending = getPendingReview(event.sessionId)
-      // Session + nonce gate: only a reply to the current dispatch proceeds.
-      if (event.nonce !== pending?.nonce) {
+      // Session + nonce gate — both are part of the store key (VIM-297), so
+      // only a reply echoing a live dispatch's nonce on its own pty resolves.
+      const pending = getPendingReview(event.sessionId, event.nonce)
+      if (pending === undefined) {
         return
       }
 
@@ -186,7 +187,7 @@ export const useAgentReply = ({
         }
 
         if (pending.byHandle.size === 0) {
-          clearPendingReview(event.sessionId)
+          clearPendingReview(event.sessionId, event.nonce)
         } else {
           setPendingReview(pending)
         }
@@ -207,7 +208,7 @@ export const useAgentReply = ({
           return
         }
       }
-      clearPendingReview(event.sessionId)
+      clearPendingReview(event.sessionId, event.nonce)
     }
 
     const subscribe = async (): Promise<void> => {

--- a/src/features/diff/hooks/useFeedbackBatch.test.ts
+++ b/src/features/diff/hooks/useFeedbackBatch.test.ts
@@ -797,12 +797,82 @@ describe('useFeedbackBatchStore', () => {
     })
 
     act(() => {
-      result.current.feedbackBatch.markDispatched(999, new Set(['owner-a']))
+      result.current.feedbackBatch.markDispatched(999, new Set(['owner-a']), {
+        clearDraftForWholeBatch: true,
+      })
     })
 
     expect(result.current.feedbackDraft.draft).toBeNull()
     // The dispatched comment stays in the hunk as a thread anchor.
     expect(result.current.feedbackBatch.totalAnnotations()).toBe(1)
+    expect(result.current.feedbackBatch.pendingAnnotations()).toBe(0)
+  })
+
+  test('single-comment dispatch preserves an unrelated owner draft', () => {
+    const { result } = renderHook(() =>
+      useFeedbackBatchStore('session-a:p0', '/repo-a')
+    )
+
+    act(() => {
+      result.current.feedbackDraft.setDraft({
+        cwd: '/repo-a',
+        filePath: 'src/a.ts',
+        staged: false,
+        editId: 'owner-b',
+        side: 'additions',
+        lineNumber: 7,
+        text: 'draft b',
+      })
+
+      result.current.feedbackBatch.addAnnotation(
+        '/repo-a',
+        'src/a.ts',
+        false,
+        makeAnnotation('owner-a')
+      )
+    })
+
+    act(() => {
+      result.current.feedbackBatch.markDispatched(999, new Set(['owner-a']), {
+        clearDraftForWholeBatch: false,
+      })
+    })
+
+    expect(result.current.feedbackDraft.draft?.text).toBe('draft b')
+    expect(result.current.feedbackBatch.pendingAnnotations()).toBe(0)
+  })
+
+  test('single-comment dispatch clears the draft for the sent edit', () => {
+    const { result } = renderHook(() =>
+      useFeedbackBatchStore('session-a:p0', '/repo-a')
+    )
+
+    act(() => {
+      result.current.feedbackDraft.setDraft({
+        cwd: '/repo-a',
+        filePath: 'src/a.ts',
+        staged: false,
+        editId: 'owner-a',
+        side: 'additions',
+        lineNumber: 7,
+        text: 'draft a',
+      })
+
+      result.current.feedbackBatch.addAnnotation(
+        '/repo-a',
+        'src/a.ts',
+        false,
+        makeAnnotation('owner-a')
+      )
+    })
+
+    act(() => {
+      result.current.feedbackBatch.markDispatched(999, new Set(['owner-a']), {
+        clearDraftForWholeBatch: false,
+      })
+    })
+
+    expect(result.current.feedbackDraft.draft).toBeNull()
     expect(result.current.feedbackBatch.pendingAnnotations()).toBe(0)
   })
 

--- a/src/features/diff/hooks/useFeedbackBatch.ts
+++ b/src/features/diff/hooks/useFeedbackBatch.ts
@@ -314,7 +314,8 @@ export interface UseFeedbackBatchReturn {
    */
   markDispatched: (
     dispatchedAt: number,
-    dispatchedAnnotationIds: ReadonlySet<string>
+    dispatchedAnnotationIds: ReadonlySet<string>,
+    options?: { clearDraftForWholeBatch?: boolean }
   ) => void
   /**
    * Drop the pending comments and the open draft, leaving already dispatched
@@ -615,13 +616,15 @@ export const useFeedbackBatchStore = (
   }, [ownerKey])
 
   // Send path (VIM-282): stamp sent pending comments as dispatched and keep
-  // them in the hunk as thread anchors, then close the draft. Unchanged file lists
-  // keep their identity so Pierre does not re-tokenize files with no pending
-  // comment.
+  // them in the hunk as thread anchors. Whole-batch sends close the active draft;
+  // single-comment sends only close an editor draft for the dispatched comment.
+  // Unchanged file lists keep their identity so Pierre does not re-tokenize files
+  // with no pending comment.
   const markDispatched = useCallback(
     (
       dispatchedAt: number,
-      dispatchedAnnotationIds: ReadonlySet<string>
+      dispatchedAnnotationIds: ReadonlySet<string>,
+      options?: { clearDraftForWholeBatch?: boolean }
     ): void => {
       setBatchesByOwner((prev) => {
         const currentBatch = prev.get(ownerKey)
@@ -669,9 +672,25 @@ export const useFeedbackBatchStore = (
         return next
       })
 
-      clearOwnerDraft()
+      setDraftsByOwner((prev) => {
+        const ownerDraft = prev.get(ownerKey)
+
+        const shouldClearDraft =
+          options?.clearDraftForWholeBatch === true ||
+          (ownerDraft?.editId !== undefined &&
+            dispatchedAnnotationIds.has(ownerDraft.editId))
+
+        if (!shouldClearDraft) {
+          return prev
+        }
+
+        const next = new Map(prev)
+        next.delete(ownerKey)
+
+        return next
+      })
     },
-    [clearOwnerDraft, ownerKey]
+    [ownerKey]
   )
 
   // Discard path (VIM-282): drop pending comments and the draft, but leave

--- a/src/features/diff/services/pendingReviews.test.ts
+++ b/src/features/diff/services/pendingReviews.test.ts
@@ -2,13 +2,14 @@ import { afterEach, describe, expect, test } from 'vitest'
 import {
   clearPendingReview,
   getPendingReview,
+  prunePendingReviewOwners,
   setPendingReview,
   type PendingReview,
 } from './pendingReviews'
 
-const record = (nonce = 'abc'): PendingReview => ({
+const record = (nonce = 'abc', ownerKey = 'sess:pane'): PendingReview => ({
   ptyId: 'pty-1',
-  ownerKey: 'sess:pane',
+  ownerKey,
   nonce,
   dispatchedAt: 1,
   byHandle: new Map([
@@ -26,27 +27,54 @@ const record = (nonce = 'abc'): PendingReview => ({
   ]),
 })
 
-afterEach(() => clearPendingReview('pty-1'))
+afterEach(() => {
+  clearPendingReview('pty-1', 'abc')
+  clearPendingReview('pty-1', 'xyz')
+  clearPendingReview('pty-1', 'stale')
+})
 
 describe('pendingReviews', () => {
-  test('set then get by ptyId', () => {
+  test('set then get keyed by (ptyId, nonce)', () => {
     setPendingReview(record())
-    expect(getPendingReview('pty-1')?.nonce).toBe('abc')
+    expect(getPendingReview('pty-1', 'abc')?.nonce).toBe('abc')
+    // The pty is part of the key — the same nonce on another pty is no match.
+    expect(getPendingReview('pty-2', 'abc')).toBeUndefined()
   })
 
-  test('set replaces the prior record for the same pty', () => {
-    setPendingReview(record())
+  test('two dispatches on the same pty stay in flight concurrently (VIM-297)', () => {
+    setPendingReview(record('abc'))
     setPendingReview(record('xyz'))
-    expect(getPendingReview('pty-1')?.nonce).toBe('xyz')
+
+    expect(getPendingReview('pty-1', 'abc')?.nonce).toBe('abc')
+    expect(getPendingReview('pty-1', 'xyz')?.nonce).toBe('xyz')
   })
 
-  test('clear removes the record', () => {
-    setPendingReview(record())
-    clearPendingReview('pty-1')
-    expect(getPendingReview('pty-1')).toBeUndefined()
+  test('set replaces the prior record for the same (ptyId, nonce)', () => {
+    setPendingReview(record('abc'))
+    setPendingReview({ ...record('abc'), dispatchedAt: 2 })
+    expect(getPendingReview('pty-1', 'abc')?.dispatchedAt).toBe(2)
   })
 
-  test('get for an unknown pty is undefined', () => {
-    expect(getPendingReview('nope')).toBeUndefined()
+  test('clear removes exactly the addressed record', () => {
+    setPendingReview(record('abc'))
+    setPendingReview(record('xyz'))
+    clearPendingReview('pty-1', 'abc')
+
+    expect(getPendingReview('pty-1', 'abc')).toBeUndefined()
+    expect(getPendingReview('pty-1', 'xyz')?.nonce).toBe('xyz')
+  })
+
+  test('get for an unknown (ptyId, nonce) is undefined', () => {
+    expect(getPendingReview('nope', 'abc')).toBeUndefined()
+  })
+
+  test('prunePendingReviewOwners removes records for closed owners', () => {
+    setPendingReview(record('abc'))
+    setPendingReview(record('stale', 'stale-owner'))
+
+    prunePendingReviewOwners(new Set(['sess:pane']))
+
+    expect(getPendingReview('pty-1', 'abc')?.nonce).toBe('abc')
+    expect(getPendingReview('pty-1', 'stale')).toBeUndefined()
   })
 })

--- a/src/features/diff/services/pendingReviews.ts
+++ b/src/features/diff/services/pendingReviews.ts
@@ -27,25 +27,43 @@ export interface PendingReview {
   /** The feedback owner (sessionId:paneId) at dispatch — replies route here even
    * after the active pane changes. */
   ownerKey: string
-  /** The token the agent must echo; a superseded dispatch mints a new one. */
+  /** The token the agent must echo; each dispatch mints its own. */
   nonce: string
   dispatchedAt: number
   /** `[#n]` → the comment it addressed, in the order the dispatch numbered them. */
   byHandle: Map<number, PendingReviewHandle>
 }
 
-// ponytail: module-singleton keyed by ptyId — correlation state, not persisted
-// review data (comments persist via the feedback store). One in-flight review
-// per pty; a new dispatch replaces it.
+// Module-singleton keyed by (ptyId, nonce) — correlation state, not persisted
+// review data (comments persist via the feedback store). Multiple dispatches
+// can be in flight on one pty at once (VIM-297: a single comment sent now must
+// not clobber the batch's correlation, and vice versa); each reply resolves by
+// the nonce it echoes. Records are consumed when their replies land and are
+// pruned with their owner.
+const reviewKey = (ptyId: string, nonce: string): string =>
+  `${ptyId}\u0000${nonce}`
+
 const store = new Map<string, PendingReview>()
 
 export const setPendingReview = (review: PendingReview): void => {
-  store.set(review.ptyId, review)
+  store.set(reviewKey(review.ptyId, review.nonce), review)
 }
 
-export const getPendingReview = (ptyId: string): PendingReview | undefined =>
-  store.get(ptyId)
+export const getPendingReview = (
+  ptyId: string,
+  nonce: string
+): PendingReview | undefined => store.get(reviewKey(ptyId, nonce))
 
-export const clearPendingReview = (ptyId: string): void => {
-  store.delete(ptyId)
+export const clearPendingReview = (ptyId: string, nonce: string): void => {
+  store.delete(reviewKey(ptyId, nonce))
+}
+
+export const prunePendingReviewOwners = (
+  liveOwnerKeys: ReadonlySet<string>
+): void => {
+  for (const [key, review] of store) {
+    if (!liveOwnerKeys.has(review.ownerKey)) {
+      store.delete(key)
+    }
+  }
 }

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -104,6 +104,7 @@ import { useFeedbackBatchStore } from '../diff/hooks/useFeedbackBatch'
 import { useAgentReply } from '../diff/hooks/useAgentReply'
 import { useAgentReview } from '../diff/hooks/useAgentReview'
 import { prunePendingReviewRequestOwners } from '../diff/services/pendingReviewRequests'
+import { prunePendingReviewOwners } from '../diff/services/pendingReviews'
 import type { PaneCandidate } from '../diff/services/activePanePicker'
 import { sumLines } from '../diff/utils/sumLines'
 import { findActivePane } from '../sessions/utils/activeSessionPane'
@@ -2260,6 +2261,7 @@ const WorkspaceViewContent = (): ReactElement => {
   useLayoutEffect(() => {
     pruneFeedbackOwners(livePaneKeys)
     prunePendingReviewRequestOwners(livePaneKeys)
+    prunePendingReviewOwners(livePaneKeys)
   }, [livePaneKeys, pruneFeedbackOwners])
 
   // Capture agent replies (VIM-249): the single subscription point, mounted

--- a/tests/e2e/terminal/specs/keymap-bindings.spec.ts
+++ b/tests/e2e/terminal/specs/keymap-bindings.spec.ts
@@ -293,9 +293,14 @@ const waitForE2eBridge = async (): Promise<void> => {
 
 const activePtySessionIds = async (): Promise<string[]> =>
   browser.execute(async () => {
-    const backendIds =
-      (await window.__VIMEFLOW_E2E__?.listActivePtySessions()) ?? []
-    const rendererIds = window.__VIMEFLOW_E2E__?.getActiveSessionIds() ?? []
+    const bridge = window.__VIMEFLOW_E2E__
+    const rendererIds = bridge?.getActiveSessionIds() ?? []
+    let backendIds: string[] = []
+    try {
+      backendIds = (await bridge?.listActivePtySessions()) ?? []
+    } catch {
+      backendIds = []
+    }
 
     return Array.from(new Set([...backendIds, ...rendererIds]))
   })

--- a/tests/e2e/terminal/specs/keymap-bindings.spec.ts
+++ b/tests/e2e/terminal/specs/keymap-bindings.spec.ts
@@ -292,9 +292,13 @@ const waitForE2eBridge = async (): Promise<void> => {
 }
 
 const activePtySessionIds = async (): Promise<string[]> =>
-  browser.execute(
-    async () => (await window.__VIMEFLOW_E2E__?.listActivePtySessions()) ?? []
-  )
+  browser.execute(async () => {
+    const backendIds =
+      (await window.__VIMEFLOW_E2E__?.listActivePtySessions()) ?? []
+    const rendererIds = window.__VIMEFLOW_E2E__?.getActiveSessionIds() ?? []
+
+    return Array.from(new Set([...backendIds, ...rendererIds]))
+  })
 
 const isSplitViewDisplayed = async (): Promise<boolean> =>
   browser.execute(() => {

--- a/tests/e2e/terminal/specs/keymap-bindings.spec.ts
+++ b/tests/e2e/terminal/specs/keymap-bindings.spec.ts
@@ -292,7 +292,9 @@ const waitForE2eBridge = async (): Promise<void> => {
 }
 
 const activePtySessionIds = async (): Promise<string[]> =>
-  browser.execute(() => window.__VIMEFLOW_E2E__?.getActiveSessionIds() ?? [])
+  browser.execute(
+    async () => (await window.__VIMEFLOW_E2E__?.listActivePtySessions()) ?? []
+  )
 
 const isSplitViewDisplayed = async (): Promise<boolean> =>
   browser.execute(() => {


### PR DESCRIPTION
## Summary
- **Nonce-keyed pending reviews:** `pendingReviews` re-keys from `ptyId` (one in-flight dispatch, replaced on send) to `(ptyId, nonce)`, mirroring the finding-thread record — multiple dispatches on one pty now correlate their `agent-reply`s independently, which per-comment dispatch requires. `useAgentReply` resolves the comment path by `(sessionId, nonce)`; records prune with their owner (the old store never pruned).
- **Send-now on a pending comment row:** dispatches just that comment through the *existing* batch path — `buildFeedbackEntries` gains an id filter, `handleSendFeedback` threads it, and the existing `FinishFeedbackPopover` renders scoped to the one comment (no new dispatch machinery, no new popover). The rest of the batch stays pending and still dispatches on Finish; Copy is scoped identically; an emptied filter (comment edited/deleted mid-popover) never dispatches an empty payload.

Foundation for VIM-298 (multi-turn thread follow-ups — a follow-up is a single comment dispatched on its own). Plan: `docs/superpowers/plans/2026-07-11-vim-297-per-comment-dispatch.md`.

Closes VIM-297. Part of VIM-284.

## Test plan
- [x] Acceptance (from the issue): single-comment dispatch marks only that id pending→dispatched — Panel flow test proves the payload carries only the addressed comment (`[#1]`, no `[#2]`), the Finish chip drops to (1), and the correlation record covers exactly one handle
- [x] Acceptance: two concurrent dispatches each get their own reply attached (out-of-order nonces) — `useAgentReply` test
- [x] `npx vitest run src/features/diff src/features/workspace` — 1446 passed
- [x] Repo-wide `npm run lint`, `npm run format:check`, `npx tsc --noEmit` — green
- [x] Full vitest suite green on pre-push