### PR TITLE
feat(diff): multi-turn finding threads (VIM-298)

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -2,6 +2,10 @@ version: '0.2'
 language: en
 
 words:
+  # Multi-turn thread taxonomy (VIM-298 spec vocabulary)
+  - typeless
+  - metas
+
   # Settings dialog domain terms (UI labels / scheme + font names)
   - keymap
   - Keymap

--- a/docs/superpowers/plans/2026-07-12-vim-298-multi-turn-threads.md
+++ b/docs/superpowers/plans/2026-07-12-vim-298-multi-turn-threads.md
@@ -2009,3 +2009,5 @@ EOF
 - Spec coverage: Section 2 → Tasks 1–3, Section 3 → Task 6, Section 4 → Tasks 4, 5, 7, Section 5 → Tasks 6, 7, Section 6 → every task's tests + Task 8/9.
 - Type consistency: `ThreadGroup`/`threadGroupKey`/`threadAnchorLabel`/`followUpContextLine`/`isFollowUpComment` names match across Tasks 3, 5, 6, 7, 8; `markDispatched` options shape matches Tasks 1 and 2; `PendingReviewHandle.threadId` matches Tasks 2, 7, 8.
 - The two known judgment points for the executor: (1) existing Panel tests that asserted dispatched-comment rows will need updating to the card rendering — that is the feature, not a regression; (2) match each test file's existing harness idioms rather than inventing new ones.
+
+<!-- codex-reviewed: 2026-07-13T07:17:31Z -->

