### PR TITLE
docs(dev): document ghostty runtime + clean-env data-dir flags

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -17,6 +17,37 @@ npm run test:e2e:all  # WebdriverIO + @wdio/electron-service E2E suites
 cargo test --manifest-path crates/backend/Cargo.toml
 ```
 
+## Runtime Env Flags
+
+Set on `npm run electron:dev` (all opt-in; unset = default behavior).
+
+| Env var                                 | Effect                                                                                                                                                                                                                                                                                     |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `VIMEFLOW_USER_DATA_DIR=<dir>`          | Redirect Electron's userData to `<dir>` for a **clean dev env**. Dev otherwise shares the prod `~/Library/Application Support/vibm` dir — same sessions, settings, and agent state as the installed app. Only userData is redirected; `HOME` is left alone (faking it breaks Claude auth). |
+| `VIMEFLOW_NO_SANDBOX=1`                 | Disable the Chromium renderer sandbox — Linux dev hosts without a working SUID sandbox.                                                                                                                                                                                                    |
+| `VIMEFLOW_REMOTE_DEBUGGING_PORT=<port>` | Expose a renderer DevTools endpoint at `http://127.0.0.1:<port>/json/list` (unpackaged only).                                                                                                                                                                                              |
+
+### Ghostty native runtime (macOS)
+
+The native Ghostty terminal path is opt-in in dev. Use the wrapper script or set the flags yourself:
+
+```bash
+npm run electron:dev:ghostty   # = VITE_GHOSTTY_NATIVE_MACOS_PARENT=1 VITE_NATIVE_OVERLAY=1 on port 5174
+```
+
+| Env var                              | Effect                                                                                         |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| `VITE_GHOSTTY_NATIVE_MACOS_PARENT=1` | Enable the native Ghostty parent-window surface (the macOS backbone; always on when packaged). |
+| `VITE_NATIVE_OVERLAY=1`              | Enable native overlay layering used with the parent surface.                                   |
+| `VITE_GHOSTTY_NATIVE_MACOS=1`        | Enable the older native helper path (superseded by the parent path).                           |
+| `GHOSTTY_RESIZE_THROTTLE_MS=<ms>`    | Override the resize throttle for the native parent surface.                                    |
+
+Run dev alongside the installed prod app with the native terminal and a clean profile:
+
+```bash
+VIMEFLOW_USER_DATA_DIR=/tmp/vimeflow-dev npm run electron:dev:ghostty
+```
+
 ## Tech Stack
 
 - **Desktop**: Electron shell + Rust `vimeflow-backend` sidecar

--- a/electron/sandbox.test.ts
+++ b/electron/sandbox.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest'
 import {
   VIMEFLOW_NO_SANDBOX_ENV,
+  VIMEFLOW_USER_DATA_DIR_ENV,
   electronStartupArgs,
   isElectronNoSandboxRequested,
 } from './sandbox'
@@ -25,5 +26,15 @@ describe('Electron sandbox startup args', () => {
         WAYLAND_DISPLAY: undefined,
       })
     ).toEqual(['.'])
+  })
+
+  test('redirects userData only when a dir is provided', () => {
+    expect(
+      electronStartupArgs({ [VIMEFLOW_USER_DATA_DIR_ENV]: '/tmp/vimeflow-dev' })
+    ).toEqual(['.', '--user-data-dir=/tmp/vimeflow-dev'])
+
+    expect(electronStartupArgs({ [VIMEFLOW_USER_DATA_DIR_ENV]: '  ' })).toEqual(
+      ['.']
+    )
   })
 })

--- a/electron/sandbox.ts
+++ b/electron/sandbox.ts
@@ -1,11 +1,29 @@
 export const VIMEFLOW_NO_SANDBOX_ENV = 'VIMEFLOW_NO_SANDBOX'
 
+export const VIMEFLOW_USER_DATA_DIR_ENV = 'VIMEFLOW_USER_DATA_DIR'
+
 type Env = Readonly<Record<string, string | undefined>>
 
 export const isElectronNoSandboxRequested = (env: Env = process.env): boolean =>
   env[VIMEFLOW_NO_SANDBOX_ENV] === '1'
 
-export const electronStartupArgs = (env: Env = process.env): string[] => [
-  '.',
-  ...(isElectronNoSandboxRequested(env) ? ['--no-sandbox'] : []),
-]
+// Dev shares the prod userData dir (Electron derives it from package.json name),
+// so a dev run reads/writes the same sessions, settings, and agent state as the
+// installed app. Set VIMEFLOW_USER_DATA_DIR to point dev at a throwaway dir and
+// get a clean env that never touches prod. HOME is left alone (fake HOME breaks
+// Claude auth) — only Electron's userData is redirected.
+const requestedUserDataDir = (env: Env): string | undefined => {
+  const dir = env[VIMEFLOW_USER_DATA_DIR_ENV]?.trim()
+
+  return dir !== undefined && dir.length > 0 ? dir : undefined
+}
+
+export const electronStartupArgs = (env: Env = process.env): string[] => {
+  const userDataDir = requestedUserDataDir(env)
+
+  return [
+    '.',
+    ...(isElectronNoSandboxRequested(env) ? ['--no-sandbox'] : []),
+    ...(userDataDir !== undefined ? [`--user-data-dir=${userDataDir}`] : []),
+  ]
+}


### PR DESCRIPTION
## What

Adds a **Runtime Env Flags** section to `DEVELOPMENT.md` so devs and agents can discover the dev-server knobs without grepping the source:

- **`VIMEFLOW_USER_DATA_DIR=<dir>`** — run dev against a throwaway userData dir for a clean env. Dev otherwise shares the prod `~/Library/Application Support/vibm` dir (same sessions, settings, agent state). Only userData is redirected; `HOME` is left alone (faking it breaks Claude auth).
- Native Ghostty runtime flags (`VITE_GHOSTTY_NATIVE_MACOS_PARENT`, `VITE_NATIVE_OVERLAY`, `VITE_GHOSTTY_NATIVE_MACOS`, `GHOSTTY_RESIZE_THROTTLE_MS`) and the `npm run electron:dev:ghostty` wrapper.
- Existing `VIMEFLOW_NO_SANDBOX` / `VIMEFLOW_REMOTE_DEBUGGING_PORT` flags.

## Why the code change

The documented `--user-data-dir` knob didn't actually work on this branch — `electronStartupArgs` only gated `--no-sandbox`, and `--` args to `npm run electron:dev` reach Vite, not Electron. Re-added the env-gated `--user-data-dir` arg (mirrors the `VIMEFLOW_NO_SANDBOX` pattern) so the documented flag is real, with a unit test.

## Test

- `electron/sandbox.test.ts` — new cases for the userData-dir gate (empty/whitespace → no arg).
- Repo-wide lint + prettier + type-check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)