### PR TITLE
chore: serialize lint-staged tasks to survive memory pressure

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx lint-staged
+npx lint-staged --concurrent false


### PR DESCRIPTION
## Summary
- Run the pre-commit lint-staged globs with `--concurrent false`: the type-checked ESLint program and the whole-repo `tsc --noEmit` each peak ~1 GB (measured with `/usr/bin/time -l`); running them simultaneously right after a full vitest run repeatedly got a hook child SIGKILLed under memory pressure (`tsc --noEmit failed without output (KILLED)`, 3× on 2026-07-10/11 in fresh worktrees). Sequential tasks peak alone; the checks themselves are unchanged.

## Test plan
- [x] Reproduced the hook flow in a scratch worktree with the exact staged set from a failing commit — sequential run completes (`[COMPLETED] eslint` before the next glob starts, `[COMPLETED] tsc --noEmit`)
- [x] Measured: `tsc --noEmit` 0.9 GB / 7.3 s; type-checked eslint on the 5-file set 1.1 GB / 4.9 s — confirming the concurrent peak, not either task alone, is the exposure

Refs VIM-332