### PR TITLE
fix(terminal): restore pane shortcuts from dock

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -83,7 +83,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 40       | 19   | 2026-07-13   |
 | [Module Boundaries](patterns/module-boundaries.md)                                                   | code-quality       | 19       | 8    | 2026-07-11   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 13       | 3    | 2026-06-15   |
-| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 37       | 11   | 2026-07-09   |
+| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 37       | 12   | 2026-07-09   |
 | [Verify Render Target](patterns/verify-render-target.md)                                             | code-quality       | 3        | 1    | 2026-07-01   |
 | [UI Visual Regression](patterns/ui-visual-regression.md)                                             | code-quality       | 27       | 17   | 2026-07-05   |
 | [Status Indicator Display](patterns/status-indicator-display.md)                                     | code-quality       | 3        | 0    | 2026-05-26   |
@@ -110,7 +110,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Shared Controller Segmentation](patterns/shared-controller-segmentation.md)                         | react-patterns     | 2        | 0    | 2026-06-18   |
 | [Vite HMR Static Dependencies](patterns/vite-hmr-static-deps.md)                                     | code-quality       | 3        | 2    | 2026-06-18   |
 | [Custom Pane Layout Preservation](patterns/custom-pane-layout-preservation.md)                       | correctness        | 13       | 5    | 2026-06-22   |
-| [Pane Slot Identity](patterns/pane-slot-identity.md)                                                 | correctness        | 5        | 1    | 2026-07-08   |
+| [Pane Slot Identity](patterns/pane-slot-identity.md)                                                 | correctness        | 6        | 2    | 2026-07-14   |
 | [Transient UI Side Effects](patterns/transient-ui-side-effects.md)                                   | react-patterns     | 18       | 9    | 2026-07-07   |
 | [Async Global State Mutation](patterns/async-global-state-mutation.md)                               | backend            | 1        | 0    | 2026-06-19   |
 | [Boolean Sentinel Consistency](patterns/boolean-sentinel-consistency.md)                             | code-quality       | 2        | 1    | 2026-06-22   |

--- a/docs/reviews/patterns/keyboard-shortcut-guards.md
+++ b/docs/reviews/patterns/keyboard-shortcut-guards.md
@@ -3,7 +3,7 @@ id: keyboard-shortcut-guards
 category: keyboard-shortcuts
 created: 2026-05-18
 last_updated: 2026-07-09
-ref_count: 11
+ref_count: 12
 ---
 
 # Keyboard Shortcut Guards

--- a/docs/reviews/patterns/pane-slot-identity.md
+++ b/docs/reviews/patterns/pane-slot-identity.md
@@ -2,8 +2,8 @@
 id: pane-slot-identity
 category: correctness
 created: 2026-06-19
-last_updated: 2026-07-08
-ref_count: 1
+last_updated: 2026-07-14
+ref_count: 2
 ---
 
 # Pane Slot Identity
@@ -78,4 +78,20 @@ pass the `slotId` through every layer that needs to act on a specific cell.
 - **Fix:** Resolve active and occupied slot ids from `resolvePanePlacement`, then
   choose directional neighbors from the layout slot geometry and map the chosen
   slot back to its assigned pane. Added slot-placement regression coverage.
+- **Commit:** same commit as this entry
+
+### 6. Numbered pane focus used hidden panes after layout shrink
+
+- **Source:** github-codex-connector | PR #695 round 1 | 2026-07-14
+- **Severity:** P2 / MEDIUM
+- **File:** `src/features/terminal/hooks/usePaneShortcuts.ts`
+- **Finding:** `SplitView` used `selectVisiblePanes(...)` when a smaller layout
+  rescued an active pane beyond the prefix slice, so a single visible rescued pane
+  advertised `Mod+1`. The numbered shortcut resolver still placed every
+  `session.panes` entry, making `Mod+1` from the dock target hidden `p0` instead
+  of the visible active pane.
+- **Fix:** Resolve numbered focus targets from the same visible pane set used by
+  `SplitView`, then preserve the dock reclaim path as a focus-only no-op when the
+  visible target is already active. Added a dock regression for a rescued active
+  pane in single-pane focus.
 - **Commit:** same commit as this entry