--- a/docs/superpowers/plans/2026-07-12-vim-298-multi-turn-threads.md
+++ b/docs/superpowers/plans/2026-07-12-vim-298-multi-turn-threads.md
@@ -181,6 +181,8 @@ test('a placed finding self-roots its thread', async () => {
 
 In `Panel.test.tsx`, if the file already has a dispatch-path test asserting `setPendingReview` contents, extend it to assert each handle now carries `threadId` equal to the dispatched comment's id; otherwise add one following the file's existing dispatch test setup.
 
+**Existing assertion to update:** `useAgentReview.test.ts` (~lines 325–332) exactly compares the anchored handle shape — it will fail once handles carry `threadId`. Extend that expected object with `threadId: <the placed finding's comment id>` as part of this task (it is the behavior change, not collateral).
+
 - [ ] **Step 2: Run to verify they fail**
 
 Run: `npx vitest run src/features/diff/hooks/useAgentReply.test.ts src/features/diff/hooks/useAgentReview.test.ts src/features/diff/Panel.test.tsx`
@@ -351,11 +353,15 @@ describe('buildThreadGroups', () => {
 })
 
 describe('threadRollup', () => {
-  test('is total over the latest turn', () => {
+  test('is total over the latest turn (full outcome matrix)', () => {
     const agent = (outcome?: ReviewComment['outcome']) =>
       annotation({ id: 'g', author: 'agent', ...(outcome ? { outcome } : {}) })
 
+    expect(threadRollup([agent('reply')], false).label).toBe('Replied')
     expect(threadRollup([agent('clarify')], false).label).toBe('Awaiting you')
+    expect(threadRollup([agent('resolved')], false).label).toBe('Resolved')
+    expect(threadRollup([agent('deferred')], false).label).toBe('Deferred')
+    expect(threadRollup([agent('rejected')], false).label).toBe('Rejected')
     expect(threadRollup([agent()], false).label).toBe('Replied')
     expect(
       threadRollup(
@@ -366,6 +372,7 @@ describe('threadRollup', () => {
     expect(
       threadRollup([annotation({ id: 'r', author: 'reviewer' })], false).label
     ).toBe('Open')
+    // Local resolve overrides every derived state.
     expect(threadRollup([agent('rejected')], true).label).toBe('Resolved')
   })
 })
@@ -751,6 +758,21 @@ test('followUpContextLine phrases by author, truncates, and strips controls', ()
   expect(hostile).not.toContain('\x1b')
   expect(hostile).not.toContain('\r')
 })
+
+test('a category-less dispatched ROOT is not a follow-up', () => {
+  // threadId === id (self-rooted) + no category → still the default Change
+  // request in the payload, NOT [#n · Follow-up].
+  expect(
+    isFollowUpComment({
+      id: 'c1',
+      threadId: 'c1',
+      text: 't',
+      author: 'self',
+      createdAt: 1,
+      dispatchedAt: 1000,
+    })
+  ).toBe(false)
+})
 ```
 
 - [ ] **Step 2: Run to verify they fail**
@@ -763,10 +785,16 @@ Expected: FAIL — `followUpContextLine` not exported; label renders `Change req
 (a) After `CATEGORY_INSTRUCTION`, add:
 
 ```ts
-/** A typeless thread follow-up (VIM-298): threadId set, no category chosen. */
+/**
+ * A typeless thread follow-up (VIM-298): belongs to ANOTHER root's thread and
+ * has no category. `threadId !== id` is load-bearing — a dispatched ROOT
+ * self-stamps `threadId === id` and may legitimately omit category (defaults
+ * to a change request); it must NOT be classified as a follow-up.
+ */
 export const isFollowUpComment = (comment: ReviewComment): boolean =>
   comment.author === 'self' &&
   comment.threadId !== undefined &&
+  comment.threadId !== comment.id &&
   comment.category === undefined
 
 const FOLLOW_UP_LABEL = 'Follow-up'
@@ -970,6 +998,28 @@ describe('ReviewThreadCard', () => {
     expect(screen.getByText('Why does the cap live here?')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /reopen/i })).toBeInTheDocument()
   })
+
+  test('re-resolving after an expanded reopen collapses again', () => {
+    // expand-while-resolved is reset when the thread reopens: render resolved,
+    // expand via the disclosure, rerender with resolved: false (reopened),
+    // then rerender resolved: true again → the card must be COLLAPSED.
+    const resolved = group({
+      resolved: true,
+      rollup: { label: 'Resolved', chip: 'text-success' },
+    })
+    const { rerender } = render(
+      <ReviewThreadCard group={resolved} anchorLabel="line R40" actions={actions()} />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /thread/i }))
+    rerender(
+      <ReviewThreadCard group={group()} anchorLabel="line R40" actions={actions()} />
+    )
+    rerender(
+      <ReviewThreadCard group={resolved} anchorLabel="line R40" actions={actions()} />
+    )
+
+    expect(screen.queryByText('Why does the cap live here?')).toBeNull()
+  })
 })
 ```
 
@@ -981,7 +1031,7 @@ Expected: FAIL — module does not exist.
 - [ ] **Step 3: Implement** — create `src/features/diff/components/ReviewThreadCard.tsx`:
 
 ```tsx
-import { useState, type ReactElement } from 'react'
+import { useEffect, useState, type ReactElement } from 'react'
 import type { DiffLineAnnotation } from '@pierre/diffs'
 import {
   reviewCommentCategory,
@@ -1130,6 +1180,15 @@ export const ReviewThreadCard = ({
   actions = undefined,
 }: ReviewThreadCardProps): ReactElement => {
   const [expandedWhileResolved, setExpandedWhileResolved] = useState(false)
+
+  // Reset the read-only expansion whenever the thread reopens, so the NEXT
+  // resolve collapses again (expand → Reopen → Resolve must not stay open).
+  useEffect((): void => {
+    if (!group.resolved) {
+      setExpandedWhileResolved(false)
+    }
+  }, [group.resolved])
+
   const collapsed = group.resolved && !expandedWhileResolved
   const expanded = !collapsed
 
@@ -1265,20 +1324,26 @@ git commit -m "feat(diff): GitHub-style thread card component (VIM-298)"
 
 **Files:**
 - Modify: `src/features/diff/components/PanelBody.tsx`
+- Modify: `src/features/diff/components/Notifier.tsx` (`FinishFeedbackState.onCopy` becomes optional — `onCopy?: () => void`; `FinishFeedbackPopover` already treats it as optional)
 - Modify: `src/features/diff/Panel.tsx`
 - Test: `src/features/diff/Panel.test.tsx`, `src/features/diff/components/PanelBody.test.tsx`
 
 - [ ] **Step 1: Write the failing tests.**
 
-In `PanelBody.test.tsx` (follow the file's existing render harness for `MultiFileDiff` — it already mocks/mounts Pierre):
+In `PanelBody.test.tsx`: the file's existing Pierre mock **ignores `renderAnnotation`** — extend the mock first so annotations are observable, e.g. have the mocked `MultiFileDiff` render `props.lineAnnotations?.map((a) => <div key={…}>{props.renderAnnotation?.(a)}</div>)`. Then:
 
 ```ts
 test('a grouped anchor renders the thread card instead of a row', () => {
   // Render PanelBody with lineAnnotations = [anchor] and
-  // thread={{ groups: new Map([['c1', <group with 2 turns>]]), replyingThreadId: null,
-  //   replyDraft: '', onStartReply: vi.fn(), ... }}
+  // thread={{ groups: new Map([['c1', <group with 2 turns>]]),
+  //   actions: { replyingThreadId: null, replyDraft: '', onStartReply: vi.fn(), ... } }}
   // Assert both turn texts render inside one container and no send/edit/delete
   // IconButtons are present for those turns.
+})
+
+test('thread without actions renders a footer-less card', () => {
+  // Same render with thread={{ groups, actions: undefined }} —
+  // assert no Reply/Resolve buttons (capability gating, spec Section 3).
 })
 ```
 
@@ -1298,6 +1363,26 @@ test('thread reply dispatches alone, inserts post-write pre-stamped, and reopens
   //    - the root's resolvedAt is cleared (reply implies reopen)
   // 4. Failure path: make writePty reject → assert no comment was inserted and the
   //    reply editor is still open with its text.
+})
+
+test('popover cancel preserves the draft and creates nothing', () => {
+  // Reply → confirm (popover opens) → cancel the popover.
+  // Assert: no writePty call, no new annotation, and reopening Reply shows the
+  // same draft text (the per-thread draft map was not cleared).
+})
+
+test('the reply draft survives a MultiFileDiff remount', () => {
+  // Open the reply editor, type text, then force PanelBody's render key to
+  // change (the harness can bump the diff/highlight revision or rerender with a
+  // new key). Assert the editor still shows the typed text — it is controlled
+  // from Panel state, not textarea-local.
+})
+
+test('a repo-subdirectory cwd resolves both path forms', () => {
+  // Batch under cwd '/repo/sub' with repoRootForCwd('/repo/sub') → '/repo'.
+  // Dispatch a follow-up and assert: the payload path is '/repo/src/foo.ts'
+  // (repo-root-resolved), while the registered handle carries the
+  // repo-relative batch coordinates { cwd: '/repo/sub', filePath: 'src/foo.ts' }.
 })
 ```
 
@@ -1322,8 +1407,7 @@ import { ReviewThreadCard } from './ReviewThreadCard'
 (b) New prop types + prop:
 
 ```ts
-export interface PanelThreadProps {
-  groups: Map<string, ThreadGroup>
+export interface PanelThreadActions {
   /** threadId whose reply editor is open; null = none. */
   replyingThreadId: string | null
   replyDraft: string
@@ -1333,6 +1417,12 @@ export interface PanelThreadProps {
   onCancelReply: () => void
   onResolve: (threadId: string) => void
   onReopen: (threadId: string) => void
+}
+
+export interface PanelThreadProps {
+  groups: Map<string, ThreadGroup>
+  /** Omitted → footer-less cards (no dispatch capability, spec Section 3). */
+  actions?: PanelThreadActions
 }
 ```
 
@@ -1344,24 +1434,33 @@ add `thread?: PanelThreadProps` to `PanelBodyProps` and destructure `thread = un
               const groupKey = threadGroupKey(annotation)
               const group =
                 groupKey === undefined ? undefined : thread?.groups.get(groupKey)
-              if (group !== undefined && thread !== undefined) {
+              if (group !== undefined) {
+                const actions = thread?.actions
+
                 return (
                   <ReviewThreadCard
                     key={`thread:${group.threadId}`}
                     group={group}
                     anchorLabel={threadAnchorLabel(group.turns[0] ?? annotation)}
-                    actions={{
-                      replying: thread.replyingThreadId === group.threadId,
-                      replyDraft: thread.replyDraft,
-                      onStartReply: (): void =>
-                        thread.onStartReply(group.threadId),
-                      onReplyDraftChange: thread.onReplyDraftChange,
-                      onSubmitReply: (text): void =>
-                        thread.onSubmitReply(group.threadId, text),
-                      onCancelReply: thread.onCancelReply,
-                      onResolve: (): void => thread.onResolve(group.threadId),
-                      onReopen: (): void => thread.onReopen(group.threadId),
-                    }}
+                    actions={
+                      actions === undefined
+                        ? undefined
+                        : {
+                            replying:
+                              actions.replyingThreadId === group.threadId,
+                            replyDraft: actions.replyDraft,
+                            onStartReply: (): void =>
+                              actions.onStartReply(group.threadId),
+                            onReplyDraftChange: actions.onReplyDraftChange,
+                            onSubmitReply: (text): void =>
+                              actions.onSubmitReply(group.threadId, text),
+                            onCancelReply: actions.onCancelReply,
+                            onResolve: (): void =>
+                              actions.onResolve(group.threadId),
+                            onReopen: (): void =>
+                              actions.onReopen(group.threadId),
+                          }
+                    }
                   />
                 )
               }
@@ -1374,13 +1473,15 @@ add `thread?: PanelThreadProps` to `PanelBodyProps` and destructure `thread = un
 (b) State, next to `sendNowCommentId`:
 
 ```ts
-  // Thread reply draft (VIM-298) — Panel-owned so a MultiFileDiff remount
-  // cannot erase typed text. Cleared only by explicit cancel or a successful
-  // dispatch.
-  const [threadReply, setThreadReply] = useState<{
-    threadId: string
-    text: string
-  } | null>(null)
+  // Thread reply drafts (VIM-298), keyed by threadId so starting a reply on
+  // one thread never discards another thread's typed text. Panel-owned so a
+  // MultiFileDiff remount cannot erase them; an entry is cleared ONLY by that
+  // thread's explicit cancel or its successful dispatch.
+  const [replyDrafts, setReplyDrafts] = useState<ReadonlyMap<string, string>>(
+    new Map()
+  )
+  // Thread whose reply editor is currently open; null = none.
+  const [replyingThreadId, setReplyingThreadId] = useState<string | null>(null)
   // Thread whose follow-up is awaiting the scoped confirm popover (VIM-298);
   // mutually exclusive with finishOpen / sendNowCommentId.
   const [replyDispatchThreadId, setReplyDispatchThreadId] = useState<
@@ -1430,11 +1531,16 @@ add `thread?: PanelThreadProps` to `PanelBodyProps` and destructure `thread = un
   // never sweep it and a write failure leaves no local record.
   const handleSendThreadReply = useCallback(
     (pane: PaneCandidate): void => {
-      if (sendingFeedbackRef.current || threadReply === null) {
+      if (sendingFeedbackRef.current || replyDispatchThreadId === null) {
         return
       }
-      const group = threadGroupById.get(threadReply.threadId)
-      if (group === undefined || feedbackDispatch === undefined) {
+      const draftText = replyDrafts.get(replyDispatchThreadId) ?? ''
+      const group = threadGroupById.get(replyDispatchThreadId)
+      if (
+        group === undefined ||
+        feedbackDispatch === undefined ||
+        draftText.trim().length === 0
+      ) {
         setReplyDispatchThreadId(null)
 
         return
@@ -1450,7 +1556,7 @@ add `thread?: PanelThreadProps` to `PanelBodyProps` and destructure `thread = un
 
           const comment: ReviewComment = {
             id: nextFeedbackCommentId(),
-            text: threadReply.text,
+            text: draftText,
             author: 'self',
             createdAt: Date.now(),
             threadId: group.threadId,
@@ -1537,7 +1643,16 @@ add `thread?: PanelThreadProps` to `PanelBodyProps` and destructure `thread = un
             )
           }
 
-          setThreadReply(null)
+          // Clear ONLY this thread's draft (successful dispatch).
+          setReplyDrafts((prev) => {
+            const next = new Map(prev)
+            next.delete(group.threadId)
+
+            return next
+          })
+          setReplyingThreadId((current) =>
+            current === group.threadId ? null : current
+          )
           setReplyDispatchThreadId(null)
           const focusTerminal = feedbackDispatch.focusTerminal
           if (focusTerminal !== undefined) {
@@ -1553,7 +1668,8 @@ add `thread?: PanelThreadProps` to `PanelBodyProps` and destructure `thread = un
       })()
     },
     [
-      threadReply,
+      replyDispatchThreadId,
+      replyDrafts,
       threadGroupById,
       feedback,
       feedbackDispatch,
@@ -1595,19 +1711,43 @@ add `thread?: PanelThreadProps` to `PanelBodyProps` and destructure `thread = un
   )
 
   const threadProps = {
-    replyingThreadId: threadReply?.threadId ?? null,
-    replyDraft: threadReply?.text ?? '',
-    onStartReply: (threadId: string): void =>
-      setThreadReply({ threadId, text: '' }),
-    onReplyDraftChange: (text: string): void =>
-      setThreadReply((prev) => (prev === null ? prev : { ...prev, text })),
+    replyingThreadId,
+    replyDraft:
+      replyingThreadId === null
+        ? ''
+        : (replyDrafts.get(replyingThreadId) ?? ''),
+    // Switching to another thread's Reply closes the first editor but its
+    // draft stays in the map — reopening restores it.
+    onStartReply: (threadId: string): void => setReplyingThreadId(threadId),
+    onReplyDraftChange: (text: string): void => {
+      setReplyDrafts((prev) => {
+        if (replyingThreadId === null) {
+          return prev
+        }
+        const next = new Map(prev)
+        next.set(replyingThreadId, text)
+
+        return next
+      })
+    },
     onSubmitReply: (threadId: string, text: string): void => {
-      setThreadReply({ threadId, text })
+      setReplyDrafts((prev) => new Map(prev).set(threadId, text))
       setFinishOpen(false)
       setSendNowCommentId(null)
       setReplyDispatchThreadId(threadId)
     },
-    onCancelReply: (): void => setThreadReply(null),
+    // Explicit cancel clears ONLY the active thread's draft.
+    onCancelReply: (): void => {
+      if (replyingThreadId !== null) {
+        setReplyDrafts((prev) => {
+          const next = new Map(prev)
+          next.delete(replyingThreadId)
+
+          return next
+        })
+      }
+      setReplyingThreadId(null)
+    },
     onResolve: resolveThread,
     onReopen: reopenThread,
   }
@@ -1663,7 +1803,11 @@ Also update `onFinishFeedback` to clear the reply scope: add `setReplyDispatchTh
 ```tsx
             lineAnnotations={lineThreads.collapsed}
             ...
-            thread={{ groups: lineThreads.groups, ...threadProps }}
+            thread={{
+              groups: lineThreads.groups,
+              // Capability gating: no dispatch surface → footer-less cards.
+              actions: feedbackDispatch === undefined ? undefined : threadProps,
+            }}
 ```
 
 (h) File strip — replace the `fileCommentsForSelectedFile.map(...)` body: map over `fileThreads.collapsed` instead; for each annotation, look up `threadGroupKey(annotation)` in `fileThreads.groups`; when a group exists render:
@@ -1673,22 +1817,31 @@ Also update `onFinishFeedback` to clear the reply scope: add `setReplyDispatchTh
                     key={`thread:${group.threadId}`}
                     group={group}
                     anchorLabel={threadAnchorLabel(group.turns[0] ?? annotation)}
-                    actions={{
-                      replying: threadProps.replyingThreadId === group.threadId,
-                      replyDraft: threadProps.replyDraft,
-                      onStartReply: (): void =>
-                        threadProps.onStartReply(group.threadId),
-                      onReplyDraftChange: threadProps.onReplyDraftChange,
-                      onSubmitReply: (text): void =>
-                        threadProps.onSubmitReply(group.threadId, text),
-                      onCancelReply: threadProps.onCancelReply,
-                      onResolve: (): void => threadProps.onResolve(group.threadId),
-                      onReopen: (): void => threadProps.onReopen(group.threadId),
-                    }}
+                    actions={
+                      feedbackDispatch === undefined
+                        ? undefined
+                        : {
+                            replying:
+                              threadProps.replyingThreadId === group.threadId,
+                            replyDraft: threadProps.replyDraft,
+                            onStartReply: (): void =>
+                              threadProps.onStartReply(group.threadId),
+                            onReplyDraftChange: threadProps.onReplyDraftChange,
+                            onSubmitReply: (text): void =>
+                              threadProps.onSubmitReply(group.threadId, text),
+                            onCancelReply: threadProps.onCancelReply,
+                            onResolve: (): void =>
+                              threadProps.onResolve(group.threadId),
+                            onReopen: (): void =>
+                              threadProps.onReopen(group.threadId),
+                          }
+                    }
                   />
 ```
 
 otherwise keep the existing `ReviewCommentRow` branch unchanged (pending file comments keep send-now/edit/delete).
+
+(i) `Notifier.tsx` — change `FinishFeedbackState`'s `onCopy: () => void` to `onCopy?: () => void` (it is forwarded to `FinishFeedbackPopover`, whose prop is already optional; a reply-scoped popover passes no `onCopy`).
 
 - [ ] **Step 5: Run the diff feature suite**
 
@@ -1698,7 +1851,7 @@ Expected: PASS — including all pre-existing Panel/PanelBody/integration tests 
 - [ ] **Step 6: Commit**
 
 ```bash
-git add src/features/diff/Panel.tsx src/features/diff/components/PanelBody.tsx src/features/diff/Panel.test.tsx src/features/diff/components/PanelBody.test.tsx
+git add src/features/diff/Panel.tsx src/features/diff/components/PanelBody.tsx src/features/diff/components/Notifier.tsx src/features/diff/Panel.test.tsx src/features/diff/components/PanelBody.test.tsx
 git commit -m "feat(diff): thread cards + follow-up dispatch wiring (VIM-298)"
 ```
 
@@ -1712,15 +1865,24 @@ git commit -m "feat(diff): thread cards + follow-up dispatch wiring (VIM-298)"
 - [ ] **Step 1: Extend the harness.** The file already mounts a real `useFeedbackBatchStore` + `useAgentReply` with a mocked `agent-reply` listener. Add a second Harness that renders thread cards through the real selector:
 
 ```tsx
+// Captured so tests can seed the store from OUTSIDE the component (the store
+// exists only inside the harness). Reset in beforeEach.
+let capturedStore: ReturnType<typeof useFeedbackBatchStore> | null = null
+
 const ThreadHarness = (): ReactElement => {
   const store = useFeedbackBatchStore(OWNER, CWD)
+  capturedStore = store
+
+  // Stable across rerenders: a changing nextCommentId identity would
+  // resubscribe useAgentReply on every render.
+  const [nextCommentId] = useState(() => {
+    let n = 0
+
+    return (): string => `agent-${++n}`
+  })
   useAgentReply({
     addAnnotationForOwner: store.feedbackBatch.addAnnotationForOwner,
-    nextCommentId: (() => {
-      let n = 0
-
-      return (): string => `agent-${++n}`
-    })(),
+    nextCommentId,
   })
 
   const annotations = store.feedbackBatch.annotationsForFile(CWD, FILE, false)
@@ -1749,7 +1911,7 @@ const ThreadHarness = (): ReactElement => {
 }
 ```
 
-(Watch the `nextCommentId` closure — create it with `useRef`/`useState` initializer if StrictMode double-invocation makes the counter unstable; follow the existing harness's approach to ids.)
+Seed operations run through `capturedStore` inside `act(...)` after the initial `render(<ThreadHarness />)` — e.g. `act(() => { capturedStore?.feedbackBatch.addAnnotationForOwner(OWNER, CWD, FILE, false, …) })`.
 
 - [ ] **Step 2: Write the loop test:**
 
@@ -1777,6 +1939,14 @@ test('comment → reply → follow-up → second reply renders one 4-turn card',
   // → assert 4 turns in order (Why? / clarify text / follow-up text / resolved
   //   text), rollup 'Resolved' (from the outcome, thread NOT collapsed —
   //   resolvedAt is unset), and the follow-up turn shows no category chip.
+})
+
+test('a late agent reply after local resolve appends without unresolving', async () => {
+  // Seed a dispatched root WITH resolvedAt set (locally resolved) + a live
+  // pendingReview handle for nonce 'n3'. emitReply for 'n3'.
+  // → assert the card stays collapsed (rollup 'Resolved', turn count ticked
+  //   up to 2) and the root's resolvedAt is unchanged — local resolution is
+  //   authoritative (spec Section 5).
 })
 ```
 

--- a/docs/superpowers/plans/2026-07-12-vim-298-multi-turn-threads.md
+++ b/docs/superpowers/plans/2026-07-12-vim-298-multi-turn-threads.md
@@ -1,0 +1,1841 @@
+# VIM-298 Multi-Turn Finding Threads Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the one-shot inline Q&A into multi-turn conversations: turns at one anchor render as a single GitHub-style thread card with a Reply/Resolve footer, and a follow-up dispatches alone to the agent via the VIM-297 single-comment path.
+
+**Architecture:** A `threadId` on `ReviewComment` links turns (stamped at dispatch, inherited by agent replies through `PendingReviewHandle`); a pure render-layer selector pre-groups annotations into one anchor per thread before Pierre (mechanism A); a new `ReviewThreadCard` renders the settled demo recipe; follow-ups are created atomically with a successful dispatch (post-write, pre-stamped insert). Resolve is local state (`resolvedAt` on the root).
+
+**Tech Stack:** React 19 + TypeScript, `@pierre/diffs` (`MultiFileDiff` annotations), Vitest + Testing Library. Frontend only — no Rust/bindings changes.
+
+**Spec:** `docs/superpowers/specs/2026-07-11-vim-298-multi-turn-threads-design.md` (codex-reviewed). Read it first; every design rule referenced below (groupKey, rollup totality, atomic follow-up, affinity v1) is normative there.
+
+**Working rules for the executor:**
+
+- Run everything from the worktree root (`.claude/worktrees/vim-298-thread-ui`), branch `feature/vim-298`.
+- TDD per task: failing test → implement → pass → commit. `test()` not `it()`; Testing Library role queries first; inline single-use test data.
+- No hardcoded colors outside `src/theme/**` (`vimeflow/no-hardcoded-colors`); no `title=` attributes; no `console.log`; explicit return types on exports.
+- If the pre-commit hook is killed under memory pressure, run `npx lint-staged --concurrent false` manually — do not skip the gate silently.
+
+## File Structure
+
+| File | Change |
+| --- | --- |
+| `src/features/diff/hooks/useFeedbackBatch.ts` | `ReviewComment` gains `threadId`/`resolvedAt`/`dispatchedTo`; `markDispatched` stamps thread fields; cap check keys on pending-ness |
+| `src/features/diff/services/pendingReviews.ts` | `PendingReviewHandle` gains `threadId` |
+| `src/features/diff/hooks/useAgentReply.ts` | `attachAgentNote` copies `handle.threadId` |
+| `src/features/diff/hooks/useAgentReview.ts` | findings self-root (`threadId = id`); anchored handles carry it |
+| `src/features/diff/reviewCategoryMeta.ts` | `THREAD_ROLLUP_META` |
+| `src/features/diff/services/threadGroups.ts` (new) | `threadGroupKey`, `threadRollup`, `buildThreadGroups`, `threadAnchorLabel`, `ThreadGroup` |
+| `src/features/diff/components/ReviewCommentEditor.tsx` | `mode: 'comment' \| 'reply'` |
+| `src/features/diff/services/feedbackDispatch.ts` | Follow-up label/instruction, `followUpContextLine`, payload context param |
+| `src/features/diff/components/ReviewThreadCard.tsx` (new) | The thread card (settled demo recipe) |
+| `src/features/diff/components/PanelBody.tsx` | Thread-group branch in `renderAnnotation` |
+| `src/features/diff/Panel.tsx` | Grouping memos, reply draft state, `handleSendThreadReply`, popover scoping, resolve/reopen, file strip |
+| `src/features/diff/agentReplyThread.integration.test.tsx` | Full multi-turn loop |
+
+---
+
+### Task 1: Thread fields on `ReviewComment` + stamping + cap fix
+
+**Files:**
+- Modify: `src/features/diff/hooks/useFeedbackBatch.ts`
+- Test: `src/features/diff/hooks/useFeedbackBatch.test.ts`
+
+- [ ] **Step 1: Write the failing tests** (append to the existing file's describe structure, reusing its store-harness patterns — the file already tests `markDispatched` and the cap):
+
+```ts
+test('markDispatched stamps threadId as its own id on a root comment', () => {
+  // seed one pending self comment with id 'c1' via the file's existing add helper,
+  // then:
+  //   markDispatched(1000, new Set(['c1']))
+  // assert the annotation's metadata now has dispatchedAt: 1000 and threadId: 'c1'
+})
+
+test('markDispatched preserves an existing threadId (follow-up must not fork)', () => {
+  // seed a pending self comment with metadata { id: 'c2', threadId: 'root-1', ... }
+  //   markDispatched(1000, new Set(['c2']))
+  // assert metadata.threadId === 'root-1' (NOT 'c2')
+})
+
+test('markDispatched stamps dispatchedTo when provided', () => {
+  //   markDispatched(1000, new Set(['c1']), { dispatchedTo: 'pty-9' })
+  // assert metadata.dispatchedTo === 'pty-9'
+})
+
+test('an already-dispatched self insert succeeds at the 50-pending cap', () => {
+  // seed exactly 50 pending self comments (loop addAnnotation)
+  // then addAnnotation with metadata { id: 'f1', author: 'self',
+  //   dispatchedAt: 1000, threadId: 'root-1', text: 'follow', createdAt: 1 }
+  // assert the result is 'ok' and the annotation is in the batch
+})
+
+test('a pending self insert is still rejected at the cap', () => {
+  // seed 50 pending; addAnnotation of a pending self comment → 'cap-reached'
+})
+```
+
+Write them as real tests against `useFeedbackBatchStore` exactly the way neighboring tests in the file construct it (renderHook or the file's harness component — match what is already there).
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npx vitest run src/features/diff/hooks/useFeedbackBatch.test.ts`
+Expected: the new tests FAIL (`threadId` undefined; cap insert returns 'cap-reached').
+
+- [ ] **Step 3: Implement.** In `useFeedbackBatch.ts`:
+
+(a) Extend `ReviewComment` (after the `target` field):
+
+```ts
+  /**
+   * Root comment id of the thread this turn belongs to (VIM-298). Stamped on
+   * dispatch (`threadId ?? id` — a follow-up keeps its root, a root self-roots);
+   * agent replies inherit it from the dispatch handle. Pending comments never
+   * carry one — they are not conversations yet.
+   */
+  threadId?: string
+  /**
+   * Local thread resolution (VIM-298), set on the thread ROOT only. Purely
+   * client-side — nothing is dispatched on resolve; a late agent turn does not
+   * clear it (resolution is authoritative).
+   */
+  resolvedAt?: number
+  /** ptyId of the session this comment was dispatched to (VIM-298 affinity). */
+  dispatchedTo?: string
+```
+
+(b) In `markDispatched`, extend the options type to
+`options?: { clearDraftForWholeBatch?: boolean; dispatchedTo?: string }` and replace the stamping object:
+
+```ts
+                ? {
+                    ...annotation,
+                    metadata: {
+                      ...annotation.metadata,
+                      dispatchedAt,
+                      threadId:
+                        annotation.metadata.threadId ?? annotation.metadata.id,
+                      ...(options?.dispatchedTo === undefined
+                        ? {}
+                        : { dispatchedTo: options.dispatchedTo }),
+                    },
+                  }
+                : annotation
+```
+
+(c) Cap-exempt dispatched inserts — in `addAnnotationForOwner` there are TWO cap checks (optimistic ref + inside `setBatchesByOwner`). In both, replace the condition `annotation.metadata.author === 'self'` with `isPendingReviewAnnotation(annotation)`:
+
+```ts
+      if (
+        isPendingReviewAnnotation(annotation) &&
+        countPendingInBatch(optimisticBatch) >= SOFT_CAP
+      ) {
+```
+
+(The cap guards the *pending* review the user is assembling; a pre-stamped dispatched follow-up is thread history, like agent output. `isPendingReviewAnnotation` = `author === 'self' && dispatchedAt === undefined`, so pending behavior is unchanged.)
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `npx vitest run src/features/diff/hooks/useFeedbackBatch.test.ts`
+Expected: PASS (all, including pre-existing tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/diff/hooks/useFeedbackBatch.ts src/features/diff/hooks/useFeedbackBatch.test.ts
+git commit -m "feat(diff): thread fields on ReviewComment + dispatch stamping (VIM-298)"
+```
+
+---
+
+### Task 2: `threadId` through handles, agent replies, and finding placement
+
+**Files:**
+- Modify: `src/features/diff/services/pendingReviews.ts`
+- Modify: `src/features/diff/Panel.tsx` (`buildFeedbackEntries`, `handleSendFeedback`)
+- Modify: `src/features/diff/hooks/useAgentReply.ts`
+- Modify: `src/features/diff/hooks/useAgentReview.ts`
+- Test: `src/features/diff/hooks/useAgentReply.test.ts`, `src/features/diff/hooks/useAgentReview.test.ts`, `src/features/diff/Panel.test.tsx`
+
+- [ ] **Step 1: Write the failing tests.**
+
+In `useAgentReply.test.ts` (match the file's existing event-emission harness):
+
+```ts
+test('an agent reply inherits the handle threadId', async () => {
+  // setPendingReview with byHandle: new Map([[1, { cwd, filePath, staged: false,
+  //   lineNumber: 5, side: 'additions', target: undefined, threadId: 'root-1' }]])
+  // emit an agent-reply for [#1]
+  // assert addAnnotationForOwner was called with metadata containing threadId: 'root-1'
+})
+```
+
+In `useAgentReview.test.ts`:
+
+```ts
+test('a placed finding self-roots its thread', async () => {
+  // emit an agent-review event with one line-scoped finding on a diffed file
+  // assert the placed annotation's metadata.threadId === metadata.id
+})
+```
+
+In `Panel.test.tsx`, if the file already has a dispatch-path test asserting `setPendingReview` contents, extend it to assert each handle now carries `threadId` equal to the dispatched comment's id; otherwise add one following the file's existing dispatch test setup.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npx vitest run src/features/diff/hooks/useAgentReply.test.ts src/features/diff/hooks/useAgentReview.test.ts src/features/diff/Panel.test.tsx`
+Expected: new tests FAIL (no `threadId` anywhere).
+
+- [ ] **Step 3: Implement.**
+
+(a) `pendingReviews.ts` — add to `PendingReviewHandle` after `target`:
+
+```ts
+  /**
+   * The thread the addressed comment roots or belongs to (VIM-298):
+   * `comment.threadId ?? comment.id`, captured at handle registration so the
+   * agent's reply lands in the same thread group.
+   */
+  threadId?: string
+```
+
+(b) `Panel.tsx` `buildFeedbackEntries` — in the `handles.set(...)` object add:
+
+```ts
+            threadId: annotation.metadata.threadId ?? annotation.metadata.id,
+```
+
+(c) `Panel.tsx` `handleSendFeedback` — the `feedback.markDispatched(...)` call's options become:
+
+```ts
+            { clearDraftForWholeBatch: onlyCommentId === undefined, dispatchedTo: pane.ptyId }
+```
+
+(d) `useAgentReply.ts` `attachAgentNote` — in the metadata object, after the `target` spread:
+
+```ts
+            ...(handle.threadId === undefined
+              ? {}
+              : { threadId: handle.threadId }),
+```
+
+(e) `useAgentReview.ts` — in `reviewerAnnotation`, self-root the finding:
+
+```ts
+      const id = nextCommentId()
+      const metadata: ReviewComment = {
+        id,
+        threadId: id,
+        text: finding.text,
+        author: 'reviewer',
+        reviewer,
+        category: finding.category as ReviewCommentCategory,
+        createdAt: Date.now(),
+      }
+```
+
+(remove the old `id: nextCommentId(),` line). Then in the `byOrdinal.set(ordinal, { kind: 'anchored', ... })` handle object add `threadId: annotation.metadata.id,`.
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `npx vitest run src/features/diff/hooks/useAgentReply.test.ts src/features/diff/hooks/useAgentReview.test.ts src/features/diff/Panel.test.tsx src/features/diff/agentReplyThread.integration.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/diff/services/pendingReviews.ts src/features/diff/Panel.tsx src/features/diff/hooks/useAgentReply.ts src/features/diff/hooks/useAgentReview.ts src/features/diff/hooks/useAgentReply.test.ts src/features/diff/hooks/useAgentReview.test.ts src/features/diff/Panel.test.tsx
+git commit -m "feat(diff): thread identity through dispatch handles and replies (VIM-298)"
+```
+
+---
+
+### Task 3: Grouping selector + rollup metas
+
+**Files:**
+- Modify: `src/features/diff/reviewCategoryMeta.ts`
+- Create: `src/features/diff/services/threadGroups.ts`
+- Test: `src/features/diff/services/threadGroups.test.ts`
+
+- [ ] **Step 1: Write the failing test** — create `src/features/diff/services/threadGroups.test.ts`:
+
+```ts
+import { describe, expect, test } from 'vitest'
+import type { DiffLineAnnotation } from '@pierre/diffs'
+import type { ReviewComment } from '../hooks/useFeedbackBatch'
+import { DRAFT_ID } from '../hooks/useFeedbackBatch'
+import {
+  buildThreadGroups,
+  threadAnchorLabel,
+  threadGroupKey,
+  threadRollup,
+} from './threadGroups'
+
+const LOCATION = { cwd: '/repo', filePath: 'src/foo.ts', staged: false }
+
+const annotation = (
+  metadata: Partial<ReviewComment> & { id: string },
+  lineNumber = 5
+): DiffLineAnnotation<ReviewComment> => ({
+  side: 'additions',
+  lineNumber,
+  metadata: {
+    text: 't',
+    author: 'self',
+    createdAt: 1,
+    ...metadata,
+  } as ReviewComment,
+})
+
+describe('threadGroupKey', () => {
+  test('pending self comments and the draft sentinel have no key', () => {
+    expect(threadGroupKey(annotation({ id: 'p1' }))).toBeUndefined()
+    expect(threadGroupKey(annotation({ id: DRAFT_ID }))).toBeUndefined()
+  })
+
+  test('threadId wins; dispatched and non-self fall back to own id', () => {
+    expect(
+      threadGroupKey(annotation({ id: 'a1', threadId: 'root-1' }))
+    ).toBe('root-1')
+    expect(
+      threadGroupKey(annotation({ id: 'c1', dispatchedAt: 1000 }))
+    ).toBe('c1')
+    expect(threadGroupKey(annotation({ id: 'g1', author: 'agent' }))).toBe('g1')
+  })
+})
+
+describe('buildThreadGroups', () => {
+  test('collapses a thread to one anchor and passes pending through', () => {
+    const root = annotation({ id: 'c1', dispatchedAt: 1000, threadId: 'c1' })
+    const reply = annotation({ id: 'g1', author: 'agent', threadId: 'c1' })
+    const pending = annotation({ id: 'p1' })
+    const { collapsed, groups } = buildThreadGroups(
+      [root, reply, pending],
+      LOCATION
+    )
+
+    expect(collapsed).toEqual([root, pending])
+    expect(groups.get('c1')?.turns).toEqual([root, reply])
+    expect(groups.get('c1')).toMatchObject(LOCATION)
+  })
+
+  test('two roots on one line stay two groups', () => {
+    const { groups } = buildThreadGroups(
+      [
+        annotation({ id: 'c1', dispatchedAt: 1, threadId: 'c1' }),
+        annotation({ id: 'c2', dispatchedAt: 2, threadId: 'c2' }),
+      ],
+      LOCATION
+    )
+
+    expect(groups.size).toBe(2)
+  })
+
+  test('resolved derives from the root comment', () => {
+    const { groups } = buildThreadGroups(
+      [
+        annotation({
+          id: 'c1',
+          dispatchedAt: 1,
+          threadId: 'c1',
+          resolvedAt: 2000,
+        }),
+        annotation({ id: 'g1', author: 'agent', threadId: 'c1' }),
+      ],
+      LOCATION
+    )
+
+    expect(groups.get('c1')?.resolved).toBe(true)
+    expect(groups.get('c1')?.rollup.label).toBe('Resolved')
+  })
+})
+
+describe('threadRollup', () => {
+  test('is total over the latest turn', () => {
+    const agent = (outcome?: ReviewComment['outcome']) =>
+      annotation({ id: 'g', author: 'agent', ...(outcome ? { outcome } : {}) })
+
+    expect(threadRollup([agent('clarify')], false).label).toBe('Awaiting you')
+    expect(threadRollup([agent()], false).label).toBe('Replied')
+    expect(
+      threadRollup(
+        [agent('clarify'), annotation({ id: 'f', dispatchedAt: 3 })],
+        false
+      ).label
+    ).toBe('Sent')
+    expect(
+      threadRollup([annotation({ id: 'r', author: 'reviewer' })], false).label
+    ).toBe('Open')
+    expect(threadRollup([agent('rejected')], true).label).toBe('Resolved')
+  })
+})
+
+describe('threadAnchorLabel', () => {
+  test('labels line, range, and file anchors', () => {
+    expect(threadAnchorLabel(annotation({ id: 'a' }, 40))).toBe('line R40')
+    expect(
+      threadAnchorLabel(
+        annotation({
+          id: 'b',
+          target: {
+            scope: 'range',
+            side: 'additions',
+            startLine: 88,
+            endLine: 94,
+          },
+        })
+      )
+    ).toBe('lines R88-R94')
+    expect(
+      threadAnchorLabel(annotation({ id: 'c', target: { scope: 'file' } }, 0))
+    ).toBe('file')
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/features/diff/services/threadGroups.test.ts`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement.**
+
+(a) `reviewCategoryMeta.ts` — append:
+
+```ts
+/**
+ * Chip metas for thread rollup states that no single agent turn carries
+ * (VIM-298): Sent = latest turn is a dispatched user turn (awaiting the
+ * agent); Open = a reviewer finding with no agent turn yet; Resolved =
+ * the user resolved the thread locally (reuses the outcome meta).
+ */
+export const THREAD_ROLLUP_META = {
+  sent: { label: 'Sent', chip: 'text-primary' },
+  open: { label: 'Open', chip: 'text-on-surface-variant' },
+  resolved: AGENT_OUTCOME_META.resolved,
+} as const
+```
+
+(b) Create `src/features/diff/services/threadGroups.ts`:
+
+```ts
+import type { DiffLineAnnotation } from '@pierre/diffs'
+import type { ReviewComment } from '../hooks/useFeedbackBatch'
+import { AGENT_OUTCOME_META, THREAD_ROLLUP_META } from '../reviewCategoryMeta'
+
+/**
+ * One rendered conversation (VIM-298): the store stays flat, this is the
+ * derived view-model. `turns` is store order (arrival order — attachAgentNote
+ * appends). The batch-location snapshot is captured at group construction so
+ * the follow-up dispatch has both the repo-relative handle coordinates and an
+ * input to the repo-root resolver without re-deriving from render-time props.
+ */
+export interface ThreadGroup {
+  threadId: string
+  turns: DiffLineAnnotation<ReviewComment>[]
+  rollup: { label: string; chip: string }
+  resolved: boolean
+  cwd: string
+  filePath: string
+  staged: boolean
+}
+
+export interface ThreadGroupsResult {
+  /** One anchor annotation per group + pass-through pending/draft rows. */
+  collapsed: DiffLineAnnotation<ReviewComment>[]
+  groups: Map<string, ThreadGroup>
+}
+
+/**
+ * The grouping key: threadId when present; orphan agent/reviewer annotations
+ * and legacy dispatched roots self-key; pending user comments (and the draft
+ * sentinel) have none — they render as flat rows, never inside a card.
+ */
+export const threadGroupKey = (
+  annotation: DiffLineAnnotation<ReviewComment>
+): string | undefined =>
+  annotation.metadata.threadId ??
+  (annotation.metadata.author !== 'self' ||
+  annotation.metadata.dispatchedAt !== undefined
+    ? annotation.metadata.id
+    : undefined)
+
+/**
+ * Total rollup over the LATEST turn (a dispatched follow-up after a `clarify`
+ * flips the thread back to awaiting the agent), with local resolve on top.
+ * Every self turn inside a thread is dispatched by construction (follow-ups
+ * are created atomically with a successful dispatch), so the self arm is Sent.
+ */
+export const threadRollup = (
+  turns: DiffLineAnnotation<ReviewComment>[],
+  resolved: boolean
+): { label: string; chip: string } => {
+  if (resolved) {
+    return THREAD_ROLLUP_META.resolved
+  }
+
+  const latest = turns[turns.length - 1]?.metadata
+  if (latest === undefined || latest.author === 'reviewer') {
+    return THREAD_ROLLUP_META.open
+  }
+
+  if (latest.author === 'agent') {
+    return latest.outcome === undefined
+      ? AGENT_OUTCOME_META.reply
+      : AGENT_OUTCOME_META[latest.outcome]
+  }
+
+  return THREAD_ROLLUP_META.sent
+}
+
+export const buildThreadGroups = (
+  annotations: DiffLineAnnotation<ReviewComment>[],
+  location: { cwd: string; filePath: string; staged: boolean }
+): ThreadGroupsResult => {
+  const groups = new Map<string, ThreadGroup>()
+  const collapsed: DiffLineAnnotation<ReviewComment>[] = []
+
+  for (const annotation of annotations) {
+    const key = threadGroupKey(annotation)
+    if (key === undefined) {
+      collapsed.push(annotation)
+      continue
+    }
+
+    const existing = groups.get(key)
+    if (existing === undefined) {
+      groups.set(key, {
+        threadId: key,
+        turns: [annotation],
+        rollup: THREAD_ROLLUP_META.open,
+        resolved: false,
+        ...location,
+      })
+      collapsed.push(annotation)
+      continue
+    }
+
+    existing.turns.push(annotation)
+  }
+
+  for (const group of groups.values()) {
+    const root =
+      group.turns.find((turn) => turn.metadata.id === group.threadId) ??
+      group.turns[0]
+    group.resolved = root?.metadata.resolvedAt !== undefined
+    group.rollup = threadRollup(group.turns, group.resolved)
+  }
+
+  return { collapsed, groups }
+}
+
+/**
+ * Anchor label for the card header, total over line / range / file scopes
+ * (PanelBody's private annotationTargetLabel only labels ranges).
+ */
+export const threadAnchorLabel = (
+  annotation: DiffLineAnnotation<ReviewComment>
+): string => {
+  const target = annotation.metadata.target
+  if (target?.scope === 'file') {
+    return 'file'
+  }
+
+  if (target?.scope === 'range') {
+    const prefix = target.side === 'deletions' ? 'L' : 'R'
+
+    return target.startLine === target.endLine
+      ? `line ${prefix}${target.startLine}`
+      : `lines ${prefix}${target.startLine}-${prefix}${target.endLine}`
+  }
+
+  const prefix = annotation.side === 'deletions' ? 'L' : 'R'
+
+  return `line ${prefix}${annotation.lineNumber}`
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npx vitest run src/features/diff/services/threadGroups.test.ts src/features/diff/reviewCategoryMeta.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/diff/services/threadGroups.ts src/features/diff/services/threadGroups.test.ts src/features/diff/reviewCategoryMeta.ts
+git commit -m "feat(diff): thread grouping selector + rollup metas (VIM-298)"
+```
+
+---
+
+### Task 4: `reply` mode on `ReviewCommentEditor`
+
+**Files:**
+- Modify: `src/features/diff/components/ReviewCommentEditor.tsx`
+- Test: `src/features/diff/components/ReviewCommentEditor.test.tsx`
+
+- [ ] **Step 1: Write the failing tests** (append to the existing test file):
+
+```ts
+test('reply mode hides category tabs and relabels the chrome', () => {
+  render(
+    <ReviewCommentEditor
+      mode="reply"
+      chrome="plain"
+      surfaceRole="none"
+      onConfirm={vi.fn()}
+      onCancel={vi.fn()}
+    />
+  )
+
+  expect(screen.getByText('Reply to thread')).toBeInTheDocument()
+  expect(screen.queryByRole('button', { name: 'Question' })).toBeNull()
+  expect(screen.getByPlaceholderText('Reply to the agent…')).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: 'Reply' })).toBeInTheDocument()
+})
+
+test('reply mode ignores the ctrl+h/l category cycle', async () => {
+  const onConfirm = vi.fn()
+  render(
+    <ReviewCommentEditor mode="reply" onConfirm={onConfirm} onCancel={vi.fn()} />
+  )
+
+  const textarea = screen.getByPlaceholderText('Reply to the agent…')
+  fireEvent.keyDown(textarea, { key: 'l', ctrlKey: true })
+  fireEvent.change(textarea, { target: { value: 'follow-up' } })
+  fireEvent.keyDown(textarea, { key: 'Enter' })
+
+  expect(onConfirm).toHaveBeenCalledWith('follow-up', 'change')
+})
+```
+
+(The second test pins that confirm still passes the default category — the reply-mode caller ignores it, per spec.)
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npx vitest run src/features/diff/components/ReviewCommentEditor.test.tsx`
+Expected: FAIL — unknown prop / 'Local comment' rendered.
+
+- [ ] **Step 3: Implement.** In `ReviewCommentEditor.tsx`:
+
+(a) Add to `ReviewCommentEditorBaseProps`:
+
+```ts
+  /**
+   * 'reply' = a typeless thread follow-up (VIM-298): category tabs hidden and
+   * the cycle shortcuts inert, chrome copy reads Reply. Default 'comment'.
+   */
+  mode?: 'comment' | 'reply'
+```
+
+destructure `mode = 'comment'` in the component.
+
+(b) Guard the cycle at the top of `cycleCategory`:
+
+```ts
+    if (mode === 'reply') {
+      return
+    }
+```
+
+(c) Header label: replace the literal `Local comment` text node with `{mode === 'reply' ? 'Reply to thread' : 'Local comment'}`.
+
+(d) Wrap the category-tabs `<div className="flex flex-wrap items-center gap-1">…</div>` block in `{mode === 'reply' ? null : ( … )}`.
+
+(e) Textarea placeholder: `placeholder={mode === 'reply' ? 'Reply to the agent…' : 'Request change'}`.
+
+(f) Confirm button text: `{mode === 'reply' ? 'Reply' : 'Comment'}`.
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `npx vitest run src/features/diff/components/ReviewCommentEditor.test.tsx`
+Expected: PASS (including all pre-existing tests — default mode unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/diff/components/ReviewCommentEditor.tsx src/features/diff/components/ReviewCommentEditor.test.tsx
+git commit -m "feat(diff): typeless reply mode on the comment editor (VIM-298)"
+```
+
+---
+
+### Task 5: Follow-up payload formatting
+
+**Files:**
+- Modify: `src/features/diff/services/feedbackDispatch.ts`
+- Test: `src/features/diff/services/feedbackDispatch.test.ts`
+
+- [ ] **Step 1: Write the failing tests** (append; reuse the file's existing entry-construction helpers):
+
+```ts
+test('a typeless follow-up renders as [#n · Follow-up] with the context line', () => {
+  const payload = formatFeedbackPayload(
+    [
+      {
+        filePath: '/repo/src/auth.ts',
+        staged: false,
+        annotations: [
+          {
+            side: 'additions',
+            lineNumber: 42,
+            metadata: {
+              id: 'f1',
+              text: 'How does that interact with resize?',
+              author: 'self',
+              createdAt: 1,
+              threadId: 'root-1',
+            },
+          },
+        ],
+      },
+    ],
+    'abc123',
+    '> ↩ Continuing our thread — your last reply: "The pool applies backpressure"'
+  )
+
+  expect(payload).toContain('[#1 · Follow-up] /repo/src/auth.ts:42')
+  expect(payload).toContain(
+    '> ↩ Continuing our thread — your last reply: "The pool applies backpressure"'
+  )
+  expect(payload).toContain('> → Answer inline in your reply. Do not edit files.')
+  expect(payload).not.toContain('Change request')
+})
+
+test('followUpContextLine phrases by author, truncates, and strips controls', () => {
+  expect(
+    followUpContextLine({
+      id: 'g1',
+      text: 'short answer',
+      author: 'agent',
+      createdAt: 1,
+    })
+  ).toBe('> ↩ Continuing our thread — your last reply: "short answer"')
+
+  expect(
+    followUpContextLine({
+      id: 'r1',
+      text: 'finding text',
+      author: 'reviewer',
+      createdAt: 1,
+    })
+  ).toContain('the finding: "finding text"')
+
+  expect(
+    followUpContextLine({
+      id: 'c1',
+      text: 'my question',
+      author: 'self',
+      createdAt: 1,
+    })
+  ).toContain('my earlier comment: "my question"')
+
+  const long = followUpContextLine({
+    id: 'g2',
+    text: 'x'.repeat(300),
+    author: 'agent',
+    createdAt: 1,
+  })
+  expect(long).toContain('(truncated)')
+  expect(long.length).toBeLessThan(300)
+
+  // Paste-breakout regression: agent-controlled text cannot terminate the
+  // bracketed paste or inject CR into the prompt.
+  const hostile = followUpContextLine({
+    id: 'g3',
+    text: 'evil\x1b[201~\rinjected',
+    author: 'agent',
+    createdAt: 1,
+  })
+  expect(hostile).not.toContain('\x1b')
+  expect(hostile).not.toContain('\r')
+})
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npx vitest run src/features/diff/services/feedbackDispatch.test.ts`
+Expected: FAIL — `followUpContextLine` not exported; label renders `Change request`.
+
+- [ ] **Step 3: Implement.** In `feedbackDispatch.ts`:
+
+(a) After `CATEGORY_INSTRUCTION`, add:
+
+```ts
+/** A typeless thread follow-up (VIM-298): threadId set, no category chosen. */
+export const isFollowUpComment = (comment: ReviewComment): boolean =>
+  comment.author === 'self' &&
+  comment.threadId !== undefined &&
+  comment.category === undefined
+
+const FOLLOW_UP_LABEL = 'Follow-up'
+const FOLLOW_UP_INSTRUCTION = 'Answer inline in your reply. Do not edit files.'
+const FOLLOW_UP_EXCERPT_MAX = 200
+
+/**
+ * The one-line continuation marker quoting the latest prior turn (VIM-298).
+ * The excerpt is agent-controlled text, so it passes the same control-char
+ * strip as everything else entering the bracketed paste.
+ */
+export const followUpContextLine = (previous: ReviewComment): string => {
+  const phrasing =
+    previous.author === 'agent'
+      ? 'your last reply'
+      : previous.author === 'reviewer'
+        ? 'the finding'
+        : 'my earlier comment'
+  const clean = stripControls(previous.text)
+  const truncated = clean.length > FOLLOW_UP_EXCERPT_MAX
+  const excerpt = truncated ? clean.slice(0, FOLLOW_UP_EXCERPT_MAX) : clean
+
+  return `> ↩ Continuing our thread — ${phrasing}: "${excerpt}"${truncated ? ' (truncated)' : ''}`
+}
+```
+
+(b) `formatFeedbackPayload` gains a third parameter `followUpContext?: string`. In the per-annotation loop, compute follow-up-aware label/instruction and insert the context line:
+
+```ts
+      const followUp = isFollowUpComment(annotation.metadata)
+      const label = followUp ? FOLLOW_UP_LABEL : CATEGORY_LABEL[category]
+      const instruction = followUp
+        ? FOLLOW_UP_INSTRUCTION
+        : CATEGORY_INSTRUCTION[category]
+
+      blocks.push(
+        [
+          `> [#${index} · ${label}] ${formatAnnotationTarget(entry, annotation)}`,
+          ...(followUp && followUpContext !== undefined
+            ? [followUpContext]
+            : []),
+          ...textLines,
+          `> → ${instruction}`,
+          '>',
+        ].join('\n')
+      )
+```
+
+(c) `dispatchFeedbackBatch` gains a trailing optional `followUpContext?: string` parameter, passed through to `formatFeedbackPayload(entries, nonce, followUpContext)`.
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `npx vitest run src/features/diff/services/feedbackDispatch.test.ts`
+Expected: PASS (existing dispatch-vocab pins untouched — non-follow-up output is byte-identical).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/diff/services/feedbackDispatch.ts src/features/diff/services/feedbackDispatch.test.ts
+git commit -m "feat(diff): follow-up payload format + thread context line (VIM-298)"
+```
+
+---
+
+### Task 6: `ReviewThreadCard`
+
+**Files:**
+- Create: `src/features/diff/components/ReviewThreadCard.tsx`
+- Test: `src/features/diff/components/ReviewThreadCard.test.tsx`
+
+- [ ] **Step 1: Write the failing test** — create the test file:
+
+```tsx
+import { describe, expect, test, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import type { ThreadGroup } from '../services/threadGroups'
+import { ReviewThreadCard } from './ReviewThreadCard'
+
+const group = (overrides: Partial<ThreadGroup> = {}): ThreadGroup => ({
+  threadId: 'c1',
+  turns: [
+    {
+      side: 'additions',
+      lineNumber: 40,
+      metadata: {
+        id: 'c1',
+        text: 'Why does the cap live here?',
+        author: 'self',
+        category: 'question',
+        createdAt: 1,
+        dispatchedAt: 1000,
+        threadId: 'c1',
+      },
+    },
+    {
+      side: 'additions',
+      lineNumber: 40,
+      metadata: {
+        id: 'g1',
+        text: 'The pool applies backpressure per write.',
+        author: 'agent',
+        outcome: 'reply',
+        createdAt: 2,
+        threadId: 'c1',
+      },
+    },
+  ],
+  rollup: { label: 'Replied', chip: 'text-success' },
+  resolved: false,
+  cwd: '/repo',
+  filePath: 'src/foo.ts',
+  staged: false,
+  ...overrides,
+})
+
+const actions = (
+  overrides: Partial<Parameters<typeof ReviewThreadCard>[0]['actions']> = {}
+): NonNullable<Parameters<typeof ReviewThreadCard>[0]['actions']> => ({
+  replying: false,
+  replyDraft: '',
+  onStartReply: vi.fn(),
+  onReplyDraftChange: vi.fn(),
+  onSubmitReply: vi.fn(),
+  onCancelReply: vi.fn(),
+  onResolve: vi.fn(),
+  onReopen: vi.fn(),
+  ...overrides,
+})
+
+describe('ReviewThreadCard', () => {
+  test('renders header, ordered turns, chips, and the footer pair', () => {
+    render(
+      <ReviewThreadCard group={group()} anchorLabel="line R40" actions={actions()} />
+    )
+
+    expect(screen.getByText('line R40')).toBeInTheDocument()
+    expect(screen.getByText('2 turns')).toBeInTheDocument()
+    expect(screen.getByText('Replied')).toBeInTheDocument()
+    expect(screen.getByText('Why does the cap live here?')).toBeInTheDocument()
+    expect(
+      screen.getByText('The pool applies backpressure per write.')
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /reply/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /resolve/i })).toBeInTheDocument()
+  })
+
+  test('typeless follow-up turns render no category chip', () => {
+    const g = group()
+    g.turns.push({
+      side: 'additions',
+      lineNumber: 40,
+      metadata: {
+        id: 'f1',
+        text: 'And during drags?',
+        author: 'self',
+        createdAt: 3,
+        dispatchedAt: 2000,
+        threadId: 'c1',
+      },
+    })
+    render(<ReviewThreadCard group={g} anchorLabel="line R40" actions={actions()} />)
+
+    // Exactly one category chip (the root's Question) despite two self turns.
+    expect(screen.getAllByText('Question')).toHaveLength(1)
+  })
+
+  test('reply expands the editor; confirm submits the draft', () => {
+    const a = actions({ replying: true, replyDraft: 'follow-up text' })
+    render(<ReviewThreadCard group={group()} anchorLabel="line R40" actions={a} />)
+
+    fireEvent.keyDown(screen.getByPlaceholderText('Reply to the agent…'), {
+      key: 'Enter',
+    })
+    expect(a.onSubmitReply).toHaveBeenCalledWith('follow-up text')
+  })
+
+  test('no actions → no footer', () => {
+    render(<ReviewThreadCard group={group()} anchorLabel="line R40" />)
+
+    expect(screen.queryByRole('button', { name: /reply/i })).toBeNull()
+  })
+
+  test('resolved collapses to a disclosure header; expanding reveals Reopen', () => {
+    render(
+      <ReviewThreadCard
+        group={group({
+          resolved: true,
+          rollup: { label: 'Resolved', chip: 'text-success' },
+        })}
+        anchorLabel="line R40"
+        actions={actions()}
+      />
+    )
+
+    expect(screen.queryByText('Why does the cap live here?')).toBeNull()
+    const disclosure = screen.getByRole('button', { name: /thread/i })
+    expect(disclosure).toHaveAttribute('aria-expanded', 'false')
+
+    fireEvent.click(disclosure)
+    expect(disclosure).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByText('Why does the cap live here?')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /reopen/i })).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/features/diff/components/ReviewThreadCard.test.tsx`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement** — create `src/features/diff/components/ReviewThreadCard.tsx`:
+
+```tsx
+import { useState, type ReactElement } from 'react'
+import type { DiffLineAnnotation } from '@pierre/diffs'
+import {
+  reviewCommentCategory,
+  type ReviewComment,
+} from '../hooks/useFeedbackBatch'
+import { AGENT_OUTCOME_META, REVIEW_CATEGORY_META } from '../reviewCategoryMeta'
+import { isFollowUpComment } from '../services/feedbackDispatch'
+import type { ThreadGroup } from '../services/threadGroups'
+import { formatSentAgo } from './ReviewCommentRow'
+import { ReviewCommentEditor } from './ReviewCommentEditor'
+
+export interface ReviewThreadCardActions {
+  /** True while this thread's reply editor is open (Panel-owned draft state). */
+  replying: boolean
+  replyDraft: string
+  onStartReply: () => void
+  onReplyDraftChange: (text: string) => void
+  onSubmitReply: (text: string) => void
+  onCancelReply: () => void
+  onResolve: () => void
+  onReopen: () => void
+}
+
+interface ReviewThreadCardProps {
+  group: ThreadGroup
+  anchorLabel: string
+  /** Omitted → footer-less card (no dispatch capability in this context). */
+  actions?: ReviewThreadCardActions
+}
+
+const HAIRLINE = {
+  borderTop:
+    '1px solid color-mix(in srgb, var(--color-on-surface) 12%, transparent)',
+} as const
+
+const Chip = ({
+  label,
+  className,
+}: {
+  label: string
+  className: string
+}): ReactElement => (
+  <span
+    className={`inline-flex items-center rounded bg-surface-container-highest/70 px-1.5 py-px text-[10px] font-medium ${className}`}
+  >
+    {label}
+  </span>
+)
+
+const turnChip = (comment: ReviewComment): ReactElement | null => {
+  if (comment.author === 'agent') {
+    return comment.outcome === undefined ? (
+      <Chip label="Agent reply" className="text-success" />
+    ) : (
+      <Chip
+        label={AGENT_OUTCOME_META[comment.outcome].label}
+        className={AGENT_OUTCOME_META[comment.outcome].chip}
+      />
+    )
+  }
+
+  // Typeless follow-ups carry no chip; categorized user/reviewer turns show
+  // their raise intent (VIM-298 taxonomy).
+  if (comment.author === 'self' && isFollowUpComment(comment)) {
+    return null
+  }
+
+  const meta = REVIEW_CATEGORY_META[reviewCommentCategory(comment)]
+
+  return <Chip label={meta.label} className={meta.chip} />
+}
+
+const turnIdentity = (
+  comment: ReviewComment
+): { avatarClass: string; initial: string; name: string } => {
+  if (comment.author === 'agent') {
+    return {
+      avatarClass: 'bg-primary-container/60 text-primary',
+      initial: 'A',
+      name: 'Agent',
+    }
+  }
+
+  if (comment.author === 'reviewer') {
+    const name = comment.reviewer ?? 'Reviewer'
+
+    return {
+      avatarClass: 'bg-surface-container-highest text-on-surface-variant',
+      initial: name.charAt(0).toUpperCase(),
+      name,
+    }
+  }
+
+  return {
+    avatarClass: 'bg-surface-container-highest text-on-surface-variant',
+    initial: 'Y',
+    name: 'You',
+  }
+}
+
+const TurnRow = ({
+  turn,
+  first,
+}: {
+  turn: DiffLineAnnotation<ReviewComment>
+  first: boolean
+}): ReactElement => {
+  const comment = turn.metadata
+  const identity = turnIdentity(comment)
+  const timestamp =
+    comment.author === 'self' && comment.dispatchedAt !== undefined
+      ? `Sent ${formatSentAgo(comment.dispatchedAt, Date.now())}`
+      : formatSentAgo(comment.createdAt, Date.now())
+
+  return (
+    <div className="px-4 py-2.5" style={first ? undefined : HAIRLINE}>
+      <div className="mb-1 flex flex-wrap items-center gap-1.5">
+        <span
+          aria-hidden="true"
+          className={`flex h-4 w-4 items-center justify-center rounded-full text-[9px] font-bold ${identity.avatarClass}`}
+        >
+          {identity.initial}
+        </span>
+        <span className="text-[11px] font-medium text-on-surface">
+          {identity.name}
+        </span>
+        {turnChip(comment)}
+        <span className="text-[10px] text-on-surface-variant">{timestamp}</span>
+      </div>
+      <p className="whitespace-pre-wrap break-words pl-[22px] text-xs leading-5 text-on-surface">
+        {comment.text}
+      </p>
+    </div>
+  )
+}
+
+/**
+ * A multi-turn review conversation (VIM-298) — the GitHub-style card settled
+ * in the demo-first pass: tonal container, header with anchor + rollup + turn
+ * count, hairline-divided turns, paired Reply/Resolve footer. Resolved threads
+ * collapse to the header behind an accessible disclosure.
+ */
+export const ReviewThreadCard = ({
+  group,
+  anchorLabel,
+  actions = undefined,
+}: ReviewThreadCardProps): ReactElement => {
+  const [expandedWhileResolved, setExpandedWhileResolved] = useState(false)
+  const collapsed = group.resolved && !expandedWhileResolved
+  const expanded = !collapsed
+
+  const header = (
+    <>
+      <span className="font-mono">{anchorLabel}</span>
+      <Chip label={group.rollup.label} className={group.rollup.chip} />
+      <span>
+        {group.turns.length} turn{group.turns.length === 1 ? '' : 's'}
+      </span>
+    </>
+  )
+
+  return (
+    <div className="mx-3 my-2 overflow-hidden rounded-lg bg-surface-container-high/80">
+      {group.resolved ? (
+        <button
+          type="button"
+          aria-expanded={expanded}
+          aria-label={`Resolved thread on ${anchorLabel}, ${group.turns.length} turns`}
+          onClick={(): void => setExpandedWhileResolved(!expandedWhileResolved)}
+          className="flex w-full items-center gap-2 px-4 py-2 text-left text-[10px] text-on-surface-variant"
+          style={{
+            background:
+              'color-mix(in srgb, var(--color-on-surface) 4%, transparent)',
+          }}
+        >
+          {header}
+          <span
+            aria-hidden="true"
+            className="material-symbols-outlined ml-auto text-sm leading-none"
+          >
+            {expanded ? 'expand_less' : 'expand_more'}
+          </span>
+        </button>
+      ) : (
+        <div
+          className="flex items-center gap-2 px-4 py-2 text-[10px] text-on-surface-variant"
+          style={{
+            background:
+              'color-mix(in srgb, var(--color-on-surface) 4%, transparent)',
+          }}
+        >
+          {header}
+        </div>
+      )}
+
+      {expanded
+        ? group.turns.map((turn, index) => (
+            <TurnRow key={turn.metadata.id} turn={turn} first={index === 0} />
+          ))
+        : null}
+
+      {expanded && actions !== undefined ? (
+        <div style={HAIRLINE}>
+          {actions.replying ? (
+            <div className="px-2 py-1.5">
+              <ReviewCommentEditor
+                mode="reply"
+                chrome="plain"
+                surfaceRole="none"
+                targetLabel={anchorLabel}
+                value={actions.replyDraft}
+                onTextChange={actions.onReplyDraftChange}
+                onConfirm={(text): void => actions.onSubmitReply(text)}
+                onCancel={actions.onCancelReply}
+              />
+            </div>
+          ) : (
+            <div className="flex items-center justify-end gap-2 px-4 py-2">
+              <button
+                type="button"
+                onClick={actions.onStartReply}
+                className="rounded-md px-3 py-1.5 text-[11px] font-medium text-primary hover:bg-surface-container-highest/60"
+                style={{
+                  background:
+                    'color-mix(in srgb, var(--color-primary) 12%, transparent)',
+                }}
+              >
+                ↳ Reply
+              </button>
+              {group.resolved ? (
+                <button
+                  type="button"
+                  onClick={actions.onReopen}
+                  className="rounded-md px-3 py-1.5 text-[11px] font-medium text-on-surface-variant hover:bg-surface-container-highest/60 hover:text-on-surface"
+                  style={{
+                    background:
+                      'color-mix(in srgb, var(--color-on-surface) 6%, transparent)',
+                  }}
+                >
+                  ⟲ Reopen
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={actions.onResolve}
+                  className="rounded-md px-3 py-1.5 text-[11px] font-medium text-on-surface-variant hover:bg-surface-container-highest/60 hover:text-on-surface"
+                  style={{
+                    background:
+                      'color-mix(in srgb, var(--color-on-surface) 6%, transparent)',
+                  }}
+                >
+                  ✓ Resolve
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+```
+
+Note: the editor is mounted **controlled** (`value` + `onTextChange`) — the draft lives in Panel state so a `MultiFileDiff` remount cannot erase typed text (spec Section 4).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npx vitest run src/features/diff/components/ReviewThreadCard.test.tsx`
+Expected: PASS. If cspell flags `Reopen`/`expand_more` etc., fix spelling config only if it is a real dictionary gap (these are real words/identifiers; `⟲`/`↳` are symbols and fine).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/diff/components/ReviewThreadCard.tsx src/features/diff/components/ReviewThreadCard.test.tsx
+git commit -m "feat(diff): GitHub-style thread card component (VIM-298)"
+```
+
+---
+
+### Task 7: Panel + PanelBody wiring (grouping, reply dispatch, resolve)
+
+**Files:**
+- Modify: `src/features/diff/components/PanelBody.tsx`
+- Modify: `src/features/diff/Panel.tsx`
+- Test: `src/features/diff/Panel.test.tsx`, `src/features/diff/components/PanelBody.test.tsx`
+
+- [ ] **Step 1: Write the failing tests.**
+
+In `PanelBody.test.tsx` (follow the file's existing render harness for `MultiFileDiff` — it already mocks/mounts Pierre):
+
+```ts
+test('a grouped anchor renders the thread card instead of a row', () => {
+  // Render PanelBody with lineAnnotations = [anchor] and
+  // thread={{ groups: new Map([['c1', <group with 2 turns>]]), replyingThreadId: null,
+  //   replyDraft: '', onStartReply: vi.fn(), ... }}
+  // Assert both turn texts render inside one container and no send/edit/delete
+  // IconButtons are present for those turns.
+})
+```
+
+In `Panel.test.tsx` add the reply-dispatch orchestration test (reuse the file's existing dispatch harness that drives `handleSendFeedback` through the Finish popover — same mocks: `writePty`, candidates):
+
+```ts
+test('thread reply dispatches alone, inserts post-write pre-stamped, and reopens', () => {
+  // 1. Seed a dispatched root (threadId 'c1', resolvedAt set) + one agent turn + one
+  //    UNRELATED pending comment 'p9'.
+  // 2. Open the thread reply editor, type text, confirm → the Finish popover opens
+  //    scoped (commentCount 1).
+  // 3. Confirm the popover pane → assert:
+  //    - writePty payload contains '[#1 · Follow-up]' and '↩ Continuing our thread'
+  //    - the batch now contains the follow-up WITH dispatchedAt, dispatchedTo and
+  //      threadId 'c1' (never observable as pending)
+  //    - 'p9' is still pending (untouched)
+  //    - the root's resolvedAt is cleared (reply implies reopen)
+  // 4. Failure path: make writePty reject → assert no comment was inserted and the
+  //    reply editor is still open with its text.
+})
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npx vitest run src/features/diff/Panel.test.tsx src/features/diff/components/PanelBody.test.tsx`
+Expected: new tests FAIL.
+
+- [ ] **Step 3: Implement PanelBody.** In `PanelBody.tsx`:
+
+(a) Imports:
+
+```ts
+import {
+  threadAnchorLabel,
+  threadGroupKey,
+  type ThreadGroup,
+} from '../services/threadGroups'
+import { ReviewThreadCard } from './ReviewThreadCard'
+```
+
+(b) New prop types + prop:
+
+```ts
+export interface PanelThreadProps {
+  groups: Map<string, ThreadGroup>
+  /** threadId whose reply editor is open; null = none. */
+  replyingThreadId: string | null
+  replyDraft: string
+  onStartReply: (threadId: string) => void
+  onReplyDraftChange: (text: string) => void
+  onSubmitReply: (threadId: string, text: string) => void
+  onCancelReply: () => void
+  onResolve: (threadId: string) => void
+  onReopen: (threadId: string) => void
+}
+```
+
+add `thread?: PanelThreadProps` to `PanelBodyProps` and destructure `thread = undefined`.
+
+(c) In `renderAnnotation`, after the `isDraft || isEditing` branch and before the `ReviewCommentRow` return:
+
+```ts
+              const groupKey = threadGroupKey(annotation)
+              const group =
+                groupKey === undefined ? undefined : thread?.groups.get(groupKey)
+              if (group !== undefined && thread !== undefined) {
+                return (
+                  <ReviewThreadCard
+                    key={`thread:${group.threadId}`}
+                    group={group}
+                    anchorLabel={threadAnchorLabel(group.turns[0] ?? annotation)}
+                    actions={{
+                      replying: thread.replyingThreadId === group.threadId,
+                      replyDraft: thread.replyDraft,
+                      onStartReply: (): void =>
+                        thread.onStartReply(group.threadId),
+                      onReplyDraftChange: thread.onReplyDraftChange,
+                      onSubmitReply: (text): void =>
+                        thread.onSubmitReply(group.threadId, text),
+                      onCancelReply: thread.onCancelReply,
+                      onResolve: (): void => thread.onResolve(group.threadId),
+                      onReopen: (): void => thread.onReopen(group.threadId),
+                    }}
+                  />
+                )
+              }
+```
+
+- [ ] **Step 4: Implement Panel.** In `Panel.tsx`:
+
+(a) Imports: `buildThreadGroups`, `threadAnchorLabel`, `threadGroupKey`, `type ThreadGroup` from `./services/threadGroups`; `followUpContextLine` from `./services/feedbackDispatch`; `ReviewThreadCard` from `./components/ReviewThreadCard`.
+
+(b) State, next to `sendNowCommentId`:
+
+```ts
+  // Thread reply draft (VIM-298) — Panel-owned so a MultiFileDiff remount
+  // cannot erase typed text. Cleared only by explicit cancel or a successful
+  // dispatch.
+  const [threadReply, setThreadReply] = useState<{
+    threadId: string
+    text: string
+  } | null>(null)
+  // Thread whose follow-up is awaiting the scoped confirm popover (VIM-298);
+  // mutually exclusive with finishOpen / sendNowCommentId.
+  const [replyDispatchThreadId, setReplyDispatchThreadId] = useState<
+    string | null
+  >(null)
+```
+
+(c) Grouping memos, after `lineAnnotations` is available (below the `useReviewCommentDraft` destructure):
+
+```ts
+  const lineThreads = useMemo(
+    () =>
+      buildThreadGroups(lineAnnotations, {
+        cwd,
+        filePath: selectedFilePath ?? '',
+        staged: selectedFileStaged,
+      }),
+    [lineAnnotations, cwd, selectedFilePath, selectedFileStaged]
+  )
+
+  const fileThreads = useMemo(
+    () =>
+      buildThreadGroups(fileCommentsForSelectedFile, {
+        cwd,
+        filePath: selectedFileEntry?.path ?? '',
+        staged: selectedFileEntry?.staged ?? false,
+      }),
+    [fileCommentsForSelectedFile, cwd, selectedFileEntry]
+  )
+
+  const threadGroupById = useMemo((): Map<string, ThreadGroup> => {
+    const merged = new Map(lineThreads.groups)
+    for (const [key, group] of fileThreads.groups) {
+      merged.set(key, group)
+    }
+
+    return merged
+  }, [lineThreads, fileThreads])
+```
+
+(d) The reply-dispatch handler, after `handleSendFeedback` (mirrors its shape; the follow-up is created ONLY after the write succeeds — spec Section 4):
+
+```ts
+  // VIM-298: dispatch a thread follow-up. The comment is never stored pending —
+  // it is built ephemerally for the payload and inserted post-write already
+  // stamped (dispatchedAt/dispatchedTo/threadId), so whole-batch Finish can
+  // never sweep it and a write failure leaves no local record.
+  const handleSendThreadReply = useCallback(
+    (pane: PaneCandidate): void => {
+      if (sendingFeedbackRef.current || threadReply === null) {
+        return
+      }
+      const group = threadGroupById.get(threadReply.threadId)
+      if (group === undefined || feedbackDispatch === undefined) {
+        setReplyDispatchThreadId(null)
+
+        return
+      }
+      sendingFeedbackRef.current = true
+      void (async (): Promise<void> => {
+        try {
+          const anchor = group.turns[0]
+          const previous = group.turns[group.turns.length - 1]
+          if (anchor === undefined || previous === undefined) {
+            return
+          }
+
+          const comment: ReviewComment = {
+            id: nextFeedbackCommentId(),
+            text: threadReply.text,
+            author: 'self',
+            createdAt: Date.now(),
+            threadId: group.threadId,
+            ...(anchor.metadata.target === undefined
+              ? {}
+              : { target: anchor.metadata.target }),
+          }
+
+          // Same repo-root resolution as buildFeedbackEntries: absolute prompt
+          // path for the agent, repo-relative coordinates for the handle.
+          const entryRepoRoot = repoRootRef.repoRootForCwd?.(group.cwd)
+          const resolvedRepoRoot =
+            entryRepoRoot && entryRepoRoot.length > 0
+              ? entryRepoRoot
+              : (response?.repoRoot ?? repoRootRef.current)
+          const promptPath = resolvedRepoRoot
+            ? `${resolvedRepoRoot}/${group.filePath}`
+            : group.filePath
+
+          const nonce = makeDispatchNonce()
+          await dispatchFeedbackBatch(
+            pane.paneId,
+            pane.ptyId,
+            [
+              {
+                filePath: promptPath,
+                staged: group.staged,
+                annotations: [
+                  {
+                    side: anchor.side,
+                    lineNumber: anchor.lineNumber,
+                    metadata: comment,
+                  },
+                ],
+              },
+            ],
+            nonce,
+            feedbackDispatch.writePty,
+            followUpContextLine(previous.metadata)
+          )
+
+          if (feedbackOwnerKey !== undefined) {
+            setPendingReview({
+              ptyId: pane.ptyId,
+              ownerKey: feedbackOwnerKey,
+              nonce,
+              dispatchedAt: Date.now(),
+              byHandle: new Map([
+                [
+                  1,
+                  {
+                    cwd: group.cwd,
+                    filePath: group.filePath,
+                    staged: group.staged,
+                    lineNumber: anchor.lineNumber,
+                    side: anchor.side,
+                    target: anchor.metadata.target,
+                    threadId: group.threadId,
+                  },
+                ],
+              ]),
+            })
+          }
+
+          // Post-write insert, pre-stamped: never observable as pending.
+          feedback.addAnnotation(group.cwd, group.filePath, group.staged, {
+            side: anchor.side,
+            lineNumber: anchor.lineNumber,
+            metadata: {
+              ...comment,
+              dispatchedAt: Date.now(),
+              dispatchedTo: pane.ptyId,
+            },
+          })
+
+          // Reply implies reopen — only after a successful dispatch.
+          if (group.resolved) {
+            feedback.updateAnnotation(
+              group.cwd,
+              group.filePath,
+              group.staged,
+              group.threadId,
+              { resolvedAt: undefined }
+            )
+          }
+
+          setThreadReply(null)
+          setReplyDispatchThreadId(null)
+          const focusTerminal = feedbackDispatch.focusTerminal
+          if (focusTerminal !== undefined) {
+            setTimeout(focusTerminal, 0)
+          }
+        } catch {
+          // Write failed: keep the editor open with its text; nothing was inserted.
+          setReplyDispatchThreadId(null)
+          notifyInfo('Terminal session ended; reply not sent.')
+        } finally {
+          sendingFeedbackRef.current = false
+        }
+      })()
+    },
+    [
+      threadReply,
+      threadGroupById,
+      feedback,
+      feedbackDispatch,
+      feedbackOwnerKey,
+      notifyInfo,
+      repoRootRef,
+      response,
+    ]
+  )
+```
+
+(If `nextFeedbackCommentId` is declared below this point in the file, reference it the way sibling callbacks do — it is a stable module-level/hook helper already used by `confirmCommentEditor`.)
+
+(e) The shared thread action handlers:
+
+```ts
+  const resolveThread = useCallback(
+    (threadId: string): void => {
+      const group = threadGroupById.get(threadId)
+      if (group !== undefined) {
+        feedback.updateAnnotation(group.cwd, group.filePath, group.staged, threadId, {
+          resolvedAt: Date.now(),
+        })
+      }
+    },
+    [feedback, threadGroupById]
+  )
+
+  const reopenThread = useCallback(
+    (threadId: string): void => {
+      const group = threadGroupById.get(threadId)
+      if (group !== undefined) {
+        feedback.updateAnnotation(group.cwd, group.filePath, group.staged, threadId, {
+          resolvedAt: undefined,
+        })
+      }
+    },
+    [feedback, threadGroupById]
+  )
+
+  const threadProps = {
+    replyingThreadId: threadReply?.threadId ?? null,
+    replyDraft: threadReply?.text ?? '',
+    onStartReply: (threadId: string): void =>
+      setThreadReply({ threadId, text: '' }),
+    onReplyDraftChange: (text: string): void =>
+      setThreadReply((prev) => (prev === null ? prev : { ...prev, text })),
+    onSubmitReply: (threadId: string, text: string): void => {
+      setThreadReply({ threadId, text })
+      setFinishOpen(false)
+      setSendNowCommentId(null)
+      setReplyDispatchThreadId(threadId)
+    },
+    onCancelReply: (): void => setThreadReply(null),
+    onResolve: resolveThread,
+    onReopen: reopenThread,
+  }
+```
+
+(`updateAnnotation` spreads `{ resolvedAt: undefined }` into the metadata — consumers only ever check `!== undefined`, so an explicit-undefined property is equivalent to absent.)
+
+(f) Popover scoping — update the existing pieces:
+
+```ts
+  const isFinishPopoverOpen =
+    finishOpen || sendNowCommentId !== null || replyDispatchThreadId !== null
+```
+
+and in the `finishFeedback` object:
+
+```ts
+    commentCount:
+      sendNowCommentId !== null || replyDispatchThreadId !== null
+        ? 1
+        : feedbackCount,
+    fileCount:
+      sendNowCommentId !== null || replyDispatchThreadId !== null
+        ? 1
+        : pendingFileCount,
+    onCancel: (): void => {
+      setFinishOpen(false)
+      setSendNowCommentId(null)
+      setReplyDispatchThreadId(null)
+    },
+    onSend: (pane: PaneCandidate): void => {
+      if (replyDispatchThreadId !== null) {
+        handleSendThreadReply(pane)
+
+        return
+      }
+      handleSendFeedback(pane, sendNowCommentId ?? undefined)
+    },
+    // A follow-up has no persisted comment to copy — hide Copy for reply sends.
+    ...(replyDispatchThreadId !== null
+      ? {}
+      : {
+          onCopy: (): void => handleCopyFeedback(sendNowCommentId ?? undefined),
+        }),
+```
+
+(adjust the `finishFeedback` consumer so `onCopy` is optional — `FinishFeedbackPopover` already treats it as optional).
+
+Also update `onFinishFeedback` to clear the reply scope: add `setReplyDispatchThreadId(null)` beside `setSendNowCommentId(null)`.
+
+(g) Wire PanelBody:
+
+```tsx
+            lineAnnotations={lineThreads.collapsed}
+            ...
+            thread={{ groups: lineThreads.groups, ...threadProps }}
+```
+
+(h) File strip — replace the `fileCommentsForSelectedFile.map(...)` body: map over `fileThreads.collapsed` instead; for each annotation, look up `threadGroupKey(annotation)` in `fileThreads.groups`; when a group exists render:
+
+```tsx
+                  <ReviewThreadCard
+                    key={`thread:${group.threadId}`}
+                    group={group}
+                    anchorLabel={threadAnchorLabel(group.turns[0] ?? annotation)}
+                    actions={{
+                      replying: threadProps.replyingThreadId === group.threadId,
+                      replyDraft: threadProps.replyDraft,
+                      onStartReply: (): void =>
+                        threadProps.onStartReply(group.threadId),
+                      onReplyDraftChange: threadProps.onReplyDraftChange,
+                      onSubmitReply: (text): void =>
+                        threadProps.onSubmitReply(group.threadId, text),
+                      onCancelReply: threadProps.onCancelReply,
+                      onResolve: (): void => threadProps.onResolve(group.threadId),
+                      onReopen: (): void => threadProps.onReopen(group.threadId),
+                    }}
+                  />
+```
+
+otherwise keep the existing `ReviewCommentRow` branch unchanged (pending file comments keep send-now/edit/delete).
+
+- [ ] **Step 5: Run the diff feature suite**
+
+Run: `npx vitest run src/features/diff`
+Expected: PASS — including all pre-existing Panel/PanelBody/integration tests (dispatched single comments now render as 1-turn cards; if an existing test asserted a dispatched comment's "Sent" chip via `ReviewCommentRow`, update it to assert the card's header/rollup instead — that rendering change is the feature).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/diff/Panel.tsx src/features/diff/components/PanelBody.tsx src/features/diff/Panel.test.tsx src/features/diff/components/PanelBody.test.tsx
+git commit -m "feat(diff): thread cards + follow-up dispatch wiring (VIM-298)"
+```
+
+---
+
+### Task 8: Integration test — the full multi-turn loop
+
+**Files:**
+- Modify: `src/features/diff/agentReplyThread.integration.test.tsx`
+
+- [ ] **Step 1: Extend the harness.** The file already mounts a real `useFeedbackBatchStore` + `useAgentReply` with a mocked `agent-reply` listener. Add a second Harness that renders thread cards through the real selector:
+
+```tsx
+const ThreadHarness = (): ReactElement => {
+  const store = useFeedbackBatchStore(OWNER, CWD)
+  useAgentReply({
+    addAnnotationForOwner: store.feedbackBatch.addAnnotationForOwner,
+    nextCommentId: (() => {
+      let n = 0
+
+      return (): string => `agent-${++n}`
+    })(),
+  })
+
+  const annotations = store.feedbackBatch.annotationsForFile(CWD, FILE, false)
+  const { collapsed, groups } = buildThreadGroups(annotations, {
+    cwd: CWD,
+    filePath: FILE,
+    staged: false,
+  })
+
+  return (
+    <div>
+      {collapsed.map((annotation) => {
+        const key = threadGroupKey(annotation)
+        const group = key === undefined ? undefined : groups.get(key)
+
+        return group === undefined ? null : (
+          <ReviewThreadCard
+            key={group.threadId}
+            group={group}
+            anchorLabel={threadAnchorLabel(annotation)}
+          />
+        )
+      })}
+    </div>
+  )
+}
+```
+
+(Watch the `nextCommentId` closure — create it with `useRef`/`useState` initializer if StrictMode double-invocation makes the counter unstable; follow the existing harness's approach to ids.)
+
+- [ ] **Step 2: Write the loop test:**
+
+```ts
+test('comment → reply → follow-up → second reply renders one 4-turn card', async () => {
+  // Seed the dispatched root directly (the Panel dispatch path is covered by
+  // Panel.test.tsx; this exercises the reply→attach→group→render pipeline):
+  //   addAnnotationForOwner(OWNER, CWD, FILE, false, { side: 'additions',
+  //     lineNumber: 5, metadata: { id: 'c1', text: 'Why?', author: 'self',
+  //     category: 'question', createdAt: 1, dispatchedAt: 1000, threadId: 'c1',
+  //     dispatchedTo: 'pty-1' } })
+  //   setPendingReview({ ptyId: 'pty-1', ownerKey: OWNER, nonce: 'n1',
+  //     dispatchedAt: 1000, byHandle: new Map([[1, { cwd: CWD, filePath: FILE,
+  //     staged: false, lineNumber: 5, side: 'additions', target: undefined,
+  //     threadId: 'c1' }]]) })
+  // emitReply for nonce 'n1', [#1] status 'clarify'
+  // → assert ONE card, 2 turns, rollup chip 'Awaiting you'
+  //
+  // Seed the follow-up as the dispatch path would insert it (post-write,
+  // pre-stamped): id 'f1', threadId 'c1', dispatchedAt 2000, no category.
+  //   setPendingReview for nonce 'n2' with handle threadId 'c1'
+  // → assert rollup chip flips to 'Sent'
+  //
+  // emitReply for nonce 'n2', [#1] status 'resolved'
+  // → assert 4 turns in order (Why? / clarify text / follow-up text / resolved
+  //   text), rollup 'Resolved' (from the outcome, thread NOT collapsed —
+  //   resolvedAt is unset), and the follow-up turn shows no category chip.
+})
+```
+
+Write the seeds/assertions as real code following the existing test's `emitReply`/`act` pattern.
+
+- [ ] **Step 3: Run to verify**
+
+Run: `npx vitest run src/features/diff/agentReplyThread.integration.test.tsx`
+Expected: PASS (and the pre-existing single round-trip test still passes).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/features/diff/agentReplyThread.integration.test.tsx
+git commit -m "test(diff): multi-turn thread integration loop (VIM-298)"
+```
+
+---
+
+### Task 9: Full gate, push, PR
+
+- [ ] **Step 1: Repo-wide gate** (CI's Code Quality check is repo-wide, not diff-scoped):
+
+Run:
+```bash
+npm run lint && npm run format:check && npm run type-check:generated && npx vitest run
+```
+Expected: all green. Known environment flakes (not caused by this PR, do not chase): `editorFileLifecycleStatus` home-path casing on macOS.
+
+- [ ] **Step 2: Push and open the PR**
+
+```bash
+git push -u origin feature/vim-298
+PATH="/opt/homebrew/bin:$PATH" gh pr create \
+  --title "feat(diff): multi-turn finding threads (VIM-298)" \
+  --label auto-review --label auto-approve \
+  --body "$(cat <<'EOF'
+## Summary
+- Turns at one anchor render as a single GitHub-style thread card (header rollup, hairline turn rows, paired Reply/Resolve footer) — recipe settled in the VIM-298 demo-first pass.
+- Reply on a thread dispatches ONLY that follow-up ([#1 · Follow-up] + quoted-context line) via the VIM-297 single-comment path; the agent's next reply lands on the same thread via threadId-carrying handles.
+- Follow-ups are created atomically with a successful dispatch (post-write, pre-stamped insert — cap-exempt); Resolve is local state with collapse + reopen.
+
+Spec: docs/superpowers/specs/2026-07-11-vim-298-multi-turn-threads-design.md (codex-reviewed)
+Plan: docs/superpowers/plans/2026-07-12-vim-298-multi-turn-threads.md
+
+Closes VIM-298
+Part of VIM-284
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Post-merge cleanup (operator note, NOT part of this branch):** delete `preview.html`, `preview-thread-demo.tsx`, `vite.preview.config.ts` from the **main checkout** and stop the throwaway Vite preview server — the recipe now lives in the spec.
+
+---
+
+## Self-Review Notes (already applied)
+
+- Spec coverage: Section 2 → Tasks 1–3, Section 3 → Task 6, Section 4 → Tasks 4, 5, 7, Section 5 → Tasks 6, 7, Section 6 → every task's tests + Task 8/9.
+- Type consistency: `ThreadGroup`/`threadGroupKey`/`threadAnchorLabel`/`followUpContextLine`/`isFollowUpComment` names match across Tasks 3, 5, 6, 7, 8; `markDispatched` options shape matches Tasks 1 and 2; `PendingReviewHandle.threadId` matches Tasks 2, 7, 8.
+- The two known judgment points for the executor: (1) existing Panel tests that asserted dispatched-comment rows will need updating to the card rendering — that is the feature, not a regression; (2) match each test file's existing harness idioms rather than inventing new ones.

--- a/docs/superpowers/plans/2026-07-12-vim-298-multi-turn-threads.md
+++ b/docs/superpowers/plans/2026-07-12-vim-298-multi-turn-threads.md
@@ -19,26 +19,27 @@
 
 ## File Structure
 
-| File | Change |
-| --- | --- |
-| `src/features/diff/hooks/useFeedbackBatch.ts` | `ReviewComment` gains `threadId`/`resolvedAt`/`dispatchedTo`; `markDispatched` stamps thread fields; cap check keys on pending-ness |
-| `src/features/diff/services/pendingReviews.ts` | `PendingReviewHandle` gains `threadId` |
-| `src/features/diff/hooks/useAgentReply.ts` | `attachAgentNote` copies `handle.threadId` |
-| `src/features/diff/hooks/useAgentReview.ts` | findings self-root (`threadId = id`); anchored handles carry it |
-| `src/features/diff/reviewCategoryMeta.ts` | `THREAD_ROLLUP_META` |
-| `src/features/diff/services/threadGroups.ts` (new) | `threadGroupKey`, `threadRollup`, `buildThreadGroups`, `threadAnchorLabel`, `ThreadGroup` |
-| `src/features/diff/components/ReviewCommentEditor.tsx` | `mode: 'comment' \| 'reply'` |
-| `src/features/diff/services/feedbackDispatch.ts` | Follow-up label/instruction, `followUpContextLine`, payload context param |
-| `src/features/diff/components/ReviewThreadCard.tsx` (new) | The thread card (settled demo recipe) |
-| `src/features/diff/components/PanelBody.tsx` | Thread-group branch in `renderAnnotation` |
-| `src/features/diff/Panel.tsx` | Grouping memos, reply draft state, `handleSendThreadReply`, popover scoping, resolve/reopen, file strip |
-| `src/features/diff/agentReplyThread.integration.test.tsx` | Full multi-turn loop |
+| File                                                      | Change                                                                                                                              |
+| --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `src/features/diff/hooks/useFeedbackBatch.ts`             | `ReviewComment` gains `threadId`/`resolvedAt`/`dispatchedTo`; `markDispatched` stamps thread fields; cap check keys on pending-ness |
+| `src/features/diff/services/pendingReviews.ts`            | `PendingReviewHandle` gains `threadId`                                                                                              |
+| `src/features/diff/hooks/useAgentReply.ts`                | `attachAgentNote` copies `handle.threadId`                                                                                          |
+| `src/features/diff/hooks/useAgentReview.ts`               | findings self-root (`threadId = id`); anchored handles carry it                                                                     |
+| `src/features/diff/reviewCategoryMeta.ts`                 | `THREAD_ROLLUP_META`                                                                                                                |
+| `src/features/diff/services/threadGroups.ts` (new)        | `threadGroupKey`, `threadRollup`, `buildThreadGroups`, `threadAnchorLabel`, `ThreadGroup`                                           |
+| `src/features/diff/components/ReviewCommentEditor.tsx`    | `mode: 'comment' \| 'reply'`                                                                                                        |
+| `src/features/diff/services/feedbackDispatch.ts`          | Follow-up label/instruction, `followUpContextLine`, payload context param                                                           |
+| `src/features/diff/components/ReviewThreadCard.tsx` (new) | The thread card (settled demo recipe)                                                                                               |
+| `src/features/diff/components/PanelBody.tsx`              | Thread-group branch in `renderAnnotation`                                                                                           |
+| `src/features/diff/Panel.tsx`                             | Grouping memos, reply draft state, `handleSendThreadReply`, popover scoping, resolve/reopen, file strip                             |
+| `src/features/diff/agentReplyThread.integration.test.tsx` | Full multi-turn loop                                                                                                                |
 
 ---
 
 ### Task 1: Thread fields on `ReviewComment` + stamping + cap fix
 
 **Files:**
+
 - Modify: `src/features/diff/hooks/useFeedbackBatch.ts`
 - Test: `src/features/diff/hooks/useFeedbackBatch.test.ts`
 
@@ -132,7 +133,7 @@ Expected: the new tests FAIL (`threadId` undefined; cap insert returns 'cap-reac
       ) {
 ```
 
-(The cap guards the *pending* review the user is assembling; a pre-stamped dispatched follow-up is thread history, like agent output. `isPendingReviewAnnotation` = `author === 'self' && dispatchedAt === undefined`, so pending behavior is unchanged.)
+(The cap guards the _pending_ review the user is assembling; a pre-stamped dispatched follow-up is thread history, like agent output. `isPendingReviewAnnotation` = `author === 'self' && dispatchedAt === undefined`, so pending behavior is unchanged.)
 
 - [ ] **Step 4: Run to verify they pass**
 
@@ -151,6 +152,7 @@ git commit -m "feat(diff): thread fields on ReviewComment + dispatch stamping (V
 ### Task 2: `threadId` through handles, agent replies, and finding placement
 
 **Files:**
+
 - Modify: `src/features/diff/services/pendingReviews.ts`
 - Modify: `src/features/diff/Panel.tsx` (`buildFeedbackEntries`, `handleSendFeedback`)
 - Modify: `src/features/diff/hooks/useAgentReply.ts`
@@ -224,16 +226,16 @@ Expected: new tests FAIL (no `threadId` anywhere).
 (e) `useAgentReview.ts` — in `reviewerAnnotation`, self-root the finding:
 
 ```ts
-      const id = nextCommentId()
-      const metadata: ReviewComment = {
-        id,
-        threadId: id,
-        text: finding.text,
-        author: 'reviewer',
-        reviewer,
-        category: finding.category as ReviewCommentCategory,
-        createdAt: Date.now(),
-      }
+const id = nextCommentId()
+const metadata: ReviewComment = {
+  id,
+  threadId: id,
+  text: finding.text,
+  author: 'reviewer',
+  reviewer,
+  category: finding.category as ReviewCommentCategory,
+  createdAt: Date.now(),
+}
 ```
 
 (remove the old `id: nextCommentId(),` line). Then in the `byOrdinal.set(ordinal, { kind: 'anchored', ... })` handle object add `threadId: annotation.metadata.id,`.
@@ -255,6 +257,7 @@ git commit -m "feat(diff): thread identity through dispatch handles and replies 
 ### Task 3: Grouping selector + rollup metas
 
 **Files:**
+
 - Modify: `src/features/diff/reviewCategoryMeta.ts`
 - Create: `src/features/diff/services/threadGroups.ts`
 - Test: `src/features/diff/services/threadGroups.test.ts`
@@ -296,12 +299,12 @@ describe('threadGroupKey', () => {
   })
 
   test('threadId wins; dispatched and non-self fall back to own id', () => {
-    expect(
-      threadGroupKey(annotation({ id: 'a1', threadId: 'root-1' }))
-    ).toBe('root-1')
-    expect(
-      threadGroupKey(annotation({ id: 'c1', dispatchedAt: 1000 }))
-    ).toBe('c1')
+    expect(threadGroupKey(annotation({ id: 'a1', threadId: 'root-1' }))).toBe(
+      'root-1'
+    )
+    expect(threadGroupKey(annotation({ id: 'c1', dispatchedAt: 1000 }))).toBe(
+      'c1'
+    )
     expect(threadGroupKey(annotation({ id: 'g1', author: 'agent' }))).toBe('g1')
   })
 })
@@ -579,6 +582,7 @@ git commit -m "feat(diff): thread grouping selector + rollup metas (VIM-298)"
 ### Task 4: `reply` mode on `ReviewCommentEditor`
 
 **Files:**
+
 - Modify: `src/features/diff/components/ReviewCommentEditor.tsx`
 - Test: `src/features/diff/components/ReviewCommentEditor.test.tsx`
 
@@ -641,9 +645,9 @@ destructure `mode = 'comment'` in the component.
 (b) Guard the cycle at the top of `cycleCategory`:
 
 ```ts
-    if (mode === 'reply') {
-      return
-    }
+if (mode === 'reply') {
+  return
+}
 ```
 
 (c) Header label: replace the literal `Local comment` text node with `{mode === 'reply' ? 'Reply to thread' : 'Local comment'}`.
@@ -671,6 +675,7 @@ git commit -m "feat(diff): typeless reply mode on the comment editor (VIM-298)"
 ### Task 5: Follow-up payload formatting
 
 **Files:**
+
 - Modify: `src/features/diff/services/feedbackDispatch.ts`
 - Test: `src/features/diff/services/feedbackDispatch.test.ts`
 
@@ -706,7 +711,9 @@ test('a typeless follow-up renders as [#n · Follow-up] with the context line', 
   expect(payload).toContain(
     '> ↩ Continuing our thread — your last reply: "The pool applies backpressure"'
   )
-  expect(payload).toContain('> → Answer inline in your reply. Do not edit files.')
+  expect(payload).toContain(
+    '> → Answer inline in your reply. Do not edit files.'
+  )
   expect(payload).not.toContain('Change request')
 })
 
@@ -824,23 +831,21 @@ export const followUpContextLine = (previous: ReviewComment): string => {
 (b) `formatFeedbackPayload` gains a third parameter `followUpContext?: string`. In the per-annotation loop, compute follow-up-aware label/instruction and insert the context line:
 
 ```ts
-      const followUp = isFollowUpComment(annotation.metadata)
-      const label = followUp ? FOLLOW_UP_LABEL : CATEGORY_LABEL[category]
-      const instruction = followUp
-        ? FOLLOW_UP_INSTRUCTION
-        : CATEGORY_INSTRUCTION[category]
+const followUp = isFollowUpComment(annotation.metadata)
+const label = followUp ? FOLLOW_UP_LABEL : CATEGORY_LABEL[category]
+const instruction = followUp
+  ? FOLLOW_UP_INSTRUCTION
+  : CATEGORY_INSTRUCTION[category]
 
-      blocks.push(
-        [
-          `> [#${index} · ${label}] ${formatAnnotationTarget(entry, annotation)}`,
-          ...(followUp && followUpContext !== undefined
-            ? [followUpContext]
-            : []),
-          ...textLines,
-          `> → ${instruction}`,
-          '>',
-        ].join('\n')
-      )
+blocks.push(
+  [
+    `> [#${index} · ${label}] ${formatAnnotationTarget(entry, annotation)}`,
+    ...(followUp && followUpContext !== undefined ? [followUpContext] : []),
+    ...textLines,
+    `> → ${instruction}`,
+    '>',
+  ].join('\n')
+)
 ```
 
 (c) `dispatchFeedbackBatch` gains a trailing optional `followUpContext?: string` parameter, passed through to `formatFeedbackPayload(entries, nonce, followUpContext)`.
@@ -862,6 +867,7 @@ git commit -m "feat(diff): follow-up payload format + thread context line (VIM-2
 ### Task 6: `ReviewThreadCard`
 
 **Files:**
+
 - Create: `src/features/diff/components/ReviewThreadCard.tsx`
 - Test: `src/features/diff/components/ReviewThreadCard.test.tsx`
 
@@ -927,7 +933,11 @@ const actions = (
 describe('ReviewThreadCard', () => {
   test('renders header, ordered turns, chips, and the footer pair', () => {
     render(
-      <ReviewThreadCard group={group()} anchorLabel="line R40" actions={actions()} />
+      <ReviewThreadCard
+        group={group()}
+        anchorLabel="line R40"
+        actions={actions()}
+      />
     )
 
     expect(screen.getByText('line R40')).toBeInTheDocument()
@@ -955,7 +965,9 @@ describe('ReviewThreadCard', () => {
         threadId: 'c1',
       },
     })
-    render(<ReviewThreadCard group={g} anchorLabel="line R40" actions={actions()} />)
+    render(
+      <ReviewThreadCard group={g} anchorLabel="line R40" actions={actions()} />
+    )
 
     // Exactly one category chip (the root's Question) despite two self turns.
     expect(screen.getAllByText('Question')).toHaveLength(1)
@@ -963,7 +975,9 @@ describe('ReviewThreadCard', () => {
 
   test('reply expands the editor; confirm submits the draft', () => {
     const a = actions({ replying: true, replyDraft: 'follow-up text' })
-    render(<ReviewThreadCard group={group()} anchorLabel="line R40" actions={a} />)
+    render(
+      <ReviewThreadCard group={group()} anchorLabel="line R40" actions={a} />
+    )
 
     fireEvent.keyDown(screen.getByPlaceholderText('Reply to the agent…'), {
       key: 'Enter',
@@ -1008,14 +1022,26 @@ describe('ReviewThreadCard', () => {
       rollup: { label: 'Resolved', chip: 'text-success' },
     })
     const { rerender } = render(
-      <ReviewThreadCard group={resolved} anchorLabel="line R40" actions={actions()} />
+      <ReviewThreadCard
+        group={resolved}
+        anchorLabel="line R40"
+        actions={actions()}
+      />
     )
     fireEvent.click(screen.getByRole('button', { name: /thread/i }))
     rerender(
-      <ReviewThreadCard group={group()} anchorLabel="line R40" actions={actions()} />
+      <ReviewThreadCard
+        group={group()}
+        anchorLabel="line R40"
+        actions={actions()}
+      />
     )
     rerender(
-      <ReviewThreadCard group={resolved} anchorLabel="line R40" actions={actions()} />
+      <ReviewThreadCard
+        group={resolved}
+        anchorLabel="line R40"
+        actions={actions()}
+      />
     )
 
     expect(screen.queryByText('Why does the cap live here?')).toBeNull()
@@ -1323,6 +1349,7 @@ git commit -m "feat(diff): GitHub-style thread card component (VIM-298)"
 ### Task 7: Panel + PanelBody wiring (grouping, reply dispatch, resolve)
 
 **Files:**
+
 - Modify: `src/features/diff/components/PanelBody.tsx`
 - Modify: `src/features/diff/components/Notifier.tsx` (`FinishFeedbackState.onCopy` becomes optional — `onCopy?: () => void`; `FinishFeedbackPopover` already treats it as optional)
 - Modify: `src/features/diff/Panel.tsx`
@@ -1473,212 +1500,212 @@ add `thread?: PanelThreadProps` to `PanelBodyProps` and destructure `thread = un
 (b) State, next to `sendNowCommentId`:
 
 ```ts
-  // Thread reply drafts (VIM-298), keyed by threadId so starting a reply on
-  // one thread never discards another thread's typed text. Panel-owned so a
-  // MultiFileDiff remount cannot erase them; an entry is cleared ONLY by that
-  // thread's explicit cancel or its successful dispatch.
-  const [replyDrafts, setReplyDrafts] = useState<ReadonlyMap<string, string>>(
-    new Map()
-  )
-  // Thread whose reply editor is currently open; null = none.
-  const [replyingThreadId, setReplyingThreadId] = useState<string | null>(null)
-  // Thread whose follow-up is awaiting the scoped confirm popover (VIM-298);
-  // mutually exclusive with finishOpen / sendNowCommentId.
-  const [replyDispatchThreadId, setReplyDispatchThreadId] = useState<
-    string | null
-  >(null)
+// Thread reply drafts (VIM-298), keyed by threadId so starting a reply on
+// one thread never discards another thread's typed text. Panel-owned so a
+// MultiFileDiff remount cannot erase them; an entry is cleared ONLY by that
+// thread's explicit cancel or its successful dispatch.
+const [replyDrafts, setReplyDrafts] = useState<ReadonlyMap<string, string>>(
+  new Map()
+)
+// Thread whose reply editor is currently open; null = none.
+const [replyingThreadId, setReplyingThreadId] = useState<string | null>(null)
+// Thread whose follow-up is awaiting the scoped confirm popover (VIM-298);
+// mutually exclusive with finishOpen / sendNowCommentId.
+const [replyDispatchThreadId, setReplyDispatchThreadId] = useState<
+  string | null
+>(null)
 ```
 
 (c) Grouping memos, after `lineAnnotations` is available (below the `useReviewCommentDraft` destructure):
 
 ```ts
-  const lineThreads = useMemo(
-    () =>
-      buildThreadGroups(lineAnnotations, {
-        cwd,
-        filePath: selectedFilePath ?? '',
-        staged: selectedFileStaged,
-      }),
-    [lineAnnotations, cwd, selectedFilePath, selectedFileStaged]
-  )
+const lineThreads = useMemo(
+  () =>
+    buildThreadGroups(lineAnnotations, {
+      cwd,
+      filePath: selectedFilePath ?? '',
+      staged: selectedFileStaged,
+    }),
+  [lineAnnotations, cwd, selectedFilePath, selectedFileStaged]
+)
 
-  const fileThreads = useMemo(
-    () =>
-      buildThreadGroups(fileCommentsForSelectedFile, {
-        cwd,
-        filePath: selectedFileEntry?.path ?? '',
-        staged: selectedFileEntry?.staged ?? false,
-      }),
-    [fileCommentsForSelectedFile, cwd, selectedFileEntry]
-  )
+const fileThreads = useMemo(
+  () =>
+    buildThreadGroups(fileCommentsForSelectedFile, {
+      cwd,
+      filePath: selectedFileEntry?.path ?? '',
+      staged: selectedFileEntry?.staged ?? false,
+    }),
+  [fileCommentsForSelectedFile, cwd, selectedFileEntry]
+)
 
-  const threadGroupById = useMemo((): Map<string, ThreadGroup> => {
-    const merged = new Map(lineThreads.groups)
-    for (const [key, group] of fileThreads.groups) {
-      merged.set(key, group)
-    }
+const threadGroupById = useMemo((): Map<string, ThreadGroup> => {
+  const merged = new Map(lineThreads.groups)
+  for (const [key, group] of fileThreads.groups) {
+    merged.set(key, group)
+  }
 
-    return merged
-  }, [lineThreads, fileThreads])
+  return merged
+}, [lineThreads, fileThreads])
 ```
 
 (d) The reply-dispatch handler, after `handleSendFeedback` (mirrors its shape; the follow-up is created ONLY after the write succeeds — spec Section 4):
 
 ```ts
-  // VIM-298: dispatch a thread follow-up. The comment is never stored pending —
-  // it is built ephemerally for the payload and inserted post-write already
-  // stamped (dispatchedAt/dispatchedTo/threadId), so whole-batch Finish can
-  // never sweep it and a write failure leaves no local record.
-  const handleSendThreadReply = useCallback(
-    (pane: PaneCandidate): void => {
-      if (sendingFeedbackRef.current || replyDispatchThreadId === null) {
-        return
-      }
-      const draftText = replyDrafts.get(replyDispatchThreadId) ?? ''
-      const group = threadGroupById.get(replyDispatchThreadId)
-      if (
-        group === undefined ||
-        feedbackDispatch === undefined ||
-        draftText.trim().length === 0
-      ) {
-        setReplyDispatchThreadId(null)
+// VIM-298: dispatch a thread follow-up. The comment is never stored pending —
+// it is built ephemerally for the payload and inserted post-write already
+// stamped (dispatchedAt/dispatchedTo/threadId), so whole-batch Finish can
+// never sweep it and a write failure leaves no local record.
+const handleSendThreadReply = useCallback(
+  (pane: PaneCandidate): void => {
+    if (sendingFeedbackRef.current || replyDispatchThreadId === null) {
+      return
+    }
+    const draftText = replyDrafts.get(replyDispatchThreadId) ?? ''
+    const group = threadGroupById.get(replyDispatchThreadId)
+    if (
+      group === undefined ||
+      feedbackDispatch === undefined ||
+      draftText.trim().length === 0
+    ) {
+      setReplyDispatchThreadId(null)
 
-        return
-      }
-      sendingFeedbackRef.current = true
-      void (async (): Promise<void> => {
-        try {
-          const anchor = group.turns[0]
-          const previous = group.turns[group.turns.length - 1]
-          if (anchor === undefined || previous === undefined) {
-            return
-          }
-
-          const comment: ReviewComment = {
-            id: nextFeedbackCommentId(),
-            text: draftText,
-            author: 'self',
-            createdAt: Date.now(),
-            threadId: group.threadId,
-            ...(anchor.metadata.target === undefined
-              ? {}
-              : { target: anchor.metadata.target }),
-          }
-
-          // Same repo-root resolution as buildFeedbackEntries: absolute prompt
-          // path for the agent, repo-relative coordinates for the handle.
-          const entryRepoRoot = repoRootRef.repoRootForCwd?.(group.cwd)
-          const resolvedRepoRoot =
-            entryRepoRoot && entryRepoRoot.length > 0
-              ? entryRepoRoot
-              : (response?.repoRoot ?? repoRootRef.current)
-          const promptPath = resolvedRepoRoot
-            ? `${resolvedRepoRoot}/${group.filePath}`
-            : group.filePath
-
-          const nonce = makeDispatchNonce()
-          await dispatchFeedbackBatch(
-            pane.paneId,
-            pane.ptyId,
-            [
-              {
-                filePath: promptPath,
-                staged: group.staged,
-                annotations: [
-                  {
-                    side: anchor.side,
-                    lineNumber: anchor.lineNumber,
-                    metadata: comment,
-                  },
-                ],
-              },
-            ],
-            nonce,
-            feedbackDispatch.writePty,
-            followUpContextLine(previous.metadata)
-          )
-
-          if (feedbackOwnerKey !== undefined) {
-            setPendingReview({
-              ptyId: pane.ptyId,
-              ownerKey: feedbackOwnerKey,
-              nonce,
-              dispatchedAt: Date.now(),
-              byHandle: new Map([
-                [
-                  1,
-                  {
-                    cwd: group.cwd,
-                    filePath: group.filePath,
-                    staged: group.staged,
-                    lineNumber: anchor.lineNumber,
-                    side: anchor.side,
-                    target: anchor.metadata.target,
-                    threadId: group.threadId,
-                  },
-                ],
-              ]),
-            })
-          }
-
-          // Post-write insert, pre-stamped: never observable as pending.
-          feedback.addAnnotation(group.cwd, group.filePath, group.staged, {
-            side: anchor.side,
-            lineNumber: anchor.lineNumber,
-            metadata: {
-              ...comment,
-              dispatchedAt: Date.now(),
-              dispatchedTo: pane.ptyId,
-            },
-          })
-
-          // Reply implies reopen — only after a successful dispatch.
-          if (group.resolved) {
-            feedback.updateAnnotation(
-              group.cwd,
-              group.filePath,
-              group.staged,
-              group.threadId,
-              { resolvedAt: undefined }
-            )
-          }
-
-          // Clear ONLY this thread's draft (successful dispatch).
-          setReplyDrafts((prev) => {
-            const next = new Map(prev)
-            next.delete(group.threadId)
-
-            return next
-          })
-          setReplyingThreadId((current) =>
-            current === group.threadId ? null : current
-          )
-          setReplyDispatchThreadId(null)
-          const focusTerminal = feedbackDispatch.focusTerminal
-          if (focusTerminal !== undefined) {
-            setTimeout(focusTerminal, 0)
-          }
-        } catch {
-          // Write failed: keep the editor open with its text; nothing was inserted.
-          setReplyDispatchThreadId(null)
-          notifyInfo('Terminal session ended; reply not sent.')
-        } finally {
-          sendingFeedbackRef.current = false
+      return
+    }
+    sendingFeedbackRef.current = true
+    void (async (): Promise<void> => {
+      try {
+        const anchor = group.turns[0]
+        const previous = group.turns[group.turns.length - 1]
+        if (anchor === undefined || previous === undefined) {
+          return
         }
-      })()
-    },
-    [
-      replyDispatchThreadId,
-      replyDrafts,
-      threadGroupById,
-      feedback,
-      feedbackDispatch,
-      feedbackOwnerKey,
-      notifyInfo,
-      repoRootRef,
-      response,
-    ]
-  )
+
+        const comment: ReviewComment = {
+          id: nextFeedbackCommentId(),
+          text: draftText,
+          author: 'self',
+          createdAt: Date.now(),
+          threadId: group.threadId,
+          ...(anchor.metadata.target === undefined
+            ? {}
+            : { target: anchor.metadata.target }),
+        }
+
+        // Same repo-root resolution as buildFeedbackEntries: absolute prompt
+        // path for the agent, repo-relative coordinates for the handle.
+        const entryRepoRoot = repoRootRef.repoRootForCwd?.(group.cwd)
+        const resolvedRepoRoot =
+          entryRepoRoot && entryRepoRoot.length > 0
+            ? entryRepoRoot
+            : (response?.repoRoot ?? repoRootRef.current)
+        const promptPath = resolvedRepoRoot
+          ? `${resolvedRepoRoot}/${group.filePath}`
+          : group.filePath
+
+        const nonce = makeDispatchNonce()
+        await dispatchFeedbackBatch(
+          pane.paneId,
+          pane.ptyId,
+          [
+            {
+              filePath: promptPath,
+              staged: group.staged,
+              annotations: [
+                {
+                  side: anchor.side,
+                  lineNumber: anchor.lineNumber,
+                  metadata: comment,
+                },
+              ],
+            },
+          ],
+          nonce,
+          feedbackDispatch.writePty,
+          followUpContextLine(previous.metadata)
+        )
+
+        if (feedbackOwnerKey !== undefined) {
+          setPendingReview({
+            ptyId: pane.ptyId,
+            ownerKey: feedbackOwnerKey,
+            nonce,
+            dispatchedAt: Date.now(),
+            byHandle: new Map([
+              [
+                1,
+                {
+                  cwd: group.cwd,
+                  filePath: group.filePath,
+                  staged: group.staged,
+                  lineNumber: anchor.lineNumber,
+                  side: anchor.side,
+                  target: anchor.metadata.target,
+                  threadId: group.threadId,
+                },
+              ],
+            ]),
+          })
+        }
+
+        // Post-write insert, pre-stamped: never observable as pending.
+        feedback.addAnnotation(group.cwd, group.filePath, group.staged, {
+          side: anchor.side,
+          lineNumber: anchor.lineNumber,
+          metadata: {
+            ...comment,
+            dispatchedAt: Date.now(),
+            dispatchedTo: pane.ptyId,
+          },
+        })
+
+        // Reply implies reopen — only after a successful dispatch.
+        if (group.resolved) {
+          feedback.updateAnnotation(
+            group.cwd,
+            group.filePath,
+            group.staged,
+            group.threadId,
+            { resolvedAt: undefined }
+          )
+        }
+
+        // Clear ONLY this thread's draft (successful dispatch).
+        setReplyDrafts((prev) => {
+          const next = new Map(prev)
+          next.delete(group.threadId)
+
+          return next
+        })
+        setReplyingThreadId((current) =>
+          current === group.threadId ? null : current
+        )
+        setReplyDispatchThreadId(null)
+        const focusTerminal = feedbackDispatch.focusTerminal
+        if (focusTerminal !== undefined) {
+          setTimeout(focusTerminal, 0)
+        }
+      } catch {
+        // Write failed: keep the editor open with its text; nothing was inserted.
+        setReplyDispatchThreadId(null)
+        notifyInfo('Terminal session ended; reply not sent.')
+      } finally {
+        sendingFeedbackRef.current = false
+      }
+    })()
+  },
+  [
+    replyDispatchThreadId,
+    replyDrafts,
+    threadGroupById,
+    feedback,
+    feedbackDispatch,
+    feedbackOwnerKey,
+    notifyInfo,
+    repoRootRef,
+    response,
+  ]
+)
 ```
 
 (If `nextFeedbackCommentId` is declared below this point in the file, reference it the way sibling callbacks do — it is a stable module-level/hook helper already used by `confirmCommentEditor`.)
@@ -1686,71 +1713,81 @@ add `thread?: PanelThreadProps` to `PanelBodyProps` and destructure `thread = un
 (e) The shared thread action handlers:
 
 ```ts
-  const resolveThread = useCallback(
-    (threadId: string): void => {
-      const group = threadGroupById.get(threadId)
-      if (group !== undefined) {
-        feedback.updateAnnotation(group.cwd, group.filePath, group.staged, threadId, {
+const resolveThread = useCallback(
+  (threadId: string): void => {
+    const group = threadGroupById.get(threadId)
+    if (group !== undefined) {
+      feedback.updateAnnotation(
+        group.cwd,
+        group.filePath,
+        group.staged,
+        threadId,
+        {
           resolvedAt: Date.now(),
-        })
-      }
-    },
-    [feedback, threadGroupById]
-  )
-
-  const reopenThread = useCallback(
-    (threadId: string): void => {
-      const group = threadGroupById.get(threadId)
-      if (group !== undefined) {
-        feedback.updateAnnotation(group.cwd, group.filePath, group.staged, threadId, {
-          resolvedAt: undefined,
-        })
-      }
-    },
-    [feedback, threadGroupById]
-  )
-
-  const threadProps = {
-    replyingThreadId,
-    replyDraft:
-      replyingThreadId === null
-        ? ''
-        : (replyDrafts.get(replyingThreadId) ?? ''),
-    // Switching to another thread's Reply closes the first editor but its
-    // draft stays in the map — reopening restores it.
-    onStartReply: (threadId: string): void => setReplyingThreadId(threadId),
-    onReplyDraftChange: (text: string): void => {
-      setReplyDrafts((prev) => {
-        if (replyingThreadId === null) {
-          return prev
         }
+      )
+    }
+  },
+  [feedback, threadGroupById]
+)
+
+const reopenThread = useCallback(
+  (threadId: string): void => {
+    const group = threadGroupById.get(threadId)
+    if (group !== undefined) {
+      feedback.updateAnnotation(
+        group.cwd,
+        group.filePath,
+        group.staged,
+        threadId,
+        {
+          resolvedAt: undefined,
+        }
+      )
+    }
+  },
+  [feedback, threadGroupById]
+)
+
+const threadProps = {
+  replyingThreadId,
+  replyDraft:
+    replyingThreadId === null ? '' : (replyDrafts.get(replyingThreadId) ?? ''),
+  // Switching to another thread's Reply closes the first editor but its
+  // draft stays in the map — reopening restores it.
+  onStartReply: (threadId: string): void => setReplyingThreadId(threadId),
+  onReplyDraftChange: (text: string): void => {
+    setReplyDrafts((prev) => {
+      if (replyingThreadId === null) {
+        return prev
+      }
+      const next = new Map(prev)
+      next.set(replyingThreadId, text)
+
+      return next
+    })
+  },
+  onSubmitReply: (threadId: string, text: string): void => {
+    setReplyDrafts((prev) => new Map(prev).set(threadId, text))
+    setFinishOpen(false)
+    setSendNowCommentId(null)
+    setReplyDispatchThreadId(threadId)
+  },
+  // Explicit cancel clears ONLY the active thread's draft.
+  onCancelReply: (): void => {
+    if (replyingThreadId !== null) {
+      setReplyDrafts((prev) => {
         const next = new Map(prev)
-        next.set(replyingThreadId, text)
+        next.delete(replyingThreadId)
 
         return next
       })
-    },
-    onSubmitReply: (threadId: string, text: string): void => {
-      setReplyDrafts((prev) => new Map(prev).set(threadId, text))
-      setFinishOpen(false)
-      setSendNowCommentId(null)
-      setReplyDispatchThreadId(threadId)
-    },
-    // Explicit cancel clears ONLY the active thread's draft.
-    onCancelReply: (): void => {
-      if (replyingThreadId !== null) {
-        setReplyDrafts((prev) => {
-          const next = new Map(prev)
-          next.delete(replyingThreadId)
-
-          return next
-        })
-      }
-      setReplyingThreadId(null)
-    },
-    onResolve: resolveThread,
-    onReopen: reopenThread,
-  }
+    }
+    setReplyingThreadId(null)
+  },
+  onResolve: resolveThread,
+  onReopen: reopenThread,
+}
 ```
 
 (`updateAnnotation` spreads `{ resolvedAt: undefined }` into the metadata — consumers only ever check `!== undefined`, so an explicit-undefined property is equivalent to absent.)
@@ -1758,8 +1795,8 @@ add `thread?: PanelThreadProps` to `PanelBodyProps` and destructure `thread = un
 (f) Popover scoping — update the existing pieces:
 
 ```ts
-  const isFinishPopoverOpen =
-    finishOpen || sendNowCommentId !== null || replyDispatchThreadId !== null
+const isFinishPopoverOpen =
+  finishOpen || sendNowCommentId !== null || replyDispatchThreadId !== null
 ```
 
 and in the `finishFeedback` object:
@@ -1813,30 +1850,26 @@ Also update `onFinishFeedback` to clear the reply scope: add `setReplyDispatchTh
 (h) File strip — replace the `fileCommentsForSelectedFile.map(...)` body: map over `fileThreads.collapsed` instead; for each annotation, look up `threadGroupKey(annotation)` in `fileThreads.groups`; when a group exists render:
 
 ```tsx
-                  <ReviewThreadCard
-                    key={`thread:${group.threadId}`}
-                    group={group}
-                    anchorLabel={threadAnchorLabel(group.turns[0] ?? annotation)}
-                    actions={
-                      feedbackDispatch === undefined
-                        ? undefined
-                        : {
-                            replying:
-                              threadProps.replyingThreadId === group.threadId,
-                            replyDraft: threadProps.replyDraft,
-                            onStartReply: (): void =>
-                              threadProps.onStartReply(group.threadId),
-                            onReplyDraftChange: threadProps.onReplyDraftChange,
-                            onSubmitReply: (text): void =>
-                              threadProps.onSubmitReply(group.threadId, text),
-                            onCancelReply: threadProps.onCancelReply,
-                            onResolve: (): void =>
-                              threadProps.onResolve(group.threadId),
-                            onReopen: (): void =>
-                              threadProps.onReopen(group.threadId),
-                          }
-                    }
-                  />
+<ReviewThreadCard
+  key={`thread:${group.threadId}`}
+  group={group}
+  anchorLabel={threadAnchorLabel(group.turns[0] ?? annotation)}
+  actions={
+    feedbackDispatch === undefined
+      ? undefined
+      : {
+          replying: threadProps.replyingThreadId === group.threadId,
+          replyDraft: threadProps.replyDraft,
+          onStartReply: (): void => threadProps.onStartReply(group.threadId),
+          onReplyDraftChange: threadProps.onReplyDraftChange,
+          onSubmitReply: (text): void =>
+            threadProps.onSubmitReply(group.threadId, text),
+          onCancelReply: threadProps.onCancelReply,
+          onResolve: (): void => threadProps.onResolve(group.threadId),
+          onReopen: (): void => threadProps.onReopen(group.threadId),
+        }
+  }
+/>
 ```
 
 otherwise keep the existing `ReviewCommentRow` branch unchanged (pending file comments keep send-now/edit/delete).
@@ -1860,6 +1893,7 @@ git commit -m "feat(diff): thread cards + follow-up dispatch wiring (VIM-298)"
 ### Task 8: Integration test — the full multi-turn loop
 
 **Files:**
+
 - Modify: `src/features/diff/agentReplyThread.integration.test.tsx`
 
 - [ ] **Step 1: Extend the harness.** The file already mounts a real `useFeedbackBatchStore` + `useAgentReply` with a mocked `agent-reply` listener. Add a second Harness that renders thread cards through the real selector:
@@ -1971,9 +2005,11 @@ git commit -m "test(diff): multi-turn thread integration loop (VIM-298)"
 - [ ] **Step 1: Repo-wide gate** (CI's Code Quality check is repo-wide, not diff-scoped):
 
 Run:
+
 ```bash
 npm run lint && npm run format:check && npm run type-check:generated && npx vitest run
 ```
+
 Expected: all green. Known environment flakes (not caused by this PR, do not chase): `editorFileLifecycleStatus` home-path casing on macOS.
 
 - [ ] **Step 2: Push and open the PR**

--- a/docs/superpowers/specs/2026-07-11-vim-298-multi-turn-threads-design.md
+++ b/docs/superpowers/specs/2026-07-11-vim-298-multi-turn-threads-design.md
@@ -1,0 +1,198 @@
+# Multi-turn finding threads — GitHub-style conversation UI + follow-up dispatch — VIM-298
+
+**Issue:** VIM-298 (epic VIM-284 — Inline Agent Q&A). Depends on VIM-297 (merged, PR #684) and VIM-310 (merged, PR #683).
+
+**Delivery:** one PR on `feature/vim-298`.
+
+**Builds on (all merged):** per-comment dispatch with the nonce-keyed `pendingReviews` store + send-now row action scoped through `FinishFeedbackPopover` (VIM-297, PR #684); the agent outcome axis on `ReviewComment` + `AGENT_OUTCOME_META` chips + never-consumed finding-thread records (VIM-304 PR-3: backend #679, frontend #683 — tracked as VIM-322/VIM-310); agent replies attaching as `author: 'agent'` annotations via `useAgentReply`/`attachAgentNote` (VIM-249/283).
+
+**Design provenance:** the thread-card recipe was settled in a demo-first pass (throwaway `preview-thread-demo.tsx`, per the issue's design note) — GitHub-style wrapping container, header rollup, hairline dividers, paired footer actions, and the real `ReviewCommentEditor` for replies. Exact values are in Section 3.
+
+## Section 1 — Problem & Goals
+
+### Problem
+
+Inline Q&A (VIM-249) is a single round-trip: a user comment dispatches, one agent reply attaches below it, and the exchange dead-ends. There is no reply affordance on the exchange — to continue, the user would have to add a _new_ comment at the same line, which is unlinked to the conversation, forced through the category tabs, dispatched with no indication to the agent that it continues an earlier exchange, and rendered as yet another disconnected card.
+
+VIM-297 built the dispatch foundation: a single comment can dispatch alone (other pending comments untouched) and its reply correlates independently via the nonce-keyed pending store. VIM-304 PR-3 gave agent turns an outcome axis (`reply`/`clarify`/`resolved`/`deferred`/`rejected`). What's missing is the loop: **reply on the thread → dispatch only that follow-up, marked as a continuation → next agent reply lands on the same thread → repeat**.
+
+Visually, turns today render as disconnected stacked cards (one per annotation). A multi-turn conversation needs to read as one thread.
+
+### Goals
+
+1. After an agent reply, the user can reply on the thread; submitting dispatches **only that follow-up** via the VIM-297 single-comment path.
+2. The agent's next reply attaches to the same thread; arbitrary turn counts work (Q → A → follow-up → A2 → …), rendered in order.
+3. Turns at one anchor render as **one GitHub-style conversation card** (recipe settled in the VIM-298 demo pass): wrapping container, header with anchor + rollup chip + turn count, hairline-divided turn rows, footer with paired **↳ Reply** / **✓ Resolve** actions.
+4. Other pending comments are untouched by a follow-up dispatch.
+5. Threads can be **resolved locally**: rollup flips to Resolved and the card collapses to its header (expand on click). Nothing is dispatched on resolve.
+
+### Non-goals
+
+- Persistence of comments/threads across sessions (VIM-282).
+- Whole-changelist delegated review dispatch (VIM-327).
+- Reply capture for kimi/opencode (VIM-293).
+- Notifying the agent on resolve — resolve is purely local UI state.
+- Review-level notes (`ReviewLevelNote`, unanchored) — they have no diff anchor, so they do not become thread cards and gain no reply affordance in this PR.
+- Changing the pending-comment (pre-dispatch) row UX — flat rows, send-now, edit, delete all stay as shipped in VIM-297.
+
+## Section 2 — Thread identity, view-model & grouping
+
+### Thread identity: `threadId` on `ReviewComment`
+
+Threads need a stable identity — "same `(line, side)`" is not enough, since two independent roots can share an anchor and their turns would interleave. A new optional field:
+
+```ts
+/** Root comment id of the thread this turn belongs to. A comment whose
+ *  threadId equals its own id (or a dispatched comment with none) is a root. */
+threadId?: string
+```
+
+Stamping (all in-memory — there is no persisted legacy data to migrate). The one normalization rule, used everywhere: **`effectiveThreadId = comment.threadId ?? comment.id`** — so a root self-roots and a follow-up (created with the root's `threadId`, Section 4) keeps it. In particular `markDispatched` must NOT overwrite an existing `threadId`:
+
+- **User comment on dispatch:** `markDispatched` stamps `threadId = comment.threadId ?? comment.id`. Pending comments without a thread never carry `threadId` — they are not conversations yet.
+- **Agent reply (comment path):** `PendingReviewHandle` gains `threadId = comment.threadId ?? comment.id`, captured at handle registration in `buildFeedbackEntries` (which runs _before_ `markDispatched` — hence the same normalization, not a read of the stamped value); `attachAgentNote` copies it onto the agent annotation.
+- **Agent reply (finding path):** `FindingThreadRecord.byOrdinal` already records the placed finding's `commentId` — the anchored finding is stamped `threadId = commentId` at placement in `useAgentReview`, and finding-thread turns inherit it the same way. Delegated findings thereby become thread roots for free (per the VIM-304 spec's intent).
+- **Follow-up:** created with the root's `threadId` (Section 4).
+
+### Grouping: a render-layer transform (mechanism A — pre-group)
+
+The store stays **flat** — turns remain sibling `DiffLineAnnotation<ReviewComment>` entries; `threadId` is data, not nesting. Grouping happens between the store and Pierre, in a memoized selector in `Panel`:
+
+1. Partition annotations by a synthesized grouping key (all fields live on the annotation's `metadata: ReviewComment`): `groupKey(a) = a.metadata.threadId ?? (a.metadata.author !== 'self' || a.metadata.dispatchedAt !== undefined ? a.metadata.id : undefined)`. A `undefined` key (pending user comments, the draft sentinel) passes through untouched as a flat row; the second arm makes orphan agent/reviewer annotations and legacy dispatched roots one-turn groups keyed by their own id, consistent with the in-flight rule below.
+2. Each group collapses to its **first annotation** (the anchor) in the `lineAnnotations` array handed to `MultiFileDiff`, so Pierre opens exactly one slot per thread.
+3. A `Map<groupKey, ThreadGroup>` rides alongside to `PanelBody`; `renderAnnotation` checks it — anchor of a group → `<ReviewThreadCard>`, otherwise the existing draft-editor / flat-row branches, unchanged.
+
+The same selector runs on **both** annotation lists: Pierre's line-level list (`isLineLevelReviewAnnotation`) _and_ the file-level strip (`isFileLevelReviewAnnotation`, rendered as plain rows outside Pierre in `Panel`). File-scoped threads — including delegated findings downgraded to file scope — get the same `ReviewThreadCard` in the file-comments strip, with the Reply footer; only review-level notes (no annotation at all) stay out of scope.
+
+```ts
+interface ThreadGroup {
+  threadId: string
+  /** Store-order turns (arrival order — attachAgentNote appends). */
+  turns: DiffLineAnnotation<ReviewComment>[]
+  rollup: { label: string; chip: string }
+  resolved: boolean
+}
+```
+
+**In-flight rule:** an annotation renders inside a thread card exactly when its `groupKey` is defined — which by construction means "dispatched, or authored by the agent/reviewer". A lone un-replied dispatched comment is a 1-turn card ("Sent…" state); an orphan agent annotation (no threadId, e.g. constructed by older tests) is a 1-turn card keyed by its own id.
+
+**Ordering:** store array order within the group (chronological by construction; `createdAt` ties are irrelevant since order is positional).
+
+**Rollup derivation** — a total function of the **latest turn** (not the latest agent turn — a dispatched follow-up after a `clarify` must flip the thread back to awaiting the agent), with the local resolve override on top:
+
+1. Thread locally resolved (Section 5) → **Resolved**.
+2. Latest turn `author: 'agent'` → `AGENT_OUTCOME_META[outcome]`, falling back to the "Replied" meta when `outcome` is absent (fallback agent notes may omit it).
+3. Latest turn `author: 'self'` → **Sent** (awaiting agent). This arm is total because no undispatched self turn can exist inside a thread: follow-ups are created atomically with a successful dispatch (Section 4), and pending root comments have no `threadId` yet.
+4. Latest turn `author: 'reviewer'` (a finding with no agent turn yet) → **Open**.
+
+The non-agent rollup states get complete chip metas (a small `THREAD_ROLLUP_META` beside the existing metas): **Sent** `text-primary` (matching the existing Sent badge), **Open** `text-on-surface-variant`, **Resolved** reusing `AGENT_OUTCOME_META.resolved`'s `text-success`.
+
+**What thread turns lose:** inside a card, per-turn edit/delete/send-now actions are dropped in v1 — the card's operations are the footer pair (Reply / Resolve). Pending flat rows keep all VIM-297 actions.
+
+**1:1 consumers audit:** the collapse happens _after_ everything that counts comments — `buildFeedbackEntries`, pending counts, and the Finish popover all read the store, not the Pierre-bound array. The only consumers of the collapsed array are `MultiFileDiff` (slots/gutter) and `renderAnnotation` itself; the plan adds a test pinning that dispatch counting is unaffected by grouping.
+
+## Section 3 — Thread card UI (the settled recipe)
+
+New component `src/features/diff/components/ReviewThreadCard.tsx`, rendered by `renderAnnotation` for a group's anchor (and by the file-comments strip for file-scoped groups). All values below were settled in the demo-first pass the issue's design note asked for; colors are theme tokens / `color-mix(var(--color-*))` only (per `vimeflow/no-hardcoded-colors`), no visible borders — hairlines are on-surface mixes, consistent with The Lens.
+
+**Container** — `mx-3 my-2 overflow-hidden rounded-lg bg-surface-container-high/80`.
+
+**Header strip** — `px-4 py-2`, `text-[10px] text-on-surface-variant`, background `color-mix(in srgb, var(--color-on-surface) 4%, transparent)`. Content: anchor label — the existing `annotationTargetLabel` in `PanelBody` is private and only labels range targets, so it is **extended and exported** (or superseded by a `threadAnchorLabel` helper) to cover all three cases: plain line ("line R40"), range ("lines R88–94"), and file scope ("file"), the **rollup chip** (same `Chip` shape as category chips: `rounded bg-surface-container-highest/70 px-1.5 py-px text-[10px] font-medium` + the meta's text class), and the turn count ("4 turns"). In the resolved state the header doubles as the collapsed card (Section 5).
+
+**Turn rows** — `px-4 py-2.5`; rows after the first get a hairline `border-top: 1px solid color-mix(in srgb, var(--color-on-surface) 12%, transparent)`. No per-author background tint (evaluated, rejected). Each row:
+
+- identity line: 16px round avatar (agent: `bg-primary-container/60 text-primary` "A"; user: `bg-surface-container-highest text-on-surface-variant`; reviewer: same neutral treatment with the reviewer's initial), name ("You" / "Agent" / reviewer name, `text-[11px] font-medium`), chip (user turn with category → `REVIEW_CATEGORY_META`; agent turn → `AGENT_OUTCOME_META[outcome]` with the existing "Agent reply" fallback; typeless follow-ups → no chip), and a relative timestamp (`text-[10px]`) — dispatched self turns use `dispatchedAt` ("Sent 2m ago", reusing the pure time-ago formatter already in `ReviewCommentRow`); all other turns (agent, reviewer, and reviewer/orphan-agent roots, which have no `dispatchedAt`) use `createdAt`.
+- body: `whitespace-pre-wrap break-words text-xs leading-5 pl-[22px]` (indented under the avatar; `pre-wrap` preserves the multiline text the editor accepts, matching `ReviewCommentRow`).
+
+**Footer** — hairline-divided from the turns. Default: right-aligned matched pair, `px-4 py-2`:
+
+- **↳ Reply** — `rounded-md px-3 py-1.5 text-[11px] font-medium text-primary`, background `color-mix(in srgb, var(--color-primary) 12%, transparent)`, hover `bg-surface-container-highest/60`.
+- **✓ Resolve** — same shape, `text-on-surface-variant`, background `color-mix(in srgb, var(--color-on-surface) 6%, transparent)`, hover lifts to `text-on-surface`. Resolved threads swap it for **⟲ Reopen** (Section 5).
+
+Clicking Reply swaps the footer for the real `ReviewCommentEditor` (`chrome="plain"`, `surfaceRole="none"`, new reply mode — Section 4) in a `px-2 py-1.5` wrapper; Cancel/confirm restores the button pair.
+
+**Capability gating** — the footer renders iff `Panel` passes an `onReplyToThread` handler, mirroring how the send-now action is gated on `onSendComment !== undefined` today (there is no panel-level read-only flag; capability is expressed by handler presence). Contexts without dispatch capability omit the handler and get a footer-less card.
+
+**Rejected variants (for the record):** flat stack, indent, connector-rail and indent+rail structures; hover-on-agent-row reply affordance; latest-turn-only rollup; per-author tint; compact density. All were evaluated against the GitHub-conversation variant in the demo and dropped.
+
+## Section 4 — Reply flow (follow-up dispatch)
+
+### Editor: a `reply` mode on `ReviewCommentEditor`
+
+New prop `mode?: 'comment' | 'reply'` (default `'comment'`, existing behavior untouched). In reply mode:
+
+- category tabs and the ⌃H/⌃L hint are hidden; the cycle shortcuts are inert — follow-ups are **typeless** (per the VIM-310 taxonomy: user/reviewer _raise_ with a category, thread replies don't).
+- header reads **"Reply to thread"** (in place of "Local comment"); the right-side target copy stays the anchor label.
+- confirm button reads **"Reply"**; placeholder "Reply to the agent…".
+- `onConfirm(text, category)` keeps its signature; the category argument is ignored by the reply-mode caller (no signature churn).
+
+`ReviewThreadCard` mounts it with `chrome="plain"`, `surfaceRole="none"`, `mode="reply"`. Cancel discards the draft text (uncontrolled, same as other editor cancels).
+
+### Creating + dispatching the follow-up — atomic with dispatch
+
+A follow-up is **never stored as a pending comment**: it enters the batch store only together with a successful dispatch. This keeps three invariants for free — whole-batch Finish can never sweep a follow-up, keyboard comment-navigation never targets a hidden in-card pending turn, and no in-card edit/delete/send controls are needed for a state that cannot exist.
+
+On confirm, `Panel`'s `onReplyToThread(threadId, text)`:
+
+1. Opens the **same scoped confirm flow as send-now** (`FinishFeedbackPopover` scoped to one item) against the panel's agent candidate. **Cancelled → nothing is created**; the reply editor stays open with the text intact, so nothing is lost.
+2. On confirm: creates the follow-up `ReviewComment` — `author: 'self'`, **no `category`**, `threadId` = the thread's id, same `(lineNumber, side)` and `target` as the anchor — and dispatches it in the same handler. **Not via the render-closure `buildFeedbackEntries`** (which scans the render-time batch for _pending_ annotations and would not see a same-callback insert): a dedicated `dispatchFollowUp` builds the single `DispatchEntry` directly from the just-created comment and shares the lower-level primitives — nonce minting, payload formatting, `[#n]` handle registration (the handle carrying `threadId` per Section 2), `pendingReviews` registration, and a scoped `markDispatched`. Other pending comments are untouched by construction.
+3. **UI state commits only after the dispatch write succeeds**: the editor closes and (Section 5) `resolvedAt` clears at that point; a write failure keeps the editor open with the text and creates no comment.
+
+### Agent affinity (routing to the originating session)
+
+Thread lifetime already bounds this problem: batches are owned by the agent pane (`prunePendingReviewOwners`), so a thread whose originating pane closes is pruned with it — a live thread's panel candidate _is_ in practice the originating session, and `WorkspaceView` supplies exactly that one candidate today (there is no live-pane inventory to search).
+
+v1 therefore ships the send-now flow verbatim (step 1 above) — no new pane machinery. Additionally, `markDispatched` stamps **`dispatchedTo`** (the target ptyId) on the comments it dispatches, which (a) lets the payload/context layer know the conversation continuity is real, and (b) enables the fast-follow of skipping the confirm popover when `dispatchedTo` matches the current candidate. Delegated finding roots never pass through `markDispatched` and carry no `dispatchedTo` — their first follow-up simply goes through the confirm flow like any other.
+
+### Payload: marking the continuation
+
+`formatFeedbackPayload` renders typeless follow-ups as **`[#1 · Follow-up]`** (category label position) and inserts one context line after the location line:
+
+```
+> [#1 · Follow-up] src/auth.ts:42 (additions) [unstaged]
+> ↩ Continuing our thread — your last reply: "The pool applies backpressure per write; the cap bounds …" (truncated)
+> ─ Can you help me understand how that interacts with the resize path?
+> → Answer inline in your reply. Do not edit files.
+```
+
+The context input is explicit: `dispatchFollowUp` receives the `ThreadGroup` and quotes the **latest turn preceding the follow-up**, with author-appropriate phrasing — `your last reply: "…"` for an agent turn, `the finding: "…"` for a reviewer turn (a finding not yet answered), `my earlier comment: "…"` when the only prior turn is the user's own (a Sent card awaiting its first answer). Reply is available on every card; the rule is total.
+
+The excerpt is truncated to ~200 chars **and passes through the same terminal-control sanitization `formatFeedbackPayload` already applies** (stripping ESC/CR/bracketed-paste terminators — the quoted text is agent-controlled, so a paste-breakout regression test rides with this). The `VIMEFLOW_REPLY` footer (nonce + `[#n]` ids) is unchanged — the agent's answer routes exactly like any VIM-297 reply and lands on the thread via the handle's `threadId`.
+
+## Section 5 — Resolve & collapse
+
+### State
+
+`ReviewComment` gains **`resolvedAt?: number`**, set on the thread's **root** comment only (the annotation whose id equals the thread id) via the existing `updateAnnotation` machinery. Local-only, in-memory like all comment state; it rides into VIM-282 persistence for free when that lands. `ThreadGroup.resolved` derives from the root's `resolvedAt`.
+
+### Behavior
+
+- **✓ Resolve** (footer) → stamps `resolvedAt`. The card collapses to its **header only** — anchor label, **Resolved** rollup chip, turn count — plus an expand chevron. Turn rows and footer are hidden.
+- Clicking the collapsed header **expands** the card for reading (an expanded-while-resolved state); the footer then shows **↳ Reply** and **⟲ Reopen** (in Resolve's slot). Collapsing again is a header click.
+- **⟲ Reopen** → clears `resolvedAt`; the thread returns to its normal expanded state and derived rollup.
+- **Reply implies reopen**: a follow-up that _successfully dispatches_ on a resolved thread clears `resolvedAt` — you don't converse on a closed thread. (Cancelling the picker or a failed write reopens nothing; Section 4's commit-after-write rule governs.)
+
+### Precedence with late-arriving agent turns (deferred from Section 1)
+
+**Local resolution is authoritative.** An agent reply that arrives after the user resolved (an in-flight dispatch completing late) **appends to the thread but does not clear `resolvedAt`** — the collapsed header's turn count ticks up, the rollup stays Resolved. Rationale: resolve is the user saying "I'm done here"; an answer to a question they no longer have shouldn't re-open work. The turn is not lost — expanding shows it. (Mirrors GitHub: new pushes don't unresolve conversations.)
+
+Expanded/collapsed is ephemeral component state; `resolvedAt` is the durable-ish fact.
+
+## Section 6 — Testing & rollout
+
+### Tests (co-located, `test()` not `it()`)
+
+- **Grouping selector** — `groupKey` partition: pending/draft pass through; dispatched root self-roots; follow-up + agent turns join the root's group; two roots on one line stay two groups; orphan agent annotation becomes a 1-turn group; file-level and line-level lists both grouped; collapse hands Pierre exactly one anchor per group.
+- **threadId stamping** — `markDispatched` preserves an existing `threadId` (the follow-up-fork regression codex caught in review); handle registration normalizes `threadId ?? id`; `attachAgentNote` copies the handle's threadId; finding placement stamps `threadId = commentId`.
+- **Rollup** — total-function table: latest-agent per outcome + missing-outcome fallback, latest-self (always Sent), reviewer-only (Open), resolved override; `THREAD_ROLLUP_META` chip classes.
+- **`ReviewThreadCard`** — turn order, chips (category / outcome / none for typeless), header content, footer pair, reply-editor swap, collapse/expand/reopen, read-only hides footer.
+- **Editor reply mode** — tabs hidden, ⌃H/⌃L inert, labels, confirm passes text.
+- **Reply dispatch** — follow-up created typeless with root's threadId/anchor; only that comment dispatched (others untouched — pin the VIM-297 invariant); confirm flow scoped to the follow-up, popover cancel → no comment created and editor text preserved, dispatch write failure → editor stays open and no comment persists; payload renders `[#1 · Follow-up]` + context line with author-appropriate phrasing for agent/reviewer/self-only threads (respecting the dispatch-vocab pins); context excerpt passes control-character sanitization (paste-breakout regression); reply-implies-reopen only after successful dispatch.
+- **Integration** — full loop: comment → dispatch → agent reply → follow-up → second agent reply, asserting one card with 4 ordered turns and rollup transitions; late reply after resolve appends without unresolving.
+
+### Rollout & cleanup
+
+- Single PR on `feature/vim-298`: `Closes VIM-298` + `Part of VIM-284`, `auto-review` + `auto-approve` labels.
+- Full local gate before push: repo-wide `lint`, `format:check`, `type-check:generated`, `vitest run` (the Code Quality CI check is repo-wide).
+- Delete the demo artifacts (`preview.html`, `preview-thread-demo.tsx`, `vite.preview.config.ts`) from the main checkout once this spec merges — the recipe now lives in Section 3.
+- No backend/Rust changes; no bindings churn expected.

--- a/docs/superpowers/specs/2026-07-11-vim-298-multi-turn-threads-design.md
+++ b/docs/superpowers/specs/2026-07-11-vim-298-multi-turn-threads-design.md
@@ -71,6 +71,15 @@ interface ThreadGroup {
   turns: DiffLineAnnotation<ReviewComment>[]
   rollup: { label: string; chip: string }
   resolved: boolean
+  /** Immutable batch-location snapshot, captured from the batch key at
+   *  group construction. The follow-up dispatch needs both forms: the
+   *  repo-relative coordinates for PendingReviewHandle and the repo-root
+   *  resolver (same one buildFeedbackEntries uses) for the agent-facing
+   *  path — carrying them here avoids re-deriving from render-time props
+   *  (docs/reviews/patterns/derived-state-consistency.md §22). */
+  cwd: string
+  filePath: string
+  staged: boolean
 }
 ```
 
@@ -109,7 +118,7 @@ New component `src/features/diff/components/ReviewThreadCard.tsx`, rendered by `
 - **↳ Reply** — `rounded-md px-3 py-1.5 text-[11px] font-medium text-primary`, background `color-mix(in srgb, var(--color-primary) 12%, transparent)`, hover `bg-surface-container-highest/60`.
 - **✓ Resolve** — same shape, `text-on-surface-variant`, background `color-mix(in srgb, var(--color-on-surface) 6%, transparent)`, hover lifts to `text-on-surface`. Resolved threads swap it for **⟲ Reopen** (Section 5).
 
-Clicking Reply swaps the footer for the real `ReviewCommentEditor` (`chrome="plain"`, `surfaceRole="none"`, new reply mode — Section 4) in a `px-2 py-1.5` wrapper; Cancel/confirm restores the button pair.
+Clicking Reply swaps the footer for the real `ReviewCommentEditor` (`chrome="plain"`, `surfaceRole="none"`, new reply mode — Section 4) in a `px-2 py-1.5` wrapper. Cancel restores the button pair immediately; confirm restores it only once the dispatch write succeeds (Section 4's commit-after-write rule).
 
 **Capability gating** — the footer renders iff `Panel` passes an `onReplyToThread` handler, mirroring how the send-now action is gated on `onSendComment !== undefined` today (there is no panel-level read-only flag; capability is expressed by handler presence). Contexts without dispatch capability omit the handler and get a footer-less card.
 
@@ -126,7 +135,7 @@ New prop `mode?: 'comment' | 'reply'` (default `'comment'`, existing behavior un
 - confirm button reads **"Reply"**; placeholder "Reply to the agent…".
 - `onConfirm(text, category)` keeps its signature; the category argument is ignored by the reply-mode caller (no signature churn).
 
-`ReviewThreadCard` mounts it with `chrome="plain"`, `surfaceRole="none"`, `mode="reply"`. Cancel discards the draft text (uncontrolled, same as other editor cancels).
+`ReviewThreadCard` mounts it with `chrome="plain"`, `surfaceRole="none"`, `mode="reply"`, and **controlled**: the reply draft (text + which thread is replying) lives in `Panel` state keyed by `threadId`, mirroring the Panel-owned `commentDraftText` of the main draft flow. This is load-bearing, not style — `MultiFileDiff` is remounted whenever its render key changes (highlight-cache revision, diff refresh, theme), and an uncontrolled textarea inside it would silently erase typed text. The draft is cleared by exactly two events: explicit editor Cancel, or successful dispatch.
 
 ### Creating + dispatching the follow-up — atomic with dispatch
 
@@ -135,14 +144,15 @@ A follow-up is **never stored as a pending comment**: it enters the batch store 
 On confirm, `Panel`'s `onReplyToThread(threadId, text)`:
 
 1. Opens the **same scoped confirm flow as send-now** (`FinishFeedbackPopover` scoped to one item) against the panel's agent candidate. **Cancelled → nothing is created**; the reply editor stays open with the text intact, so nothing is lost.
-2. On confirm: creates the follow-up `ReviewComment` — `author: 'self'`, **no `category`**, `threadId` = the thread's id, same `(lineNumber, side)` and `target` as the anchor — and dispatches it in the same handler. **Not via the render-closure `buildFeedbackEntries`** (which scans the render-time batch for _pending_ annotations and would not see a same-callback insert): a dedicated `dispatchFollowUp` builds the single `DispatchEntry` directly from the just-created comment and shares the lower-level primitives — nonce minting, payload formatting, `[#n]` handle registration (the handle carrying `threadId` per Section 2), `pendingReviews` registration, and a scoped `markDispatched`. Other pending comments are untouched by construction.
-3. **UI state commits only after the dispatch write succeeds**: the editor closes and (Section 5) `resolvedAt` clears at that point; a write failure keeps the editor open with the text and creates no comment.
+2. On confirm: a dedicated `dispatchFollowUp` builds the single `DispatchEntry` from an **ephemeral** follow-up comment — `author: 'self'`, **no `category`**, `threadId` = the thread's id, same `(lineNumber, side)` and `target` as the anchor, batch location from the `ThreadGroup` snapshot — **not** via the render-closure `buildFeedbackEntries` (which scans the render-time batch for _pending_ annotations and would not see a same-callback insert). It shares the lower-level primitives: nonce minting, payload formatting, `[#n]` handle registration (the handle carrying `threadId` per Section 2), and `pendingReviews` registration, in the same order relative to the terminal write as the batch path. Other pending comments are untouched by construction.
+3. **The store insert happens after the write succeeds, already stamped** (`dispatchedAt`, `threadId`, `dispatchedTo` set on insertion — no `markDispatched` involved for follow-ups). The insertion path is exempt from the 50-pending soft cap: the cap guards _pending_ comments, and a dispatched follow-up is thread history like agent output — inserting _before_ the write would bounce off the cap at the boundary, letting a terminal write succeed with no local record. The exact-cap case gets a test.
+4. **UI state commits only after the dispatch write succeeds**: the editor closes, the thread-keyed draft clears, and (Section 5) `resolvedAt` clears at that point; a write failure keeps the editor open with the text and inserts no comment.
 
 ### Agent affinity (routing to the originating session)
 
 Thread lifetime already bounds this problem: batches are owned by the agent pane (`prunePendingReviewOwners`), so a thread whose originating pane closes is pruned with it — a live thread's panel candidate _is_ in practice the originating session, and `WorkspaceView` supplies exactly that one candidate today (there is no live-pane inventory to search).
 
-v1 therefore ships the send-now flow verbatim (step 1 above) — no new pane machinery. Additionally, `markDispatched` stamps **`dispatchedTo`** (the target ptyId) on the comments it dispatches, which (a) lets the payload/context layer know the conversation continuity is real, and (b) enables the fast-follow of skipping the confirm popover when `dispatchedTo` matches the current candidate. Delegated finding roots never pass through `markDispatched` and carry no `dispatchedTo` — their first follow-up simply goes through the confirm flow like any other.
+v1 therefore ships the send-now flow verbatim (step 1 above) — no new pane machinery. Additionally, dispatched comments carry **`dispatchedTo`** (the target ptyId): `markDispatched` stamps it on the batch/send-now paths, and the follow-up insertion (step 3) sets it directly. This (a) records that the conversation continuity is real, and (b) enables the fast-follow of skipping the confirm popover when `dispatchedTo` matches the current candidate. Delegated finding roots never pass through either path and carry no `dispatchedTo` — their first follow-up simply goes through the confirm flow like any other.
 
 ### Payload: marking the continuation
 
@@ -168,7 +178,7 @@ The excerpt is truncated to ~200 chars **and passes through the same terminal-co
 ### Behavior
 
 - **✓ Resolve** (footer) → stamps `resolvedAt`. The card collapses to its **header only** — anchor label, **Resolved** rollup chip, turn count — plus an expand chevron. Turn rows and footer are hidden.
-- Clicking the collapsed header **expands** the card for reading (an expanded-while-resolved state); the footer then shows **↳ Reply** and **⟲ Reopen** (in Resolve's slot). Collapsing again is a header click.
+- The collapsed/expanded toggle is an accessible disclosure: the header (or its chevron region) is a semantic `<button>` with `aria-expanded`, activatable by click and Enter/Space. Expanding shows the card for reading (an expanded-while-resolved state); the footer then shows **↳ Reply** and **⟲ Reopen** (in Resolve's slot). Collapsing again is the same toggle.
 - **⟲ Reopen** → clears `resolvedAt`; the thread returns to its normal expanded state and derived rollup.
 - **Reply implies reopen**: a follow-up that _successfully dispatches_ on a resolved thread clears `resolvedAt` — you don't converse on a closed thread. (Cancelling the picker or a failed write reopens nothing; Section 4's commit-after-write rule governs.)
 
@@ -185,9 +195,9 @@ Expanded/collapsed is ephemeral component state; `resolvedAt` is the durable-ish
 - **Grouping selector** — `groupKey` partition: pending/draft pass through; dispatched root self-roots; follow-up + agent turns join the root's group; two roots on one line stay two groups; orphan agent annotation becomes a 1-turn group; file-level and line-level lists both grouped; collapse hands Pierre exactly one anchor per group.
 - **threadId stamping** — `markDispatched` preserves an existing `threadId` (the follow-up-fork regression codex caught in review); handle registration normalizes `threadId ?? id`; `attachAgentNote` copies the handle's threadId; finding placement stamps `threadId = commentId`.
 - **Rollup** — total-function table: latest-agent per outcome + missing-outcome fallback, latest-self (always Sent), reviewer-only (Open), resolved override; `THREAD_ROLLUP_META` chip classes.
-- **`ReviewThreadCard`** — turn order, chips (category / outcome / none for typeless), header content, footer pair, reply-editor swap, collapse/expand/reopen, read-only hides footer.
+- **`ReviewThreadCard`** — turn order, chips (category / outcome / none for typeless), header content, footer pair, reply-editor swap, collapse/expand/reopen via the role-queried disclosure button (`aria-expanded`, Enter/Space), reply draft survives a `MultiFileDiff` remount (Panel-owned state), missing `onReplyToThread` hides the footer.
 - **Editor reply mode** — tabs hidden, ⌃H/⌃L inert, labels, confirm passes text.
-- **Reply dispatch** — follow-up created typeless with root's threadId/anchor; only that comment dispatched (others untouched — pin the VIM-297 invariant); confirm flow scoped to the follow-up, popover cancel → no comment created and editor text preserved, dispatch write failure → editor stays open and no comment persists; payload renders `[#1 · Follow-up]` + context line with author-appropriate phrasing for agent/reviewer/self-only threads (respecting the dispatch-vocab pins); context excerpt passes control-character sanitization (paste-breakout regression); reply-implies-reopen only after successful dispatch.
+- **Reply dispatch** — follow-up created typeless with root's threadId/anchor; only that comment dispatched (others untouched — pin the VIM-297 invariant); confirm flow scoped to the follow-up, popover cancel → no comment created and editor text preserved, dispatch write failure → editor stays open and no comment persists; post-write insertion lands already-stamped (`dispatchedAt`/`threadId`/`dispatchedTo`) and succeeds at exactly 50 pending comments (cap-exemption boundary case); batch-location snapshot flows from `ThreadGroup` (repo-relative handle coordinates + repo-root-resolved payload path, including a repo-subdirectory cwd case); payload renders `[#1 · Follow-up]` + context line with author-appropriate phrasing for agent/reviewer/self-only threads (respecting the dispatch-vocab pins); context excerpt passes control-character sanitization (paste-breakout regression); reply-implies-reopen only after successful dispatch.
 - **Integration** — full loop: comment → dispatch → agent reply → follow-up → second agent reply, asserting one card with 4 ordered turns and rollup transitions; late reply after resolve appends without unresolving.
 
 ### Rollout & cleanup

--- a/docs/superpowers/specs/2026-07-11-vim-298-multi-turn-threads-design.md
+++ b/docs/superpowers/specs/2026-07-11-vim-298-multi-turn-threads-design.md
@@ -206,3 +206,5 @@ Expanded/collapsed is ephemeral component state; `resolvedAt` is the durable-ish
 - Full local gate before push: repo-wide `lint`, `format:check`, `type-check:generated`, `vitest run` (the Code Quality CI check is repo-wide).
 - Delete the demo artifacts (`preview.html`, `preview-thread-demo.tsx`, `vite.preview.config.ts`) from the main checkout once this spec merges — the recipe now lives in Section 3.
 - No backend/Rust changes; no bindings churn expected.
+
+<!-- codex-reviewed: 2026-07-13T06:09:05Z -->

--- a/src/features/diff/Panel.test.tsx
+++ b/src/features/diff/Panel.test.tsx
@@ -6154,6 +6154,379 @@ describe('Panel', () => {
 
       spy.mockRestore()
     })
+
+    test('thread reply dispatches alone, inserts post-write pre-stamped, and reopens (VIM-298)', async (): Promise<void> => {
+      const user = userEvent.setup()
+      const writePty = vi.fn().mockResolvedValue(undefined)
+      const focusTerminal = vi.fn()
+
+      const candidate: PaneCandidate = {
+        paneId: 'pane-1',
+        ptyId: 'pty-1',
+        tabName: 'Tab 1',
+        agentLabel: 'Claude Code',
+        cwd: '/repo',
+        status: 'running',
+        isFocused: true,
+      }
+
+      // Seed: dispatched root (resolved) + agent turn + unrelated pending comment
+      const addAnnotation = vi.fn(() => 'ok' as const)
+      const updateAnnotation = vi.fn()
+
+      const batchAnnotations: DiffLineAnnotation<ReviewComment>[] = [
+        {
+          lineNumber: 5,
+          side: 'additions',
+          metadata: {
+            id: 'root-c1',
+            text: 'Why does this work?',
+            author: 'self',
+            category: 'question',
+            createdAt: 1000,
+            dispatchedAt: 1000,
+            dispatchedTo: 'pty-1',
+            threadId: 'root-c1',
+            resolvedAt: 9999,
+          },
+        },
+        {
+          lineNumber: 5,
+          side: 'additions',
+          metadata: {
+            id: 'agent-g1',
+            text: 'Because of backpressure.',
+            author: 'agent',
+            outcome: 'clarify',
+            createdAt: 2000,
+            threadId: 'root-c1',
+          },
+        },
+        {
+          lineNumber: 1,
+          side: 'additions',
+          metadata: {
+            id: 'pending-p9',
+            text: 'Unrelated pending comment',
+            author: 'self',
+            createdAt: 3000,
+          },
+        },
+      ]
+
+      const feedbackBatch: UseFeedbackBatchReturn = {
+        batch: new Map([
+          [makeBatchKey('/repo', 'src/foo.ts', false), batchAnnotations],
+        ]),
+        annotationsForFile: () => batchAnnotations,
+        addAnnotation,
+        addAnnotationForOwner: vi.fn(() => 'ok' as const),
+        updateAnnotation,
+        removeAnnotation: vi.fn(),
+        clearBatch: vi.fn(),
+        clearPending: vi.fn(),
+        markDispatched: vi.fn(),
+        totalAnnotations: () => 3,
+        // Only pending-p9 is pending (no dispatchedAt, author self)
+        pendingAnnotations: () => 1,
+      }
+
+      render(
+        <Panel
+          cwd="/repo"
+          selectedFile={{ path: 'src/foo.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+          feedbackOwnerKey="sess:pane-1"
+          feedbackBatch={feedbackBatch}
+          feedbackDispatch={{
+            candidates: [candidate],
+            writePty,
+            focusTerminal,
+          }}
+        />
+      )
+
+      setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
+
+      // The thread card renders in the annotation slot. The thread is resolved so
+      // it starts collapsed — expand it first via the disclosure button.
+      const annotationSlot = screen.getByTestId('annotation-slot')
+
+      const disclosureButton = within(annotationSlot).getByRole('button', {
+        name: /thread/i,
+      })
+      await user.click(disclosureButton)
+
+      // Now the footer is visible — click Reply.
+      const replyButton = within(annotationSlot).getByRole('button', {
+        name: /reply/i,
+      })
+      await user.click(replyButton)
+
+      // The reply editor should now be visible inside the thread card.
+      const replyTextarea = within(annotationSlot).getByPlaceholderText(
+        'Reply to the agent…'
+      )
+      await user.type(replyTextarea, 'How does that interact with resize?')
+      fireEvent.keyDown(replyTextarea, { key: 'Enter' })
+
+      // Confirm popover should open scoped to 1 comment.
+      const popover = await screen.findByRole('dialog', {
+        name: 'Finish feedback',
+      })
+      expect(popover).toHaveTextContent(/Send 1 comment/)
+
+      // No Copy button for a reply (no persisted comment to copy).
+      expect(
+        within(popover).queryByRole('button', { name: /copy/i })
+      ).not.toBeInTheDocument()
+
+      await user.keyboard('Y')
+
+      await waitFor(() => expect(writePty).toHaveBeenCalledTimes(1))
+
+      const [, payload] = writePty.mock.calls[0]
+      expect(typeof payload).toBe('string')
+      // Follow-up label present.
+      expect(payload as string).toContain('[#1 · Follow-up]')
+      // Context line from the agent turn.
+      expect(payload as string).toContain('Continuing our thread')
+
+      // Post-write addAnnotation is called with pre-stamped metadata.
+      expect(addAnnotation).toHaveBeenCalledOnce()
+
+      const addedAnnotation = addAnnotation.mock
+        .calls[0][3] as DiffLineAnnotation<ReviewComment>
+      expect(addedAnnotation.metadata.dispatchedAt).toBeDefined()
+      expect(addedAnnotation.metadata.dispatchedTo).toBe('pty-1')
+      expect(addedAnnotation.metadata.threadId).toBe('root-c1')
+
+      // Reply on a resolved thread → resolvedAt cleared.
+      expect(updateAnnotation).toHaveBeenCalledWith(
+        '/repo',
+        'src/foo.ts',
+        false,
+        'root-c1',
+        { resolvedAt: undefined }
+      )
+
+      // Unrelated pending comment is untouched (addAnnotation called exactly once — the follow-up only).
+      expect(addedAnnotation.metadata.id).not.toBe('pending-p9')
+
+      await waitFor(() => expect(focusTerminal).toHaveBeenCalledOnce())
+    })
+
+    test('thread reply: write failure leaves no inserted comment and keeps the editor open (VIM-298)', async (): Promise<void> => {
+      const user = userEvent.setup()
+      const writePty = vi.fn().mockRejectedValue(new Error('pty closed'))
+
+      const candidate: PaneCandidate = {
+        paneId: 'pane-1',
+        ptyId: 'pty-1',
+        tabName: 'Tab 1',
+        agentLabel: 'Claude Code',
+        cwd: '/repo',
+        status: 'running',
+        isFocused: true,
+      }
+
+      const addAnnotation = vi.fn(() => 'ok' as const)
+
+      const batchAnnotations: DiffLineAnnotation<ReviewComment>[] = [
+        {
+          lineNumber: 5,
+          side: 'additions',
+          metadata: {
+            id: 'root-c2',
+            text: 'Root question',
+            author: 'self',
+            category: 'question',
+            createdAt: 1000,
+            dispatchedAt: 1000,
+            threadId: 'root-c2',
+          },
+        },
+        {
+          lineNumber: 5,
+          side: 'additions',
+          metadata: {
+            id: 'agent-g2',
+            text: 'Agent reply.',
+            author: 'agent',
+            outcome: 'reply',
+            createdAt: 2000,
+            threadId: 'root-c2',
+          },
+        },
+      ]
+
+      const feedbackBatch: UseFeedbackBatchReturn = {
+        batch: new Map([
+          [makeBatchKey('/repo', 'src/foo.ts', false), batchAnnotations],
+        ]),
+        annotationsForFile: () => batchAnnotations,
+        addAnnotation,
+        addAnnotationForOwner: vi.fn(() => 'ok' as const),
+        updateAnnotation: vi.fn(),
+        removeAnnotation: vi.fn(),
+        clearBatch: vi.fn(),
+        clearPending: vi.fn(),
+        markDispatched: vi.fn(),
+        totalAnnotations: () => 2,
+        pendingAnnotations: () => 0,
+      }
+
+      render(
+        <Panel
+          cwd="/repo"
+          selectedFile={{ path: 'src/foo.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+          feedbackOwnerKey="sess:pane-1"
+          feedbackBatch={feedbackBatch}
+          feedbackDispatch={{
+            candidates: [candidate],
+            writePty,
+            focusTerminal: vi.fn(),
+          }}
+        />
+      )
+
+      setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
+
+      const annotationSlot = screen.getByTestId('annotation-slot')
+      await user.click(
+        within(annotationSlot).getByRole('button', { name: /reply/i })
+      )
+
+      const replyTextarea = within(annotationSlot).getByPlaceholderText(
+        'Reply to the agent…'
+      )
+      await user.type(replyTextarea, 'Follow-up question')
+      fireEvent.keyDown(replyTextarea, { key: 'Enter' })
+
+      await screen.findByRole('dialog', { name: 'Finish feedback' })
+      await user.keyboard('Y')
+
+      // Write rejected — no comment inserted.
+      await waitFor(() => expect(writePty).toHaveBeenCalledOnce())
+      expect(addAnnotation).not.toHaveBeenCalled()
+
+      // Notification is shown.
+      expect(
+        await screen.findByText(/Terminal session ended/)
+      ).toBeInTheDocument()
+    })
+
+    test('popover cancel preserves the reply draft and creates nothing (VIM-298)', async (): Promise<void> => {
+      const user = userEvent.setup()
+      const writePty = vi.fn().mockResolvedValue(undefined)
+
+      const candidate: PaneCandidate = {
+        paneId: 'pane-1',
+        ptyId: 'pty-1',
+        tabName: 'Tab 1',
+        agentLabel: 'Claude Code',
+        cwd: '/repo',
+        status: 'running',
+        isFocused: true,
+      }
+
+      const addAnnotation = vi.fn(() => 'ok' as const)
+
+      const batchAnnotations: DiffLineAnnotation<ReviewComment>[] = [
+        {
+          lineNumber: 5,
+          side: 'additions',
+          metadata: {
+            id: 'root-c3',
+            text: 'Root question',
+            author: 'self',
+            category: 'question',
+            createdAt: 1000,
+            dispatchedAt: 1000,
+            threadId: 'root-c3',
+          },
+        },
+        {
+          lineNumber: 5,
+          side: 'additions',
+          metadata: {
+            id: 'agent-g3',
+            text: 'Agent reply.',
+            author: 'agent',
+            outcome: 'reply',
+            createdAt: 2000,
+            threadId: 'root-c3',
+          },
+        },
+      ]
+
+      const feedbackBatch: UseFeedbackBatchReturn = {
+        batch: new Map([
+          [makeBatchKey('/repo', 'src/foo.ts', false), batchAnnotations],
+        ]),
+        annotationsForFile: () => batchAnnotations,
+        addAnnotation,
+        addAnnotationForOwner: vi.fn(() => 'ok' as const),
+        updateAnnotation: vi.fn(),
+        removeAnnotation: vi.fn(),
+        clearBatch: vi.fn(),
+        clearPending: vi.fn(),
+        markDispatched: vi.fn(),
+        totalAnnotations: () => 2,
+        pendingAnnotations: () => 0,
+      }
+
+      render(
+        <Panel
+          cwd="/repo"
+          selectedFile={{ path: 'src/foo.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+          feedbackBatch={feedbackBatch}
+          feedbackDispatch={{
+            candidates: [candidate],
+            writePty,
+            focusTerminal: vi.fn(),
+          }}
+        />
+      )
+
+      setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
+
+      const annotationSlot = screen.getByTestId('annotation-slot')
+      await user.click(
+        within(annotationSlot).getByRole('button', { name: /reply/i })
+      )
+
+      const replyTextarea = within(annotationSlot).getByPlaceholderText(
+        'Reply to the agent…'
+      )
+      await user.type(replyTextarea, 'Typed draft text')
+      fireEvent.keyDown(replyTextarea, { key: 'Enter' })
+
+      const popover = await screen.findByRole('dialog', {
+        name: 'Finish feedback',
+      })
+
+      // Cancel the popover.
+      const cancelButton = within(popover).getByRole('button', {
+        name: /cancel/i,
+      })
+      await user.click(cancelButton)
+
+      // No writePty call, no annotation inserted.
+      expect(writePty).not.toHaveBeenCalled()
+      expect(addAnnotation).not.toHaveBeenCalled()
+
+      // After cancel, re-opening the reply editor should still show the draft.
+      await user.click(
+        within(annotationSlot).getByRole('button', { name: /reply/i })
+      )
+
+      expect(
+        within(annotationSlot).getByPlaceholderText('Reply to the agent…')
+      ).toHaveValue('Typed draft text')
+    })
   })
 
   describe('diff search wiring', () => {

--- a/src/features/diff/Panel.test.tsx
+++ b/src/features/diff/Panel.test.tsx
@@ -5997,6 +5997,9 @@ describe('Panel', () => {
       expect(pending?.ownerKey).toBe('sess:pane-1')
       expect(pending?.byHandle.get(1)?.filePath).toBe('src/foo.ts')
       expect(pending?.byHandle.get(1)?.lineNumber).toBe(1)
+      // VIM-298: handle carries the threadId so a reply lands in the right thread.
+      const handle1 = pending?.byHandle.get(1)
+      expect(handle1?.threadId).toBeDefined()
 
       clearPendingReview('pty-1', nonce) // module singleton — don't leak into other tests
     })

--- a/src/features/diff/Panel.test.tsx
+++ b/src/features/diff/Panel.test.tsx
@@ -6171,7 +6171,9 @@ describe('Panel', () => {
       }
 
       // Seed: dispatched root (resolved) + agent turn + unrelated pending comment
-      const addAnnotation = vi.fn(() => 'ok' as const)
+      const addAnnotation = vi.fn<UseFeedbackBatchReturn['addAnnotation']>(
+        () => 'ok'
+      )
       const updateAnnotation = vi.fn()
 
       const batchAnnotations: DiffLineAnnotation<ReviewComment>[] = [
@@ -6295,8 +6297,7 @@ describe('Panel', () => {
       // Post-write addAnnotation is called with pre-stamped metadata.
       expect(addAnnotation).toHaveBeenCalledOnce()
 
-      const addedAnnotation = addAnnotation.mock
-        .calls[0][3] as DiffLineAnnotation<ReviewComment>
+      const addedAnnotation = addAnnotation.mock.calls[0][3]
       expect(addedAnnotation.metadata.dispatchedAt).toBeDefined()
       expect(addedAnnotation.metadata.dispatchedTo).toBe('pty-1')
       expect(addedAnnotation.metadata.threadId).toBe('root-c1')

--- a/src/features/diff/Panel.test.tsx
+++ b/src/features/diff/Panel.test.tsx
@@ -5997,9 +5997,12 @@ describe('Panel', () => {
       expect(pending?.ownerKey).toBe('sess:pane-1')
       expect(pending?.byHandle.get(1)?.filePath).toBe('src/foo.ts')
       expect(pending?.byHandle.get(1)?.lineNumber).toBe(1)
-      // VIM-298: handle carries the threadId so a reply lands in the right thread.
+      // VIM-298: handle carries the threadId so a reply lands in the right
+      // thread. The only dispatched comment is a fresh root, which self-roots —
+      // its threadId must be its own generated comment id (counter value is
+      // order-dependent across tests, hence a shape match, not a literal).
       const handle1 = pending?.byHandle.get(1)
-      expect(handle1?.threadId).toBeDefined()
+      expect(handle1?.threadId).toMatch(/^feedback-comment-\d+$/)
 
       clearPendingReview('pty-1', nonce) // module singleton — don't leak into other tests
     })

--- a/src/features/diff/Panel.test.tsx
+++ b/src/features/diff/Panel.test.tsx
@@ -6527,6 +6527,147 @@ describe('Panel', () => {
         within(annotationSlot).getByPlaceholderText('Reply to the agent…')
       ).toHaveValue('Typed draft text')
     })
+
+    test('repo-subdirectory cwd: writePty receives absolute path and pending handle carries repo-relative coords (VIM-298)', async (): Promise<void> => {
+      const user = userEvent.setup()
+      const writePty = vi.fn().mockResolvedValue(undefined)
+      const focusTerminal = vi.fn()
+
+      // Re-mock with the subdirectory cwd so the Panel does not enter loading state.
+      vi.spyOn(useGitStatusModule, 'useGitStatus').mockReturnValue({
+        files: [{ path: 'src/foo.ts', status: 'modified', staged: false }],
+        filesCwd: '/repo/sub',
+        loading: false,
+        error: null,
+        refresh: vi.fn(),
+        idle: false,
+      })
+
+      vi.spyOn(useFileDiffModule, 'useFileDiff').mockReturnValue(
+        fileDiffMock({
+          diff: inlineFileDiff,
+          loading: false,
+          error: null,
+          oldText: 'old',
+          newText: 'new',
+          rawDiff: '',
+          repoRoot: '/repo',
+        })
+      )
+
+      const candidate: PaneCandidate = {
+        paneId: 'pane-1',
+        ptyId: 'pty-1',
+        tabName: 'Tab 1',
+        agentLabel: 'Claude Code',
+        cwd: '/repo/sub',
+        status: 'running',
+        isFocused: true,
+      }
+
+      const addAnnotation = vi.fn(() => 'ok' as const)
+
+      // Annotations keyed under the subdirectory cwd.
+      const batchAnnotations: DiffLineAnnotation<ReviewComment>[] = [
+        {
+          lineNumber: 5,
+          side: 'additions',
+          metadata: {
+            id: 'root-sub1',
+            text: 'Root question from sub.',
+            author: 'self',
+            category: 'question',
+            createdAt: 1000,
+            dispatchedAt: 1000,
+            threadId: 'root-sub1',
+          },
+        },
+        {
+          lineNumber: 5,
+          side: 'additions',
+          metadata: {
+            id: 'agent-sub1',
+            text: 'Agent sub reply.',
+            author: 'agent',
+            outcome: 'reply',
+            createdAt: 2000,
+            threadId: 'root-sub1',
+          },
+        },
+      ]
+
+      const feedbackBatch: UseFeedbackBatchReturn = {
+        batch: new Map([
+          [makeBatchKey('/repo/sub', 'src/foo.ts', false), batchAnnotations],
+        ]),
+        annotationsForFile: () => batchAnnotations,
+        addAnnotation,
+        addAnnotationForOwner: vi.fn(() => 'ok' as const),
+        updateAnnotation: vi.fn(),
+        removeAnnotation: vi.fn(),
+        clearBatch: vi.fn(),
+        clearPending: vi.fn(),
+        markDispatched: vi.fn(),
+        totalAnnotations: () => 2,
+        pendingAnnotations: () => 0,
+      }
+
+      render(
+        <Panel
+          cwd="/repo/sub"
+          selectedFile={{ path: 'src/foo.ts', staged: false, cwd: '/repo/sub' }}
+          onSelectedFileChange={vi.fn()}
+          feedbackOwnerKey="sess:pane-1"
+          feedbackBatch={feedbackBatch}
+          feedbackDispatch={{
+            candidates: [candidate],
+            writePty,
+            focusTerminal,
+          }}
+          feedbackRepoRootRef={{
+            current: '',
+            repoRootForCwd: (entryCwd: string): string =>
+              entryCwd === '/repo/sub' ? '/repo' : '',
+          }}
+        />
+      )
+
+      setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
+
+      const annotationSlot = screen.getByTestId('annotation-slot')
+      await user.click(
+        within(annotationSlot).getByRole('button', { name: /reply/i })
+      )
+
+      const replyTextarea = within(annotationSlot).getByPlaceholderText(
+        'Reply to the agent…'
+      )
+      await user.type(replyTextarea, 'Sub-directory follow-up')
+      fireEvent.keyDown(replyTextarea, { key: 'Enter' })
+
+      const popover = await screen.findByRole('dialog', {
+        name: 'Finish feedback',
+      })
+      expect(popover).toHaveTextContent(/Send 1 comment/)
+
+      await user.keyboard('Y')
+
+      await waitFor(() => expect(writePty).toHaveBeenCalledOnce())
+
+      // The prompt sent to the agent must carry the ABSOLUTE path so the agent
+      // can resolve it from any working directory.
+      const [, payload] = writePty.mock.calls[0]
+      expect(payload as string).toContain('/repo/src/foo.ts')
+
+      // The pending handle must carry REPO-RELATIVE coordinates (cwd + relative
+      // filePath) matching the batch key, not the absolute prompt path.
+      const nonce = /"nonce":"(\w+)"/.exec(payload as string)?.[1] ?? ''
+      const pending = getPendingReview('pty-1', nonce)
+      expect(pending?.byHandle.get(1)?.cwd).toBe('/repo/sub')
+      expect(pending?.byHandle.get(1)?.filePath).toBe('src/foo.ts')
+
+      clearPendingReview('pty-1', nonce)
+    })
   })
 
   describe('diff search wiring', () => {

--- a/src/features/diff/Panel.test.tsx
+++ b/src/features/diff/Panel.test.tsx
@@ -6317,6 +6317,87 @@ describe('Panel', () => {
       await waitFor(() => expect(focusTerminal).toHaveBeenCalledOnce())
     })
 
+    test('clicking Resolve stamps resolvedAt on the thread root (VIM-298)', async (): Promise<void> => {
+      const user = userEvent.setup()
+      const updateAnnotation = vi.fn()
+
+      const batchAnnotations: DiffLineAnnotation<ReviewComment>[] = [
+        {
+          lineNumber: 5,
+          side: 'additions',
+          metadata: {
+            id: 'root-c1',
+            text: 'Why does this work?',
+            author: 'self',
+            category: 'question',
+            createdAt: 1000,
+            dispatchedAt: 1000,
+            dispatchedTo: 'pty-1',
+            threadId: 'root-c1',
+          },
+        },
+        {
+          lineNumber: 5,
+          side: 'additions',
+          metadata: {
+            id: 'agent-g1',
+            text: 'Because of backpressure.',
+            author: 'agent',
+            outcome: 'reply',
+            createdAt: 2000,
+            threadId: 'root-c1',
+          },
+        },
+      ]
+
+      const feedbackBatch: UseFeedbackBatchReturn = {
+        batch: new Map([
+          [makeBatchKey('/repo', 'src/foo.ts', false), batchAnnotations],
+        ]),
+        annotationsForFile: () => batchAnnotations,
+        addAnnotation: vi.fn(() => 'ok' as const),
+        addAnnotationForOwner: vi.fn(() => 'ok' as const),
+        updateAnnotation,
+        removeAnnotation: vi.fn(),
+        clearBatch: vi.fn(),
+        clearPending: vi.fn(),
+        markDispatched: vi.fn(),
+        totalAnnotations: () => 2,
+        pendingAnnotations: () => 0,
+      }
+
+      render(
+        <Panel
+          cwd="/repo"
+          selectedFile={{ path: 'src/foo.ts', staged: false, cwd: '/repo' }}
+          onSelectedFileChange={vi.fn()}
+          feedbackOwnerKey="sess:pane-1"
+          feedbackBatch={feedbackBatch}
+          feedbackDispatch={{
+            candidates: [],
+            writePty: vi.fn(),
+            focusTerminal: vi.fn(),
+          }}
+        />
+      )
+
+      setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
+
+      const annotationSlot = screen.getByTestId('annotation-slot')
+
+      await user.click(
+        within(annotationSlot).getByRole('button', { name: /resolve/i })
+      )
+
+      expect(updateAnnotation).toHaveBeenCalledWith(
+        '/repo',
+        'src/foo.ts',
+        false,
+        'root-c1',
+        { resolvedAt: expect.any(Number) }
+      )
+    })
+
     test('thread reply: write failure leaves no inserted comment and keeps the editor open (VIM-298)', async (): Promise<void> => {
       const user = userEvent.setup()
       const writePty = vi.fn().mockRejectedValue(new Error('pty closed'))

--- a/src/features/diff/Panel.tsx
+++ b/src/features/diff/Panel.tsx
@@ -804,6 +804,7 @@ export const Panel = ({
             lineNumber: annotation.lineNumber,
             side: annotation.side,
             target: annotation.metadata.target,
+            threadId: annotation.metadata.threadId ?? annotation.metadata.id,
           })
         }
       }
@@ -866,7 +867,7 @@ export const Panel = ({
                 entry.annotations.map((annotation) => annotation.metadata.id)
               )
             ),
-            { clearDraftForWholeBatch: onlyCommentId === undefined }
+            { clearDraftForWholeBatch: onlyCommentId === undefined, dispatchedTo: pane.ptyId }
           )
           setFinishOpen(false)
           setSendNowCommentId(null)

--- a/src/features/diff/Panel.tsx
+++ b/src/features/diff/Panel.tsx
@@ -43,6 +43,7 @@ import { useDiffSearch } from './hooks/useDiffSearch'
 import { useDiffRangeBars } from './hooks/useDiffRangeBars'
 import {
   dispatchFeedbackBatch,
+  followUpContextLine,
   formatFeedbackPayload,
   makeDispatchNonce,
   type DispatchEntry,
@@ -67,8 +68,15 @@ import { useToolbarState } from './hooks/useToolbarState'
 import { useReviewTargetNavigation } from './hooks/useReviewTargetNavigation'
 import { useVisualSelection } from './hooks/useVisualSelection'
 import { useRequestReview } from './hooks/useRequestReview'
+import {
+  buildThreadGroups,
+  threadAnchorLabel,
+  threadGroupKey,
+  type ThreadGroup,
+} from './services/threadGroups'
 import { Notifier } from './components/Notifier'
 import { PanelBody } from './components/PanelBody'
+import { ReviewThreadCard } from './components/ReviewThreadCard'
 import { DiffSearchButton } from './components/DiffSearchButton'
 import { DiffSearchPopup } from './components/DiffSearchPopup'
 import { ReviewCommentEditor } from './components/ReviewCommentEditor'
@@ -701,6 +709,35 @@ export const Panel = ({
     focusDiffRoot,
   })
 
+  const lineThreads = useMemo(
+    () =>
+      buildThreadGroups(lineAnnotations, {
+        cwd,
+        filePath: selectedFilePath ?? '',
+        staged: selectedFileStaged,
+      }),
+    [lineAnnotations, cwd, selectedFilePath, selectedFileStaged]
+  )
+
+  const fileThreads = useMemo(
+    () =>
+      buildThreadGroups(fileCommentsForSelectedFile, {
+        cwd,
+        filePath: selectedFileEntry?.path ?? '',
+        staged: selectedFileEntry?.staged ?? false,
+      }),
+    [fileCommentsForSelectedFile, cwd, selectedFileEntry]
+  )
+
+  const threadGroupById = useMemo((): Map<string, ThreadGroup> => {
+    const merged = new Map(lineThreads.groups)
+    for (const [key, group] of fileThreads.groups) {
+      merged.set(key, group)
+    }
+
+    return merged
+  }, [lineThreads, fileThreads])
+
   const fileCommentDraftTarget =
     annotationTarget !== null && isFileAnnotationTarget(annotationTarget)
       ? annotationTarget
@@ -723,6 +760,22 @@ export const Panel = ({
   // The comment being single-sent (VIM-297); scopes the Finish popover +
   // dispatch to exactly that comment. null = whole-batch behavior.
   const [sendNowCommentId, setSendNowCommentId] = useState<string | null>(null)
+
+  // Thread reply drafts (VIM-298), keyed by threadId so starting a reply on
+  // one thread never discards another thread's typed text. Panel-owned so a
+  // MultiFileDiff remount cannot erase them; an entry is cleared ONLY by that
+  // thread's explicit cancel or its successful dispatch.
+  const [replyDrafts, setReplyDrafts] = useState<ReadonlyMap<string, string>>(
+    new Map()
+  )
+  // Thread whose reply editor is currently open; null = none.
+  const [replyingThreadId, setReplyingThreadId] = useState<string | null>(null)
+
+  // Thread whose follow-up is awaiting the scoped confirm popover (VIM-298);
+  // mutually exclusive with finishOpen / sendNowCommentId.
+  const [replyDispatchThreadId, setReplyDispatchThreadId] = useState<
+    string | null
+  >(null)
 
   const [keyboardConfirmAction, setKeyboardConfirmAction] =
     useState<KeyboardConfirmAction | null>(null)
@@ -894,6 +947,163 @@ export const Panel = ({
     ]
   )
 
+  // VIM-298: dispatch a thread follow-up. The comment is never stored pending —
+  // it is built ephemerally for the payload and inserted post-write already
+  // stamped (dispatchedAt/dispatchedTo/threadId), so whole-batch Finish can
+  // never sweep it and a write failure leaves no local record.
+  const handleSendThreadReply = useCallback(
+    (pane: PaneCandidate): void => {
+      if (sendingFeedbackRef.current || replyDispatchThreadId === null) {
+        return
+      }
+      const draftText = replyDrafts.get(replyDispatchThreadId) ?? ''
+      const group = threadGroupById.get(replyDispatchThreadId)
+      if (
+        group === undefined ||
+        feedbackDispatch === undefined ||
+        draftText.trim().length === 0
+      ) {
+        setReplyDispatchThreadId(null)
+
+        return
+      }
+      sendingFeedbackRef.current = true
+      void (async (): Promise<void> => {
+        try {
+          // `group.turns` is guaranteed non-empty by buildThreadGroups (the
+          // constructor always pushes the first annotation before creating a group).
+          const [anchor] = group.turns
+          const previous = group.turns[group.turns.length - 1]
+
+          const comment: ReviewComment = {
+            id: nextFeedbackCommentId(),
+            text: draftText,
+            author: 'self',
+            createdAt: Date.now(),
+            threadId: group.threadId,
+            ...(anchor.metadata.target === undefined
+              ? {}
+              : { target: anchor.metadata.target }),
+          }
+
+          // Same repo-root resolution as buildFeedbackEntries: absolute prompt
+          // path for the agent, repo-relative coordinates for the handle.
+          const entryRepoRoot = repoRootRef.repoRootForCwd?.(group.cwd)
+
+          const resolvedRepoRoot =
+            entryRepoRoot && entryRepoRoot.length > 0
+              ? entryRepoRoot
+              : (response?.repoRoot ?? repoRootRef.current)
+
+          const promptPath = resolvedRepoRoot
+            ? `${resolvedRepoRoot}/${group.filePath}`
+            : group.filePath
+
+          const nonce = makeDispatchNonce()
+          await dispatchFeedbackBatch(
+            pane.paneId,
+            pane.ptyId,
+            [
+              {
+                filePath: promptPath,
+                staged: group.staged,
+                annotations: [
+                  {
+                    side: anchor.side,
+                    lineNumber: anchor.lineNumber,
+                    metadata: comment,
+                  },
+                ],
+              },
+            ],
+            nonce,
+            feedbackDispatch.writePty,
+            followUpContextLine(previous.metadata)
+          )
+
+          if (feedbackOwnerKey !== undefined) {
+            setPendingReview({
+              ptyId: pane.ptyId,
+              ownerKey: feedbackOwnerKey,
+              nonce,
+              dispatchedAt: Date.now(),
+              byHandle: new Map([
+                [
+                  1,
+                  {
+                    cwd: group.cwd,
+                    filePath: group.filePath,
+                    staged: group.staged,
+                    lineNumber: anchor.lineNumber,
+                    side: anchor.side,
+                    target: anchor.metadata.target,
+                    threadId: group.threadId,
+                  },
+                ],
+              ]),
+            })
+          }
+
+          // Post-write insert, pre-stamped: never observable as pending.
+          feedback.addAnnotation(group.cwd, group.filePath, group.staged, {
+            side: anchor.side,
+            lineNumber: anchor.lineNumber,
+            metadata: {
+              ...comment,
+              dispatchedAt: Date.now(),
+              dispatchedTo: pane.ptyId,
+            },
+          })
+
+          // Reply implies reopen — only after a successful dispatch.
+          if (group.resolved) {
+            feedback.updateAnnotation(
+              group.cwd,
+              group.filePath,
+              group.staged,
+              group.threadId,
+              { resolvedAt: undefined }
+            )
+          }
+
+          // Clear ONLY this thread's draft (successful dispatch).
+          setReplyDrafts((prev) => {
+            const next = new Map(prev)
+            next.delete(group.threadId)
+
+            return next
+          })
+
+          setReplyingThreadId((current) =>
+            current === group.threadId ? null : current
+          )
+          setReplyDispatchThreadId(null)
+          const focusTerminal = feedbackDispatch.focusTerminal
+          if (focusTerminal !== undefined) {
+            setTimeout(focusTerminal, 0)
+          }
+        } catch {
+          // Write failed: keep the editor open with its text; nothing was inserted.
+          setReplyDispatchThreadId(null)
+          notifyInfo('Terminal session ended; reply not sent.')
+        } finally {
+          sendingFeedbackRef.current = false
+        }
+      })()
+    },
+    [
+      replyDispatchThreadId,
+      replyDrafts,
+      threadGroupById,
+      feedback,
+      feedbackDispatch,
+      feedbackOwnerKey,
+      notifyInfo,
+      repoRootRef,
+      response,
+    ]
+  )
+
   // Copy the whole review to the clipboard — the escape hatch when no agent is
   // running to send to (comments are otherwise trapped in the batch). It uses
   // the same resolved paths as the send path so pasted feedback works from an
@@ -928,6 +1138,84 @@ export const Panel = ({
     },
     [buildFeedbackEntries, notifyInfo]
   )
+
+  const resolveThread = useCallback(
+    (threadId: string): void => {
+      const group = threadGroupById.get(threadId)
+      if (group !== undefined) {
+        feedback.updateAnnotation(
+          group.cwd,
+          group.filePath,
+          group.staged,
+          threadId,
+          {
+            resolvedAt: Date.now(),
+          }
+        )
+      }
+    },
+    [feedback, threadGroupById]
+  )
+
+  const reopenThread = useCallback(
+    (threadId: string): void => {
+      const group = threadGroupById.get(threadId)
+      if (group !== undefined) {
+        feedback.updateAnnotation(
+          group.cwd,
+          group.filePath,
+          group.staged,
+          threadId,
+          {
+            resolvedAt: undefined,
+          }
+        )
+      }
+    },
+    [feedback, threadGroupById]
+  )
+
+  const threadProps = {
+    replyingThreadId,
+    replyDraft:
+      replyingThreadId === null
+        ? ''
+        : (replyDrafts.get(replyingThreadId) ?? ''),
+    // Switching to another thread's Reply closes the first editor but its
+    // draft stays in the map — reopening restores it.
+    onStartReply: (threadId: string): void => setReplyingThreadId(threadId),
+    onReplyDraftChange: (text: string): void => {
+      setReplyDrafts((prev) => {
+        if (replyingThreadId === null) {
+          return prev
+        }
+        const next = new Map(prev)
+        next.set(replyingThreadId, text)
+
+        return next
+      })
+    },
+    onSubmitReply: (threadId: string, text: string): void => {
+      setReplyDrafts((prev) => new Map(prev).set(threadId, text))
+      setFinishOpen(false)
+      setSendNowCommentId(null)
+      setReplyDispatchThreadId(threadId)
+    },
+    // Explicit cancel clears ONLY the active thread's draft.
+    onCancelReply: (): void => {
+      if (replyingThreadId !== null) {
+        setReplyDrafts((prev) => {
+          const next = new Map(prev)
+          next.delete(replyingThreadId)
+
+          return next
+        })
+      }
+      setReplyingThreadId(null)
+    },
+    onResolve: resolveThread,
+    onReopen: reopenThread,
+  }
 
   // Request review (VIM-304): the whole "arm a pending request, then dispatch or
   // copy it" flow lives in useRequestReview so this component stays a renderer.
@@ -1947,7 +2235,8 @@ export const Panel = ({
     closeCommentEditor()
   }, [cancelVisualSelection, closeCommentEditor])
 
-  const isFinishPopoverOpen = finishOpen || sendNowCommentId !== null
+  const isFinishPopoverOpen =
+    finishOpen || sendNowCommentId !== null || replyDispatchThreadId !== null
 
   useKeyboard({
     enabled: true,
@@ -2097,6 +2386,7 @@ export const Panel = ({
       ? (): void => {
           review.closePopover()
           setSendNowCommentId(null)
+          setReplyDispatchThreadId(null)
           setFinishOpen(true)
         }
       : undefined
@@ -2107,16 +2397,35 @@ export const Panel = ({
       allPanes: feedbackDispatch?.candidates ?? [],
       diffCwd: cwd,
     }),
-    // Single-send (VIM-297) reuses the popover scoped to one comment.
-    commentCount: sendNowCommentId !== null ? 1 : feedbackCount,
-    fileCount: sendNowCommentId !== null ? 1 : pendingFileCount,
+    // Single-send (VIM-297) or reply dispatch (VIM-298) reuses the popover
+    // scoped to one comment.
+    commentCount:
+      sendNowCommentId !== null || replyDispatchThreadId !== null
+        ? 1
+        : feedbackCount,
+    fileCount:
+      sendNowCommentId !== null || replyDispatchThreadId !== null
+        ? 1
+        : pendingFileCount,
     onCancel: (): void => {
       setFinishOpen(false)
       setSendNowCommentId(null)
+      setReplyDispatchThreadId(null)
     },
-    onSend: (pane: PaneCandidate): void =>
-      handleSendFeedback(pane, sendNowCommentId ?? undefined),
-    onCopy: (): void => handleCopyFeedback(sendNowCommentId ?? undefined),
+    onSend: (pane: PaneCandidate): void => {
+      if (replyDispatchThreadId !== null) {
+        handleSendThreadReply(pane)
+
+        return
+      }
+      handleSendFeedback(pane, sendNowCommentId ?? undefined)
+    },
+    // A follow-up has no persisted comment to copy — hide Copy for reply sends.
+    ...(replyDispatchThreadId !== null
+      ? {}
+      : {
+          onCopy: (): void => handleCopyFeedback(sendNowCommentId ?? undefined),
+        }),
   }
 
   // The "Request review" affordance (VIM-304) — always available when a file
@@ -2398,40 +2707,85 @@ export const Panel = ({
                 data-testid="file-level-comments-list"
                 className="flex min-h-0 flex-col gap-1 overflow-y-auto pr-1"
               >
-                {fileCommentsForSelectedFile.map((annotation) => (
-                  <ReviewCommentRow
-                    key={annotation.metadata.id}
-                    comment={annotation.metadata}
-                    editShortcut="Shift+U"
-                    deleteShortcut={null}
-                    onSendNow={(): void => {
-                      setFinishOpen(false)
-                      setSendNowCommentId(annotation.metadata.id)
-                    }}
-                    onEdit={(): void => {
-                      setFileCommentAnchorPoint(null)
-                      setAnnotationTarget({
-                        scope: 'file',
-                        filePath: selectedFileEntry.path,
-                        staged: selectedFileEntry.staged,
-                        editId: annotation.metadata.id,
-                      })
-                      setCommentDraftText(annotation.metadata.text, false)
-                      setCommentCategory(
-                        reviewCommentCategory(annotation.metadata)
-                      )
-                    }}
-                    onDelete={(): void => {
-                      focusDiffRoot()
-                      feedback.removeAnnotation(
-                        cwd,
-                        selectedFileEntry.path,
-                        selectedFileEntry.staged,
-                        annotation.metadata.id
-                      )
-                    }}
-                  />
-                ))}
+                {fileThreads.collapsed.map((annotation) => {
+                  const fileGroupKey = threadGroupKey(annotation)
+
+                  const fileGroup =
+                    fileGroupKey === undefined
+                      ? undefined
+                      : fileThreads.groups.get(fileGroupKey)
+
+                  if (fileGroup !== undefined) {
+                    return (
+                      <ReviewThreadCard
+                        key={`thread:${fileGroup.threadId}`}
+                        group={fileGroup}
+                        anchorLabel={threadAnchorLabel(
+                          fileGroup.turns[0] ?? annotation
+                        )}
+                        actions={
+                          feedbackDispatch === undefined
+                            ? undefined
+                            : {
+                                replying:
+                                  threadProps.replyingThreadId ===
+                                  fileGroup.threadId,
+                                replyDraft: threadProps.replyDraft,
+                                onStartReply: (): void =>
+                                  threadProps.onStartReply(fileGroup.threadId),
+                                onReplyDraftChange:
+                                  threadProps.onReplyDraftChange,
+                                onSubmitReply: (text): void =>
+                                  threadProps.onSubmitReply(
+                                    fileGroup.threadId,
+                                    text
+                                  ),
+                                onCancelReply: threadProps.onCancelReply,
+                                onResolve: (): void =>
+                                  threadProps.onResolve(fileGroup.threadId),
+                                onReopen: (): void =>
+                                  threadProps.onReopen(fileGroup.threadId),
+                              }
+                        }
+                      />
+                    )
+                  }
+
+                  return (
+                    <ReviewCommentRow
+                      key={annotation.metadata.id}
+                      comment={annotation.metadata}
+                      editShortcut="Shift+U"
+                      deleteShortcut={null}
+                      onSendNow={(): void => {
+                        setFinishOpen(false)
+                        setSendNowCommentId(annotation.metadata.id)
+                      }}
+                      onEdit={(): void => {
+                        setFileCommentAnchorPoint(null)
+                        setAnnotationTarget({
+                          scope: 'file',
+                          filePath: selectedFileEntry.path,
+                          staged: selectedFileEntry.staged,
+                          editId: annotation.metadata.id,
+                        })
+                        setCommentDraftText(annotation.metadata.text, false)
+                        setCommentCategory(
+                          reviewCommentCategory(annotation.metadata)
+                        )
+                      }}
+                      onDelete={(): void => {
+                        focusDiffRoot()
+                        feedback.removeAnnotation(
+                          cwd,
+                          selectedFileEntry.path,
+                          selectedFileEntry.staged,
+                          annotation.metadata.id
+                        )
+                      }}
+                    />
+                  )
+                })}
               </div>
             </div>
           ) : null}
@@ -2445,7 +2799,7 @@ export const Panel = ({
             renderKey={panelRenderKey}
             options={diffOptionsWithSearch}
             selectedLines={selectedLines}
-            lineAnnotations={lineAnnotations}
+            lineAnnotations={lineThreads.collapsed}
             annotationTarget={annotationTarget}
             commentDraftText={commentDraftText}
             commentCategory={commentCategory}
@@ -2466,6 +2820,11 @@ export const Panel = ({
             onCommentCategoryChange={setCommentCategory}
             onConfirmComment={confirmCommentEditor}
             onCancelComment={cancelCommentEditor}
+            thread={{
+              groups: lineThreads.groups,
+              // Capability gating: no dispatch surface → footer-less cards.
+              actions: feedbackDispatch === undefined ? undefined : threadProps,
+            }}
           />
         </div>
       </div>

--- a/src/features/diff/Panel.tsx
+++ b/src/features/diff/Panel.tsx
@@ -867,7 +867,10 @@ export const Panel = ({
                 entry.annotations.map((annotation) => annotation.metadata.id)
               )
             ),
-            { clearDraftForWholeBatch: onlyCommentId === undefined, dispatchedTo: pane.ptyId }
+            {
+              clearDraftForWholeBatch: onlyCommentId === undefined,
+              dispatchedTo: pane.ptyId,
+            }
           )
           setFinishOpen(false)
           setSendNowCommentId(null)

--- a/src/features/diff/Panel.tsx
+++ b/src/features/diff/Panel.tsx
@@ -75,7 +75,7 @@ import {
   type ThreadGroup,
 } from './services/threadGroups'
 import { Notifier } from './components/Notifier'
-import { PanelBody } from './components/PanelBody'
+import { bindThreadCardActions, PanelBody } from './components/PanelBody'
 import { ReviewThreadCard } from './components/ReviewThreadCard'
 import { DiffSearchButton } from './components/DiffSearchButton'
 import { DiffSearchPopup } from './components/DiffSearchPopup'
@@ -2268,6 +2268,7 @@ export const Panel = ({
     onFinishReview: (): void => {
       if (feedback.pendingAnnotations() > 0 && !review.open) {
         setSendNowCommentId(null)
+        setReplyDispatchThreadId(null)
         setFinishOpen(true)
       }
     },
@@ -2726,26 +2727,10 @@ export const Panel = ({
                         actions={
                           feedbackDispatch === undefined
                             ? undefined
-                            : {
-                                replying:
-                                  threadProps.replyingThreadId ===
-                                  fileGroup.threadId,
-                                replyDraft: threadProps.replyDraft,
-                                onStartReply: (): void =>
-                                  threadProps.onStartReply(fileGroup.threadId),
-                                onReplyDraftChange:
-                                  threadProps.onReplyDraftChange,
-                                onSubmitReply: (text): void =>
-                                  threadProps.onSubmitReply(
-                                    fileGroup.threadId,
-                                    text
-                                  ),
-                                onCancelReply: threadProps.onCancelReply,
-                                onResolve: (): void =>
-                                  threadProps.onResolve(fileGroup.threadId),
-                                onReopen: (): void =>
-                                  threadProps.onReopen(fileGroup.threadId),
-                              }
+                            : bindThreadCardActions(
+                                threadProps,
+                                fileGroup.threadId
+                              )
                         }
                       />
                     )
@@ -2759,6 +2744,7 @@ export const Panel = ({
                       deleteShortcut={null}
                       onSendNow={(): void => {
                         setFinishOpen(false)
+                        setReplyDispatchThreadId(null)
                         setSendNowCommentId(annotation.metadata.id)
                       }}
                       onEdit={(): void => {
@@ -2812,6 +2798,7 @@ export const Panel = ({
             onDeleteComment={removeFeedbackAnnotation}
             onSendComment={(id: string): void => {
               setFinishOpen(false)
+              setReplyDispatchThreadId(null)
               setSendNowCommentId(id)
             }}
             onCommentTextChange={(text): void => {

--- a/src/features/diff/agentReplyThread.integration.test.tsx
+++ b/src/features/diff/agentReplyThread.integration.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import type { ReactElement } from 'react'
+import { useState, type ReactElement } from 'react'
 import { render, screen, act } from '@testing-library/react'
 import { listen } from '@/lib/backend'
 import type { BackendApi } from '@/lib/backend'
@@ -8,6 +8,12 @@ import { useFeedbackBatchStore } from './hooks/useFeedbackBatch'
 import { useAgentReply } from './hooks/useAgentReply'
 import { ReviewCommentRow } from './components/ReviewCommentRow'
 import { clearPendingReview, setPendingReview } from './services/pendingReviews'
+import {
+  buildThreadGroups,
+  threadAnchorLabel,
+  threadGroupKey,
+} from './services/threadGroups'
+import { ReviewThreadCard } from './components/ReviewThreadCard'
 
 // End-to-end wiring for the inline agent Q&A thread (VIM-249): a real
 // useFeedbackBatchStore + useAgentReply mounted together (the WorkspaceView
@@ -55,6 +61,52 @@ const Harness = (): ReactElement => {
   )
 }
 
+// Captured so tests can seed the store from OUTSIDE the component (the store
+// exists only inside the harness). Reset in beforeEach.
+let capturedStore: ReturnType<typeof useFeedbackBatchStore> | null = null
+
+const ThreadHarness = (): ReactElement => {
+  const store = useFeedbackBatchStore(OWNER, CWD)
+  capturedStore = store
+
+  // Stable across rerenders: a changing nextCommentId identity would
+  // resubscribe useAgentReply on every render.
+  const [nextCommentId] = useState(() => {
+    let n = 0
+
+    return (): string => `agent-${++n}`
+  })
+  useAgentReply({
+    addAnnotationForOwner: store.feedbackBatch.addAnnotationForOwner,
+    nextCommentId,
+  })
+
+  const annotations = store.feedbackBatch.annotationsForFile(CWD, FILE, false)
+
+  const { collapsed, groups } = buildThreadGroups(annotations, {
+    cwd: CWD,
+    filePath: FILE,
+    staged: false,
+  })
+
+  return (
+    <div>
+      {collapsed.map((annotation) => {
+        const key = threadGroupKey(annotation)
+        const group = key === undefined ? undefined : groups.get(key)
+
+        return group === undefined ? null : (
+          <ReviewThreadCard
+            key={group.threadId}
+            group={group}
+            anchorLabel={threadAnchorLabel(annotation)}
+          />
+        )
+      })}
+    </div>
+  )
+}
+
 const emitReply = async (event: AgentReplyEvent): Promise<void> => {
   await act(async () => {
     await Promise.resolve() // let listen() register the callback
@@ -66,6 +118,7 @@ const emitReply = async (event: AgentReplyEvent): Promise<void> => {
 
 beforeEach(() => {
   listeners.clear()
+  capturedStore = null
   window.vimeflow = {
     invoke: vi.fn(),
     listen: vi.fn(),
@@ -75,6 +128,9 @@ beforeEach(() => {
 
 afterEach(() => {
   clearPendingReview('pty-1', 'abc')
+  clearPendingReview('pty-1', 'n1')
+  clearPendingReview('pty-1', 'n2')
+  clearPendingReview('pty-1', 'n3')
   delete window.vimeflow
 })
 
@@ -118,5 +174,248 @@ describe('inline agent Q&A thread (integration)', () => {
     // carrying its outcome chip (VIM-304 PR-3: "reply" reads as "Replied").
     expect(screen.getByText('Replied')).toBeInTheDocument()
     expect(screen.getByText('Because latency.')).toBeInTheDocument()
+  })
+})
+
+describe('multi-turn thread loop (VIM-298 integration)', () => {
+  test('comment → reply → follow-up → second reply renders one 4-turn card', async () => {
+    render(<ThreadHarness />)
+
+    // Seed the dispatched root — mirroring what Panel.handleSendFeedback inserts
+    // (post-dispatch, pre-stamped fields: dispatchedAt, dispatchedTo, threadId).
+    act(() => {
+      capturedStore?.feedbackBatch.addAnnotationForOwner(
+        OWNER,
+        CWD,
+        FILE,
+        false,
+        {
+          side: 'additions',
+          lineNumber: 5,
+          metadata: {
+            id: 'c1',
+            text: 'Why?',
+            author: 'self',
+            category: 'question',
+            createdAt: 1,
+            dispatchedAt: 1000,
+            threadId: 'c1',
+            dispatchedTo: 'pty-1',
+          },
+        }
+      )
+    })
+
+    setPendingReview({
+      ptyId: 'pty-1',
+      ownerKey: OWNER,
+      nonce: 'n1',
+      dispatchedAt: 1000,
+      byHandle: new Map([
+        [
+          1,
+          {
+            cwd: CWD,
+            filePath: FILE,
+            staged: false,
+            lineNumber: 5,
+            side: 'additions',
+            target: undefined,
+            threadId: 'c1',
+          },
+        ],
+      ]),
+    })
+
+    // First agent reply: status 'clarify' — the agent needs more info.
+    await emitReply({
+      sessionId: 'pty-1',
+      nonce: 'n1',
+      rawText: 'Can you clarify which cap you mean?',
+      replies: [
+        {
+          id: 1,
+          status: 'clarify',
+          target: 'comment',
+          text: 'Can you clarify which cap you mean?',
+        },
+      ],
+    })
+
+    // ONE card should exist with 2 turns; rollup should show 'Awaiting you'.
+    // 'Awaiting you' appears in both the header rollup chip and the agent
+    // turn's outcome chip — use getAllByText deliberately.
+    expect(screen.getByText('2 turns')).toBeInTheDocument()
+    expect(screen.getAllByText('Awaiting you').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText('Why?')).toBeInTheDocument()
+    expect(
+      screen.getByText('Can you clarify which cap you mean?')
+    ).toBeInTheDocument()
+
+    // Seed the follow-up exactly as the dispatch path inserts it (post-write,
+    // pre-stamped: has dispatchedAt, no category — category-less follow-up).
+    act(() => {
+      capturedStore?.feedbackBatch.addAnnotationForOwner(
+        OWNER,
+        CWD,
+        FILE,
+        false,
+        {
+          side: 'additions',
+          lineNumber: 5,
+          metadata: {
+            id: 'f1',
+            text: 'The soft write cap at 50 comments.',
+            author: 'self',
+            createdAt: 2000,
+            dispatchedAt: 2000,
+            threadId: 'c1',
+          },
+        }
+      )
+    })
+
+    setPendingReview({
+      ptyId: 'pty-1',
+      ownerKey: OWNER,
+      nonce: 'n2',
+      dispatchedAt: 2000,
+      byHandle: new Map([
+        [
+          1,
+          {
+            cwd: CWD,
+            filePath: FILE,
+            staged: false,
+            lineNumber: 5,
+            side: 'additions',
+            target: undefined,
+            threadId: 'c1',
+          },
+        ],
+      ]),
+    })
+
+    // After the follow-up seed, rollup flips to 'Sent' (latest turn is self).
+    expect(screen.getByText('Sent')).toBeInTheDocument()
+
+    // Second agent reply: status 'resolved' — confirms the full loop.
+    await emitReply({
+      sessionId: 'pty-1',
+      nonce: 'n2',
+      rawText: 'Got it, the write-queue depth limit.',
+      replies: [
+        {
+          id: 1,
+          status: 'resolved',
+          target: 'comment',
+          text: 'Got it, the write-queue depth limit.',
+        },
+      ],
+    })
+
+    // 4 turns in document order; rollup 'Resolved' from the agent outcome
+    // (thread NOT collapsed — resolvedAt is unset, resolution is by outcome only).
+    // 'Resolved' appears in both the header chip and the agent turn chip;
+    // use getAllByText deliberately.
+    expect(screen.getByText('4 turns')).toBeInTheDocument()
+    expect(screen.getAllByText('Resolved').length).toBeGreaterThanOrEqual(1)
+
+    // All four turn texts visible (thread not collapsed).
+    expect(screen.getByText('Why?')).toBeInTheDocument()
+    expect(
+      screen.getByText('Can you clarify which cap you mean?')
+    ).toBeInTheDocument()
+
+    expect(
+      screen.getByText('The soft write cap at 50 comments.')
+    ).toBeInTheDocument()
+
+    expect(
+      screen.getByText('Got it, the write-queue depth limit.')
+    ).toBeInTheDocument()
+
+    // The follow-up turn (id 'f1') has no category chip — it has no category.
+    // Only the root's 'Question' chip should appear.
+    expect(screen.getAllByText('Question')).toHaveLength(1)
+  })
+
+  test('a late agent reply after local resolve appends without clearing resolution', async () => {
+    render(<ThreadHarness />)
+
+    // Seed a dispatched root WITH resolvedAt set (locally resolved).
+    act(() => {
+      capturedStore?.feedbackBatch.addAnnotationForOwner(
+        OWNER,
+        CWD,
+        FILE,
+        false,
+        {
+          side: 'additions',
+          lineNumber: 5,
+          metadata: {
+            id: 'c1',
+            text: 'Is this safe?',
+            author: 'self',
+            category: 'question',
+            createdAt: 1,
+            dispatchedAt: 1000,
+            threadId: 'c1',
+            dispatchedTo: 'pty-1',
+            resolvedAt: 1500,
+          },
+        }
+      )
+    })
+
+    setPendingReview({
+      ptyId: 'pty-1',
+      ownerKey: OWNER,
+      nonce: 'n3',
+      dispatchedAt: 1000,
+      byHandle: new Map([
+        [
+          1,
+          {
+            cwd: CWD,
+            filePath: FILE,
+            staged: false,
+            lineNumber: 5,
+            side: 'additions',
+            target: undefined,
+            threadId: 'c1',
+          },
+        ],
+      ]),
+    })
+
+    // The card should be collapsed (resolved) with turn count showing 1.
+    expect(screen.getByText('1 turn')).toBeInTheDocument()
+    expect(screen.getByText('Resolved')).toBeInTheDocument()
+    // Collapsed: the root's text is NOT visible.
+    expect(screen.queryByText('Is this safe?')).not.toBeInTheDocument()
+
+    // Late agent reply arrives after local resolution.
+    await emitReply({
+      sessionId: 'pty-1',
+      nonce: 'n3',
+      rawText: 'Yes, the pool is safe.',
+      replies: [
+        {
+          id: 1,
+          status: 'reply',
+          target: 'comment',
+          text: 'Yes, the pool is safe.',
+        },
+      ],
+    })
+
+    // Turn count ticks up to 2, rollup stays 'Resolved' (local resolution is
+    // authoritative — the agent reply does NOT unset resolvedAt).
+    expect(screen.getByText('2 turns')).toBeInTheDocument()
+    expect(screen.getByText('Resolved')).toBeInTheDocument()
+    // Still collapsed — the late reply did not unresolved the thread.
+    expect(screen.queryByText('Is this safe?')).not.toBeInTheDocument()
+    expect(screen.queryByText('Yes, the pool is safe.')).not.toBeInTheDocument()
   })
 })

--- a/src/features/diff/components/Notifier.tsx
+++ b/src/features/diff/components/Notifier.tsx
@@ -17,7 +17,7 @@ interface FinishFeedbackState {
   fileCount: number
   onCancel: () => void
   onSend: (pane: PaneCandidate) => void
-  onCopy: () => void
+  onCopy?: () => void
 }
 
 interface RequestReviewState {

--- a/src/features/diff/components/PanelBody.test.tsx
+++ b/src/features/diff/components/PanelBody.test.tsx
@@ -255,6 +255,91 @@ describe('PanelBody', () => {
     ).not.toBeInTheDocument()
   })
 
+  test('reply draft survives a MultiFileDiff remount triggered by renderKey change (VIM-298)', () => {
+    const anchorAnnotation: DiffLineAnnotation<ReviewComment> = {
+      side: 'additions',
+      lineNumber: 40,
+      metadata: {
+        id: 'c-draft',
+        text: 'Original question.',
+        author: 'self',
+        category: 'question',
+        createdAt: 1,
+        dispatchedAt: 1000,
+        threadId: 'c-draft',
+      },
+    }
+
+    const group: ThreadGroup = {
+      threadId: 'c-draft',
+      turns: [
+        anchorAnnotation,
+        {
+          side: 'additions',
+          lineNumber: 40,
+          metadata: {
+            id: 'g-draft',
+            text: 'Agent answer.',
+            author: 'agent',
+            outcome: 'reply',
+            createdAt: 2,
+            threadId: 'c-draft',
+          },
+        },
+      ],
+      rollup: { label: 'Replied', chip: 'text-success' },
+      resolved: false,
+      cwd: '/repo',
+      filePath: 'src/foo.ts',
+      staged: false,
+    }
+
+    const sharedActions = {
+      replyingThreadId: 'c-draft',
+      replyDraft: 'typed text',
+      onStartReply: vi.fn(),
+      onReplyDraftChange: vi.fn(),
+      onSubmitReply: vi.fn(),
+      onCancelReply: vi.fn(),
+      onResolve: vi.fn(),
+      onReopen: vi.fn(),
+    }
+
+    const threadProp = {
+      groups: new Map([['c-draft', group]]),
+      actions: sharedActions,
+    }
+
+    const { rerender } = renderBody({
+      lineAnnotations: [anchorAnnotation],
+      thread: threadProp,
+    })
+
+    // The reply editor is open; confirm the textarea shows the draft text.
+    const textareaBefore = screen.getByPlaceholderText('Reply to the agent…')
+    expect(textareaBefore).toHaveValue('typed text')
+
+    // Change renderKey — this causes effectiveRenderKey to change, which
+    // remounts MultiFileDiff (it is keyed by effectiveRenderKey in PanelBody).
+    rerender(
+      <PanelBody
+        {...createBodyProps({
+          renderKey: 'pierre-dark:word:remounted',
+          lineAnnotations: [anchorAnnotation],
+          thread: threadProp,
+        })}
+      />
+    )
+
+    // The MultiFileDiff was remounted — DOM node identity must have changed.
+    const textareaAfter = screen.getByPlaceholderText('Reply to the agent…')
+    expect(textareaAfter).not.toBe(textareaBefore)
+
+    // Draft value is still present because it flows from props above the
+    // remount boundary, not from internal textarea state.
+    expect(textareaAfter).toHaveValue('typed text')
+  })
+
   test('thread without actions renders a footer-less card', () => {
     const anchorAnnotation: DiffLineAnnotation<ReviewComment> = {
       side: 'additions',

--- a/src/features/diff/components/PanelBody.test.tsx
+++ b/src/features/diff/components/PanelBody.test.tsx
@@ -1,16 +1,18 @@
-import { createRef, type ReactNode } from 'react'
+import { createRef, type ReactElement, type ReactNode } from 'react'
 import { act, render, screen, waitFor } from '@testing-library/react'
-import type { FileDiffOptions } from '@pierre/diffs'
+import type { DiffLineAnnotation, FileDiffOptions } from '@pierre/diffs'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { PanelBody } from './PanelBody'
 import type { ReviewComment } from '../hooks/useFeedbackBatch'
 import type { PierreFileInputs } from '../services/pierreAdapter'
+import type { ThreadGroup } from '../services/threadGroups'
 
 interface MultiFileDiffMockProps {
   oldFile: { name: string }
   newFile: { name: string }
-  lineAnnotations: unknown[]
+  lineAnnotations: DiffLineAnnotation<ReviewComment>[]
   options: { diffStyle?: string }
+  renderAnnotation?: (a: DiffLineAnnotation<ReviewComment>) => ReactElement
 }
 
 interface WorkerPoolMock {
@@ -30,6 +32,7 @@ vi.mock('@pierre/diffs/react', () => ({
     newFile,
     lineAnnotations,
     options,
+    renderAnnotation = undefined,
   }: MultiFileDiffMockProps): ReactNode => {
     pierreReactMock.renderCount += 1
 
@@ -41,7 +44,13 @@ vi.mock('@pierre/diffs/react', () => ({
         data-annotations={lineAnnotations.length}
         data-diff-style={options.diffStyle}
         data-render-count={pierreReactMock.renderCount}
-      />
+      >
+        {renderAnnotation !== undefined
+          ? lineAnnotations.map((a) => (
+              <div key={a.metadata.id}>{renderAnnotation(a)}</div>
+            ))
+          : null}
+      </div>
     )
   },
 }))
@@ -172,5 +181,118 @@ describe('PanelBody', () => {
         '2'
       )
     )
+  })
+
+  test('a grouped anchor renders the thread card instead of a row', () => {
+    const anchorAnnotation: DiffLineAnnotation<ReviewComment> = {
+      side: 'additions',
+      lineNumber: 40,
+      metadata: {
+        id: 'c1',
+        text: 'Why does the cap live here?',
+        author: 'self',
+        category: 'question',
+        createdAt: 1,
+        dispatchedAt: 1000,
+        threadId: 'c1',
+      },
+    }
+
+    const group: ThreadGroup = {
+      threadId: 'c1',
+      turns: [
+        anchorAnnotation,
+        {
+          side: 'additions',
+          lineNumber: 40,
+          metadata: {
+            id: 'g1',
+            text: 'The pool applies backpressure.',
+            author: 'agent',
+            outcome: 'reply',
+            createdAt: 2,
+            threadId: 'c1',
+          },
+        },
+      ],
+      rollup: { label: 'Replied', chip: 'text-success' },
+      resolved: false,
+      cwd: '/repo',
+      filePath: 'src/foo.ts',
+      staged: false,
+    }
+
+    renderBody({
+      lineAnnotations: [anchorAnnotation],
+      thread: {
+        groups: new Map([['c1', group]]),
+        actions: {
+          replyingThreadId: null,
+          replyDraft: '',
+          onStartReply: vi.fn(),
+          onReplyDraftChange: vi.fn(),
+          onSubmitReply: vi.fn(),
+          onCancelReply: vi.fn(),
+          onResolve: vi.fn(),
+          onReopen: vi.fn(),
+        },
+      },
+    })
+
+    // Both turn texts render inside one card container.
+    expect(screen.getByText('Why does the cap live here?')).toBeInTheDocument()
+    expect(
+      screen.getByText('The pool applies backpressure.')
+    ).toBeInTheDocument()
+
+    // No send/edit/delete buttons from ReviewCommentRow for the dispatched anchor.
+    expect(
+      screen.queryByRole('button', { name: 'Send comment now' })
+    ).not.toBeInTheDocument()
+
+    expect(
+      screen.queryByRole('button', { name: 'Edit comment' })
+    ).not.toBeInTheDocument()
+  })
+
+  test('thread without actions renders a footer-less card', () => {
+    const anchorAnnotation: DiffLineAnnotation<ReviewComment> = {
+      side: 'additions',
+      lineNumber: 40,
+      metadata: {
+        id: 'c2',
+        text: 'Finding text here.',
+        author: 'reviewer',
+        createdAt: 1,
+        threadId: 'c2',
+      },
+    }
+
+    const group: ThreadGroup = {
+      threadId: 'c2',
+      turns: [anchorAnnotation],
+      rollup: { label: 'Open', chip: 'text-on-surface-variant' },
+      resolved: false,
+      cwd: '/repo',
+      filePath: 'src/foo.ts',
+      staged: false,
+    }
+
+    renderBody({
+      lineAnnotations: [anchorAnnotation],
+      thread: {
+        groups: new Map([['c2', group]]),
+        actions: undefined,
+      },
+    })
+
+    expect(screen.getByText('Finding text here.')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /reply/i })
+    ).not.toBeInTheDocument()
+
+    expect(
+      screen.queryByRole('button', { name: /resolve/i })
+    ).not.toBeInTheDocument()
   })
 })

--- a/src/features/diff/components/PanelBody.tsx
+++ b/src/features/diff/components/PanelBody.tsx
@@ -30,7 +30,10 @@ import { DiffNarrowPlaceholder } from './DiffNarrowPlaceholder'
 import { DIFF_MIN_WIDTH_PX } from './toolbar'
 import { ReviewCommentEditor } from './ReviewCommentEditor'
 import { ReviewCommentRow } from './ReviewCommentRow'
-import { ReviewThreadCard } from './ReviewThreadCard'
+import {
+  ReviewThreadCard,
+  type ReviewThreadCardActions,
+} from './ReviewThreadCard'
 
 const ErrorCard = ({ message }: { message: string }): ReactElement => (
   <div
@@ -157,6 +160,25 @@ export interface PanelThreadProps {
   /** Omitted → footer-less cards (no dispatch capability, spec Section 3). */
   actions?: PanelThreadActions
 }
+
+/**
+ * Curries a thread's id into the Panel-level action bundle, producing the
+ * per-card actions ReviewThreadCard expects. Shared by the line-level card
+ * branch below and Panel's file-comments strip so the two sites cannot drift.
+ */
+export const bindThreadCardActions = (
+  actions: PanelThreadActions,
+  threadId: string
+): ReviewThreadCardActions => ({
+  replying: actions.replyingThreadId === threadId,
+  replyDraft: actions.replyDraft,
+  onStartReply: (): void => actions.onStartReply(threadId),
+  onReplyDraftChange: actions.onReplyDraftChange,
+  onSubmitReply: (text): void => actions.onSubmitReply(threadId, text),
+  onCancelReply: actions.onCancelReply,
+  onResolve: (): void => actions.onResolve(threadId),
+  onReopen: (): void => actions.onReopen(threadId),
+})
 
 interface PanelBodyProps {
   scrollBodyRef: RefObject<HTMLDivElement | null>
@@ -305,22 +327,7 @@ export const PanelBody = ({
                     actions={
                       threadActions === undefined
                         ? undefined
-                        : {
-                            replying:
-                              threadActions.replyingThreadId === group.threadId,
-                            replyDraft: threadActions.replyDraft,
-                            onStartReply: (): void =>
-                              threadActions.onStartReply(group.threadId),
-                            onReplyDraftChange:
-                              threadActions.onReplyDraftChange,
-                            onSubmitReply: (text): void =>
-                              threadActions.onSubmitReply(group.threadId, text),
-                            onCancelReply: threadActions.onCancelReply,
-                            onResolve: (): void =>
-                              threadActions.onResolve(group.threadId),
-                            onReopen: (): void =>
-                              threadActions.onReopen(group.threadId),
-                          }
+                        : bindThreadCardActions(threadActions, group.threadId)
                     }
                   />
                 )

--- a/src/features/diff/components/PanelBody.tsx
+++ b/src/features/diff/components/PanelBody.tsx
@@ -21,10 +21,16 @@ import {
 } from '../hooks/useFeedbackBatch'
 import type { AnnotationTarget } from '../hooks/useReviewCommentDraft'
 import type { PierreFileInputs } from '../services/pierreAdapter'
+import {
+  threadAnchorLabel,
+  threadGroupKey,
+  type ThreadGroup,
+} from '../services/threadGroups'
 import { DiffNarrowPlaceholder } from './DiffNarrowPlaceholder'
 import { DIFF_MIN_WIDTH_PX } from './toolbar'
 import { ReviewCommentEditor } from './ReviewCommentEditor'
 import { ReviewCommentRow } from './ReviewCommentRow'
+import { ReviewThreadCard } from './ReviewThreadCard'
 
 const ErrorCard = ({ message }: { message: string }): ReactElement => (
   <div
@@ -134,6 +140,24 @@ const useHighlightCacheRevision = (diffCacheKey: string | null): number => {
   return revision
 }
 
+export interface PanelThreadActions {
+  /** threadId whose reply editor is open; null = none. */
+  replyingThreadId: string | null
+  replyDraft: string
+  onStartReply: (threadId: string) => void
+  onReplyDraftChange: (text: string) => void
+  onSubmitReply: (threadId: string, text: string) => void
+  onCancelReply: () => void
+  onResolve: (threadId: string) => void
+  onReopen: (threadId: string) => void
+}
+
+export interface PanelThreadProps {
+  groups: Map<string, ThreadGroup>
+  /** Omitted → footer-less cards (no dispatch capability, spec Section 3). */
+  actions?: PanelThreadActions
+}
+
 interface PanelBodyProps {
   scrollBodyRef: RefObject<HTMLDivElement | null>
   diffError: Error | null
@@ -160,6 +184,8 @@ interface PanelBodyProps {
   onCommentCategoryChange: (category: ReviewCommentCategory) => void
   onConfirmComment: (text: string, category: ReviewCommentCategory) => void
   onCancelComment: () => void
+  /** Thread grouping data for VIM-298 card rendering. */
+  thread?: PanelThreadProps
 }
 
 export const PanelBody = ({
@@ -187,6 +213,7 @@ export const PanelBody = ({
   onCommentCategoryChange,
   onConfirmComment,
   onCancelComment,
+  thread = undefined,
 }: PanelBodyProps): ReactElement => {
   const highlightCacheRevision = useHighlightCacheRevision(
     pierreInputs?.diffCacheKey ?? null
@@ -255,6 +282,46 @@ export const PanelBody = ({
                     onCategoryChange={onCommentCategoryChange}
                     onConfirm={onConfirmComment}
                     onCancel={onCancelComment}
+                  />
+                )
+              }
+
+              const groupKey = threadGroupKey(annotation)
+
+              const group =
+                groupKey === undefined
+                  ? undefined
+                  : thread?.groups.get(groupKey)
+              if (group !== undefined) {
+                const threadActions = thread?.actions
+
+                return (
+                  <ReviewThreadCard
+                    key={`thread:${group.threadId}`}
+                    group={group}
+                    anchorLabel={threadAnchorLabel(
+                      group.turns[0] ?? annotation
+                    )}
+                    actions={
+                      threadActions === undefined
+                        ? undefined
+                        : {
+                            replying:
+                              threadActions.replyingThreadId === group.threadId,
+                            replyDraft: threadActions.replyDraft,
+                            onStartReply: (): void =>
+                              threadActions.onStartReply(group.threadId),
+                            onReplyDraftChange:
+                              threadActions.onReplyDraftChange,
+                            onSubmitReply: (text): void =>
+                              threadActions.onSubmitReply(group.threadId, text),
+                            onCancelReply: threadActions.onCancelReply,
+                            onResolve: (): void =>
+                              threadActions.onResolve(group.threadId),
+                            onReopen: (): void =>
+                              threadActions.onReopen(group.threadId),
+                          }
+                    }
                   />
                 )
               }

--- a/src/features/diff/components/ReviewCommentEditor.test.tsx
+++ b/src/features/diff/components/ReviewCommentEditor.test.tsx
@@ -403,4 +403,41 @@ describe('ReviewCommentEditor', () => {
     await user.keyboard('{Control>}l{/Control}')
     expect(handleCategoryChange).toHaveBeenCalledWith('suggestion')
   })
+
+  test('reply mode hides category tabs and relabels the chrome', () => {
+    render(
+      <ReviewCommentEditor
+        mode="reply"
+        chrome="plain"
+        surfaceRole="none"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Reply to thread')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Question' })).toBeNull()
+    expect(
+      screen.getByPlaceholderText('Reply to the agent…')
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Reply' })).toBeInTheDocument()
+  })
+
+  test('reply mode ignores the ctrl+h/l category cycle', async () => {
+    const onConfirm = vi.fn()
+    render(
+      <ReviewCommentEditor
+        mode="reply"
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />
+    )
+
+    const textarea = screen.getByPlaceholderText('Reply to the agent…')
+    fireEvent.keyDown(textarea, { key: 'l', ctrlKey: true })
+    fireEvent.change(textarea, { target: { value: 'follow-up' } })
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+
+    expect(onConfirm).toHaveBeenCalledWith('follow-up', 'change')
+  })
 })

--- a/src/features/diff/components/ReviewCommentEditor.test.tsx
+++ b/src/features/diff/components/ReviewCommentEditor.test.tsx
@@ -435,6 +435,7 @@ describe('ReviewCommentEditor', () => {
 
     const textarea = screen.getByPlaceholderText('Reply to the agent…')
     fireEvent.keyDown(textarea, { key: 'l', ctrlKey: true })
+    fireEvent.keyDown(textarea, { key: 'h', ctrlKey: true })
     fireEvent.change(textarea, { target: { value: 'follow-up' } })
     fireEvent.keyDown(textarea, { key: 'Enter' })
 

--- a/src/features/diff/components/ReviewCommentEditor.test.tsx
+++ b/src/features/diff/components/ReviewCommentEditor.test.tsx
@@ -423,7 +423,7 @@ describe('ReviewCommentEditor', () => {
     expect(screen.getByRole('button', { name: 'Reply' })).toBeInTheDocument()
   })
 
-  test('reply mode ignores the ctrl+h/l category cycle', async () => {
+  test('reply mode ignores the ctrl+h/l category cycle', () => {
     const onConfirm = vi.fn()
     render(
       <ReviewCommentEditor

--- a/src/features/diff/components/ReviewCommentEditor.tsx
+++ b/src/features/diff/components/ReviewCommentEditor.tsx
@@ -20,6 +20,11 @@ interface ReviewCommentEditorBaseProps {
   onCategoryChange?: (category: ReviewCommentCategory) => void
   onConfirm: (text: string, category: ReviewCommentCategory) => void
   onCancel: () => void
+  /**
+   * 'reply' = a typeless thread follow-up (VIM-298): category tabs hidden and
+   * the cycle shortcuts inert, chrome copy reads Reply. Default 'comment'.
+   */
+  mode?: 'comment' | 'reply'
 }
 
 type ReviewCommentEditorProps = ReviewCommentEditorBaseProps & {
@@ -113,6 +118,7 @@ export const ReviewCommentEditor = ({
   onCategoryChange = undefined,
   onConfirm,
   onCancel,
+  mode = 'comment',
 }: ReviewCommentEditorProps): ReactElement => {
   const [uncontrolledText, setUncontrolledText] = useState(initialText)
 
@@ -132,6 +138,9 @@ export const ReviewCommentEditor = ({
 
   // Ctrl+H / Ctrl+L cycle the category (vim h/l).
   const cycleCategory = (direction: 1 | -1): void => {
+    if (mode === 'reply') {
+      return
+    }
     const count = REVIEW_COMMENT_CATEGORIES.length
     const index = REVIEW_COMMENT_CATEGORIES.indexOf(selectedCategory)
 
@@ -188,37 +197,39 @@ export const ReviewCommentEditor = ({
           >
             comment
           </span>
-          Local comment
+          {mode === 'reply' ? 'Reply to thread' : 'Local comment'}
         </span>
         <span className="min-w-0 truncate text-right text-on-surface-variant text-[0.7rem]">
           Comment on {targetDescription}
         </span>
       </div>
-      <div className="flex flex-wrap items-center gap-1">
-        {REVIEW_COMMENT_CATEGORIES.map((option) => {
-          const meta = REVIEW_CATEGORY_META[option]
-          const active = option === selectedCategory
+      {mode === 'reply' ? null : (
+        <div className="flex flex-wrap items-center gap-1">
+          {REVIEW_COMMENT_CATEGORIES.map((option) => {
+            const meta = REVIEW_CATEGORY_META[option]
+            const active = option === selectedCategory
 
-          return (
-            <button
-              key={option}
-              type="button"
-              aria-pressed={active}
-              onClick={(): void => updateCategory(option)}
-              className={`rounded px-2 py-0.5 text-[11px] transition-colors ${
-                active
-                  ? `bg-surface-container-highest ${meta.chip}`
-                  : 'text-on-surface-variant hover:text-on-surface'
-              }`}
-            >
-              {meta.label}
-            </button>
-          )
-        })}
-        <span className="ml-auto text-[10px] text-on-surface-variant/70">
-          ⌃H / ⌃L
-        </span>
-      </div>
+            return (
+              <button
+                key={option}
+                type="button"
+                aria-pressed={active}
+                onClick={(): void => updateCategory(option)}
+                className={`rounded px-2 py-0.5 text-[11px] transition-colors ${
+                  active
+                    ? `bg-surface-container-highest ${meta.chip}`
+                    : 'text-on-surface-variant hover:text-on-surface'
+                }`}
+              >
+                {meta.label}
+              </button>
+            )
+          })}
+          <span className="ml-auto text-[10px] text-on-surface-variant/70">
+            ⌃H / ⌃L
+          </span>
+        </div>
+      )}
       <textarea
         ref={textareaRef}
         value={text}
@@ -272,7 +283,9 @@ export const ReviewCommentEditor = ({
         }}
         rows={3}
         className="resize-none rounded bg-surface-container/60 p-2 text-xs text-on-surface placeholder:text-on-surface-variant/60 focus:outline-none focus:ring-1 focus:ring-primary"
-        placeholder="Request change"
+        placeholder={
+          mode === 'reply' ? 'Reply to the agent…' : 'Request change'
+        }
       />
       <div className="flex justify-end gap-2">
         <button
@@ -288,7 +301,7 @@ export const ReviewCommentEditor = ({
           disabled={text.trim().length === 0}
           className="rounded-md bg-primary px-3 py-1 text-xs text-on-primary hover:bg-primary/80 disabled:opacity-50"
         >
-          Comment
+          {mode === 'reply' ? 'Reply' : 'Comment'}
         </button>
       </div>
     </div>

--- a/src/features/diff/components/ReviewThreadCard.test.tsx
+++ b/src/features/diff/components/ReviewThreadCard.test.tsx
@@ -1,0 +1,176 @@
+import { describe, expect, test, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import type { ThreadGroup } from '../services/threadGroups'
+import { ReviewThreadCard } from './ReviewThreadCard'
+
+const group = (overrides: Partial<ThreadGroup> = {}): ThreadGroup => ({
+  threadId: 'c1',
+  turns: [
+    {
+      side: 'additions',
+      lineNumber: 40,
+      metadata: {
+        id: 'c1',
+        text: 'Why does the cap live here?',
+        author: 'self',
+        category: 'question',
+        createdAt: 1,
+        dispatchedAt: 1000,
+        threadId: 'c1',
+      },
+    },
+    {
+      side: 'additions',
+      lineNumber: 40,
+      metadata: {
+        id: 'g1',
+        text: 'The pool applies backpressure per write.',
+        author: 'agent',
+        outcome: 'reply',
+        createdAt: 2,
+        threadId: 'c1',
+      },
+    },
+  ],
+  rollup: { label: 'Replied', chip: 'text-success' },
+  resolved: false,
+  cwd: '/repo',
+  filePath: 'src/foo.ts',
+  staged: false,
+  ...overrides,
+})
+
+const actions = (
+  overrides: Partial<Parameters<typeof ReviewThreadCard>[0]['actions']> = {}
+): NonNullable<Parameters<typeof ReviewThreadCard>[0]['actions']> => ({
+  replying: false,
+  replyDraft: '',
+  onStartReply: vi.fn(),
+  onReplyDraftChange: vi.fn(),
+  onSubmitReply: vi.fn(),
+  onCancelReply: vi.fn(),
+  onResolve: vi.fn(),
+  onReopen: vi.fn(),
+  ...overrides,
+})
+
+describe('ReviewThreadCard', () => {
+  test('renders header, ordered turns, chips, and the footer pair', () => {
+    render(
+      <ReviewThreadCard
+        group={group()}
+        anchorLabel="line R40"
+        actions={actions()}
+      />
+    )
+
+    expect(screen.getByText('line R40')).toBeInTheDocument()
+    expect(screen.getByText('2 turns')).toBeInTheDocument()
+    expect(screen.getAllByText('Replied').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText('Why does the cap live here?')).toBeInTheDocument()
+    expect(
+      screen.getByText('The pool applies backpressure per write.')
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /reply/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /resolve/i })).toBeInTheDocument()
+  })
+
+  test('category-less follow-up turns render no chip', () => {
+    const g = group()
+    g.turns.push({
+      side: 'additions',
+      lineNumber: 40,
+      metadata: {
+        id: 'f1',
+        text: 'And during drags?',
+        author: 'self',
+        createdAt: 3,
+        dispatchedAt: 2000,
+        threadId: 'c1',
+      },
+    })
+
+    render(
+      <ReviewThreadCard group={g} anchorLabel="line R40" actions={actions()} />
+    )
+
+    // Exactly one category chip (the root's Question) despite two self turns.
+    expect(screen.getAllByText('Question')).toHaveLength(1)
+  })
+
+  test('reply expands the editor; confirm submits the draft', () => {
+    const a = actions({ replying: true, replyDraft: 'follow-up text' })
+    render(
+      <ReviewThreadCard group={group()} anchorLabel="line R40" actions={a} />
+    )
+
+    fireEvent.keyDown(screen.getByPlaceholderText('Reply to the agent…'), {
+      key: 'Enter',
+    })
+    expect(a.onSubmitReply).toHaveBeenCalledWith('follow-up text')
+  })
+
+  test('no actions → no footer', () => {
+    render(<ReviewThreadCard group={group()} anchorLabel="line R40" />)
+
+    expect(screen.queryByRole('button', { name: /reply/i })).toBeNull()
+  })
+
+  test('resolved collapses to a disclosure header; expanding reveals Reopen', () => {
+    render(
+      <ReviewThreadCard
+        group={group({
+          resolved: true,
+          rollup: { label: 'Resolved', chip: 'text-success' },
+        })}
+        anchorLabel="line R40"
+        actions={actions()}
+      />
+    )
+
+    expect(screen.queryByText('Why does the cap live here?')).toBeNull()
+    const disclosure = screen.getByRole('button', { name: /thread/i })
+    expect(disclosure).toHaveAttribute('aria-expanded', 'false')
+
+    fireEvent.click(disclosure)
+    expect(disclosure).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByText('Why does the cap live here?')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /reopen/i })).toBeInTheDocument()
+  })
+
+  test('re-resolving after an expanded reopen collapses again', () => {
+    // expand-while-resolved is reset when the thread reopens: render resolved,
+    // expand via the disclosure, rerender with resolved: false (reopened),
+    // then rerender resolved: true again → the card must be COLLAPSED.
+    const resolved = group({
+      resolved: true,
+      rollup: { label: 'Resolved', chip: 'text-success' },
+    })
+
+    const { rerender } = render(
+      <ReviewThreadCard
+        group={resolved}
+        anchorLabel="line R40"
+        actions={actions()}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /thread/i }))
+    rerender(
+      <ReviewThreadCard
+        group={group()}
+        anchorLabel="line R40"
+        actions={actions()}
+      />
+    )
+
+    rerender(
+      <ReviewThreadCard
+        group={resolved}
+        anchorLabel="line R40"
+        actions={actions()}
+      />
+    )
+
+    expect(screen.queryByText('Why does the cap live here?')).toBeNull()
+  })
+})

--- a/src/features/diff/components/ReviewThreadCard.test.tsx
+++ b/src/features/diff/components/ReviewThreadCard.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, test, vi } from 'vitest'
 import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import type { ThreadGroup } from '../services/threadGroups'
 import { ReviewThreadCard } from './ReviewThreadCard'
 
@@ -172,5 +173,48 @@ describe('ReviewThreadCard', () => {
     )
 
     expect(screen.queryByText('Why does the cap live here?')).toBeNull()
+  })
+
+  test('the disclosure activates via Enter and Space', async () => {
+    const user = userEvent.setup()
+    render(
+      <ReviewThreadCard
+        group={group({
+          resolved: true,
+          rollup: { label: 'Resolved', chip: 'text-success' },
+        })}
+        anchorLabel="line R40"
+        actions={actions()}
+      />
+    )
+
+    const disclosure = screen.getByRole('button', { name: /thread/i })
+    disclosure.focus()
+    await user.keyboard('{Enter}')
+    expect(disclosure).toHaveAttribute('aria-expanded', 'true')
+    await user.keyboard(' ')
+    expect(disclosure).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  test('reviewer turns show the reviewer name with its initial avatar', () => {
+    const g = group()
+    g.turns.push({
+      side: 'additions',
+      lineNumber: 40,
+      metadata: {
+        id: 'r1',
+        text: 'Consider pooling here.',
+        author: 'reviewer',
+        reviewer: 'codex',
+        category: 'suggestion',
+        createdAt: 3,
+        threadId: 'c1',
+      },
+    })
+    render(<ReviewThreadCard group={g} anchorLabel="line R40" />)
+
+    expect(screen.getByText('codex')).toBeInTheDocument()
+    expect(screen.getByText('C')).toBeInTheDocument()
+    expect(screen.getByText('Suggestion')).toBeInTheDocument()
   })
 })

--- a/src/features/diff/components/ReviewThreadCard.tsx
+++ b/src/features/diff/components/ReviewThreadCard.tsx
@@ -236,7 +236,7 @@ export const ReviewThreadCard = ({
                     'color-mix(in srgb, var(--color-primary) 12%, transparent)',
                 }}
               >
-                ↳ Reply
+                <span aria-hidden="true">↳ </span>Reply
               </button>
               {group.resolved ? (
                 <button
@@ -248,7 +248,7 @@ export const ReviewThreadCard = ({
                       'color-mix(in srgb, var(--color-on-surface) 6%, transparent)',
                   }}
                 >
-                  ⟲ Reopen
+                  <span aria-hidden="true">⟲ </span>Reopen
                 </button>
               ) : (
                 <button
@@ -260,7 +260,7 @@ export const ReviewThreadCard = ({
                       'color-mix(in srgb, var(--color-on-surface) 6%, transparent)',
                   }}
                 >
-                  ✓ Resolve
+                  <span aria-hidden="true">✓ </span>Resolve
                 </button>
               )}
             </div>

--- a/src/features/diff/components/ReviewThreadCard.tsx
+++ b/src/features/diff/components/ReviewThreadCard.tsx
@@ -176,7 +176,7 @@ export const ReviewThreadCard = ({
         <button
           type="button"
           aria-expanded={expanded}
-          aria-label={`Resolved thread on ${anchorLabel}, ${group.turns.length} turns`}
+          aria-label={`Resolved thread on ${anchorLabel}, ${group.turns.length} turn${group.turns.length === 1 ? '' : 's'}`}
           onClick={(): void => setExpandedWhileResolved(!expandedWhileResolved)}
           className="flex w-full items-center gap-2 px-4 py-2 text-left text-[10px] text-on-surface-variant"
           style={{

--- a/src/features/diff/components/ReviewThreadCard.tsx
+++ b/src/features/diff/components/ReviewThreadCard.tsx
@@ -1,0 +1,272 @@
+import { useEffect, useState, type ReactElement } from 'react'
+import type { DiffLineAnnotation } from '@pierre/diffs'
+import {
+  reviewCommentCategory,
+  type ReviewComment,
+} from '../hooks/useFeedbackBatch'
+import { AGENT_OUTCOME_META, REVIEW_CATEGORY_META } from '../reviewCategoryMeta'
+import { isFollowUpComment } from '../services/feedbackDispatch'
+import type { ThreadGroup } from '../services/threadGroups'
+import { formatSentAgo } from './ReviewCommentRow'
+import { ReviewCommentEditor } from './ReviewCommentEditor'
+
+export interface ReviewThreadCardActions {
+  /** True while this thread's reply editor is open (Panel-owned draft state). */
+  replying: boolean
+  replyDraft: string
+  onStartReply: () => void
+  onReplyDraftChange: (text: string) => void
+  onSubmitReply: (text: string) => void
+  onCancelReply: () => void
+  onResolve: () => void
+  onReopen: () => void
+}
+
+interface ReviewThreadCardProps {
+  group: ThreadGroup
+  anchorLabel: string
+  /** Omitted → footer-less card (no dispatch capability in this context). */
+  actions?: ReviewThreadCardActions
+}
+
+const HAIRLINE = {
+  borderTop:
+    '1px solid color-mix(in srgb, var(--color-on-surface) 12%, transparent)',
+} as const
+
+const Chip = ({
+  label,
+  className,
+}: {
+  label: string
+  className: string
+}): ReactElement => (
+  <span
+    className={`inline-flex items-center rounded bg-surface-container-highest/70 px-1.5 py-px text-[10px] font-medium ${className}`}
+  >
+    {label}
+  </span>
+)
+
+const turnChip = (comment: ReviewComment): ReactElement | null => {
+  if (comment.author === 'agent') {
+    return comment.outcome === undefined ? (
+      <Chip label="Agent reply" className="text-success" />
+    ) : (
+      <Chip
+        label={AGENT_OUTCOME_META[comment.outcome].label}
+        className={AGENT_OUTCOME_META[comment.outcome].chip}
+      />
+    )
+  }
+
+  // Follow-ups with no category carry no chip; categorized user/reviewer turns
+  // show their raise intent (VIM-298 taxonomy).
+  if (comment.author === 'self' && isFollowUpComment(comment)) {
+    return null
+  }
+
+  const meta = REVIEW_CATEGORY_META[reviewCommentCategory(comment)]
+
+  return <Chip label={meta.label} className={meta.chip} />
+}
+
+const turnIdentity = (
+  comment: ReviewComment
+): { avatarClass: string; initial: string; name: string } => {
+  if (comment.author === 'agent') {
+    return {
+      avatarClass: 'bg-primary-container/60 text-primary',
+      initial: 'A',
+      name: 'Agent',
+    }
+  }
+
+  if (comment.author === 'reviewer') {
+    const name = comment.reviewer ?? 'Reviewer'
+
+    return {
+      avatarClass: 'bg-surface-container-highest text-on-surface-variant',
+      initial: name.charAt(0).toUpperCase(),
+      name,
+    }
+  }
+
+  return {
+    avatarClass: 'bg-surface-container-highest text-on-surface-variant',
+    initial: 'Y',
+    name: 'You',
+  }
+}
+
+const TurnRow = ({
+  turn,
+  first,
+}: {
+  turn: DiffLineAnnotation<ReviewComment>
+  first: boolean
+}): ReactElement => {
+  const comment = turn.metadata
+  const identity = turnIdentity(comment)
+
+  const timestamp =
+    comment.author === 'self' && comment.dispatchedAt !== undefined
+      ? `Sent ${formatSentAgo(comment.dispatchedAt, Date.now())}`
+      : formatSentAgo(comment.createdAt, Date.now())
+
+  return (
+    <div className="px-4 py-2.5" style={first ? undefined : HAIRLINE}>
+      <div className="mb-1 flex flex-wrap items-center gap-1.5">
+        <span
+          aria-hidden="true"
+          className={`flex h-4 w-4 items-center justify-center rounded-full text-[9px] font-bold ${identity.avatarClass}`}
+        >
+          {identity.initial}
+        </span>
+        <span className="text-[11px] font-medium text-on-surface">
+          {identity.name}
+        </span>
+        {turnChip(comment)}
+        <span className="text-[10px] text-on-surface-variant">{timestamp}</span>
+      </div>
+      <p className="whitespace-pre-wrap break-words pl-[22px] text-xs leading-5 text-on-surface">
+        {comment.text}
+      </p>
+    </div>
+  )
+}
+
+/**
+ * A multi-turn review conversation (VIM-298) — the GitHub-style card settled
+ * in the demo-first pass: tonal container, header with anchor + rollup + turn
+ * count, hairline-divided turns, paired Reply/Resolve footer. Resolved threads
+ * collapse to the header behind an accessible disclosure.
+ */
+export const ReviewThreadCard = ({
+  group,
+  anchorLabel,
+  actions = undefined,
+}: ReviewThreadCardProps): ReactElement => {
+  const [expandedWhileResolved, setExpandedWhileResolved] = useState(false)
+
+  // Reset the read-only expansion whenever the thread reopens, so the NEXT
+  // resolve collapses again (expand → Reopen → Resolve must not stay open).
+  useEffect((): void => {
+    if (!group.resolved) {
+      setExpandedWhileResolved(false)
+    }
+  }, [group.resolved])
+
+  const collapsed = group.resolved && !expandedWhileResolved
+  const expanded = !collapsed
+
+  const header = (
+    <>
+      <span className="font-mono">{anchorLabel}</span>
+      <Chip label={group.rollup.label} className={group.rollup.chip} />
+      <span>
+        {group.turns.length} turn{group.turns.length === 1 ? '' : 's'}
+      </span>
+    </>
+  )
+
+  return (
+    <div className="mx-3 my-2 overflow-hidden rounded-lg bg-surface-container-high/80">
+      {group.resolved ? (
+        <button
+          type="button"
+          aria-expanded={expanded}
+          aria-label={`Resolved thread on ${anchorLabel}, ${group.turns.length} turns`}
+          onClick={(): void => setExpandedWhileResolved(!expandedWhileResolved)}
+          className="flex w-full items-center gap-2 px-4 py-2 text-left text-[10px] text-on-surface-variant"
+          style={{
+            background:
+              'color-mix(in srgb, var(--color-on-surface) 4%, transparent)',
+          }}
+        >
+          {header}
+          <span
+            aria-hidden="true"
+            className="material-symbols-outlined ml-auto text-sm leading-none"
+          >
+            {expanded ? 'expand_less' : 'expand_more'}
+          </span>
+        </button>
+      ) : (
+        <div
+          className="flex items-center gap-2 px-4 py-2 text-[10px] text-on-surface-variant"
+          style={{
+            background:
+              'color-mix(in srgb, var(--color-on-surface) 4%, transparent)',
+          }}
+        >
+          {header}
+        </div>
+      )}
+
+      {expanded
+        ? group.turns.map((turn, index) => (
+            <TurnRow key={turn.metadata.id} turn={turn} first={index === 0} />
+          ))
+        : null}
+
+      {expanded && actions !== undefined ? (
+        <div style={HAIRLINE}>
+          {actions.replying ? (
+            <div className="px-2 py-1.5">
+              <ReviewCommentEditor
+                mode="reply"
+                chrome="plain"
+                surfaceRole="none"
+                targetLabel={anchorLabel}
+                value={actions.replyDraft}
+                onTextChange={actions.onReplyDraftChange}
+                onConfirm={(text): void => actions.onSubmitReply(text)}
+                onCancel={actions.onCancelReply}
+              />
+            </div>
+          ) : (
+            <div className="flex items-center justify-end gap-2 px-4 py-2">
+              <button
+                type="button"
+                onClick={actions.onStartReply}
+                className="rounded-md px-3 py-1.5 text-[11px] font-medium text-primary hover:bg-surface-container-highest/60"
+                style={{
+                  background:
+                    'color-mix(in srgb, var(--color-primary) 12%, transparent)',
+                }}
+              >
+                ↳ Reply
+              </button>
+              {group.resolved ? (
+                <button
+                  type="button"
+                  onClick={actions.onReopen}
+                  className="rounded-md px-3 py-1.5 text-[11px] font-medium text-on-surface-variant hover:bg-surface-container-highest/60 hover:text-on-surface"
+                  style={{
+                    background:
+                      'color-mix(in srgb, var(--color-on-surface) 6%, transparent)',
+                  }}
+                >
+                  ⟲ Reopen
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={actions.onResolve}
+                  className="rounded-md px-3 py-1.5 text-[11px] font-medium text-on-surface-variant hover:bg-surface-container-highest/60 hover:text-on-surface"
+                  style={{
+                    background:
+                      'color-mix(in srgb, var(--color-on-surface) 6%, transparent)',
+                  }}
+                >
+                  ✓ Resolve
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/features/diff/hooks/useAgentReply.test.ts
+++ b/src/features/diff/hooks/useAgentReply.test.ts
@@ -510,24 +510,25 @@ describe('finding-thread replies (VIM-304 PR-3)', () => {
 describe('thread identity in agent replies (VIM-298)', () => {
   test('an agent reply inherits the handle threadId', async () => {
     setPendingReview(
-      pending(
-        new Map([
-          [1, handle({ lineNumber: 5, threadId: 'root-1' })],
-        ])
-      )
+      pending(new Map([[1, handle({ lineNumber: 5, threadId: 'root-1' })]]))
     )
     mount()
     await emit(
       event({
         replies: [
-          { id: 1, status: 'reply', target: 'comment', text: 'Because latency.' },
+          {
+            id: 1,
+            status: 'reply',
+            target: 'comment',
+            text: 'Because latency.',
+          },
         ],
       })
     )
 
     expect(addAnnotationForOwner).toHaveBeenCalledTimes(1)
-    expect(
-      addAnnotationForOwner.mock.calls[0][4].metadata.threadId
-    ).toBe('root-1')
+    expect(addAnnotationForOwner.mock.calls[0][4].metadata.threadId).toBe(
+      'root-1'
+    )
   })
 })

--- a/src/features/diff/hooks/useAgentReply.test.ts
+++ b/src/features/diff/hooks/useAgentReply.test.ts
@@ -506,3 +506,28 @@ describe('finding-thread replies (VIM-304 PR-3)', () => {
     expect(addAnnotationForOwner).not.toHaveBeenCalled()
   })
 })
+
+describe('thread identity in agent replies (VIM-298)', () => {
+  test('an agent reply inherits the handle threadId', async () => {
+    setPendingReview(
+      pending(
+        new Map([
+          [1, handle({ lineNumber: 5, threadId: 'root-1' })],
+        ])
+      )
+    )
+    mount()
+    await emit(
+      event({
+        replies: [
+          { id: 1, status: 'reply', target: 'comment', text: 'Because latency.' },
+        ],
+      })
+    )
+
+    expect(addAnnotationForOwner).toHaveBeenCalledTimes(1)
+    expect(
+      addAnnotationForOwner.mock.calls[0][4].metadata.threadId
+    ).toBe('root-1')
+  })
+})

--- a/src/features/diff/hooks/useAgentReply.ts
+++ b/src/features/diff/hooks/useAgentReply.ts
@@ -78,6 +78,9 @@ export const useAgentReply = ({
             // Inherit the original comment's scope so a file-level reply stays
             // file-scoped and a range reply keeps its span (VIM-249).
             ...(handle.target === undefined ? {} : { target: handle.target }),
+            ...(handle.threadId === undefined
+              ? {}
+              : { threadId: handle.threadId }),
             ...(outcome === undefined ? {} : { outcome }),
           },
         }

--- a/src/features/diff/hooks/useAgentReview.test.ts
+++ b/src/features/diff/hooks/useAgentReview.test.ts
@@ -329,6 +329,7 @@ describe('finding-thread transition (VIM-304 PR-3)', () => {
         lineNumber: 42,
         side: 'additions',
         target: undefined,
+        threadId: placed.metadata.id,
       })
     }
 
@@ -376,5 +377,17 @@ describe('finding-thread transition (VIM-304 PR-3)', () => {
     await emit(event({ findings: [] }))
 
     expect(getFindingThreadRecord('pty-1', 'abc')).toBeUndefined()
+  })
+})
+
+describe('thread identity in placed findings (VIM-298)', () => {
+  test('a placed finding self-roots its thread', async () => {
+    setPendingReviewRequest(request())
+    mount()
+    await emit(event({ findings: [finding({ line: 42 })] }))
+
+    expect(addAnnotationForOwner).toHaveBeenCalledTimes(1)
+    const annotation = addAnnotationForOwner.mock.calls[0][4]
+    expect(annotation.metadata.threadId).toBe(annotation.metadata.id)
   })
 })

--- a/src/features/diff/hooks/useAgentReview.ts
+++ b/src/features/diff/hooks/useAgentReview.ts
@@ -211,7 +211,7 @@ export const useAgentReview = ({
             lineNumber: annotation.lineNumber,
             side: annotation.side,
             target: annotation.metadata.target,
-            threadId: annotation.metadata.id,
+            threadId: annotation.metadata.threadId ?? annotation.metadata.id,
           },
         })
       }

--- a/src/features/diff/hooks/useAgentReview.ts
+++ b/src/features/diff/hooks/useAgentReview.ts
@@ -84,8 +84,10 @@ export const useAgentReview = ({
       reviewer: string,
       downgradeToFile: boolean
     ): DiffLineAnnotation<ReviewComment> => {
+      const id = nextCommentId()
       const metadata: ReviewComment = {
-        id: nextCommentId(),
+        id,
+        threadId: id,
         text: finding.text,
         author: 'reviewer',
         reviewer,
@@ -209,6 +211,7 @@ export const useAgentReview = ({
             lineNumber: annotation.lineNumber,
             side: annotation.side,
             target: annotation.metadata.target,
+            threadId: annotation.metadata.id,
           },
         })
       }

--- a/src/features/diff/hooks/useAgentReview.ts
+++ b/src/features/diff/hooks/useAgentReview.ts
@@ -85,6 +85,7 @@ export const useAgentReview = ({
       downgradeToFile: boolean
     ): DiffLineAnnotation<ReviewComment> => {
       const id = nextCommentId()
+
       const metadata: ReviewComment = {
         id,
         threadId: id,

--- a/src/features/diff/hooks/useFeedbackBatch.test.ts
+++ b/src/features/diff/hooks/useFeedbackBatch.test.ts
@@ -1043,7 +1043,11 @@ describe('thread fields on ReviewComment (VIM-298)', () => {
       result.current.markDispatched(1000, new Set(['c1']))
     })
 
-    const annotation = result.current.annotationsForFile('/repo', 'a.ts', false)[0]
+    const annotation = result.current.annotationsForFile(
+      '/repo',
+      'a.ts',
+      false
+    )[0]
     expect(annotation.metadata.dispatchedAt).toBe(1000)
     expect(annotation.metadata.threadId).toBe('c1')
   })
@@ -1069,7 +1073,11 @@ describe('thread fields on ReviewComment (VIM-298)', () => {
       result.current.markDispatched(1000, new Set(['c2']))
     })
 
-    const annotation = result.current.annotationsForFile('/repo', 'a.ts', false)[0]
+    const annotation = result.current.annotationsForFile(
+      '/repo',
+      'a.ts',
+      false
+    )[0]
     expect(annotation.metadata.threadId).toBe('root-1')
   })
 
@@ -1086,7 +1094,11 @@ describe('thread fields on ReviewComment (VIM-298)', () => {
       })
     })
 
-    const annotation = result.current.annotationsForFile('/repo', 'a.ts', false)[0]
+    const annotation = result.current.annotationsForFile(
+      '/repo',
+      'a.ts',
+      false
+    )[0]
     expect(annotation.metadata.dispatchedTo).toBe('pty-9')
   })
 

--- a/src/features/diff/hooks/useFeedbackBatch.test.ts
+++ b/src/features/diff/hooks/useFeedbackBatch.test.ts
@@ -1030,3 +1030,126 @@ describe('review annotation category + agent predicates (VIM-256)', () => {
     expect(result.current.pendingAnnotations()).toBe(1)
   })
 })
+
+describe('thread fields on ReviewComment (VIM-298)', () => {
+  test('markDispatched stamps threadId as its own id on a root comment', () => {
+    const { result } = renderHook(() => useFeedbackBatch())
+
+    act(() => {
+      result.current.addAnnotation('/repo', 'a.ts', false, makeAnnotation('c1'))
+    })
+
+    act(() => {
+      result.current.markDispatched(1000, new Set(['c1']))
+    })
+
+    const annotation = result.current.annotationsForFile('/repo', 'a.ts', false)[0]
+    expect(annotation.metadata.dispatchedAt).toBe(1000)
+    expect(annotation.metadata.threadId).toBe('c1')
+  })
+
+  test('markDispatched preserves an existing threadId (follow-up must not fork)', () => {
+    const { result } = renderHook(() => useFeedbackBatch())
+
+    act(() => {
+      result.current.addAnnotation('/repo', 'a.ts', false, {
+        side: 'additions',
+        lineNumber: 1,
+        metadata: {
+          id: 'c2',
+          text: 'follow-up',
+          author: 'self',
+          createdAt: 1,
+          threadId: 'root-1',
+        },
+      })
+    })
+
+    act(() => {
+      result.current.markDispatched(1000, new Set(['c2']))
+    })
+
+    const annotation = result.current.annotationsForFile('/repo', 'a.ts', false)[0]
+    expect(annotation.metadata.threadId).toBe('root-1')
+  })
+
+  test('markDispatched stamps dispatchedTo when provided', () => {
+    const { result } = renderHook(() => useFeedbackBatch())
+
+    act(() => {
+      result.current.addAnnotation('/repo', 'a.ts', false, makeAnnotation('c1'))
+    })
+
+    act(() => {
+      result.current.markDispatched(1000, new Set(['c1']), {
+        dispatchedTo: 'pty-9',
+      })
+    })
+
+    const annotation = result.current.annotationsForFile('/repo', 'a.ts', false)[0]
+    expect(annotation.metadata.dispatchedTo).toBe('pty-9')
+  })
+
+  test('an already-dispatched self insert succeeds at the 50-pending cap', () => {
+    const { result } = renderHook(() => useFeedbackBatch())
+
+    act(() => {
+      for (let i = 0; i < 50; i++) {
+        result.current.addAnnotation(
+          '/repo',
+          `file-${i}.ts`,
+          false,
+          makeAnnotation(`id-${i}`, 'x', i + 1)
+        )
+      }
+    })
+
+    let addResult: 'ok' | 'cap-reached' = 'cap-reached'
+    act(() => {
+      addResult = result.current.addAnnotation('/repo', 'follow.ts', false, {
+        side: 'additions',
+        lineNumber: 1,
+        metadata: {
+          id: 'f1',
+          text: 'follow',
+          author: 'self',
+          createdAt: 1,
+          dispatchedAt: 1000,
+          threadId: 'root-1',
+        },
+      })
+    })
+
+    expect(addResult).toBe('ok')
+    const list = result.current.annotationsForFile('/repo', 'follow.ts', false)
+    expect(list).toHaveLength(1)
+    expect(list[0].metadata.id).toBe('f1')
+  })
+
+  test('a pending self insert is still rejected at the cap', () => {
+    const { result } = renderHook(() => useFeedbackBatch())
+
+    act(() => {
+      for (let i = 0; i < 50; i++) {
+        result.current.addAnnotation(
+          '/repo',
+          `file-${i}.ts`,
+          false,
+          makeAnnotation(`id-${i}`, 'x', i + 1)
+        )
+      }
+    })
+
+    let addResult: 'ok' | 'cap-reached' = 'ok'
+    act(() => {
+      addResult = result.current.addAnnotation(
+        '/repo',
+        'extra.ts',
+        false,
+        makeAnnotation('extra-1')
+      )
+    })
+
+    expect(addResult).toBe('cap-reached')
+  })
+})

--- a/src/features/diff/hooks/useFeedbackBatch.ts
+++ b/src/features/diff/hooks/useFeedbackBatch.ts
@@ -81,6 +81,21 @@ export interface ReviewComment {
         startLine: number
         endLine: number
       }
+  /**
+   * Root comment id of the thread this turn belongs to (VIM-298). Stamped on
+   * dispatch (`threadId ?? id` — a follow-up keeps its root, a root self-roots);
+   * agent replies inherit it from the dispatch handle. Pending comments never
+   * carry one — they are not conversations yet.
+   */
+  threadId?: string
+  /**
+   * Local thread resolution (VIM-298), set on the thread ROOT only. Purely
+   * client-side — nothing is dispatched on resolve; a late agent turn does not
+   * clear it (resolution is authoritative).
+   */
+  resolvedAt?: number
+  /** ptyId of the session this comment was dispatched to (VIM-298 affinity). */
+  dispatchedTo?: string
 }
 
 /**
@@ -315,7 +330,7 @@ export interface UseFeedbackBatchReturn {
   markDispatched: (
     dispatchedAt: number,
     dispatchedAnnotationIds: ReadonlySet<string>,
-    options?: { clearDraftForWholeBatch?: boolean }
+    options?: { clearDraftForWholeBatch?: boolean; dispatchedTo?: string }
   ) => void
   /**
    * Drop the pending comments and the open draft, leaving already dispatched
@@ -439,7 +454,7 @@ export const useFeedbackBatchStore = (
         optimisticBatchesRef.current.get(targetOwnerKey) ?? EMPTY_BATCH
 
       if (
-        annotation.metadata.author === 'self' &&
+        isPendingReviewAnnotation(annotation) &&
         countPendingInBatch(optimisticBatch) >= SOFT_CAP
       ) {
         addAnnotationResultRef.current = 'cap-reached'
@@ -460,7 +475,7 @@ export const useFeedbackBatchStore = (
       setBatchesByOwner((prev) => {
         const currentBatch = prev.get(targetOwnerKey) ?? EMPTY_BATCH
         if (
-          annotation.metadata.author === 'self' &&
+          isPendingReviewAnnotation(annotation) &&
           countPendingInBatch(currentBatch) >= SOFT_CAP
         ) {
           addAnnotationResultRef.current = 'cap-reached'
@@ -624,7 +639,7 @@ export const useFeedbackBatchStore = (
     (
       dispatchedAt: number,
       dispatchedAnnotationIds: ReadonlySet<string>,
-      options?: { clearDraftForWholeBatch?: boolean }
+      options?: { clearDraftForWholeBatch?: boolean; dispatchedTo?: string }
     ): void => {
       setBatchesByOwner((prev) => {
         const currentBatch = prev.get(ownerKey)
@@ -655,7 +670,15 @@ export const useFeedbackBatchStore = (
               dispatchedAnnotationIds.has(annotation.metadata.id)
                 ? {
                     ...annotation,
-                    metadata: { ...annotation.metadata, dispatchedAt },
+                    metadata: {
+                      ...annotation.metadata,
+                      dispatchedAt,
+                      threadId:
+                        annotation.metadata.threadId ?? annotation.metadata.id,
+                      ...(options?.dispatchedTo === undefined
+                        ? {}
+                        : { dispatchedTo: options.dispatchedTo }),
+                    },
                   }
                 : annotation
             )

--- a/src/features/diff/reviewCategoryMeta.ts
+++ b/src/features/diff/reviewCategoryMeta.ts
@@ -31,3 +31,15 @@ export const AGENT_OUTCOME_META: Record<
   deferred: { label: 'Deferred', chip: 'text-secondary' },
   rejected: { label: 'Rejected', chip: 'text-error' },
 }
+
+/**
+ * Chip metas for thread rollup states that no single agent turn carries
+ * (VIM-298): Sent = latest turn is a dispatched user turn (awaiting the
+ * agent); Open = a reviewer finding with no agent turn yet; Resolved =
+ * the user resolved the thread locally (reuses the outcome meta).
+ */
+export const THREAD_ROLLUP_META = {
+  sent: { label: 'Sent', chip: 'text-primary' },
+  open: { label: 'Open', chip: 'text-on-surface-variant' },
+  resolved: AGENT_OUTCOME_META.resolved,
+} as const

--- a/src/features/diff/services/feedbackDispatch.test.ts
+++ b/src/features/diff/services/feedbackDispatch.test.ts
@@ -392,6 +392,7 @@ test('a typeless follow-up renders as [#n · Follow-up] with the context line', 
   expect(payload).toContain(
     '> ↩ Continuing our thread — your last reply: "The pool applies backpressure"'
   )
+
   expect(payload).toContain(
     '> → Answer inline in your reply. Do not edit files.'
   )

--- a/src/features/diff/services/feedbackDispatch.test.ts
+++ b/src/features/diff/services/feedbackDispatch.test.ts
@@ -9,6 +9,8 @@ import {
   dispatchFeedbackBatch,
   formatReviewRequest,
   dispatchReviewRequest,
+  followUpContextLine,
+  isFollowUpComment,
   type DispatchEntry,
 } from './feedbackDispatch'
 import type { ReviewedFile } from './pendingReviewRequests'
@@ -359,4 +361,103 @@ test('formatReviewRequest strips control chars from a crafted path', () => {
 
   expect(payload).not.toContain('\x1b')
   expect(payload).toContain('src/ev[201~il.ts')
+})
+
+test('a typeless follow-up renders as [#n · Follow-up] with the context line', () => {
+  const payload = formatFeedbackPayload(
+    [
+      {
+        filePath: '/repo/src/auth.ts',
+        staged: false,
+        annotations: [
+          {
+            side: 'additions',
+            lineNumber: 42,
+            metadata: {
+              id: 'f1',
+              text: 'How does that interact with resize?',
+              author: 'self',
+              createdAt: 1,
+              threadId: 'root-1',
+            },
+          },
+        ],
+      },
+    ],
+    'abc123',
+    '> ↩ Continuing our thread — your last reply: "The pool applies backpressure"'
+  )
+
+  expect(payload).toContain('[#1 · Follow-up] /repo/src/auth.ts:42')
+  expect(payload).toContain(
+    '> ↩ Continuing our thread — your last reply: "The pool applies backpressure"'
+  )
+  expect(payload).toContain(
+    '> → Answer inline in your reply. Do not edit files.'
+  )
+  expect(payload).not.toContain('Change request')
+})
+
+test('followUpContextLine phrases by author, truncates, and strips controls', () => {
+  expect(
+    followUpContextLine({
+      id: 'g1',
+      text: 'short answer',
+      author: 'agent',
+      createdAt: 1,
+    })
+  ).toBe('> ↩ Continuing our thread — your last reply: "short answer"')
+
+  expect(
+    followUpContextLine({
+      id: 'r1',
+      text: 'finding text',
+      author: 'reviewer',
+      createdAt: 1,
+    })
+  ).toContain('the finding: "finding text"')
+
+  expect(
+    followUpContextLine({
+      id: 'c1',
+      text: 'my question',
+      author: 'self',
+      createdAt: 1,
+    })
+  ).toContain('my earlier comment: "my question"')
+
+  const long = followUpContextLine({
+    id: 'g2',
+    text: 'x'.repeat(300),
+    author: 'agent',
+    createdAt: 1,
+  })
+  expect(long).toContain('(truncated)')
+  expect(long.length).toBeLessThan(300)
+
+  // Paste-breakout regression: agent-controlled text cannot terminate the
+  // bracketed paste or inject CR into the prompt.
+  const hostile = followUpContextLine({
+    id: 'g3',
+    text: 'evil\x1b[201~\rinjected',
+    author: 'agent',
+    createdAt: 1,
+  })
+  expect(hostile).not.toContain('\x1b')
+  expect(hostile).not.toContain('\r')
+})
+
+test('a category-less dispatched ROOT is not a follow-up', () => {
+  // threadId === id (self-rooted) + no category → still the default Change
+  // request in the payload, NOT [#n · Follow-up].
+  expect(
+    isFollowUpComment({
+      id: 'c1',
+      threadId: 'c1',
+      text: 't',
+      author: 'self',
+      createdAt: 1,
+      dispatchedAt: 1000,
+    })
+  ).toBe(false)
 })

--- a/src/features/diff/services/feedbackDispatch.ts
+++ b/src/features/diff/services/feedbackDispatch.ts
@@ -130,6 +130,7 @@ export const formatFeedbackPayload = (
       const category = reviewCommentCategory(annotation.metadata)
       const followUp = isFollowUpComment(annotation.metadata)
       const label = followUp ? FOLLOW_UP_LABEL : CATEGORY_LABEL[category]
+
       const instruction = followUp
         ? FOLLOW_UP_INSTRUCTION
         : CATEGORY_INSTRUCTION[category]

--- a/src/features/diff/services/feedbackDispatch.ts
+++ b/src/features/diff/services/feedbackDispatch.ts
@@ -75,13 +75,49 @@ const CATEGORY_INSTRUCTION: Record<ReviewCommentCategory, string> = {
   suggestion: 'Apply this if you agree.',
 }
 
+/**
+ * A typeless thread follow-up (VIM-298): belongs to ANOTHER root's thread and
+ * has no category. `threadId !== id` is load-bearing — a dispatched ROOT
+ * self-stamps `threadId === id` and may legitimately omit category (defaults
+ * to a change request); it must NOT be classified as a follow-up.
+ */
+export const isFollowUpComment = (comment: ReviewComment): boolean =>
+  comment.author === 'self' &&
+  comment.threadId !== undefined &&
+  comment.threadId !== comment.id &&
+  comment.category === undefined
+
+const FOLLOW_UP_LABEL = 'Follow-up'
+const FOLLOW_UP_INSTRUCTION = 'Answer inline in your reply. Do not edit files.'
+const FOLLOW_UP_EXCERPT_MAX = 200
+
+/**
+ * The one-line continuation marker quoting the latest prior turn (VIM-298).
+ * The excerpt is agent-controlled text, so it passes the same control-char
+ * strip as everything else entering the bracketed paste.
+ */
+export const followUpContextLine = (previous: ReviewComment): string => {
+  const phrasing =
+    previous.author === 'agent'
+      ? 'your last reply'
+      : previous.author === 'reviewer'
+        ? 'the finding'
+        : 'my earlier comment'
+  const clean = stripControls(previous.text)
+  const truncated = clean.length > FOLLOW_UP_EXCERPT_MAX
+  const excerpt = truncated ? clean.slice(0, FOLLOW_UP_EXCERPT_MAX) : clean
+
+  return `> ↩ Continuing our thread — ${phrasing}: "${excerpt}"${truncated ? ' (truncated)' : ''}`
+}
+
 // The structured payload the agent receives. Each item is tagged with its
 // category (the VIM-253 intent) and a [#n] handle it can reply against — the
 // seam for structured Q&A (VIM-249 / VIM-283). The category chip in the UI is
 // just the face value of this.
 export const formatFeedbackPayload = (
   entries: DispatchEntry[],
-  nonce: string
+  nonce: string,
+  followUpContext?: string
 ): string => {
   const totalCount = entries.reduce((s, e) => s + e.annotations.length, 0)
   const header = `> Inline review — ${totalCount} item${totalCount === 1 ? '' : 's'}. Reply to each by its [#n].`
@@ -92,6 +128,11 @@ export const formatFeedbackPayload = (
     for (const annotation of entry.annotations) {
       index += 1
       const category = reviewCommentCategory(annotation.metadata)
+      const followUp = isFollowUpComment(annotation.metadata)
+      const label = followUp ? FOLLOW_UP_LABEL : CATEGORY_LABEL[category]
+      const instruction = followUp
+        ? FOLLOW_UP_INSTRUCTION
+        : CATEGORY_INSTRUCTION[category]
 
       const textLines = annotation.metadata.text
         .split('\n')
@@ -99,9 +140,12 @@ export const formatFeedbackPayload = (
 
       blocks.push(
         [
-          `> [#${index} · ${CATEGORY_LABEL[category]}] ${formatAnnotationTarget(entry, annotation)}`,
+          `> [#${index} · ${label}] ${formatAnnotationTarget(entry, annotation)}`,
+          ...(followUp && followUpContext !== undefined
+            ? [followUpContext]
+            : []),
           ...textLines,
-          `> → ${CATEGORY_INSTRUCTION[category]}`,
+          `> → ${instruction}`,
           '>',
         ].join('\n')
       )
@@ -131,9 +175,10 @@ export const dispatchFeedbackBatch = async (
   ptyId: string,
   entries: DispatchEntry[],
   nonce: string,
-  writePty: (ptyId: string, data: string) => Promise<void>
+  writePty: (ptyId: string, data: string) => Promise<void>,
+  followUpContext?: string
 ): Promise<void> => {
-  const formatted = formatFeedbackPayload(entries, nonce)
+  const formatted = formatFeedbackPayload(entries, nonce, followUpContext)
   const payload = `${PASTE_START}${formatted}${PASTE_END}\r`
 
   await writePty(ptyId, payload)

--- a/src/features/diff/services/pendingReviews.ts
+++ b/src/features/diff/services/pendingReviews.ts
@@ -20,6 +20,12 @@ export interface PendingReviewHandle {
    * not as a line-0 annotation); a range comment's reply keeps its span.
    */
   target: ReviewComment['target']
+  /**
+   * The thread the addressed comment roots or belongs to (VIM-298):
+   * `comment.threadId ?? comment.id`, captured at handle registration so the
+   * agent's reply lands in the same thread group.
+   */
+  threadId?: string
 }
 
 export interface PendingReview {

--- a/src/features/diff/services/threadGroups.test.ts
+++ b/src/features/diff/services/threadGroups.test.ts
@@ -35,6 +35,7 @@ describe('threadGroupKey', () => {
     expect(threadGroupKey(annotation({ id: 'a1', threadId: 'root-1' }))).toBe(
       'root-1'
     )
+
     expect(threadGroupKey(annotation({ id: 'c1', dispatchedAt: 1000 }))).toBe(
       'c1'
     )
@@ -50,6 +51,7 @@ describe('buildThreadGroups', () => {
     const root = annotation({ id: 'c1', dispatchedAt: 1000, threadId: 'c1' })
     const reply = annotation({ id: 'g1', author: 'agent', threadId: 'c1' })
     const pending = annotation({ id: 'p1' })
+
     const { collapsed, groups } = buildThreadGroups(
       [root, reply, pending],
       LOCATION
@@ -93,7 +95,9 @@ describe('buildThreadGroups', () => {
 
 describe('threadRollup', () => {
   test('is total over the latest turn (full outcome matrix)', () => {
-    const agent = (outcome?: ReviewComment['outcome']) =>
+    const agent = (
+      outcome?: ReviewComment['outcome']
+    ): DiffLineAnnotation<ReviewComment> =>
       annotation({ id: 'g', author: 'agent', ...(outcome ? { outcome } : {}) })
 
     expect(threadRollup([agent('reply')], false).label).toBe('Replied')
@@ -108,6 +112,7 @@ describe('threadRollup', () => {
         false
       ).label
     ).toBe('Sent')
+
     expect(
       threadRollup([annotation({ id: 'r', author: 'reviewer' })], false).label
     ).toBe('Open')
@@ -119,9 +124,11 @@ describe('threadRollup', () => {
     expect(
       threadRollup([annotation({ id: 'f', dispatchedAt: 3 })], false).chip
     ).toBe('text-primary')
+
     expect(
       threadRollup([annotation({ id: 'r', author: 'reviewer' })], false).chip
     ).toBe('text-on-surface-variant')
+
     expect(threadRollup([annotation({ id: 'c' })], true).chip).toBe(
       'text-success'
     )
@@ -144,6 +151,7 @@ describe('threadAnchorLabel', () => {
         })
       )
     ).toBe('lines R88-R94')
+
     expect(
       threadAnchorLabel(
         annotation({
@@ -157,6 +165,7 @@ describe('threadAnchorLabel', () => {
         })
       )
     ).toBe('line R88')
+
     expect(
       threadAnchorLabel(annotation({ id: 'c', target: { scope: 'file' } }, 0))
     ).toBe('file')

--- a/src/features/diff/services/threadGroups.test.ts
+++ b/src/features/diff/services/threadGroups.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from 'vitest'
+import type { DiffLineAnnotation } from '@pierre/diffs'
+import type { ReviewComment } from '../hooks/useFeedbackBatch'
+import { DRAFT_ID } from '../hooks/useFeedbackBatch'
+import {
+  buildThreadGroups,
+  threadAnchorLabel,
+  threadGroupKey,
+  threadRollup,
+} from './threadGroups'
+
+const LOCATION = { cwd: '/repo', filePath: 'src/foo.ts', staged: false }
+
+const annotation = (
+  metadata: Partial<ReviewComment> & { id: string },
+  lineNumber = 5
+): DiffLineAnnotation<ReviewComment> => ({
+  side: 'additions',
+  lineNumber,
+  metadata: {
+    text: 't',
+    author: 'self',
+    createdAt: 1,
+    ...metadata,
+  } as ReviewComment,
+})
+
+describe('threadGroupKey', () => {
+  test('pending self comments and the draft sentinel have no key', () => {
+    expect(threadGroupKey(annotation({ id: 'p1' }))).toBeUndefined()
+    expect(threadGroupKey(annotation({ id: DRAFT_ID }))).toBeUndefined()
+  })
+
+  test('threadId wins; dispatched and non-self fall back to own id', () => {
+    expect(threadGroupKey(annotation({ id: 'a1', threadId: 'root-1' }))).toBe(
+      'root-1'
+    )
+    expect(threadGroupKey(annotation({ id: 'c1', dispatchedAt: 1000 }))).toBe(
+      'c1'
+    )
+    expect(threadGroupKey(annotation({ id: 'g1', author: 'agent' }))).toBe('g1')
+  })
+})
+
+describe('buildThreadGroups', () => {
+  test('collapses a thread to one anchor and passes pending through', () => {
+    const root = annotation({ id: 'c1', dispatchedAt: 1000, threadId: 'c1' })
+    const reply = annotation({ id: 'g1', author: 'agent', threadId: 'c1' })
+    const pending = annotation({ id: 'p1' })
+    const { collapsed, groups } = buildThreadGroups(
+      [root, reply, pending],
+      LOCATION
+    )
+
+    expect(collapsed).toEqual([root, pending])
+    expect(groups.get('c1')?.turns).toEqual([root, reply])
+    expect(groups.get('c1')).toMatchObject(LOCATION)
+  })
+
+  test('two roots on one line stay two groups', () => {
+    const { groups } = buildThreadGroups(
+      [
+        annotation({ id: 'c1', dispatchedAt: 1, threadId: 'c1' }),
+        annotation({ id: 'c2', dispatchedAt: 2, threadId: 'c2' }),
+      ],
+      LOCATION
+    )
+
+    expect(groups.size).toBe(2)
+  })
+
+  test('resolved derives from the root comment', () => {
+    const { groups } = buildThreadGroups(
+      [
+        annotation({
+          id: 'c1',
+          dispatchedAt: 1,
+          threadId: 'c1',
+          resolvedAt: 2000,
+        }),
+        annotation({ id: 'g1', author: 'agent', threadId: 'c1' }),
+      ],
+      LOCATION
+    )
+
+    expect(groups.get('c1')?.resolved).toBe(true)
+    expect(groups.get('c1')?.rollup.label).toBe('Resolved')
+  })
+})
+
+describe('threadRollup', () => {
+  test('is total over the latest turn (full outcome matrix)', () => {
+    const agent = (outcome?: ReviewComment['outcome']) =>
+      annotation({ id: 'g', author: 'agent', ...(outcome ? { outcome } : {}) })
+
+    expect(threadRollup([agent('reply')], false).label).toBe('Replied')
+    expect(threadRollup([agent('clarify')], false).label).toBe('Awaiting you')
+    expect(threadRollup([agent('resolved')], false).label).toBe('Resolved')
+    expect(threadRollup([agent('deferred')], false).label).toBe('Deferred')
+    expect(threadRollup([agent('rejected')], false).label).toBe('Rejected')
+    expect(threadRollup([agent()], false).label).toBe('Replied')
+    expect(
+      threadRollup(
+        [agent('clarify'), annotation({ id: 'f', dispatchedAt: 3 })],
+        false
+      ).label
+    ).toBe('Sent')
+    expect(
+      threadRollup([annotation({ id: 'r', author: 'reviewer' })], false).label
+    ).toBe('Open')
+    // Local resolve overrides every derived state.
+    expect(threadRollup([agent('rejected')], true).label).toBe('Resolved')
+  })
+})
+
+describe('threadAnchorLabel', () => {
+  test('labels line, range, and file anchors', () => {
+    expect(threadAnchorLabel(annotation({ id: 'a' }, 40))).toBe('line R40')
+    expect(
+      threadAnchorLabel(
+        annotation({
+          id: 'b',
+          target: {
+            scope: 'range',
+            side: 'additions',
+            startLine: 88,
+            endLine: 94,
+          },
+        })
+      )
+    ).toBe('lines R88-R94')
+    expect(
+      threadAnchorLabel(annotation({ id: 'c', target: { scope: 'file' } }, 0))
+    ).toBe('file')
+  })
+})

--- a/src/features/diff/services/threadGroups.test.ts
+++ b/src/features/diff/services/threadGroups.test.ts
@@ -39,6 +39,9 @@ describe('threadGroupKey', () => {
       'c1'
     )
     expect(threadGroupKey(annotation({ id: 'g1', author: 'agent' }))).toBe('g1')
+    expect(threadGroupKey(annotation({ id: 'r1', author: 'reviewer' }))).toBe(
+      'r1'
+    )
   })
 })
 
@@ -111,6 +114,18 @@ describe('threadRollup', () => {
     // Local resolve overrides every derived state.
     expect(threadRollup([agent('rejected')], true).label).toBe('Resolved')
   })
+
+  test('non-agent states carry their THREAD_ROLLUP_META chip classes', () => {
+    expect(
+      threadRollup([annotation({ id: 'f', dispatchedAt: 3 })], false).chip
+    ).toBe('text-primary')
+    expect(
+      threadRollup([annotation({ id: 'r', author: 'reviewer' })], false).chip
+    ).toBe('text-on-surface-variant')
+    expect(threadRollup([annotation({ id: 'c' })], true).chip).toBe(
+      'text-success'
+    )
+  })
 })
 
 describe('threadAnchorLabel', () => {
@@ -129,6 +144,19 @@ describe('threadAnchorLabel', () => {
         })
       )
     ).toBe('lines R88-R94')
+    expect(
+      threadAnchorLabel(
+        annotation({
+          id: 'b2',
+          target: {
+            scope: 'range',
+            side: 'additions',
+            startLine: 88,
+            endLine: 88,
+          },
+        })
+      )
+    ).toBe('line R88')
     expect(
       threadAnchorLabel(annotation({ id: 'c', target: { scope: 'file' } }, 0))
     ).toBe('file')

--- a/src/features/diff/services/threadGroups.ts
+++ b/src/features/diff/services/threadGroups.ts
@@ -53,7 +53,8 @@ export const threadRollup = (
     return THREAD_ROLLUP_META.resolved
   }
 
-  const latest = turns[turns.length - 1]?.metadata
+  const latestTurn = turns.length === 0 ? undefined : turns[turns.length - 1]
+  const latest = latestTurn?.metadata
   if (latest === undefined || latest.author === 'reviewer') {
     return THREAD_ROLLUP_META.open
   }
@@ -101,11 +102,15 @@ export const buildThreadGroups = (
     const root =
       group.turns.find((turn) => turn.metadata.id === group.threadId) ??
       group.turns[0]
-    group.resolved = root?.metadata.resolvedAt !== undefined
+    group.resolved = root.metadata.resolvedAt !== undefined
     group.rollup = threadRollup(group.turns, group.resolved)
   }
 
-  return { collapsed, groups }
+  // No groups → collapsed is element-wise identical to the input; returning
+  // the input preserves array identity so a still-mounted MultiFileDiff does
+  // not re-tokenize on a mere batch-key switch (the stable-EMPTY discipline
+  // useFeedbackBatch documents).
+  return { collapsed: groups.size === 0 ? annotations : collapsed, groups }
 }
 
 /**

--- a/src/features/diff/services/threadGroups.ts
+++ b/src/features/diff/services/threadGroups.ts
@@ -1,0 +1,134 @@
+import type { DiffLineAnnotation } from '@pierre/diffs'
+import type { ReviewComment } from '../hooks/useFeedbackBatch'
+import { AGENT_OUTCOME_META, THREAD_ROLLUP_META } from '../reviewCategoryMeta'
+
+/**
+ * One rendered conversation (VIM-298): the store stays flat, this is the
+ * derived view-model. `turns` is store order (arrival order — attachAgentNote
+ * appends). The batch-location snapshot is captured at group construction so
+ * the follow-up dispatch has both the repo-relative handle coordinates and an
+ * input to the repo-root resolver without re-deriving from render-time props.
+ */
+export interface ThreadGroup {
+  threadId: string
+  turns: DiffLineAnnotation<ReviewComment>[]
+  rollup: { label: string; chip: string }
+  resolved: boolean
+  cwd: string
+  filePath: string
+  staged: boolean
+}
+
+export interface ThreadGroupsResult {
+  /** One anchor annotation per group + pass-through pending/draft rows. */
+  collapsed: DiffLineAnnotation<ReviewComment>[]
+  groups: Map<string, ThreadGroup>
+}
+
+/**
+ * The grouping key: threadId when present; orphan agent/reviewer annotations
+ * and legacy dispatched roots self-key; pending user comments (and the draft
+ * sentinel) have none — they render as flat rows, never inside a card.
+ */
+export const threadGroupKey = (
+  annotation: DiffLineAnnotation<ReviewComment>
+): string | undefined =>
+  annotation.metadata.threadId ??
+  (annotation.metadata.author !== 'self' ||
+  annotation.metadata.dispatchedAt !== undefined
+    ? annotation.metadata.id
+    : undefined)
+
+/**
+ * Total rollup over the LATEST turn (a dispatched follow-up after a `clarify`
+ * flips the thread back to awaiting the agent), with local resolve on top.
+ * Every self turn inside a thread is dispatched by construction (follow-ups
+ * are created atomically with a successful dispatch), so the self arm is Sent.
+ */
+export const threadRollup = (
+  turns: DiffLineAnnotation<ReviewComment>[],
+  resolved: boolean
+): { label: string; chip: string } => {
+  if (resolved) {
+    return THREAD_ROLLUP_META.resolved
+  }
+
+  const latest = turns[turns.length - 1]?.metadata
+  if (latest === undefined || latest.author === 'reviewer') {
+    return THREAD_ROLLUP_META.open
+  }
+
+  if (latest.author === 'agent') {
+    return latest.outcome === undefined
+      ? AGENT_OUTCOME_META.reply
+      : AGENT_OUTCOME_META[latest.outcome]
+  }
+
+  return THREAD_ROLLUP_META.sent
+}
+
+export const buildThreadGroups = (
+  annotations: DiffLineAnnotation<ReviewComment>[],
+  location: { cwd: string; filePath: string; staged: boolean }
+): ThreadGroupsResult => {
+  const groups = new Map<string, ThreadGroup>()
+  const collapsed: DiffLineAnnotation<ReviewComment>[] = []
+
+  for (const annotation of annotations) {
+    const key = threadGroupKey(annotation)
+    if (key === undefined) {
+      collapsed.push(annotation)
+      continue
+    }
+
+    const existing = groups.get(key)
+    if (existing === undefined) {
+      groups.set(key, {
+        threadId: key,
+        turns: [annotation],
+        rollup: THREAD_ROLLUP_META.open,
+        resolved: false,
+        ...location,
+      })
+      collapsed.push(annotation)
+      continue
+    }
+
+    existing.turns.push(annotation)
+  }
+
+  for (const group of groups.values()) {
+    const root =
+      group.turns.find((turn) => turn.metadata.id === group.threadId) ??
+      group.turns[0]
+    group.resolved = root?.metadata.resolvedAt !== undefined
+    group.rollup = threadRollup(group.turns, group.resolved)
+  }
+
+  return { collapsed, groups }
+}
+
+/**
+ * Anchor label for the card header, total over line / range / file scopes
+ * (PanelBody's private annotationTargetLabel only labels ranges).
+ */
+export const threadAnchorLabel = (
+  annotation: DiffLineAnnotation<ReviewComment>
+): string => {
+  const target = annotation.metadata.target
+  if (target?.scope === 'file') {
+    return 'file'
+  }
+
+  if (target?.scope === 'range') {
+    const prefix = target.side === 'deletions' ? 'L' : 'R'
+
+    return target.startLine === target.endLine
+      ? `line ${prefix}${target.startLine}`
+      : `lines ${prefix}${target.startLine}-${prefix}${target.endLine}`
+  }
+
+  const prefix = annotation.side === 'deletions' ? 'L' : 'R'
+
+  return `line ${prefix}${annotation.lineNumber}`
+}


### PR DESCRIPTION
## Summary
- Turns at one anchor now render as a single GitHub-style thread card: dispatched comments, agent replies, and delegated findings group by `threadId` into one card per anchor with a header rollup chip, ordered turn rows, and a paired ↳ Reply / ✓ Resolve footer (recipe settled in the VIM-298 demo-first pass).
- Replies dispatch alone through the VIM-297 scoped-confirm path as typeless `[#n · Follow-up]` payloads with a quoted-context line; the follow-up is inserted post-write pre-stamped (`dispatchedAt`/`dispatchedTo`/`threadId` — never observable as pending, cap-exempt), and the agent's next reply re-attaches to the same thread via the handle's `threadId`.
- Resolve is local-only: it stamps `resolvedAt` on the thread root, collapses the card to an accessible disclosure header (Enter/Space, `aria-expanded`), supports Reopen, and a successful reply auto-reopens; late agent replies append without unresolving.

Spec: `docs/superpowers/specs/2026-07-11-vim-298-multi-turn-threads-design.md` (codex-reviewed)
Plan: `docs/superpowers/plans/2026-07-12-vim-298-multi-turn-threads.md` (codex-reviewed)

## Testing
- Repo-wide gate green: `lint`, `format:check`, `type-check`, `vitest run` (5459 passed).
- New coverage: grouping selector matrix, rollup totality, cap-boundary insert, editor reply mode, payload format + paste-breakout sanitization, thread card (incl. keyboard disclosure + remount-safe drafts), reply dispatch happy/failure/cancel paths, repo-subdirectory path forms, full multi-turn integration loop, late-reply-after-resolve.

Closes VIM-298
Part of VIM-284

🤖 Generated with [Claude Code](https://claude.com/claude-code)