--- a/src/features/terminal/hooks/usePaneShortcuts.test.ts
+++ b/src/features/terminal/hooks/usePaneShortcuts.test.ts
@@ -100,7 +100,7 @@ const renderPane = (
 ): ReturnType<typeof renderHook> =>
   renderHook(() => usePaneShortcuts({ matches: ctrlMatches, ...options }))
 
-const modZPlatforms: readonly {
+const shortcutPlatforms: readonly {
   readonly label: string
   readonly matches: UsePaneShortcutsOptions['matches']
   readonly shortcutModifiers: Partial<KeyboardEventInit>
@@ -188,7 +188,7 @@ describe('usePaneShortcuts', () => {
     expect(setSessionLayout).toHaveBeenCalledWith('s1', 'grid3x2')
   })
 
-  modZPlatforms.forEach(
+  shortcutPlatforms.forEach(
     ({ label, matches, shortcutModifiers, oppositeModifiers }) => {
       test(`${label}: Mod+Z toggles a multi-pane layout to single and back`, () => {
         const setSessionLayout = vi.fn()
@@ -749,12 +749,13 @@ describe('usePaneShortcuts container reclaim extensions', () => {
 
   test('Ctrl+1 from stale dock state outside dock passes through', () => {
     const onTerminalZoneFocus = vi.fn()
+    const setSessionActivePane = vi.fn()
     blurActiveElement()
 
     renderPane({
-      sessions: [makeSession('s1', 'single', ['p0'])],
+      sessions: [makeSession('s1', 'vsplit', ['p0', 'p1'], 1)],
       activeSessionId: 's1',
-      setSessionActivePane: vi.fn(),
+      setSessionActivePane,
       setSessionLayout: vi.fn(),
       isTerminalContainerActive: false,
       onTerminalZoneFocus,
@@ -763,6 +764,7 @@ describe('usePaneShortcuts container reclaim extensions', () => {
     const event = fire('1', { ctrlKey: true })
 
     expect(onTerminalZoneFocus).not.toHaveBeenCalled()
+    expect(setSessionActivePane).not.toHaveBeenCalled()
     expect(event.preventDefaultSpy).not.toHaveBeenCalled()
   })
 
@@ -835,31 +837,31 @@ describe('usePaneShortcuts container reclaim extensions', () => {
     expect(event.preventDefaultSpy).toHaveBeenCalled()
   })
 
-  test('Ctrl+1 from dock with vsplit (pane 1 active): calls onTerminalZoneFocus but does NOT switch pane', () => {
-    const onTerminalZoneFocus = vi.fn()
-    const setSessionActivePane = vi.fn()
-    const dockEl = attachFakeDock()
-    dockEl.focus()
+  shortcutPlatforms.forEach(({ label, matches, shortcutModifiers }) => {
+    test(`${label}: Mod+1 from dock reclaims terminal focus and switches panes`, () => {
+      const onTerminalZoneFocus = vi.fn()
+      const setSessionActivePane = vi.fn()
+      const dockElement = attachFakeDock()
 
-    renderPane({
-      sessions: [makeSession('s1', 'vsplit', ['p0', 'p1'], 1)], // p1 is active
-      activeSessionId: 's1',
-      setSessionActivePane,
-      setSessionLayout: vi.fn(),
-      isTerminalContainerActive: false,
-      onTerminalZoneFocus,
+      renderPane({
+        sessions: [makeSession('s1', 'vsplit', ['p0', 'p1'], 1)],
+        activeSessionId: 's1',
+        setSessionActivePane,
+        setSessionLayout: vi.fn(),
+        isTerminalContainerActive: false,
+        onTerminalZoneFocus,
+        matches,
+      })
+
+      const event = fire('1', shortcutModifiers)
+
+      expect(onTerminalZoneFocus).toHaveBeenCalledOnce()
+      expect(event.preventDefaultSpy).toHaveBeenCalled()
+      expect(setSessionActivePane).toHaveBeenCalledOnce()
+      expect(setSessionActivePane).toHaveBeenCalledWith('s1', 'p0')
+
+      removeFakeDock(dockElement)
     })
-
-    const event = fire('1', { ctrlKey: true })
-
-    // Focus is reclaimed — container callback fired
-    expect(onTerminalZoneFocus).toHaveBeenCalledOnce()
-    expect(event.preventDefaultSpy).toHaveBeenCalled()
-
-    // But pane should NOT be switched — the return prevents fallthrough
-    expect(setSessionActivePane).not.toHaveBeenCalled()
-
-    removeFakeDock(dockEl)
   })
 
   test('omitted reclaim params preserve already-active pass-through behavior', () => {

--- a/src/features/terminal/hooks/usePaneShortcuts.test.ts
+++ b/src/features/terminal/hooks/usePaneShortcuts.test.ts
@@ -862,6 +862,32 @@ describe('usePaneShortcuts container reclaim extensions', () => {
 
       removeFakeDock(dockElement)
     })
+
+    test(`${label}: Mod+1 from dock keeps rescued active pane focused`, () => {
+      const onTerminalZoneFocus = vi.fn()
+      const setSessionActivePane = vi.fn()
+      const dockElement = attachFakeDock()
+
+      renderPane({
+        sessions: [
+          makeSession('s1', SINGLE_PANE_FOCUS_LAYOUT_ID, ['p0', 'p1', 'p2'], 2),
+        ],
+        activeSessionId: 's1',
+        setSessionActivePane,
+        setSessionLayout: vi.fn(),
+        isTerminalContainerActive: false,
+        onTerminalZoneFocus,
+        matches,
+      })
+
+      const event = fire('1', shortcutModifiers)
+
+      expect(onTerminalZoneFocus).toHaveBeenCalledOnce()
+      expect(event.preventDefaultSpy).toHaveBeenCalled()
+      expect(setSessionActivePane).not.toHaveBeenCalled()
+
+      removeFakeDock(dockElement)
+    })
   })
 
   test('omitted reclaim params preserve already-active pass-through behavior', () => {

--- a/src/features/terminal/hooks/usePaneShortcuts.ts
+++ b/src/features/terminal/hooks/usePaneShortcuts.ts
@@ -33,6 +33,247 @@ export interface UsePaneShortcutsOptions {
   layoutRegistry?: PaneLayoutRegistry
 }
 
+const PANE_NUMBERS = [1, 2, 3, 4, 5, 6, 7, 8, 9] as const
+const PANE_DIRECTIONS = ['left', 'right', 'up', 'down'] as const
+
+const TEXT_ENTRY_SELECTOR =
+  'input, textarea, select, [contenteditable=""], [contenteditable="true"], .xterm-helper-textarea'
+const XTERM_INPUT_SELECTOR = '.xterm-helper-textarea'
+const DOCK_SELECTOR = `[data-container-id="${DOCK_CONTAINER_ID}"]`
+
+interface ShortcutContext {
+  event: KeyboardEvent
+  session: Session
+  match: UsePaneShortcutsOptions['matches']
+  setSessionActivePane: UsePaneShortcutsOptions['setSessionActivePane']
+  setSessionLayout: UsePaneShortcutsOptions['setSessionLayout']
+  focusTerminal: (() => void) | undefined
+  terminalActive: boolean | undefined
+  layoutRegistry: PaneLayoutRegistry
+  previousLayouts: Map<string, PaneLayoutId>
+}
+
+const consumeShortcut = (event: KeyboardEvent): void => {
+  event.preventDefault()
+  event.stopPropagation()
+}
+
+const hasOpenDialog = (): boolean =>
+  document.querySelector(DIALOG_SELECTOR) !== null
+
+// Handlers return true once their command matches, including guarded no-ops,
+// so one keypress never falls through to another shortcut family.
+const handleSinglePaneFocusShortcut = ({
+  event,
+  session,
+  match,
+  setSessionLayout,
+  terminalActive,
+  layoutRegistry,
+  previousLayouts,
+}: ShortcutContext): boolean => {
+  if (!match(event, 'single-pane-focus')) {
+    return false
+  }
+
+  if (
+    hasOpenDialog() ||
+    terminalActive === false ||
+    document.activeElement?.closest(TEXT_ENTRY_SELECTOR)
+  ) {
+    return true
+  }
+
+  if (session.layout === SINGLE_PANE_FOCUS_LAYOUT_ID) {
+    const previousLayoutId = previousLayouts.get(session.id) ?? null
+
+    const previousLayout =
+      previousLayoutId === null
+        ? null
+        : layoutRegistry.getLayout(previousLayoutId)
+
+    if (
+      previousLayout === null ||
+      session.panes.length > previousLayout.capacity
+    ) {
+      previousLayouts.delete(session.id)
+
+      return true
+    }
+
+    consumeShortcut(event)
+    previousLayouts.delete(session.id)
+    setSessionLayout(session.id, previousLayout.id)
+
+    return true
+  }
+
+  const currentLayout = layoutRegistry.getLayout(session.layout)
+  if (currentLayout === null) {
+    return true
+  }
+
+  consumeShortcut(event)
+  previousLayouts.set(session.id, currentLayout.id)
+  setSessionLayout(session.id, SINGLE_PANE_FOCUS_LAYOUT_ID)
+
+  return true
+}
+
+const handleNumberedPaneFocusShortcut = ({
+  event,
+  session,
+  match,
+  setSessionActivePane,
+  focusTerminal,
+  terminalActive,
+  layoutRegistry,
+}: ShortcutContext): boolean => {
+  const paneNumber = PANE_NUMBERS.find((number) =>
+    match(event, `focus-pane-${number}` as CommandId)
+  )
+  if (paneNumber === undefined) {
+    return false
+  }
+
+  if (hasOpenDialog()) {
+    return true
+  }
+
+  const layout = layoutRegistry.getFallbackLayout(session.layout)
+  const slotId = layout.definition.addOrder[paneNumber - 1]
+
+  const target = resolvePanePlacement(
+    session.panes,
+    layout,
+    session.placements
+  ).assignments.find((assignment) => assignment.slotId === slotId)?.pane
+
+  // Number shortcuts also recover terminal focus from the dock. Repeating the
+  // active pane's shortcut refocuses its terminal without changing pane state.
+  if (terminalActive !== undefined && focusTerminal !== undefined) {
+    const activeElement = document.activeElement
+
+    if (!terminalActive) {
+      if (!activeElement?.closest(DOCK_SELECTOR)) {
+        return true
+      }
+
+      focusTerminal()
+      consumeShortcut(event)
+    }
+
+    if (
+      terminalActive &&
+      target?.active &&
+      !activeElement?.closest(XTERM_INPUT_SELECTOR)
+    ) {
+      focusTerminal()
+      consumeShortcut(event)
+
+      return true
+    }
+  }
+
+  if (target === undefined || target.active) {
+    return true
+  }
+
+  consumeShortcut(event)
+  setSessionActivePane(session.id, target.id)
+
+  return true
+}
+
+const handleCycleLayoutShortcut = ({
+  event,
+  session,
+  match,
+  setSessionLayout,
+  previousLayouts,
+}: ShortcutContext): boolean => {
+  if (!match(event, 'cycle-layout')) {
+    return false
+  }
+
+  if (!isKnownLayoutId(session.layout)) {
+    return true
+  }
+
+  const currentIndex = LAYOUT_CYCLE.indexOf(session.layout)
+  if (currentIndex === -1) {
+    return true
+  }
+
+  const nextIndex = (currentIndex + 1) % LAYOUT_CYCLE.length
+  consumeShortcut(event)
+  previousLayouts.delete(session.id)
+  setSessionLayout(session.id, LAYOUT_CYCLE[nextIndex])
+
+  return true
+}
+
+const handleDirectionalPaneFocusShortcut = ({
+  event,
+  session,
+  match,
+  setSessionActivePane,
+  terminalActive,
+  layoutRegistry,
+}: ShortcutContext): boolean => {
+  const direction = PANE_DIRECTIONS.find((candidate) =>
+    match(event, `focus-pane-${candidate}` as CommandId)
+  ) as PaneDirection | undefined
+  if (direction === undefined) {
+    return false
+  }
+
+  if (!terminalActive || hasOpenDialog()) {
+    return true
+  }
+
+  const shape = layoutRegistry.getFallbackLayout(session.layout)
+  const visiblePanes = selectVisiblePanes(session.panes, shape.capacity)
+
+  const placement = resolvePanePlacement(
+    visiblePanes,
+    shape,
+    session.placements
+  )
+
+  const activeAssignment = placement.assignments.find(
+    (assignment) => assignment.pane.active
+  )
+  if (activeAssignment === undefined) {
+    return true
+  }
+
+  const paneBySlotId = new Map(
+    placement.assignments.map((assignment) => [
+      assignment.slotId,
+      assignment.pane,
+    ])
+  )
+
+  const targetSlotId = resolveDirectionalPane(
+    shape,
+    activeAssignment.slotId,
+    new Set<LayoutSlotId>(paneBySlotId.keys()),
+    direction
+  )
+
+  consumeShortcut(event)
+
+  if (targetSlotId !== null) {
+    const targetPane = paneBySlotId.get(targetSlotId)
+    if (targetPane !== undefined) {
+      setSessionActivePane(session.id, targetPane.id)
+    }
+  }
+
+  return true
+}
+
 export const usePaneShortcuts = ({
   sessions,
   activeSessionId,
@@ -67,220 +308,37 @@ export const usePaneShortcuts = ({
         return
       }
 
-      const match = matchesRef.current
-      const activeId = activeSessionIdRef.current
-      if (activeId === null) {
-        return
-      }
-
       const activeSession = sessionsRef.current.find(
-        (session) => session.id === activeId
+        (session) => session.id === activeSessionIdRef.current
       )
-      if (!activeSession) {
+      if (activeSession === undefined) {
         return
       }
 
-      if (match(event, 'single-pane-focus')) {
-        if (document.querySelector(DIALOG_SELECTOR)) {
-          return
-        }
+      const context: ShortcutContext = {
+        event,
+        session: activeSession,
+        match: matchesRef.current,
+        setSessionActivePane,
+        setSessionLayout,
+        focusTerminal: onTerminalZoneFocusRef.current,
+        terminalActive: isTerminalContainerActiveRef.current,
+        layoutRegistry: layoutRegistryRef.current,
+        previousLayouts: lastSingleToggleLayoutBySessionRef.current,
+      }
 
-        if (isTerminalContainerActiveRef.current === false) {
-          return
-        }
-
-        const activeElement = document.activeElement
-        if (
-          activeElement?.closest(
-            'input, textarea, select, [contenteditable=""], [contenteditable="true"], .xterm-helper-textarea'
-          )
-        ) {
-          return
-        }
-
-        if (activeSession.layout === SINGLE_PANE_FOCUS_LAYOUT_ID) {
-          const previousLayoutId =
-            lastSingleToggleLayoutBySessionRef.current.get(activeSession.id) ??
-            null
-
-          const previousLayout =
-            previousLayoutId === null
-              ? null
-              : layoutRegistryRef.current.getLayout(previousLayoutId)
-
-          if (
-            previousLayout === null ||
-            activeSession.panes.length > previousLayout.capacity
-          ) {
-            lastSingleToggleLayoutBySessionRef.current.delete(activeSession.id)
-
-            return
-          }
-
-          event.preventDefault()
-          event.stopPropagation()
-          lastSingleToggleLayoutBySessionRef.current.delete(activeSession.id)
-          setSessionLayout(activeSession.id, previousLayout.id)
-
-          return
-        }
-
-        const currentLayout = layoutRegistryRef.current.getLayout(
-          activeSession.layout
-        )
-        if (currentLayout === null) {
-          return
-        }
-
-        event.preventDefault()
-        event.stopPropagation()
-        lastSingleToggleLayoutBySessionRef.current.set(
-          activeSession.id,
-          currentLayout.id
-        )
-        setSessionLayout(activeSession.id, SINGLE_PANE_FOCUS_LAYOUT_ID)
-
+      // Precedence is intentional: a matched handler owns the keypress even
+      // when a guard turns it into a no-op, preventing family fallthrough.
+      if (handleSinglePaneFocusShortcut(context)) {
         return
       }
-
-      const paneNumber = ([1, 2, 3, 4, 5, 6, 7, 8, 9] as const).find((n) =>
-        match(event, `focus-pane-${n}` as CommandId)
-      )
-      if (paneNumber !== undefined) {
-        if (document.querySelector(DIALOG_SELECTOR)) {
-          return
-        }
-
-        const layout = layoutRegistryRef.current.getFallbackLayout(
-          activeSession.layout
-        )
-        const slotId = layout.definition.addOrder[paneNumber - 1]
-
-        const target = resolvePanePlacement(
-          activeSession.panes,
-          layout,
-          activeSession.placements
-        ).assignments.find((assignment) => assignment.slotId === slotId)?.pane
-
-        const terminalActive = isTerminalContainerActiveRef.current
-        const focusTerminal = onTerminalZoneFocusRef.current
-        if (terminalActive !== undefined && focusTerminal !== undefined) {
-          const activeElement = document.activeElement
-
-          if (!terminalActive) {
-            if (
-              activeElement?.closest(
-                `[data-container-id="${DOCK_CONTAINER_ID}"]`
-              )
-            ) {
-              focusTerminal()
-              event.preventDefault()
-              event.stopPropagation()
-            }
-
-            return
-          }
-
-          if (
-            target?.active &&
-            !activeElement?.closest('.xterm-helper-textarea')
-          ) {
-            focusTerminal()
-            event.preventDefault()
-            event.stopPropagation()
-
-            return
-          }
-        }
-
-        if (target === undefined || target.active) {
-          return
-        }
-
-        event.preventDefault()
-        event.stopPropagation()
-        setSessionActivePane(activeSession.id, target.id)
-
+      if (handleNumberedPaneFocusShortcut(context)) {
         return
       }
-
-      if (match(event, 'cycle-layout')) {
-        if (!isKnownLayoutId(activeSession.layout)) {
-          return
-        }
-
-        const currentIndex = LAYOUT_CYCLE.indexOf(activeSession.layout)
-        if (currentIndex === -1) {
-          return
-        }
-
-        event.preventDefault()
-        event.stopPropagation()
-        const nextIndex = (currentIndex + 1) % LAYOUT_CYCLE.length
-        lastSingleToggleLayoutBySessionRef.current.delete(activeSession.id)
-        setSessionLayout(activeSession.id, LAYOUT_CYCLE[nextIndex])
-
+      if (handleCycleLayoutShortcut(context)) {
         return
       }
-
-      const direction = (['left', 'right', 'up', 'down'] as const).find((d) =>
-        match(event, `focus-pane-${d}` as CommandId)
-      ) as PaneDirection | undefined
-      if (direction === undefined) {
-        return
-      }
-
-      if (!isTerminalContainerActiveRef.current) {
-        return
-      }
-      if (document.querySelector(DIALOG_SELECTOR)) {
-        return
-      }
-
-      const shape = layoutRegistryRef.current.getFallbackLayout(
-        activeSession.layout
-      )
-
-      const visiblePanes = selectVisiblePanes(
-        activeSession.panes,
-        shape.capacity
-      )
-
-      const placement = resolvePanePlacement(
-        visiblePanes,
-        shape,
-        activeSession.placements
-      )
-
-      const activeAssignment = placement.assignments.find(
-        (assignment) => assignment.pane.active
-      )
-      if (activeAssignment === undefined) {
-        return
-      }
-
-      const paneBySlotId = new Map(
-        placement.assignments.map((assignment) => [
-          assignment.slotId,
-          assignment.pane,
-        ])
-      )
-
-      const targetSlotId = resolveDirectionalPane(
-        shape,
-        activeAssignment.slotId,
-        new Set<LayoutSlotId>(paneBySlotId.keys()),
-        direction
-      )
-      event.preventDefault()
-      event.stopPropagation()
-
-      if (targetSlotId !== null) {
-        const targetPane = paneBySlotId.get(targetSlotId)
-        if (targetPane !== undefined) {
-          setSessionActivePane(activeSession.id, targetPane.id)
-        }
-      }
+      handleDirectionalPaneFocusShortcut(context)
     }
 
     document.addEventListener('keydown', handleKeyDown, { capture: true })

--- a/src/features/terminal/hooks/usePaneShortcuts.ts
+++ b/src/features/terminal/hooks/usePaneShortcuts.ts
@@ -142,9 +142,10 @@ const handleNumberedPaneFocusShortcut = ({
 
   const layout = layoutRegistry.getFallbackLayout(session.layout)
   const slotId = layout.definition.addOrder[paneNumber - 1]
+  const visiblePanes = selectVisiblePanes(session.panes, layout.capacity)
 
   const target = resolvePanePlacement(
-    session.panes,
+    visiblePanes,
     layout,
     session.placements
   ).assignments.find((assignment) => assignment.slotId === slotId)?.pane

--- a/src/features/workspace/components/TerminalZone.test.tsx
+++ b/src/features/workspace/components/TerminalZone.test.tsx
@@ -123,6 +123,11 @@ vi.mock('../../terminal/components/TerminalPane', () => ({
   ),
 }))
 
+vi.mock('../../browser', () => ({
+  BrowserPane: (): ReactElement => <div data-testid="browser-pane-mock" />,
+  focusBrowserPane: vi.fn().mockResolvedValue(undefined),
+}))
+
 describe('TerminalZone', () => {
   const defaultProps = {
     sessions: mockSessions.slice(0, 2), // First two sessions
@@ -217,6 +222,63 @@ describe('TerminalZone', () => {
 
     expect(ref.current).not.toBeNull()
     expect(ref.current!.focusActivePane()).toBe(false)
+  })
+
+  test('focuses the terminal zone before delegating native pane focus', () => {
+    const ref = createRef<TerminalZoneHandle>()
+    const activeSession = defaultProps.sessions[0]
+    if (activeSession === undefined) {
+      throw new Error('Expected an active session fixture')
+    }
+
+    const browserSession: Session = {
+      ...activeSession,
+      panes: activeSession.panes.map((pane) => ({
+        ...pane,
+        kind: 'browser',
+        browserUrl: 'https://example.com',
+      })),
+    }
+
+    render(
+      <>
+        <button type="button">Outside</button>
+        <TerminalZone
+          ref={ref}
+          {...defaultProps}
+          sessions={[browserSession]}
+          activeSessionId={browserSession.id}
+        />
+      </>
+    )
+
+    const outside = screen.getByRole('button', { name: 'Outside' })
+    outside.focus()
+    expect(outside).toHaveFocus()
+
+    expect(ref.current!.focusActivePane()).toBe(true)
+    expect(screen.getByTestId('terminal-zone')).toHaveFocus()
+  })
+
+  test('reports container focus once while focus moves into a pane', () => {
+    const ref = createRef<TerminalZoneHandle>()
+    const onContainerFocus = vi.fn()
+
+    render(
+      <>
+        <button type="button">Outside</button>
+        <TerminalZone
+          ref={ref}
+          {...defaultProps}
+          onContainerFocus={onContainerFocus}
+        />
+      </>
+    )
+
+    screen.getByRole('button', { name: 'Outside' }).focus()
+
+    expect(ref.current!.focusActivePane()).toBe(false)
+    expect(onContainerFocus).toHaveBeenCalledOnce()
   })
 
   test('pointer down marks terminal container active', async () => {

--- a/src/features/workspace/components/TerminalZone.tsx
+++ b/src/features/workspace/components/TerminalZone.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable react/require-default-props -- forwardRef components: ESLint cannot see through forwardRef to find destructuring defaults */
+// cspell:ignore Ghostty
 import {
   forwardRef,
   useImperativeHandle,
@@ -133,9 +134,11 @@ export const TerminalZone = forwardRef<TerminalZoneHandle, TerminalZoneProps>(
 
     useImperativeHandle(ref, () => ({
       focusActivePane(): boolean {
-        if (!activeSplitViewRef.current) {
-          outerDivRef.current?.focus()
+        // Establish a renderer focus handoff before native Ghostty takes first
+        // responder. Otherwise the dock can retain and restore stale DOM focus.
+        outerDivRef.current?.focus()
 
+        if (!activeSplitViewRef.current) {
           return false
         }
 
@@ -173,7 +176,13 @@ export const TerminalZone = forwardRef<TerminalZoneHandle, TerminalZoneProps>(
           isZoneFocused ? 'opacity-100' : 'opacity-[0.65]'
         } transition-opacity duration-[220ms]`}
         onPointerDown={handlePointerDown}
-        onFocus={(): void => {
+        onFocus={(event): void => {
+          if (
+            event.currentTarget.contains(event.relatedTarget as Node | null)
+          ) {
+            return
+          }
+
           onContainerFocus?.()
         }}
       >


### PR DESCRIPTION
## Summary

- keep Mod+1–9 pane switching active when the dock or hunk view owns focus
- establish a renderer focus handoff before native pane focus without duplicate container-focus callbacks
- refactor pane shortcut dispatch into readable command-family handlers and cover Linux/macOS modifiers

## Root cause

The numbered shortcut handler returned immediately after reclaiming terminal focus from the dock, so it never updated the active pane. Native pane focus could also leave stale DOM focus in the dock.

## Testing

- `npm test -- --run` — 443 files; 5,538 passed, 3 skipped
- `npm run lint`
- `npm run format:check`
- `npm run type-check:generated`

Refs VIM-343