### PR TITLE
feat(keymap): unify shortcuts across app runtimes (VIM-328)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -35,12 +35,12 @@ The native Ghostty terminal path is opt-in in dev. Use the wrapper script or set
 npm run electron:dev:ghostty   # = VITE_GHOSTTY_NATIVE_MACOS_PARENT=1 VITE_NATIVE_OVERLAY=1 on port 5174
 ```
 
-| Env var                              | Effect                                                                                         |
-| ------------------------------------ | ---------------------------------------------------------------------------------------------- |
-| `VITE_GHOSTTY_NATIVE_MACOS_PARENT=1` | Enable the native Ghostty parent-window surface (the macOS backbone; always on when packaged). |
-| `VITE_NATIVE_OVERLAY=1`              | Enable native overlay layering used with the parent surface.                                   |
-| `VITE_GHOSTTY_NATIVE_MACOS=1`        | Enable the older native helper path (superseded by the parent path).                           |
-| `GHOSTTY_RESIZE_THROTTLE_MS=<ms>`    | Override the resize throttle for the native parent surface.                                    |
+| Env var                              | Effect                                                                                          |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| `VITE_GHOSTTY_NATIVE_MACOS_PARENT=1` | Enable the native Ghostty parent-window surface (the macOS backbone; always on when packaged).  |
+| `VITE_NATIVE_OVERLAY=1`              | Enable native overlay layering used with the parent surface.                                    |
+| `VITE_GHOSTTY_NATIVE_MACOS=1`        | Deprecated alias for `VITE_GHOSTTY_NATIVE_MACOS_PARENT=1`; the separate helper path is retired. |
+| `GHOSTTY_RESIZE_THROTTLE_MS=<ms>`    | Override the resize throttle for the native parent surface.                                     |
 
 Run dev alongside the installed prod app with the native terminal and a clean profile:
 

--- a/docs/decisions/2026-06-15-keymap-engine-architecture.md
+++ b/docs/decisions/2026-06-15-keymap-engine-architecture.md
@@ -35,9 +35,10 @@ map vs **(P2)** introduce SQLite.
 - **Persistence: P1.** Extend `settings.json` with a `customKeybindings` map (a tolerant Rust
   deserializer keeps a malformed entry from wiping the durable file). No SQLite.
 - Supporting model decisions: per-command `matchPolicy` (`exact` default / `tolerant` for layout-
-  sensitive digit/backslash keys); a terminal-safety invariant (a rebindable override must keep
-  exactly one super); a final-set resolver (defaults ⊕ overrides validated as a set so swaps survive);
-  a pure conflict detector. Full data model in the spec.
+  sensitive digit/backslash keys); a terminal-safety invariant (a global rebindable override must
+  keep exactly one super, while focus-scoped Diff bindings may use zero or one); a final-set resolver
+  (defaults ⊕ overrides validated as a set so swaps survive); a pure conflict detector. Full data
+  model in the spec.
 - **Decomposition:** SP1 (this engine + migrate `usePaneShortcuts`/`useDockToggleShortcut`); SP2
   (editing UI); SP3 (customizable `⌘;` leader across renderer + Electron + Linux accelerator, +
   re-introduce the Vim leader chords removed in #460); SP4 (Custom / VS Code / JetBrains presets).
@@ -75,10 +76,39 @@ map vs **(P2)** introduce SQLite.
 - **Behavior drift on migration** → a behavior-preservation table test (`resolveDefault(cmd, isMac)`
   == today's hardcoded combo) + re-running each hook's existing guard suite unchanged.
 - **Durability** (a bad override wiping `settings.json`) → a total, tolerant Rust field deserializer.
-- **Terminal-safety** (an override stealing a bare key) → overrides must keep a super, enforced at
-  both the write (`setUserBinding`) and read (`resolveBindings`) boundaries.
+- **Terminal-safety** (an override stealing a bare key) → global overrides must keep a super;
+  bare/Shift-only Diff overrides are allowed because Diff dispatch is focus-scoped and ignores text
+  entry. Both rules are enforced at the write (`setUserBinding`) and read (`resolveBindings`)
+  boundaries.
 - **Leader reservation on exotic layouts** → the `⌘;` leader is reserved by its default physical code
   for standard layouts; perfect logical-key reservation is deferred to SP3 (when the leader migrates).
+
+## 2026-07-15 implementation addendum: cross-surface transport
+
+Option A still owns action dispatch: renderer hooks keep their focus, dialog, text-entry, and layout
+guards. The registry now also owns the complete transport boundary for native child surfaces. On
+initial settings load and every edit, the renderer publishes `customKeybindings`; Electron resolves
+the entire catalog for the current platform into a versioned snapshot of command id, context,
+physical `KeyboardEvent.code`, modifier policy, and resolved modifiers.
+
+That same snapshot drives all keyboard-input layers:
+
+- the workspace `BrowserWindow` forwards matching global shortcuts to its renderer;
+- each embedded browser `WebContentsView` handles its browser-local bindings and forwards matching
+  global shortcuts to the workspace renderer; and
+- each native Ghostty `NSView` receives the global projection through the C++/Swift bridge and maps
+  the AppKit hardware key code back to `KeyboardEvent.code` before matching.
+
+There are no per-key or per-command native forwarding allowlists. Adding or rebinding a global
+catalog entry therefore reaches all three layers automatically. Consumers may still apply
+action-state guards after matching (for example, suppressing a focus-pane command that targets the
+already-focused pane); those guards do not duplicate shortcut definitions. Context projection keeps
+Diff, editor, dock, terminal, and browser-local commands on their owning surfaces instead of letting
+a native terminal steal focus-scoped input.
+
+The superseded `VITE_GHOSTTY_NATIVE_MACOS` helper flag is now an alias for the parented NSView path,
+so an in-app AppKit terminal cannot bypass this snapshot transport. The standalone Swift smoke
+executable remains only as native development tooling.
 
 ## References
 

--- a/docs/design/UNIFIED.md
+++ b/docs/design/UNIFIED.md
@@ -542,7 +542,8 @@ Rules:
 ## 6. Interactions & keyboard shortcuts
 
 - **Streaming:** terminal output is raw PTY. Agent structured output prefixes `∴` in `primary-container`; one event every ~1.3–2s while `running`, stopping the instant state leaves `running`.
-- **Shortcuts:** `Mod+1–4` focus panes · `Mod+\` cycle layout · `Mod+Z` toggle active-pane focus · `Mod+E` Editor · `Mod+G` Diff · `Mod+0` toggle dock · `Mod+B` (mac) / `Ctrl+Shift+B` toggle sidebar · `Ctrl/Cmd+;` command palette · `Ctrl/Cmd+L` browser address bar · `Esc` closes overlays.
+- **Shortcuts:** `Mod+1–4` focus panes · `Mod+\` cycle layout · `Mod+Z` toggle active-pane focus · `Mod+E` Editor · `Mod+G` Diff · `Mod+0` toggle dock · `Mod+B` (mac) / `Ctrl+Shift+B` toggle sidebar · `Mod+R` toggle agent activity panel · `Ctrl/Cmd+;` command palette · `Ctrl/Cmd+L` browser address bar · `Esc` closes overlays.
+- **Shortcut registry invariant:** Settings edits resolve through one catalog snapshot shared by the shell renderer, embedded browser views, and native Ghostty views. Native surfaces do not maintain a separate shortcut allowlist; focus-scoped commands remain with their owning renderer context.
 - **Approval:** `awaiting` surfaces an approval card (Approve gradient / Deny ghost); approving snaps to `running` and prepends a `user` event.
 - **Focus model:** `activeContainerId` routes shortcuts to the terminal vs the dock; the sidebar toggle has a focus guard so compact-close never drops focus to `<body>`.
 

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -83,7 +83,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 40       | 19   | 2026-07-13   |
 | [Module Boundaries](patterns/module-boundaries.md)                                                   | code-quality       | 19       | 8    | 2026-07-11   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 13       | 3    | 2026-06-15   |
-| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 37       | 12   | 2026-07-09   |
+| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 38       | 13   | 2026-07-15   |
 | [Verify Render Target](patterns/verify-render-target.md)                                             | code-quality       | 3        | 1    | 2026-07-01   |
 | [UI Visual Regression](patterns/ui-visual-regression.md)                                             | code-quality       | 27       | 17   | 2026-07-05   |
 | [Status Indicator Display](patterns/status-indicator-display.md)                                     | code-quality       | 3        | 0    | 2026-05-26   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -83,7 +83,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [E2E Testing](patterns/e2e-testing.md)                                                               | e2e-testing        | 40       | 19   | 2026-07-13   |
 | [Module Boundaries](patterns/module-boundaries.md)                                                   | code-quality       | 19       | 8    | 2026-07-11   |
 | [Diagnostic Instrumentation](patterns/diagnostic-instrumentation.md)                                 | code-quality       | 13       | 3    | 2026-06-15   |
-| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 38       | 13   | 2026-07-15   |
+| [Keyboard Shortcut Guards](patterns/keyboard-shortcut-guards.md)                                     | keyboard-shortcuts | 39       | 14   | 2026-07-15   |
 | [Verify Render Target](patterns/verify-render-target.md)                                             | code-quality       | 3        | 1    | 2026-07-01   |
 | [UI Visual Regression](patterns/ui-visual-regression.md)                                             | code-quality       | 27       | 17   | 2026-07-05   |
 | [Status Indicator Display](patterns/status-indicator-display.md)                                     | code-quality       | 3        | 0    | 2026-05-26   |
@@ -95,7 +95,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Prototype Handoff Artifacts](patterns/prototype-handoff-artifacts.md)                               | review-process     | 2        | 0    | 2026-06-12   |
 | [CloudFormation Environment Prefix Coupling](patterns/cloudformation-environment-prefix-coupling.md) | infrastructure     | 1        | 0    | 2026-06-12   |
 | [CloudFormation Stale References](patterns/cloudformation-stale-references.md)                       | infrastructure     | 2        | 1    | 2026-06-12   |
-| [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 9        | 7    | 2026-07-13   |
+| [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 10       | 8    | 2026-07-15   |
 | [Unsafe Block Safety Comments](patterns/unsafe-block-safety-comments.md)                             | security           | 1        | 0    | 2026-06-14   |
 | [Type Contract Safety](patterns/type-contract-safety.md)                                             | code-quality       | 18       | 11   | 2026-07-09   |
 | [String Construction Hygiene](patterns/string-construction-hygiene.md)                               | code-quality       | 2        | 1    | 2026-06-19   |

--- a/docs/reviews/patterns/dead-code.md
+++ b/docs/reviews/patterns/dead-code.md
@@ -2,8 +2,8 @@
 id: dead-code
 category: code-quality
 created: 2026-06-13
-last_updated: 2026-07-13
-ref_count: 7
+last_updated: 2026-07-15
+ref_count: 8
 ---
 
 # Dead Code
@@ -104,3 +104,15 @@ code and should be removed.
 - **Fix:** Removed the obsolete snapshot ref and returned the in-flight alias
   config promise result directly.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 10. Keymap capture state accessor exported without a caller
+
+- **Source:** github-claude | PR #698 round 2 | 2026-07-15
+- **Severity:** LOW
+- **File:** `electron/command-palette-shortcut.ts`
+- **Finding:** `isKeymapCaptureActive` exposed `captureActiveByWindow` as a
+  public helper, but no Electron, renderer, or test call site used the export.
+  The capture state itself was still consumed internally by the command-palette
+  shortcut dispatcher, so only the exported accessor was dead surface.
+- **Fix:** Removed the unused export while keeping `setKeymapCaptureActive` and
+  the existing internal capture guard intact.

--- a/docs/reviews/patterns/keyboard-shortcut-guards.md
+++ b/docs/reviews/patterns/keyboard-shortcut-guards.md
@@ -3,7 +3,7 @@ id: keyboard-shortcut-guards
 category: keyboard-shortcuts
 created: 2026-05-18
 last_updated: 2026-07-15
-ref_count: 13
+ref_count: 14
 ---
 
 # Keyboard Shortcut Guards
@@ -504,3 +504,19 @@ against three classes of false-fire:
   workspace command allowlist while preserving pane-index gating, and added a
   regression test that leaves `Mod+Z` / `Ctrl+Z` in the page.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 39. Reply-mode comment shortcuts must still intercept no-op category keys
+
+- **Source:** github-claude | PR #698 round 2 | 2026-07-15
+- **Severity:** HIGH
+- **File:** `src/features/diff/components/ReviewCommentEditor.tsx`
+- **Finding:** The keymap migration wrapped the whole category-cycle shortcut
+  branch in `mode !== 'reply'`, so reply-mode Ctrl+H/Ctrl+L no longer called
+  `preventDefault()`/`stopPropagation()`. On macOS textareas, an unprevented
+  Ctrl+H can invoke native backward-delete behavior even though category
+  cycling is intentionally a no-op in reply mode.
+- **Fix:** Match and intercept the category-cycle chords in every mode, but
+  call `cycleCategory()` only outside reply mode. Added a regression assertion
+  that reply-mode Ctrl+H/Ctrl+L return `false` from `fireEvent.keyDown`.
+  Heuristic: when a shortcut is a semantic no-op in one mode, preserve the
+  event-consumption contract separately from the state mutation.

--- a/docs/reviews/patterns/keyboard-shortcut-guards.md
+++ b/docs/reviews/patterns/keyboard-shortcut-guards.md
@@ -2,8 +2,8 @@
 id: keyboard-shortcut-guards
 category: keyboard-shortcuts
 created: 2026-05-18
-last_updated: 2026-07-09
-ref_count: 12
+last_updated: 2026-07-15
+ref_count: 13
 ---
 
 # Keyboard Shortcut Guards
@@ -488,4 +488,19 @@ against three classes of false-fire:
 - **Fix:** Route Linux global accelerator callbacks through the shared window
   dispatcher with a synthesized shortcut input so source resolution, key-capture
   guards, focus, and deduplication stay identical to `before-input-event`.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 38. Browser shortcut forwarding stole page undo
+
+- **Source:** github-codex-connector | PR #698 round 1 | 2026-07-15
+- **Severity:** P2 / MEDIUM
+- **File:** `electron/browser-pane.ts`
+- **Finding:** The embedded browser `before-input-event` path matched every
+  global workspace binding and forwarded it into the app renderer. That included
+  `single-pane-focus` on `Mod+Z` / `Ctrl+Z`, so text inputs inside a
+  `WebContentsView` lost the normal page undo shortcut before renderer text-entry
+  guards could inspect the original target.
+- **Fix:** Restricted browser shortcut forwarding to an explicit browser-safe
+  workspace command allowlist while preserving pane-index gating, and added a
+  regression test that leaves `Mod+Z` / `Ctrl+Z` in the page.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/superpowers/specs/2026-06-15-keybinding-engine-design.md
+++ b/docs/superpowers/specs/2026-06-15-keybinding-engine-design.md
@@ -1,5 +1,17 @@
 # Keybinding Engine — Design (VIM-136 / SP1)
 
+> **2026-07-14 addendum:** Focus-scoped Diff commands now use this registry and Settings editor.
+> Unlike global commands, a Diff binding may use zero or one primary modifier so Vim-style bare-key
+> defaults can be replaced with Shift/Alt combinations. Diff focus and text-entry guards provide the
+> safety boundary; global bindings retain the exactly-one-super invariant described below.
+
+> **2026-07-15 addendum:** The resolved catalog is also the process/native transport contract.
+> Settings publishes the complete override map on load and edit; Electron produces one platform-
+> expanded, versioned snapshot for the workspace window, embedded browser views, and native Ghostty
+> views. Native layers match physical key codes and modifiers from that snapshot without maintaining
+> shortcut allowlists. Adding a global catalog binding therefore propagates to every input layer;
+> focus-scoped contexts remain with their renderer owner and retain their existing action guards.
+
 **Status:** Accepted (codex-reviewed 2026-06-16T04:05:18Z; TDD implementation pending in
 `feature/vim-136`).
 

--- a/electron/browser-pane.test.ts
+++ b/electron/browser-pane.test.ts
@@ -2506,7 +2506,9 @@ describe('BrowserPaneController', () => {
     )
 
     expect(preventDefault).not.toHaveBeenCalled()
-    expect(electronMock.win.webContents.executeJavaScript).not.toHaveBeenCalled()
+    expect(
+      electronMock.win.webContents.executeJavaScript
+    ).not.toHaveBeenCalled()
   })
 
   test('does not refocus the native pane after a forwarded dock shortcut', async () => {

--- a/electron/browser-pane.test.ts
+++ b/electron/browser-pane.test.ts
@@ -528,6 +528,21 @@ const platformShortcutModifier = (): { control: boolean; meta: boolean } =>
     ? { control: false, meta: true }
     : { control: true, meta: false }
 
+const activityPanelShortcutInput = (): {
+  key: string
+  code: string
+  control: boolean
+  meta: boolean
+  alt: boolean
+  shift: boolean
+} => ({
+  key: process.platform === 'darwin' ? 'r' : 'R',
+  code: 'KeyR',
+  ...platformShortcutModifier(),
+  alt: false,
+  shift: process.platform !== 'darwin',
+})
+
 const handler = (channel: string): IpcHandler => {
   const registered = electronMock.handlers.get(channel)
   if (!registered) {
@@ -2255,7 +2270,7 @@ describe('BrowserPaneController', () => {
     expect(electronMock.views[0]?.webContents.focus).toHaveBeenCalled()
   })
 
-  test('forwards Meta+R to the workspace and restores browser focus', async () => {
+  test('forwards the activity panel shortcut to the workspace and restores browser focus', async () => {
     await handler(BROWSER_PANE_CREATE)(eventForSender(), {
       sessionId: 'pty-1',
       paneId: 'p1',
@@ -2280,10 +2295,7 @@ describe('BrowserPaneController', () => {
       { preventDefault },
       {
         type: 'keyDown',
-        key: 'r',
-        code: 'KeyR',
-        ...platformShortcutModifier(),
-        alt: false,
+        ...activityPanelShortcutInput(),
       }
     )
 
@@ -2317,10 +2329,7 @@ describe('BrowserPaneController', () => {
       { preventDefault },
       {
         type: 'keyDown',
-        key: 'r',
-        code: 'KeyR',
-        ...platformShortcutModifier(),
-        alt: false,
+        ...activityPanelShortcutInput(),
         isAutoRepeat: true,
       }
     )

--- a/electron/browser-pane.test.ts
+++ b/electron/browser-pane.test.ts
@@ -2434,7 +2434,8 @@ describe('BrowserPaneController', () => {
     )
 
     const beforeInputHandler = listenerFor(0, 'before-input-event')
-    const forwardableIds = new Set([
+
+    const forwardedIds = new Set([
       'activity-panel-toggle',
       'burner-toggle',
       'cycle-layout',
@@ -2460,7 +2461,7 @@ describe('BrowserPaneController', () => {
     for (const binding of snapshot.bindings.filter(
       ({ id, context }) =>
         context === 'global' &&
-        (forwardableIds.has(id) || /^focus-pane-[2-9]$/.test(id))
+        (forwardedIds.has(id) || /^focus-pane-[2-9]$/.test(id))
     )) {
       const preventDefault = vi.fn()
 

--- a/electron/browser-pane.test.ts
+++ b/electron/browser-pane.test.ts
@@ -14,7 +14,9 @@ import {
   BROWSER_PANE_SET_BOUNDS,
   BROWSER_PANE_TABS_CHANGED,
 } from './browser-pane-channels'
-import { BrowserPaneController, isFocusAddressShortcut } from './browser-pane'
+import { createWorkspaceKeybindingSnapshot } from '../src/features/keymap/snapshot'
+import { BrowserPaneController } from './browser-pane'
+import { setWorkspaceKeybindingSnapshot } from './workspace-keybindings'
 
 interface MockLookupAddress {
   address: string
@@ -1729,59 +1731,6 @@ describe('BrowserPaneController', () => {
     )
   })
 
-  test('isFocusAddressShortcut matches the platform modifier only', () => {
-    const keyL = {
-      type: 'keyDown',
-      key: 'l',
-      code: 'KeyL',
-      control: false,
-      meta: false,
-      alt: false,
-    }
-
-    expect(isFocusAddressShortcut({ ...keyL, meta: true }, 'darwin')).toBe(true)
-    expect(isFocusAddressShortcut({ ...keyL, control: true }, 'darwin')).toBe(
-      false
-    )
-
-    expect(isFocusAddressShortcut({ ...keyL, control: true }, 'linux')).toBe(
-      true
-    )
-    expect(isFocusAddressShortcut({ ...keyL, meta: true }, 'linux')).toBe(false)
-    expect(
-      isFocusAddressShortcut({ ...keyL, meta: true, alt: true }, 'darwin')
-    ).toBe(false)
-
-    expect(
-      isFocusAddressShortcut({ ...keyL, meta: true, shift: true }, 'darwin')
-    ).toBe(false)
-
-    expect(
-      isFocusAddressShortcut(
-        { ...keyL, meta: true, isAutoRepeat: true },
-        'darwin'
-      )
-    ).toBe(false)
-
-    expect(
-      isFocusAddressShortcut({ ...keyL, meta: true, type: 'keyUp' }, 'darwin')
-    ).toBe(false)
-
-    expect(
-      isFocusAddressShortcut(
-        {
-          type: 'keyDown',
-          key: 'j',
-          code: 'KeyJ',
-          control: false,
-          meta: true,
-          alt: false,
-        },
-        'darwin'
-      )
-    ).toBe(false)
-  })
-
   test('reconnect returns existing pane without creating a new WebContentsView', async () => {
     await handler(BROWSER_PANE_CREATE)(eventForSender(), {
       sessionId: 'pty-1',
@@ -2175,7 +2124,7 @@ describe('BrowserPaneController', () => {
     expect(callbackTwo).toHaveBeenCalledWith(null)
   })
 
-  test('does not suppress digit shortcuts unless they target another pane', async () => {
+  test('gates rebound focus-pane shortcuts by pane context', async () => {
     await handler(BROWSER_PANE_CREATE)(eventForSender(), {
       sessionId: 'pty-1',
       paneId: 'p1',
@@ -2183,6 +2132,16 @@ describe('BrowserPaneController', () => {
       initialUrl: 'https://example.com/',
       shortcutContext: { paneIds: ['p1'], activePaneId: 'p1' },
     })
+
+    setWorkspaceKeybindingSnapshot(
+      electronMock.win as unknown as Parameters<
+        typeof setWorkspaceKeybindingSnapshot
+      >[0],
+      createWorkspaceKeybindingSnapshot(
+        { 'focus-pane-2': 'Mod+Alt+KeyK' },
+        process.platform
+      )
+    )
 
     const beforeInputHandler = vi
       .mocked(electronMock.views[0]?.webContents.on)
@@ -2209,10 +2168,10 @@ describe('BrowserPaneController', () => {
       { preventDefault: preventOutOfRangeDefault },
       {
         type: 'keyDown',
-        key: '2',
-        code: 'Digit2',
+        key: 'k',
+        code: 'KeyK',
         ...platformShortcutModifier(),
-        alt: false,
+        alt: true,
       }
     )
 
@@ -2235,10 +2194,10 @@ describe('BrowserPaneController', () => {
       { preventDefault: preventSwitchDefault },
       {
         type: 'keyDown',
-        key: '2',
-        code: 'Digit2',
+        key: 'k',
+        code: 'KeyK',
         ...platformShortcutModifier(),
-        alt: false,
+        alt: true,
       }
     )
 
@@ -2296,7 +2255,7 @@ describe('BrowserPaneController', () => {
     expect(electronMock.views[0]?.webContents.focus).toHaveBeenCalled()
   })
 
-  test('does not refocus the native pane after a forwarded dock shortcut', async () => {
+  test('forwards Meta+R to the workspace and restores browser focus', async () => {
     await handler(BROWSER_PANE_CREATE)(eventForSender(), {
       sessionId: 'pty-1',
       paneId: 'p1',
@@ -2306,6 +2265,199 @@ describe('BrowserPaneController', () => {
 
     vi.mocked(electronMock.win.webContents.executeJavaScript).mockResolvedValue(
       true
+    )
+
+    const beforeInputHandler = vi
+      .mocked(electronMock.views[0]?.webContents.on)
+      .mock.calls.find(([eventName]) => eventName === 'before-input-event')?.[1]
+
+    if (beforeInputHandler === undefined) {
+      throw new Error('missing before-input-event handler')
+    }
+
+    const preventDefault = vi.fn()
+    beforeInputHandler(
+      { preventDefault },
+      {
+        type: 'keyDown',
+        key: 'r',
+        code: 'KeyR',
+        ...platformShortcutModifier(),
+        alt: false,
+      }
+    )
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0)
+    })
+
+    expect(preventDefault).toHaveBeenCalledOnce()
+    expect(
+      electronMock.win.webContents.executeJavaScript
+    ).toHaveBeenCalledOnce()
+
+    expect(
+      vi.mocked(electronMock.win.webContents.executeJavaScript).mock
+        .calls[0]?.[0]
+    ).toContain('KeyR')
+    expect(electronMock.views[0]?.webContents.focus).toHaveBeenCalled()
+  })
+
+  test('preserves auto-repeat when forwarding a registry shortcut', async () => {
+    await handler(BROWSER_PANE_CREATE)(eventForSender(), {
+      sessionId: 'pty-1',
+      paneId: 'p1',
+      workspaceId: 'proj-1',
+      initialUrl: 'https://example.com/',
+    })
+
+    const beforeInputHandler = listenerFor(0, 'before-input-event')
+    const preventDefault = vi.fn()
+    beforeInputHandler(
+      { preventDefault },
+      {
+        type: 'keyDown',
+        key: 'r',
+        code: 'KeyR',
+        ...platformShortcutModifier(),
+        alt: false,
+        isAutoRepeat: true,
+      }
+    )
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0)
+    })
+
+    expect(preventDefault).toHaveBeenCalledOnce()
+    expect(
+      vi.mocked(electronMock.win.webContents.executeJavaScript).mock
+        .calls[0]?.[0]
+    ).toContain('"repeat":true')
+  })
+
+  test('uses the current registry binding instead of a hardcoded workspace key', async () => {
+    await handler(BROWSER_PANE_CREATE)(eventForSender(), {
+      sessionId: 'pty-1',
+      paneId: 'p1',
+      workspaceId: 'proj-1',
+      initialUrl: 'https://example.com/',
+    })
+
+    setWorkspaceKeybindingSnapshot(
+      electronMock.win as unknown as Parameters<
+        typeof setWorkspaceKeybindingSnapshot
+      >[0],
+      createWorkspaceKeybindingSnapshot(
+        { 'activity-panel-toggle': 'Mod+Alt+KeyK' },
+        process.platform
+      )
+    )
+
+    vi.mocked(electronMock.win.webContents.executeJavaScript).mockResolvedValue(
+      true
+    )
+
+    const beforeInputHandler = listenerFor(0, 'before-input-event')
+    const oldPreventDefault = vi.fn()
+    beforeInputHandler(
+      { preventDefault: oldPreventDefault },
+      {
+        type: 'keyDown',
+        key: 'r',
+        code: 'KeyR',
+        ...platformShortcutModifier(),
+        alt: false,
+      }
+    )
+
+    expect(oldPreventDefault).not.toHaveBeenCalled()
+    expect(
+      electronMock.win.webContents.executeJavaScript
+    ).not.toHaveBeenCalled()
+
+    const newPreventDefault = vi.fn()
+    beforeInputHandler(
+      { preventDefault: newPreventDefault },
+      {
+        type: 'keyDown',
+        key: 'k',
+        code: 'KeyK',
+        ...platformShortcutModifier(),
+        alt: true,
+      }
+    )
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0)
+    })
+
+    expect(newPreventDefault).toHaveBeenCalledOnce()
+    expect(
+      electronMock.win.webContents.executeJavaScript
+    ).toHaveBeenCalledOnce()
+
+    expect(
+      vi.mocked(electronMock.win.webContents.executeJavaScript).mock
+        .calls[0]?.[0]
+    ).toContain('KeyK')
+    expect(electronMock.views[0]?.webContents.focus).toHaveBeenCalled()
+  })
+
+  test('accepts every eligible registered global binding without an action allowlist', async () => {
+    const paneIds = Array.from({ length: 9 }, (_, index) => `p${index + 1}`)
+
+    await handler(BROWSER_PANE_CREATE)(eventForSender(), {
+      sessionId: 'pty-1',
+      paneId: 'p1',
+      workspaceId: 'proj-1',
+      initialUrl: 'https://example.com/',
+      shortcutContext: { paneIds, activePaneId: 'p1' },
+    })
+
+    const snapshot = createWorkspaceKeybindingSnapshot({}, process.platform)
+
+    setWorkspaceKeybindingSnapshot(
+      electronMock.win as unknown as Parameters<
+        typeof setWorkspaceKeybindingSnapshot
+      >[0],
+      snapshot
+    )
+
+    const beforeInputHandler = listenerFor(0, 'before-input-event')
+
+    for (const binding of snapshot.bindings.filter(
+      ({ id, context }) => context === 'global' && id !== 'focus-pane-1'
+    )) {
+      const preventDefault = vi.fn()
+
+      beforeInputHandler(
+        { preventDefault },
+        {
+          type: 'keyDown',
+          key: binding.code,
+          code: binding.code,
+          control: binding.control,
+          meta: binding.meta,
+          alt: binding.alt,
+          shift: binding.shift,
+        }
+      )
+
+      expect(preventDefault, binding.id).toHaveBeenCalledOnce()
+    }
+  })
+
+  test('does not refocus the native pane after a forwarded dock shortcut', async () => {
+    await handler(BROWSER_PANE_CREATE)(eventForSender(), {
+      sessionId: 'pty-1',
+      paneId: 'p1',
+      workspaceId: 'proj-1',
+      initialUrl: 'https://example.com/',
+    })
+
+    vi.mocked(electronMock.win.webContents.executeJavaScript).mockResolvedValue(
+      false
     )
 
     const beforeInputHandler = vi
@@ -2333,5 +2485,12 @@ describe('BrowserPaneController', () => {
 
     expect(electronMock.win.webContents.executeJavaScript).toHaveBeenCalled()
     expect(electronMock.views[0]?.webContents.focus).not.toHaveBeenCalled()
+
+    const forwardedScript = vi.mocked(
+      electronMock.win.webContents.executeJavaScript
+    ).mock.calls[0]?.[0]
+    expect(forwardedScript).toContain('proxyOwnsFocus')
+    expect(forwardedScript).toContain('dockHasFocus')
+    expect(forwardedScript).toContain('dialogOpen')
   })
 })

--- a/electron/browser-pane.test.ts
+++ b/electron/browser-pane.test.ts
@@ -2413,7 +2413,7 @@ describe('BrowserPaneController', () => {
     expect(electronMock.views[0]?.webContents.focus).toHaveBeenCalled()
   })
 
-  test('accepts every eligible registered global binding without an action allowlist', async () => {
+  test('forwards browser-safe registered global bindings', async () => {
     const paneIds = Array.from({ length: 9 }, (_, index) => `p${index + 1}`)
 
     await handler(BROWSER_PANE_CREATE)(eventForSender(), {
@@ -2434,9 +2434,33 @@ describe('BrowserPaneController', () => {
     )
 
     const beforeInputHandler = listenerFor(0, 'before-input-event')
+    const forwardableIds = new Set([
+      'activity-panel-toggle',
+      'burner-toggle',
+      'cycle-layout',
+      'dock-toggle',
+      'focus-diff',
+      'focus-editor',
+      'focus-pane-down',
+      'focus-pane-left',
+      'focus-pane-right',
+      'focus-pane-up',
+      'new-session',
+      'palette',
+      'palette-leader',
+      'session-next',
+      'session-prev',
+      'settings',
+      'settings-control',
+      'sidebar-files',
+      'sidebar-sessions',
+      'sidebar-toggle',
+    ])
 
     for (const binding of snapshot.bindings.filter(
-      ({ id, context }) => context === 'global' && id !== 'focus-pane-1'
+      ({ id, context }) =>
+        context === 'global' &&
+        (forwardableIds.has(id) || /^focus-pane-[2-9]$/.test(id))
     )) {
       const preventDefault = vi.fn()
 
@@ -2455,6 +2479,33 @@ describe('BrowserPaneController', () => {
 
       expect(preventDefault, binding.id).toHaveBeenCalledOnce()
     }
+  })
+
+  test('leaves browser text-editing shortcuts in the page', async () => {
+    await handler(BROWSER_PANE_CREATE)(eventForSender(), {
+      sessionId: 'pty-1',
+      paneId: 'p1',
+      workspaceId: 'proj-1',
+      initialUrl: 'https://example.com/',
+    })
+
+    const beforeInputHandler = listenerFor(0, 'before-input-event')
+    const preventDefault = vi.fn()
+
+    beforeInputHandler(
+      { preventDefault },
+      {
+        type: 'keyDown',
+        key: process.platform === 'darwin' ? 'z' : 'Z',
+        code: 'KeyZ',
+        ...platformShortcutModifier(),
+        alt: false,
+        shift: false,
+      }
+    )
+
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(electronMock.win.webContents.executeJavaScript).not.toHaveBeenCalled()
   })
 
   test('does not refocus the native pane after a forwarded dock shortcut', async () => {

--- a/electron/browser-pane.ts
+++ b/electron/browser-pane.ts
@@ -403,7 +403,7 @@ const loadBrowserUrl = async (
   }
 }
 
-const BROWSER_FORWARDABLE_WORKSPACE_SHORTCUT_IDS = new Set<string>([
+const BROWSER_WORKSPACE_SHORTCUT_IDS_TO_FORWARD = new Set<string>([
   'activity-panel-toggle',
   'burner-toggle',
   'cycle-layout',
@@ -432,7 +432,7 @@ const shouldForwardBrowserWorkspaceShortcut = (
 ): boolean => {
   const digitMatch = /^focus-pane-([1-9])$/.exec(commandId)
   if (!digitMatch) {
-    return BROWSER_FORWARDABLE_WORKSPACE_SHORTCUT_IDS.has(commandId)
+    return BROWSER_WORKSPACE_SHORTCUT_IDS_TO_FORWARD.has(commandId)
   }
 
   const shortcutContext = record.shortcutContext

--- a/electron/browser-pane.ts
+++ b/electron/browser-pane.ts
@@ -45,6 +45,10 @@ import {
   commandPaletteToggleDispatcherForWindow,
   type CommandPaletteShortcutSource,
 } from './command-palette-shortcut'
+import {
+  getWorkspaceKeybindingSnapshot,
+  matchingWorkspaceKeybindings,
+} from './workspace-keybindings'
 import type {
   PersistedTab,
   WorkspaceLayoutWriteSignals,
@@ -399,62 +403,11 @@ const loadBrowserUrl = async (
   }
 }
 
-const hasPlatformShortcutModifier = (
-  input: BrowserPaneShortcutInput,
-  platform: NodeJS.Platform = process.platform
-): boolean => {
-  if (input.type !== 'keyDown' || input.isAutoRepeat) {
-    return false
-  }
-
-  return platform === 'darwin'
-    ? input.meta && !input.control
-    : input.control && !input.meta
-}
-
-export const isFocusAddressShortcut = (
-  input: BrowserPaneShortcutInput,
-  platform: NodeJS.Platform = process.platform
-): boolean =>
-  input.code === 'KeyL' &&
-  !input.alt &&
-  input.shift !== true &&
-  !input.isAutoRepeat &&
-  hasPlatformShortcutModifier(input, platform)
-
-const isBrowserPaneWorkspaceShortcutInput = (
-  input: BrowserPaneShortcutInput
-): boolean => {
-  if (!hasPlatformShortcutModifier(input)) {
-    return false
-  }
-
-  if (/^Digit[1-4]$/.test(input.code) || input.code === 'Backslash') {
-    return true
-  }
-
-  if (input.alt || input.shift) {
-    return false
-  }
-
-  const key = input.key.toLowerCase()
-
-  return key === 'e' || key === 'g'
-}
-
-const shouldRefocusBrowserAfterWorkspaceShortcut = (
-  input: BrowserPaneShortcutInput
-): boolean => /^Digit[1-4]$/.test(input.code) || input.code === 'Backslash'
-
 const shouldForwardBrowserWorkspaceShortcut = (
   record: BrowserPaneRecord,
-  input: BrowserPaneShortcutInput
+  commandId: string
 ): boolean => {
-  if (!isBrowserPaneWorkspaceShortcutInput(input)) {
-    return false
-  }
-
-  const digitMatch = /^Digit([1-4])$/.exec(input.code)
+  const digitMatch = /^focus-pane-([1-9])$/.exec(commandId)
   if (!digitMatch) {
     return true
   }
@@ -483,6 +436,7 @@ const browserPaneShortcutEventInit = (
   metaKey: input.meta,
   altKey: input.alt,
   shiftKey: input.shift === true,
+  repeat: input.isAutoRepeat === true,
   bubbles: true,
   cancelable: true,
 })
@@ -1837,29 +1791,38 @@ export class BrowserPaneController {
     }
 
     webContents.on('before-input-event', (event, input) => {
-      if (isFocusAddressShortcut(input)) {
-        event.preventDefault()
-        const win = BrowserWindow.fromId(record.windowId)
-        if (win && !win.isDestroyed() && !win.webContents.isDestroyed()) {
-          win.webContents.focus()
-          win.webContents.send(BROWSER_PANE_FOCUS_ADDRESS, {
-            sessionId: record.sessionId,
-            paneId: record.paneId,
-          })
-        }
-
+      if (input.type !== 'keyDown') {
         return
       }
 
       const win = BrowserWindow.fromId(record.windowId)
+      if (!win || win.isDestroyed() || win.webContents.isDestroyed()) {
+        return
+      }
 
-      const source =
-        win && !win.isDestroyed()
-          ? commandPaletteShortcutSourceForInput(
-              input,
-              commandPaletteShortcutBindingsConfigForWindow(win)
-            )
-          : null
+      const snapshot = getWorkspaceKeybindingSnapshot(win)
+
+      const browserLocationMatch = matchingWorkspaceKeybindings(
+        snapshot,
+        input,
+        ['browser']
+      ).some(({ id }) => id === 'browser-location')
+
+      if (browserLocationMatch && !input.isAutoRepeat) {
+        event.preventDefault()
+        win.webContents.focus()
+        win.webContents.send(BROWSER_PANE_FOCUS_ADDRESS, {
+          sessionId: record.sessionId,
+          paneId: record.paneId,
+        })
+
+        return
+      }
+
+      const source = commandPaletteShortcutSourceForInput(
+        input,
+        commandPaletteShortcutBindingsConfigForWindow(win)
+      )
 
       if (source !== null) {
         event.preventDefault()
@@ -1868,7 +1831,11 @@ export class BrowserPaneController {
         return
       }
 
-      if (!shouldForwardBrowserWorkspaceShortcut(record, input)) {
+      const workspaceShortcut = matchingWorkspaceKeybindings(snapshot, input, [
+        'global',
+      ]).find(({ id }) => shouldForwardBrowserWorkspaceShortcut(record, id))
+
+      if (workspaceShortcut === undefined) {
         return
       }
 
@@ -1918,15 +1885,28 @@ export class BrowserPaneController {
                 node.getAttribute('data-pane-id') === ${JSON.stringify(record.paneId)} &&
                 node.closest('[data-browser-session-id]')?.getAttribute('data-browser-session-id') === ${JSON.stringify(record.sessionId)}
               )
-              resolve(activeBrowserPane)
+              const activeElement = document.activeElement
+              const proxyOwnsFocus = activeElement === target
+              const dockHasFocus =
+                activeElement instanceof Element &&
+                activeElement.closest('[data-container-id="dock"]') !== null
+              const dialogOpen = document.querySelector(
+                '[role="dialog"]:not([hidden]):not([aria-hidden="true"]),[role="alertdialog"]:not([hidden]):not([aria-hidden="true"])'
+              ) !== null
+              resolve(
+                activeBrowserPane &&
+                proxyOwnsFocus &&
+                !dockHasFocus &&
+                !dialogOpen
+              )
             })
           })
         })()`,
         false
       )
       if (
-        shouldRefocusBrowserAfterWorkspaceShortcut(input) &&
         shouldRefocus === true &&
+        win.isFocused() &&
         this.panes.get(record.id) === record &&
         !this.activeWebContents(record)?.isDestroyed()
       ) {

--- a/electron/browser-pane.ts
+++ b/electron/browser-pane.ts
@@ -403,13 +403,36 @@ const loadBrowserUrl = async (
   }
 }
 
+const BROWSER_FORWARDABLE_WORKSPACE_SHORTCUT_IDS = new Set<string>([
+  'activity-panel-toggle',
+  'burner-toggle',
+  'cycle-layout',
+  'dock-toggle',
+  'focus-diff',
+  'focus-editor',
+  'focus-pane-down',
+  'focus-pane-left',
+  'focus-pane-right',
+  'focus-pane-up',
+  'new-session',
+  'palette',
+  'palette-leader',
+  'session-next',
+  'session-prev',
+  'settings',
+  'settings-control',
+  'sidebar-files',
+  'sidebar-sessions',
+  'sidebar-toggle',
+])
+
 const shouldForwardBrowserWorkspaceShortcut = (
   record: BrowserPaneRecord,
   commandId: string
 ): boolean => {
   const digitMatch = /^focus-pane-([1-9])$/.exec(commandId)
   if (!digitMatch) {
-    return true
+    return BROWSER_FORWARDABLE_WORKSPACE_SHORTCUT_IDS.has(commandId)
   }
 
   const shortcutContext = record.shortcutContext

--- a/electron/command-palette-shortcut.ts
+++ b/electron/command-palette-shortcut.ts
@@ -346,9 +346,6 @@ export const setKeymapCaptureActive = (
   captureActiveByWindow.set(win, active)
 }
 
-export const isKeymapCaptureActive = (win: BrowserWindow): boolean =>
-  captureActiveByWindow.get(win) === true
-
 const createCommandPaletteToggleDispatcher = (
   win: BrowserWindow
 ): ((source?: CommandPaletteShortcutSource) => void) => {

--- a/electron/command-palette-shortcut.ts
+++ b/electron/command-palette-shortcut.ts
@@ -346,6 +346,9 @@ export const setKeymapCaptureActive = (
   captureActiveByWindow.set(win, active)
 }
 
+export const isKeymapCaptureActive = (win: BrowserWindow): boolean =>
+  captureActiveByWindow.get(win) === true
+
 const createCommandPaletteToggleDispatcher = (
   win: BrowserWindow
 ): ((source?: CommandPaletteShortcutSource) => void) => {

--- a/electron/ghostty-native-parent.test.ts
+++ b/electron/ghostty-native-parent.test.ts
@@ -1,5 +1,7 @@
 // cspell:ignore ghostty Ghostty GHOSTTY
 import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { BrowserWindow } from 'electron'
+import { DIALOG_SELECTOR } from '../src/features/workspace/containerIds'
 import {
   GHOSTTY_NATIVE_DATA,
   GHOSTTY_NATIVE_DESTROY,
@@ -16,6 +18,10 @@ import {
   isGhosttyNativeParentEnabled,
   setupGhosttyNativeParent,
 } from './ghostty-native-parent'
+import {
+  DEFAULT_WORKSPACE_KEYBINDING_SNAPSHOT,
+  setWorkspaceKeybindingSnapshot,
+} from './workspace-keybindings'
 
 const handlers = new Map<string, (...args: unknown[]) => unknown>()
 const nativeHandle = Buffer.alloc(8)
@@ -23,18 +29,22 @@ nativeHandle.writeBigUInt64LE(1n)
 
 const {
   existsSync,
+  browserWindows,
   browserWindowState,
   browserWindowOnce,
   isDestroyed,
+  isFocused,
   webContentsExecuteJavaScript,
   webContentsFocus,
   webContentsIsDestroyed,
   webContentsSend,
 } = vi.hoisted(() => ({
   existsSync: vi.fn(() => false),
+  browserWindows: new Map<number, object>(),
   browserWindowState: { id: 1 },
   browserWindowOnce: vi.fn(),
   isDestroyed: vi.fn(() => false),
+  isFocused: vi.fn(() => true),
   webContentsExecuteJavaScript: vi.fn(
     (script: string, gesture?: boolean): Promise<unknown> => {
       void script
@@ -55,18 +65,29 @@ vi.mock('node:fs', () => ({
 
 vi.mock('electron', () => ({
   BrowserWindow: {
-    fromWebContents: vi.fn(() => ({
-      id: browserWindowState.id,
-      getNativeWindowHandle: (): Buffer => nativeHandle,
-      isDestroyed,
-      once: browserWindowOnce,
-      webContents: {
-        executeJavaScript: webContentsExecuteJavaScript,
-        focus: webContentsFocus,
-        isDestroyed: webContentsIsDestroyed,
-        send: webContentsSend,
-      },
-    })),
+    fromWebContents: vi.fn(() => {
+      const existing = browserWindows.get(browserWindowState.id)
+      if (existing) {
+        return existing
+      }
+
+      const win = {
+        id: browserWindowState.id,
+        getNativeWindowHandle: (): Buffer => nativeHandle,
+        isDestroyed,
+        isFocused,
+        once: browserWindowOnce,
+        webContents: {
+          executeJavaScript: webContentsExecuteJavaScript,
+          focus: webContentsFocus,
+          isDestroyed: webContentsIsDestroyed,
+          send: webContentsSend,
+        },
+      }
+      browserWindows.set(browserWindowState.id, win)
+
+      return win
+    }),
   },
   ipcMain: {
     handle: vi.fn(
@@ -85,10 +106,13 @@ describe('ghostty native parent', () => {
     handlers.clear()
     existsSync.mockReset()
     existsSync.mockReturnValue(false)
+    browserWindows.clear()
     browserWindowState.id = 1
     browserWindowOnce.mockClear()
     isDestroyed.mockReset()
     isDestroyed.mockReturnValue(false)
+    isFocused.mockReset()
+    isFocused.mockReturnValue(true)
     webContentsExecuteJavaScript.mockReset()
     webContentsExecuteJavaScript.mockResolvedValue(false)
     webContentsFocus.mockClear()
@@ -97,10 +121,22 @@ describe('ghostty native parent', () => {
     webContentsSend.mockClear()
   })
 
-  test('enables on macOS when packaged or when the parent feature flag is set', () => {
+  test('visible-dialog selector ignores a dismissed mounted burner', () => {
+    expect(DIALOG_SELECTOR).toBe(
+      '[role="dialog"]:not([hidden]):not([aria-hidden="true"]),[role="alertdialog"]:not([hidden]):not([aria-hidden="true"])'
+    )
+  })
+
+  test('enables on macOS when packaged or either native feature flag is set', () => {
     expect(
       isGhosttyNativeParentEnabled('darwin', {
         VITE_GHOSTTY_NATIVE_MACOS_PARENT: '1',
+      })
+    ).toBe(true)
+
+    expect(
+      isGhosttyNativeParentEnabled('darwin', {
+        VITE_GHOSTTY_NATIVE_MACOS: '1',
       })
     ).toBe(true)
 
@@ -506,7 +542,7 @@ describe('ghostty native parent', () => {
       setBackgroundColor: vi.fn(),
       setForegroundColor: vi.fn(),
       setFontFamily: vi.fn(),
-      setShortcutDigits: vi.fn(),
+      setKeybindings: vi.fn(),
       write: vi.fn(),
       focus: vi.fn(),
       destroy: vi.fn(),
@@ -572,10 +608,14 @@ describe('ghostty native parent', () => {
       '#100f0f'
     )
 
-    expect(addon.setShortcutDigits).toHaveBeenNthCalledWith(
+    const replayedKeybindings = JSON.parse(
+      String(addon.setKeybindings.mock.calls[1]?.[1])
+    ) as { bindings: { id: string }[] }
+
+    expect(addon.setKeybindings).toHaveBeenNthCalledWith(
       2,
       secondSurface,
-      '23'
+      expect.any(String)
     )
 
     expect(addon.addSecondary).toHaveBeenNthCalledWith(
@@ -586,6 +626,12 @@ describe('ghostty native parent', () => {
       expect.any(Function),
       'top'
     )
+
+    expect(
+      replayedKeybindings.bindings
+        .filter(({ id }) => /^focus-pane-[1-9]$/.test(id))
+        .map(({ id }) => id)
+    ).toEqual(['focus-pane-2', 'focus-pane-3'])
 
     controller.dispose()
   })
@@ -1052,14 +1098,14 @@ describe('ghostty native parent', () => {
     controller.dispose()
   })
 
-  test('updates native shortcut digits only for real pane switches', () => {
+  test('projects and deduplicates pane-specific native keybindings', () => {
     const surface = {}
 
     const addon = {
       create: vi.fn(() => surface),
       setFrame: vi.fn(),
       setFontFamily: vi.fn(),
-      setShortcutDigits: vi.fn(),
+      setKeybindings: vi.fn(),
       write: vi.fn(),
       focus: vi.fn(),
       destroy: vi.fn(),
@@ -1094,7 +1140,38 @@ describe('ghostty native parent', () => {
       }
     )
 
-    expect(addon.setShortcutDigits).toHaveBeenLastCalledWith(surface, '23')
+    const initialKeybindings = JSON.parse(
+      String(addon.setKeybindings.mock.lastCall?.[1])
+    ) as { bindings: { id: string }[] }
+
+    expect(addon.setKeybindings).toHaveBeenLastCalledWith(
+      surface,
+      expect.any(String)
+    )
+
+    expect(
+      initialKeybindings.bindings
+        .filter(({ id }) => /^focus-pane-[1-9]$/.test(id))
+        .map(({ id }) => id)
+    ).toEqual(['focus-pane-2', 'focus-pane-3'])
+
+    expect(initialKeybindings.bindings.map(({ id }) => id)).toEqual(
+      DEFAULT_WORKSPACE_KEYBINDING_SNAPSHOT.bindings
+        .filter(({ context }) => context === 'global')
+        .filter(({ id }) => {
+          const paneMatch = /^focus-pane-([1-9])$/.exec(id)
+          if (paneMatch === null) {
+            return true
+          }
+
+          const targetPaneId = ['pane-1', 'pane-2', 'pane-3'].at(
+            Number(paneMatch[1]) - 1
+          )
+
+          return targetPaneId !== undefined && targetPaneId !== 'pane-1'
+        })
+        .map(({ id }) => id)
+    )
 
     handlers.get(GHOSTTY_NATIVE_UPDATE)?.(
       { sender: {} },
@@ -1112,7 +1189,7 @@ describe('ghostty native parent', () => {
       }
     )
 
-    expect(addon.setShortcutDigits).toHaveBeenCalledTimes(1)
+    expect(addon.setKeybindings).toHaveBeenCalledTimes(1)
 
     handlers.get(GHOSTTY_NATIVE_UPDATE)?.(
       { sender: {} },
@@ -1130,7 +1207,118 @@ describe('ghostty native parent', () => {
       }
     )
 
-    expect(addon.setShortcutDigits).toHaveBeenLastCalledWith(surface, '')
+    const inactiveKeybindings = JSON.parse(
+      String(addon.setKeybindings.mock.lastCall?.[1])
+    ) as { bindings: { id: string }[] }
+
+    expect(
+      inactiveKeybindings.bindings.filter(({ id }) =>
+        /^focus-pane-[1-9]$/.test(id)
+      )
+    ).toEqual([])
+
+    controller.dispose()
+  })
+
+  test('refreshes registry changes on live and newly created surfaces', () => {
+    const surfaces = [{ id: 'surface-1' }, { id: 'surface-2' }]
+    let createIndex = 0
+
+    const createSurface = (): object => {
+      const surface = surfaces.at(createIndex)
+      createIndex += 1
+      if (!surface) {
+        throw new Error('unexpected extra native surface')
+      }
+
+      return surface
+    }
+
+    const addon = {
+      create: vi.fn(createSurface),
+      setFrame: vi.fn(),
+      setFontFamily: vi.fn(),
+      setKeybindings: vi.fn(),
+      write: vi.fn(),
+      focus: vi.fn(),
+      destroy: vi.fn(),
+    }
+
+    const sidecar = {
+      invoke: <T>(): Promise<T> => Promise.resolve(undefined as T),
+      onEvent: vi.fn(() => vi.fn()),
+      shutdown: vi.fn(() => Promise.resolve()),
+    } satisfies Sidecar
+
+    const controller = setupGhosttyNativeParent({
+      sidecar,
+      platform: 'darwin',
+      env: { VITE_GHOSTTY_NATIVE_MACOS_PARENT: '1' },
+      addon,
+    })
+    const update = handlers.get(GHOSTTY_NATIVE_UPDATE)
+    const sender = {}
+
+    update?.(
+      { sender },
+      {
+        sessionId: 'pty-1',
+        paneId: 'pane-1',
+        cwd: '/tmp',
+        visible: true,
+        parentHeight: 900,
+        bounds: { x: 10, y: 20, width: 300, height: 200 },
+      }
+    )
+
+    const win = BrowserWindow.fromWebContents(sender as never)
+    expect(win).not.toBeNull()
+    if (!win) {
+      throw new Error('expected owning BrowserWindow')
+    }
+
+    setWorkspaceKeybindingSnapshot(win, {
+      version: 1,
+      bindings: DEFAULT_WORKSPACE_KEYBINDING_SNAPSHOT.bindings.map((binding) =>
+        binding.id === 'activity-panel-toggle'
+          ? { ...binding, code: 'KeyK', token: 'Mod+K' }
+          : binding
+      ),
+    })
+    controller.refreshKeybindings(win)
+
+    const refreshedKeybindings = JSON.parse(
+      String(addon.setKeybindings.mock.lastCall?.[1])
+    ) as { bindings: { id: string; code: string }[] }
+
+    expect(
+      refreshedKeybindings.bindings.find(
+        ({ id }) => id === 'activity-panel-toggle'
+      )?.code
+    ).toBe('KeyK')
+
+    update?.(
+      { sender },
+      {
+        sessionId: 'pty-2',
+        paneId: 'pane-2',
+        cwd: '/tmp',
+        visible: true,
+        parentHeight: 900,
+        bounds: { x: 310, y: 20, width: 300, height: 200 },
+      }
+    )
+
+    const newSurfaceKeybindings = JSON.parse(
+      String(addon.setKeybindings.mock.lastCall?.[1])
+    ) as { bindings: { id: string; code: string }[] }
+
+    expect(addon.create).toHaveBeenCalledTimes(2)
+    expect(
+      newSurfaceKeybindings.bindings.find(
+        ({ id }) => id === 'activity-panel-toggle'
+      )?.code
+    ).toBe('KeyK')
 
     controller.dispose()
   })
@@ -2022,7 +2210,8 @@ describe('ghostty native parent', () => {
         meta: boolean,
         alt: boolean,
         shift: boolean,
-        repeat: boolean
+        repeat: boolean,
+        fromSecondary?: boolean
       ) => void
     } = {}
     const surface = { id: 'surface-1' }
@@ -2038,8 +2227,11 @@ describe('ghostty native parent', () => {
       ),
       setFrame: vi.fn(),
       setFontFamily: vi.fn(),
+      addSecondary: vi.fn(),
+      setSecondaryVisible: vi.fn(),
       write: vi.fn(),
       focus: vi.fn(),
+      focusSecondary: vi.fn(),
       destroy: vi.fn(),
     }
 
@@ -2096,6 +2288,10 @@ describe('ghostty native parent', () => {
     expect(webContentsExecuteJavaScript.mock.calls[0]?.[0]).toContain(
       'data-workspace-overlay-id="pane-rename"'
     )
+
+    expect(webContentsExecuteJavaScript.mock.calls[0]?.[0]).toContain(
+      JSON.stringify(DIALOG_SELECTOR)
+    )
     expect(addon.focus).toHaveBeenCalledWith(surface)
 
     webContentsFocus.mockClear()
@@ -2130,6 +2326,21 @@ describe('ghostty native parent', () => {
     expect(webContentsFocus).toHaveBeenCalledOnce()
     expect(webContentsExecuteJavaScript).toHaveBeenCalledOnce()
     expect(webContentsExecuteJavaScript.mock.calls[0]?.[0]).toContain('KeyB')
+    expect(addon.focus).toHaveBeenCalledWith(surface)
+
+    webContentsFocus.mockClear()
+    webContentsExecuteJavaScript.mockClear()
+    addon.focus.mockClear()
+
+    callbacks.onShortcut?.('k', 'KeyK', false, true, false, false, false)
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0)
+    })
+
+    expect(webContentsFocus).toHaveBeenCalledOnce()
+    expect(webContentsExecuteJavaScript).toHaveBeenCalledOnce()
+    expect(webContentsExecuteJavaScript.mock.calls[0]?.[0]).toContain('KeyK')
     expect(addon.focus).toHaveBeenCalledWith(surface)
 
     webContentsFocus.mockClear()
@@ -2186,6 +2397,48 @@ describe('ghostty native parent', () => {
     expect(webContentsExecuteJavaScript.mock.calls[0]?.[0]).toContain(
       '"repeat":true'
     )
+
+    handlers.get(GHOSTTY_NATIVE_SECONDARY_ATTACH)?.(
+      { sender: {} },
+      {
+        sessionId: 'pty-1',
+        paneId: 'pane-1',
+        secondarySessionId: 'burner-pty',
+        placement: 'bottom',
+      }
+    )
+    webContentsFocus.mockClear()
+    webContentsExecuteJavaScript.mockClear()
+    addon.focus.mockClear()
+    addon.focusSecondary.mockClear()
+    webContentsExecuteJavaScript.mockResolvedValueOnce({
+      activeGhosttyPane: true,
+      dockHasFocus: false,
+    })
+
+    callbacks.onShortcut?.('b', 'KeyB', false, true, false, false, false, true)
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0)
+    })
+
+    expect(addon.focusSecondary).toHaveBeenCalledWith(surface)
+    expect(addon.focus).not.toHaveBeenCalled()
+
+    addon.focus.mockClear()
+    addon.focusSecondary.mockClear()
+    webContentsExecuteJavaScript.mockResolvedValueOnce({
+      activeGhosttyPane: true,
+      dockHasFocus: false,
+    })
+    callbacks.onShortcut?.('b', 'KeyB', false, true, false, false, false, false)
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0)
+    })
+
+    expect(addon.focus).toHaveBeenCalledWith(surface)
+    expect(addon.focusSecondary).not.toHaveBeenCalled()
 
     controller.dispose()
   })

--- a/electron/ghostty-native-parent.ts
+++ b/electron/ghostty-native-parent.ts
@@ -4,6 +4,7 @@ import { existsSync } from 'node:fs'
 import path from 'node:path'
 import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
+import { DIALOG_SELECTOR } from '../src/features/workspace/containerIds'
 import {
   GHOSTTY_NATIVE_DATA,
   GHOSTTY_NATIVE_DESTROY,
@@ -36,6 +37,7 @@ import {
   type GhosttyNativeShortcutContext,
   type GhosttyNativeUpdateRequest,
 } from './ghostty-native-shared'
+import { getWorkspaceKeybindingSnapshot } from './workspace-keybindings'
 
 interface GhosttyNativePayloadByKind {
   update: GhosttyNativeUpdateRequest
@@ -65,7 +67,8 @@ interface GhosttyNativeParentAddon {
       meta: boolean,
       alt: boolean,
       shift: boolean,
-      repeat: boolean
+      repeat: boolean,
+      fromSecondary?: boolean
     ) => void,
     onRenamePane: () => void
   ) => GhosttyNativeSurface
@@ -78,7 +81,7 @@ interface GhosttyNativeParentAddon {
     bottomCornerRadius: number,
     parentHeight: number
   ) => void
-  setShortcutDigits?: (surface: GhosttyNativeSurface, digits: string) => void
+  setKeybindings?: (surface: GhosttyNativeSurface, bindings: string) => void
   setBackgroundColor?: (surface: GhosttyNativeSurface, color: string) => void
   setForegroundColor?: (surface: GhosttyNativeSurface, color: string) => void
   setFontFamily?: (surface: GhosttyNativeSurface, fontFamily: string) => void
@@ -127,7 +130,8 @@ interface GhosttyNativeSurfaceState {
   lastResize: { cols: number; rows: number } | null
   resizeTimer: ReturnType<typeof setTimeout> | null
   pendingResize: { cols: number; rows: number } | null
-  lastShortcutDigits: string | null
+  shortcutContext: GhosttyNativeShortcutContext | null
+  lastKeybindings: string | null
 }
 
 interface GhosttyNativeSecondaryCallbacks {
@@ -159,6 +163,7 @@ interface GhosttyNativeShortcutInput {
 interface GhosttyNativeShortcutDispatchState {
   activeGhosttyPane: boolean
   dockHasFocus: boolean
+  dialogOpen?: boolean
 }
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -179,15 +184,18 @@ const GHOSTTY_RESIZE_THROTTLE_MS =
     ? throttleMsOverride
     : 16
 
-// Packaged macOS is the shipped Ghostty path. Dev and e2e still opt in with
-// VITE_GHOSTTY_NATIVE_MACOS_PARENT so ordinary local runs can keep the fallback.
+// Packaged macOS is the shipped Ghostty path. Dev and e2e still opt in so
+// ordinary local runs can keep the fallback. The old helper flag is retained
+// as an alias, but now selects this same parented NSView implementation.
 export const isGhosttyNativeParentEnabled = (
   platform: NodeJS.Platform = process.platform,
   env: NodeJS.ProcessEnv = process.env,
   packaged = false
 ): boolean =>
   platform === 'darwin' &&
-  (packaged || env.VITE_GHOSTTY_NATIVE_MACOS_PARENT === '1')
+  (packaged ||
+    env.VITE_GHOSTTY_NATIVE_MACOS_PARENT === '1' ||
+    env.VITE_GHOSTTY_NATIVE_MACOS === '1')
 
 const nativeParentDir = (packaged = false, resourcesPath = ''): string => {
   if (packaged) {
@@ -222,29 +230,15 @@ const isShortcutDispatchState = (
 ): value is GhosttyNativeShortcutDispatchState =>
   isRecord(value) &&
   typeof value.activeGhosttyPane === 'boolean' &&
-  typeof value.dockHasFocus === 'boolean'
+  typeof value.dockHasFocus === 'boolean' &&
+  (value.dialogOpen === undefined || typeof value.dialogOpen === 'boolean')
 
-// Keep this paired with GhosttyElectronBridge.workspaceShortcutByKeyCode until
-// VIM-294 replaces the native forwarding allowlist with a shared registry.
 const shouldRefocusGhosttyAfterWorkspaceShortcut = (
-  input: GhosttyNativeShortcutInput,
   dispatchState: GhosttyNativeShortcutDispatchState
-): boolean => {
-  if (!dispatchState.activeGhosttyPane || dispatchState.dockHasFocus) {
-    return false
-  }
-
-  return (
-    /^Digit[1-9]$/.test(input.code) ||
-    input.code === 'Backslash' ||
-    input.code === 'Digit0' ||
-    input.code === 'KeyB' ||
-    input.code === 'KeyE' ||
-    input.code === 'KeyG' ||
-    input.code === 'KeyN' ||
-    input.code === 'KeyZ'
-  )
-}
+): boolean =>
+  dispatchState.activeGhosttyPane &&
+  !dispatchState.dockHasFocus &&
+  dispatchState.dialogOpen !== true
 
 const isShortcutContext = (
   value: unknown
@@ -254,20 +248,33 @@ const isShortcutContext = (
   value.paneIds.every(isNonEmptyString) &&
   (value.activePaneId === null || isNonEmptyString(value.activePaneId))
 
-const shortcutDigitsForPane = (
+const serializedKeybindingsForPane = (
+  win: BrowserWindow,
   paneId: string,
   context: GhosttyNativeShortcutContext | null
 ): string => {
-  if (context?.activePaneId !== paneId) {
-    return ''
-  }
+  const snapshot = getWorkspaceKeybindingSnapshot(win)
 
-  return context.paneIds
-    .slice(0, 9)
-    .flatMap((targetPaneId, index) =>
-      targetPaneId === paneId ? [] : String(index + 1)
-    )
-    .join('')
+  const bindings = snapshot.bindings.filter((binding) => {
+    if (binding.context !== 'global') {
+      return false
+    }
+
+    const paneMatch = /^focus-pane-([1-9])$/.exec(binding.id)
+    if (paneMatch === null) {
+      return true
+    }
+
+    if (context?.activePaneId !== paneId) {
+      return false
+    }
+
+    const targetPaneId = context.paneIds.at(Number(paneMatch[1]) - 1)
+
+    return targetPaneId !== undefined && targetPaneId !== paneId
+  })
+
+  return JSON.stringify({ version: snapshot.version, bindings })
 }
 
 const loadAddon = (dir: string): GhosttyNativeParentAddon => {
@@ -455,6 +462,23 @@ export class GhosttyNativeParentController {
     this.windowClosedHandlers.clear()
   }
 
+  refreshKeybindings(win: BrowserWindow): void {
+    if (!this.enabled() || this.surfaces.size === 0) {
+      return
+    }
+
+    const addon = this.getOptionalAddon()
+    if (!addon?.setKeybindings) {
+      return
+    }
+
+    for (const state of this.surfaces.values()) {
+      if (state.ownerWindowId === win.id) {
+        this.applyKeybindings(addon, win, state)
+      }
+    }
+  }
+
   private update(
     sender: WebContents,
     payload: GhosttyNativeUpdateRequest
@@ -478,11 +502,7 @@ export class GhosttyNativeParentController {
     const state = this.getOrCreatePaneState(payload)
 
     const surface = this.getOrCreateSurface(addon, win, state)
-
-    const shortcutDigits = shortcutDigitsForPane(
-      state.pane.paneId,
-      payload.shortcutContext ?? null
-    )
+    state.shortcutContext = payload.shortcutContext ?? null
 
     const roundedWidth = Math.round(payload.bounds.width)
     const roundedHeight = Math.round(payload.bounds.height)
@@ -530,10 +550,7 @@ export class GhosttyNativeParentController {
       frame.bottomCornerRadius,
       frame.parentHeight
     )
-    if (state.lastShortcutDigits !== shortcutDigits) {
-      state.lastShortcutDigits = shortcutDigits
-      addon.setShortcutDigits?.(surface, shortcutDigits)
-    }
+    this.applyKeybindings(addon, win, state)
     if (state.pendingData.length > 0) {
       this.flushPendingData(addon, state)
     }
@@ -837,7 +854,8 @@ export class GhosttyNativeParentController {
       lastResize: null,
       resizeTimer: null,
       pendingResize: null,
-      lastShortcutDigits: null,
+      shortcutContext: null,
+      lastKeybindings: null,
     }
     this.surfaces.set(key, state)
 
@@ -924,7 +942,7 @@ export class GhosttyNativeParentController {
           payload: state.pane,
         })
       },
-      (shortcutKey, code, control, meta, alt, shift, repeat) => {
+      (shortcutKey, code, control, meta, alt, shift, repeat, fromSecondary) => {
         if (win.isDestroyed() || !this.surfaces.has(this.paneKey(state.pane))) {
           return
         }
@@ -948,15 +966,21 @@ export class GhosttyNativeParentController {
           return
         }
 
-        void this.forwardShortcutToAppRenderer(addon, win, state, {
-          key: shortcutKey,
-          code,
-          control,
-          meta,
-          alt,
-          shift,
-          repeat,
-        })
+        void this.forwardShortcutToAppRenderer(
+          addon,
+          win,
+          state,
+          {
+            key: shortcutKey,
+            code,
+            control,
+            meta,
+            alt,
+            shift,
+            repeat,
+          },
+          fromSecondary === true
+        )
       },
       () => {
         if (win.isDestroyed() || !this.surfaces.has(this.paneKey(state.pane))) {
@@ -1013,7 +1037,8 @@ export class GhosttyNativeParentController {
     addon: GhosttyNativeParentAddon,
     win: BrowserWindow,
     state: GhosttyNativeSurfaceState,
-    input: GhosttyNativeShortcutInput
+    input: GhosttyNativeShortcutInput,
+    fromSecondary: boolean
   ): Promise<void> {
     if (win.isDestroyed() || win.webContents.isDestroyed() || !state.surface) {
       return
@@ -1057,7 +1082,8 @@ export class GhosttyNativeParentController {
                 node.getAttribute('data-pane-id') === ${JSON.stringify(state.pane.paneId)} &&
                 node.getAttribute('data-pty-id') === ${JSON.stringify(state.pane.sessionId)}
               )
-              resolve({ activeGhosttyPane: !renameInputOpen && activeGhosttyPane, dockHasFocus })
+              const dialogOpen = document.querySelector(${JSON.stringify(DIALOG_SELECTOR)}) !== null
+              resolve({ activeGhosttyPane: !renameInputOpen && activeGhosttyPane, dockHasFocus, dialogOpen })
             })
           })
         })()`,
@@ -1066,7 +1092,7 @@ export class GhosttyNativeParentController {
 
       if (
         isShortcutDispatchState(shouldRefocus) &&
-        shouldRefocusGhosttyAfterWorkspaceShortcut(input, shouldRefocus)
+        shouldRefocusGhosttyAfterWorkspaceShortcut(shouldRefocus)
       ) {
         const key = this.paneKey(state.pane)
         const currentState = this.surfaces.get(key)
@@ -1074,8 +1100,16 @@ export class GhosttyNativeParentController {
         const currentSurface =
           currentState === state ? currentState.surface : null
 
-        if (currentSurface && !this.inputBlocked(win)) {
-          addon.focus(currentSurface)
+        if (currentSurface && win.isFocused() && !this.inputBlocked(win)) {
+          if (
+            fromSecondary &&
+            currentState?.secondary?.visible === true &&
+            addon.focusSecondary
+          ) {
+            addon.focusSecondary(currentSurface)
+          } else {
+            addon.focus(currentSurface)
+          }
         }
       }
     } catch {
@@ -1096,6 +1130,28 @@ export class GhosttyNativeParentController {
     for (const data of state.pendingData.splice(0)) {
       addon.write(state.surface, data)
     }
+  }
+
+  private applyKeybindings(
+    addon: GhosttyNativeParentAddon,
+    win: BrowserWindow,
+    state: GhosttyNativeSurfaceState
+  ): void {
+    if (!state.surface || !addon.setKeybindings) {
+      return
+    }
+
+    const keybindings = serializedKeybindingsForPane(
+      win,
+      state.pane.paneId,
+      state.shortcutContext
+    )
+    if (state.lastKeybindings === keybindings) {
+      return
+    }
+
+    state.lastKeybindings = keybindings
+    addon.setKeybindings(state.surface, keybindings)
   }
 
   // Leading+trailing throttle: forward immediately when idle, then hold a
@@ -1185,7 +1241,7 @@ export class GhosttyNativeParentController {
   private resetSurfaceScopedCaches(state: GhosttyNativeSurfaceState): void {
     state.lastBackgroundColor = null
     state.lastForegroundColor = null
-    state.lastShortcutDigits = null
+    state.lastKeybindings = null
   }
 
   private invokeSidecar(

--- a/electron/ipc-channels.ts
+++ b/electron/ipc-channels.ts
@@ -7,8 +7,6 @@ export const BACKEND_EVENT = 'backend:event'
 
 export const COMMAND_PALETTE_TOGGLE = 'command-palette:toggle'
 
-export const COMMAND_PALETTE_BINDING = 'command-palette:binding'
-
 export const KEYMAP_CAPTURE_ACTIVE = 'keymap:capture-active'
 
 export const E2E_COMMAND_PALETTE_SHORTCUT = 'e2e:command-palette-shortcut'

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -21,7 +21,6 @@ import {
 } from './csp'
 import {
   installCommandPaletteShortcutOverride,
-  setCommandPaletteShortcutBinding,
   setCommandPaletteShortcutBindings,
   setKeymapCaptureActive,
 } from './command-palette-shortcut'
@@ -30,7 +29,6 @@ import { installNavigationGuard } from './navigation-guard'
 import {
   BACKEND_EVENT,
   BACKEND_INVOKE,
-  COMMAND_PALETTE_BINDING,
   E2E_COMMAND_PALETTE_SHORTCUT,
   KEYMAP_CAPTURE_ACTIVE,
   SETTINGS_CHANGED,
@@ -47,11 +45,6 @@ import { spawnSidecar, type Sidecar } from './sidecar'
 import { setupBrowserPaneIpc, type BrowserPaneController } from './browser-pane'
 import { SettingsWindowController } from './settings-window'
 import {
-  isGhosttyNativeEnabled,
-  setupGhosttyNativeHelper,
-  type GhosttyNativeHelperController,
-} from './ghostty-native-helper'
-import {
   isGhosttyNativeParentEnabled,
   setupGhosttyNativeParent,
   type GhosttyNativeParentController,
@@ -65,6 +58,10 @@ import { WorkspaceLayoutWriter } from './workspace-layout-writer'
 import { WorkspaceTeardown } from './workspace-teardown'
 import { shouldQuitOnAllWindowsClosed } from './last-window-close'
 import type { PersistedTab } from './workspace-layout-types'
+import {
+  isWorkspaceKeybindingOverrides,
+  updateWorkspaceKeybindingsFromSettings,
+} from './workspace-keybindings'
 
 // Keep the GPU serving this window while it is occluded (covered by another
 // window) or unfocused. Chromium otherwise backgrounds the occluded window and
@@ -103,18 +100,6 @@ const E2E_RUNTIME_ARG = '--vimeflow-e2e'
 // Kept local to the main process so Electron startup never depends on a renderer
 // feature module that may later gain browser-only runtime imports.
 const SETTINGS_SCHEMA_VERSION = 1
-const COMMAND_PALETTE_BINDING_MAX_LENGTH = 64
-
-const isCommandPaletteBindingSync = (
-  value: unknown
-): value is { palette: string; leader: string } =>
-  typeof value === 'object' &&
-  value !== null &&
-  !Array.isArray(value) &&
-  'palette' in value &&
-  'leader' in value &&
-  typeof value.palette === 'string' &&
-  typeof value.leader === 'string'
 
 // E2E detection (env var OR CLI flag fallback). Hoisted above its first
 // caller (installContentSecurityPolicy at ~line 80) so the TDZ never
@@ -300,10 +285,7 @@ type InvokeEnvelope =
 
 let sidecar: Sidecar | null = null
 let browserPaneController: BrowserPaneController | null = null
-let ghosttyNativeController:
-  | GhosttyNativeHelperController
-  | GhosttyNativeParentController
-  | null = null
+let ghosttyNativeController: GhosttyNativeParentController | null = null
 // React DOM overlays in the main renderer can sit behind Ghostty's NSView;
 // this controller owns the separate native BrowserWindow used for those cases.
 let nativeOverlayController: NativeOverlayController | null = null
@@ -314,6 +296,32 @@ let settingsWindowController: SettingsWindowController | null = null
 let quitting = false
 let lastKnownOnLastWindowClosed: string | undefined
 
+const syncWorkspaceKeybindings = (settings: AppSettings): void => {
+  const win = workspaceWindow
+  if (!win || win.isDestroyed() || win.webContents.isDestroyed()) {
+    return
+  }
+
+  const snapshot = updateWorkspaceKeybindingsFromSettings(
+    win,
+    settings.customKeybindings
+  )
+  const palette = snapshot.bindings.find((entry) => entry.id === 'palette')
+
+  const leader = snapshot.bindings.find(
+    (entry) => entry.id === 'palette-leader'
+  )
+
+  if (palette && leader) {
+    setCommandPaletteShortcutBindings(win, {
+      palette: palette.token,
+      leader: leader.token,
+    })
+  }
+
+  ghosttyNativeController?.refreshKeybindings(win)
+}
+
 const RENDERER_DIAGNOSTIC_PREFIXES = [
   '[vimeflow:terminal-cwd]',
   '[vimeflow:git-branch]',
@@ -321,10 +329,6 @@ const RENDERER_DIAGNOSTIC_PREFIXES = [
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value)
-
-const isStringRecord = (value: unknown): value is Record<string, string> =>
-  isRecord(value) &&
-  Object.values(value).every((entry) => typeof entry === 'string')
 
 const isAppSettings = (value: unknown): value is AppSettings =>
   isRecord(value) &&
@@ -344,7 +348,7 @@ const isAppSettings = (value: unknown): value is AppSettings =>
   typeof value.reservoirSwell === 'string' &&
   typeof value.keymapPreset === 'string' &&
   typeof value.agentShimEnabled === 'boolean' &&
-  isStringRecord(value.customKeybindings)
+  isWorkspaceKeybindingOverrides(value.customKeybindings)
 
 const broadcastSettingsChanged = (
   settings: AppSettings,
@@ -546,15 +550,10 @@ const setupApp = async (): Promise<void> => {
     app.isPackaged
   )
 
-  const ghosttyNativeHelperEnabled = isGhosttyNativeEnabled(
-    process.platform,
-    process.env,
-    app.isPackaged
-  )
   if (ghosttyNativeParentEnabled) {
     // Preload checks process.env before exposing window.vimeflow.ghosttyNative.
-    // Set it here for packaged macOS so main, preload, and renderer agree on
-    // the shipped Ghostty runtime without requiring users to launch with env.
+    // Normalize packaged macOS and the deprecated helper flag so main,
+    // preload, and renderer agree on the parented Ghostty runtime.
     process.env.VITE_GHOSTTY_NATIVE_MACOS_PARENT = '1'
     ghosttyNativeController = setupGhosttyNativeParent({
       sidecar: spawnedSidecar,
@@ -562,11 +561,6 @@ const setupApp = async (): Promise<void> => {
       inputBlocked: (win) =>
         nativeOverlayController?.hasActiveInteractiveOverlaySurface(win) ===
         true,
-    })
-  } else if (ghosttyNativeHelperEnabled) {
-    ghosttyNativeController = setupGhosttyNativeHelper({
-      sidecar: spawnedSidecar,
-      packaged: app.isPackaged,
     })
   } else {
     ghosttyNativeController = null
@@ -663,29 +657,6 @@ const setupApp = async (): Promise<void> => {
     }
   })
 
-  ipcMain.on(COMMAND_PALETTE_BINDING, (ipcEvent, binding: unknown) => {
-    const win = BrowserWindow.fromWebContents(ipcEvent.sender)
-    if (win === null) {
-      return
-    }
-
-    if (typeof binding === 'string') {
-      if (binding.length <= COMMAND_PALETTE_BINDING_MAX_LENGTH) {
-        setCommandPaletteShortcutBinding(win, binding)
-      }
-
-      return
-    }
-
-    if (
-      isCommandPaletteBindingSync(binding) &&
-      binding.palette.length <= COMMAND_PALETTE_BINDING_MAX_LENGTH &&
-      binding.leader.length <= COMMAND_PALETTE_BINDING_MAX_LENGTH
-    ) {
-      setCommandPaletteShortcutBindings(win, binding)
-    }
-  })
-
   if (allowE2eBackendMethods) {
     ipcMain.handle(E2E_COMMAND_PALETTE_SHORTCUT, (ipcEvent): boolean => {
       const win = BrowserWindow.fromWebContents(ipcEvent.sender)
@@ -762,6 +733,7 @@ const setupApp = async (): Promise<void> => {
       }
 
       if (isAppSettings(settings)) {
+        syncWorkspaceKeybindings(settings)
         broadcastSettingsChanged(settings, ipcEvent.sender)
       }
     }

--- a/electron/preload-ghostty-env.test.ts
+++ b/electron/preload-ghostty-env.test.ts
@@ -72,7 +72,7 @@ describe('preload Ghostty env gating', () => {
     expect(ghosttyNative?.setSecondaryVisible).toEqual(expect.any(Function))
   })
 
-  test('omits secondary native methods in legacy helper mode', async () => {
+  test('routes the legacy flag to the complete parent native API', async () => {
     const api = await loadPreloadApi({
       VITE_GHOSTTY_NATIVE_MACOS: '1',
     })
@@ -87,10 +87,10 @@ describe('preload Ghostty env gating', () => {
       GHOSTTY_NATIVE_UPDATE,
       { sessionId: 'pty-1', paneId: 'pane-1' }
     )
-    expect(ghosttyNative?.attachSecondary).toBeUndefined()
-    expect(ghosttyNative?.secondaryData).toBeUndefined()
-    expect(ghosttyNative?.focusSecondary).toBeUndefined()
-    expect(ghosttyNative?.removeSecondary).toBeUndefined()
-    expect(ghosttyNative?.setSecondaryVisible).toBeUndefined()
+    expect(ghosttyNative?.attachSecondary).toEqual(expect.any(Function))
+    expect(ghosttyNative?.secondaryData).toEqual(expect.any(Function))
+    expect(ghosttyNative?.focusSecondary).toEqual(expect.any(Function))
+    expect(ghosttyNative?.removeSecondary).toEqual(expect.any(Function))
+    expect(ghosttyNative?.setSecondaryVisible).toEqual(expect.any(Function))
   })
 })

--- a/electron/preload.test.ts
+++ b/electron/preload.test.ts
@@ -19,7 +19,6 @@ import {
   BROWSER_PANE_URL_CHANGED,
 } from './browser-pane-channels'
 import {
-  COMMAND_PALETTE_BINDING,
   COMMAND_PALETTE_TOGGLE,
   DIALOG_PICK_DIRECTORY,
   E2E_COMMAND_PALETTE_SHORTCUT,
@@ -135,40 +134,6 @@ describe('preload browserPane wiring', () => {
 
   test('raises the shared ipcRenderer listener cap during preload startup', () => {
     expect(preloadSetMaxListenersCalls).toEqual([[64]])
-  })
-
-  test('setCommandPaletteBinding sends the resolved binding to main', () => {
-    const setCommandPaletteBinding = preloadApi().setCommandPaletteBinding as (
-      binding: string
-    ) => void
-
-    setCommandPaletteBinding('Mod+KeyK')
-
-    expect(electronMock.ipcRenderer.send).toHaveBeenCalledWith(
-      COMMAND_PALETTE_BINDING,
-      'Mod+KeyK'
-    )
-  })
-
-  test('setCommandPaletteBindings sends split palette bindings to main', () => {
-    const setCommandPaletteBindings = preloadApi()
-      .setCommandPaletteBindings as (bindings: {
-      palette: string
-      leader: string
-    }) => void
-
-    setCommandPaletteBindings({
-      palette: 'Mod+KeyP',
-      leader: 'Mod+KeyK',
-    })
-
-    expect(electronMock.ipcRenderer.send).toHaveBeenCalledWith(
-      COMMAND_PALETTE_BINDING,
-      {
-        palette: 'Mod+KeyP',
-        leader: 'Mod+KeyK',
-      }
-    )
   })
 
   test('e2e dispatchCommandPaletteShortcut invokes the e2e shortcut channel', async () => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -3,7 +3,6 @@ import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron'
 import {
   BACKEND_EVENT,
   BACKEND_INVOKE,
-  COMMAND_PALETTE_BINDING,
   COMMAND_PALETTE_TOGGLE,
   DIALOG_PICK_DIRECTORY,
   E2E_COMMAND_PALETTE_SHORTCUT,
@@ -70,11 +69,6 @@ const BACKEND_EVENT_MAX_LISTENERS = 64
 ipcRenderer.setMaxListeners(BACKEND_EVENT_MAX_LISTENERS)
 
 type CommandPaletteShortcutSource = 'palette' | 'leader'
-
-interface CommandPaletteBindingSync {
-  palette: string
-  leader: string
-}
 
 type InvokeEnvelope<T> =
   | { ok: true; result: T }
@@ -150,22 +144,11 @@ const setKeymapCaptureActive = (active: boolean): void => {
   ipcRenderer.send(KEYMAP_CAPTURE_ACTIVE, active)
 }
 
-const setCommandPaletteBinding = (binding: string): void => {
-  ipcRenderer.send(COMMAND_PALETTE_BINDING, binding)
-}
-
-const setCommandPaletteBindings = (
-  bindings: CommandPaletteBindingSync
-): void => {
-  ipcRenderer.send(COMMAND_PALETTE_BINDING, bindings)
-}
-
 const isNativeGhosttyPreloadEnabled =
   process.env.VITE_GHOSTTY_NATIVE_MACOS === '1' ||
   process.env.VITE_GHOSTTY_NATIVE_MACOS_PARENT === '1'
 
-const isNativeGhosttyParentPreloadEnabled =
-  process.env.VITE_GHOSTTY_NATIVE_MACOS_PARENT === '1'
+const isNativeGhosttyParentPreloadEnabled = isNativeGhosttyPreloadEnabled
 
 const ghosttyNativeBridge = isNativeGhosttyPreloadEnabled
   ? {
@@ -213,8 +196,6 @@ contextBridge.exposeInMainWorld('vimeflow', {
   listen,
   onCommandPaletteToggle,
   setKeymapCaptureActive,
-  setCommandPaletteBinding,
-  setCommandPaletteBindings,
   ...e2eBridge,
   browserPane: {
     createPane: (request: unknown): Promise<unknown> =>

--- a/electron/workspace-keybindings.test.ts
+++ b/electron/workspace-keybindings.test.ts
@@ -1,0 +1,97 @@
+import type { BrowserWindow } from 'electron'
+import { describe, expect, test } from 'vitest'
+import { CATALOG } from '../src/features/keymap/catalog'
+import { createWorkspaceKeybindingSnapshot } from '../src/features/keymap/snapshot'
+import {
+  DEFAULT_WORKSPACE_KEYBINDING_SNAPSHOT,
+  getWorkspaceKeybindingSnapshot,
+  isWorkspaceKeybindingOverrides,
+  setWorkspaceKeybindingSnapshot,
+  updateWorkspaceKeybindingsFromSettings,
+} from './workspace-keybindings'
+
+const fakeWindow = (): BrowserWindow => ({}) as BrowserWindow
+
+describe('workspace keybinding snapshots by window', () => {
+  test('falls back to the current-platform default snapshot', () => {
+    expect(getWorkspaceKeybindingSnapshot(fakeWindow())).toBe(
+      DEFAULT_WORKSPACE_KEYBINDING_SNAPSHOT
+    )
+
+    expect(DEFAULT_WORKSPACE_KEYBINDING_SNAPSHOT.bindings).toHaveLength(
+      CATALOG.length
+    )
+  })
+
+  test('stores snapshots independently per window', () => {
+    const first = fakeWindow()
+    const second = fakeWindow()
+
+    const snapshot = createWorkspaceKeybindingSnapshot(
+      { 'activity-panel-toggle': 'Mod+KeyK' },
+      'darwin'
+    )
+
+    setWorkspaceKeybindingSnapshot(first, snapshot)
+
+    expect(getWorkspaceKeybindingSnapshot(first)).toBe(snapshot)
+    expect(getWorkspaceKeybindingSnapshot(second)).toBe(
+      DEFAULT_WORKSPACE_KEYBINDING_SNAPSHOT
+    )
+  })
+
+  test('updates a window directly from settings overrides', () => {
+    const win = fakeWindow()
+
+    const snapshot = updateWorkspaceKeybindingsFromSettings(
+      win,
+      { 'activity-panel-toggle': 'Mod+Alt+KeyK' },
+      'darwin'
+    )
+
+    expect(getWorkspaceKeybindingSnapshot(win)).toBe(snapshot)
+    expect(
+      snapshot.bindings.find((entry) => entry.id === 'activity-panel-toggle')
+    ).toEqual(
+      expect.objectContaining({
+        code: 'KeyK',
+        meta: true,
+        alt: true,
+      })
+    )
+  })
+})
+
+describe('workspace keybinding override validation', () => {
+  test('accepts the backend entry and character limits', () => {
+    const bindings = Object.fromEntries(
+      Array.from({ length: 256 }, (_, index) => [
+        `command-${String(index)}`,
+        'x'.repeat(128),
+      ])
+    )
+
+    expect(isWorkspaceKeybindingOverrides(bindings)).toBe(true)
+    expect(
+      isWorkspaceKeybindingOverrides({
+        ['😀'.repeat(128)]: '😀'.repeat(128),
+      })
+    ).toBe(true)
+  })
+
+  test.each([
+    [
+      'too many entries',
+      Object.fromEntries(
+        Array.from({ length: 257 }, (_, index) => [
+          `command-${String(index)}`,
+          'Mod+KeyK',
+        ])
+      ),
+    ],
+    ['an oversized command', { ['x'.repeat(129)]: 'Mod+KeyK' }],
+    ['an oversized binding', { command: 'x'.repeat(129) }],
+  ])('rejects %s', (_label, bindings) => {
+    expect(isWorkspaceKeybindingOverrides(bindings)).toBe(false)
+  })
+})

--- a/electron/workspace-keybindings.ts
+++ b/electron/workspace-keybindings.ts
@@ -1,0 +1,91 @@
+import type { BrowserWindow } from 'electron'
+import {
+  createWorkspaceKeybindingSnapshot,
+  type WorkspaceKeybindingOverrides,
+  type WorkspaceKeybindingSnapshot,
+} from '../src/features/keymap/snapshot'
+
+export { matchingWorkspaceKeybindings } from '../src/features/keymap/snapshot'
+
+const MAX_CUSTOM_KEYBINDINGS = 256
+const MAX_KEYBINDING_CHARS = 128
+
+const hasValidKeybindingLength = (value: string): boolean => {
+  const characters = value[Symbol.iterator]()
+
+  for (let count = 0; count <= MAX_KEYBINDING_CHARS; count += 1) {
+    if (characters.next().done === true) {
+      return true
+    }
+  }
+
+  return false
+}
+
+export const isWorkspaceKeybindingOverrides = (
+  value: unknown
+): value is WorkspaceKeybindingOverrides => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false
+  }
+
+  const record = value as Record<string, unknown>
+  let count = 0
+
+  for (const command in record) {
+    if (!Object.hasOwn(record, command)) {
+      continue
+    }
+
+    count += 1
+    if (count > MAX_CUSTOM_KEYBINDINGS) {
+      return false
+    }
+
+    const binding = record[command]
+    if (
+      typeof binding !== 'string' ||
+      !hasValidKeybindingLength(command) ||
+      !hasValidKeybindingLength(binding)
+    ) {
+      return false
+    }
+  }
+
+  return true
+}
+
+export const DEFAULT_WORKSPACE_KEYBINDING_SNAPSHOT =
+  createWorkspaceKeybindingSnapshot({}, process.platform)
+
+const snapshotsByWindow = new WeakMap<
+  BrowserWindow,
+  WorkspaceKeybindingSnapshot
+>()
+
+export const getWorkspaceKeybindingSnapshot = (
+  win: BrowserWindow
+): WorkspaceKeybindingSnapshot =>
+  snapshotsByWindow.get(win) ?? DEFAULT_WORKSPACE_KEYBINDING_SNAPSHOT
+
+export const setWorkspaceKeybindingSnapshot = (
+  win: BrowserWindow,
+  snapshot: WorkspaceKeybindingSnapshot
+): void => {
+  snapshotsByWindow.set(win, snapshot)
+}
+
+export const updateWorkspaceKeybindingsFromSettings = (
+  win: BrowserWindow,
+  customKeybindings: WorkspaceKeybindingOverrides,
+  platform: string = process.platform
+): WorkspaceKeybindingSnapshot => {
+  const snapshot = createWorkspaceKeybindingSnapshot(
+    customKeybindings,
+    platform
+  )
+
+  setWorkspaceKeybindingSnapshot(win, snapshot)
+
+  return snapshot
+}

--- a/native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift
+++ b/native/ghostty-helper/Sources/GhosttyElectronBridge/GhosttyElectronBridge.swift
@@ -26,6 +26,7 @@ public typealias VimeflowGhosttyShortcutCallback = @convention(c) (
     Bool,
     Bool,
     Bool,
+    Bool,
     Bool
 ) -> Void
 
@@ -298,7 +299,8 @@ private final class CallbackBox: @unchecked Sendable {
         meta: Bool,
         alt: Bool,
         shift: Bool,
-        repeatEvent: Bool
+        repeatEvent: Bool,
+        fromSecondary: Bool
     ) {
         key.withCString { keyPointer in
             code.withCString { codePointer in
@@ -310,7 +312,8 @@ private final class CallbackBox: @unchecked Sendable {
                     meta,
                     alt,
                     shift,
-                    repeatEvent
+                    repeatEvent,
+                    fromSecondary
                 )
             }
         }
@@ -409,35 +412,76 @@ private final class EmbeddedGhosttyChild {
 
 @MainActor
 private final class EmbeddedGhosttySurface: NSObject {
-    private static let shortcutDigitByKeyCode: [UInt16: Character] = [
-        18: "1",
-        19: "2",
-        20: "3",
-        21: "4",
-        23: "5",
-        22: "6",
-        26: "7",
-        28: "8",
-        25: "9"
-    ]
+    private struct KeybindingSnapshot: Decodable {
+        let version: Int
+        let bindings: [Keybinding]
+    }
 
-    // App-owned shortcuts must cross the AppKit -> Electron boundary while
-    // Ghostty has focus. VIM-294 tracks replacing this explicit list with a
-    // shared shortcut registry; Cmd+R/reload is still a later scope.
-    private static let workspaceShortcutByKeyCode: [UInt16: (key: String, code: String)] = [
-        5: ("g", "KeyG"),
-        6: ("z", "KeyZ"),
-        11: ("b", "KeyB"),
-        14: ("e", "KeyE"),
-        29: ("0", "Digit0"),
-        42: ("\\", "Backslash"),
-        45: ("n", "KeyN")
-    ]
+    private struct Keybinding: Decodable {
+        let context: String
+        let matchPolicy: String
+        let code: String
+        let control: Bool
+        let meta: Bool
+        let alt: Bool
+        let shift: Bool
 
-    private static let workspaceShortcutCodesAllowingExtraModifiers = Set([
-        "Digit0",
-        "Backslash"
-    ])
+        func matches(_ flags: NSEvent.ModifierFlags) -> Bool {
+            guard flags.contains(.control) == control,
+                  flags.contains(.command) == meta
+            else {
+                return false
+            }
+
+            if shift {
+                guard flags.contains(.shift) else { return false }
+            } else if matchPolicy == "exact" && flags.contains(.shift) {
+                return false
+            }
+
+            if alt {
+                guard flags.contains(.option) else { return false }
+            } else if matchPolicy == "exact" && flags.contains(.option) {
+                return false
+            }
+
+            return true
+        }
+    }
+
+    // NSEvent exposes the platform's physical key code while the shared
+    // registry uses KeyboardEvent.code. This table translates the keyboard
+    // vocabulary once; app commands never appear here.
+    private static let webCodeByMacKeyCode: [UInt16: String] = [
+        0: "KeyA", 1: "KeyS", 2: "KeyD", 3: "KeyF", 4: "KeyH",
+        5: "KeyG", 6: "KeyZ", 7: "KeyX", 8: "KeyC", 9: "KeyV",
+        10: "IntlBackslash", 11: "KeyB", 12: "KeyQ", 13: "KeyW",
+        14: "KeyE", 15: "KeyR", 16: "KeyY", 17: "KeyT",
+        18: "Digit1", 19: "Digit2", 20: "Digit3", 21: "Digit4",
+        22: "Digit6", 23: "Digit5", 24: "Equal", 25: "Digit9",
+        26: "Digit7", 27: "Minus", 28: "Digit8", 29: "Digit0",
+        30: "BracketRight", 31: "KeyO", 32: "KeyU",
+        33: "BracketLeft", 34: "KeyI", 35: "KeyP", 36: "Enter",
+        37: "KeyL", 38: "KeyJ", 39: "Quote", 40: "KeyK",
+        41: "Semicolon", 42: "Backslash", 43: "Comma", 44: "Slash",
+        45: "KeyN", 46: "KeyM", 47: "Period", 48: "Tab",
+        49: "Space", 50: "Backquote", 51: "Backspace", 53: "Escape",
+        64: "F17", 65: "NumpadDecimal", 67: "NumpadMultiply",
+        69: "NumpadAdd", 71: "NumLock", 75: "NumpadDivide",
+        76: "NumpadEnter", 78: "NumpadSubtract", 79: "F18", 80: "F19",
+        81: "NumpadEqual", 82: "Numpad0", 83: "Numpad1",
+        84: "Numpad2", 85: "Numpad3", 86: "Numpad4",
+        87: "Numpad5", 88: "Numpad6", 89: "Numpad7", 90: "F20",
+        91: "Numpad8", 92: "Numpad9", 93: "IntlYen", 94: "IntlRo",
+        95: "NumpadComma", 96: "F5", 97: "F6", 98: "F7", 99: "F3",
+        100: "F8", 101: "F9", 102: "Lang2", 103: "F11",
+        104: "Lang1", 105: "F13", 106: "F16", 107: "F14",
+        109: "F10", 110: "ContextMenu", 111: "F12", 113: "F15", 114: "Insert",
+        115: "Home", 116: "PageUp", 117: "Delete", 118: "F4",
+        119: "End", 120: "F2", 121: "PageDown", 122: "F1",
+        123: "ArrowLeft", 124: "ArrowRight", 125: "ArrowDown",
+        126: "ArrowUp"
+    ]
 
     private let parentView: NSView
     private let container = EmbeddedGhosttyContainerView(frame: .zero)
@@ -445,7 +489,7 @@ private final class EmbeddedGhosttySurface: NSObject {
     private var focusMonitor: Any?
     private var contextMenuMonitor: Any?
     private var shortcutMonitor: Any?
-    private var shortcutDigits = Set<Character>()
+    private var keybindingsByCode: [String: [Keybinding]] = [:]
     private var backgroundHexColor = "000000"
     private var foregroundHexColor = "ffffff"
     private var fontFamily: String?
@@ -567,14 +611,18 @@ private final class EmbeddedGhosttySurface: NSObject {
         container.isHidden = safeWidth <= 0 || safeHeight <= 0
     }
 
-    func setShortcutDigits(_ digits: String) {
-        shortcutDigits = Set(digits.filter { character in
-            guard let value = character.wholeNumberValue else {
-                return false
-            }
+    func setKeybindings(_ value: String) {
+        guard let data = value.data(using: .utf8),
+              let snapshot = try? JSONDecoder().decode(KeybindingSnapshot.self, from: data),
+              snapshot.version == 1
+        else {
+            keybindingsByCode = [:]
+            return
+        }
 
-            return (1...9).contains(value)
-        })
+        keybindingsByCode = Dictionary(grouping: snapshot.bindings.filter {
+            $0.context == "global"
+        }, by: \.code)
     }
 
     func setBackgroundColor(_ hexColor: String) {
@@ -991,60 +1039,27 @@ private final class EmbeddedGhosttySurface: NSObject {
         }
 
         let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-        guard flags.contains(.command), !flags.contains(.control) else {
+        guard let code = Self.webCodeByMacKeyCode[event.keyCode],
+              let binding = keybindingsByCode[code]?.first(where: {
+                  $0.matches(flags)
+              })
+        else {
             return false
         }
 
-        if !flags.contains(.option),
-           !flags.contains(.shift),
-           event.charactersIgnoringModifiers == ";" {
-            callbacks.forwardShortcut(
-                key: ";",
-                code: "Semicolon",
-                control: flags.contains(.control),
-                meta: flags.contains(.command),
-                alt: flags.contains(.option),
-                shift: flags.contains(.shift),
-                repeatEvent: event.isARepeat
-            )
-
-            return true
-        }
-
-        if let shortcut = Self.workspaceShortcutByKeyCode[event.keyCode] {
-            let allowsExtraModifiers =
-                Self.workspaceShortcutCodesAllowingExtraModifiers.contains(shortcut.code)
-            if allowsExtraModifiers || (!flags.contains(.option) && !flags.contains(.shift)) {
-                callbacks.forwardShortcut(
-                    key: shortcut.key,
-                    code: shortcut.code,
-                    control: flags.contains(.control),
-                    meta: flags.contains(.command),
-                    alt: flags.contains(.option),
-                    shift: flags.contains(.shift),
-                    repeatEvent: event.isARepeat
-                )
-
-                return true
-            }
-        }
-
-        guard let digit = Self.shortcutDigitByKeyCode[event.keyCode] else {
-            return false
-        }
-
-        guard shortcutDigits.contains(digit) else {
-            return false
-        }
+        let key = event.charactersIgnoringModifiers.flatMap {
+            $0.isEmpty ? nil : $0
+        } ?? code
 
         callbacks.forwardShortcut(
-            key: String(digit),
-            code: "Digit\(digit)",
+            key: key,
+            code: binding.code,
             control: flags.contains(.control),
             meta: flags.contains(.command),
             alt: flags.contains(.option),
             shift: flags.contains(.shift),
-            repeatEvent: event.isARepeat
+            repeatEvent: event.isARepeat,
+            fromSecondary: secondaryFocused
         )
 
         return true
@@ -1118,20 +1133,20 @@ public func vimeflowGhosttySetFrame(
     }
 }
 
-@_cdecl("vimeflow_ghostty_set_shortcut_digits")
-public func vimeflowGhosttySetShortcutDigits(
+@_cdecl("vimeflow_ghostty_set_keybindings")
+public func vimeflowGhosttySetKeybindings(
     _ surfacePointer: UnsafeMutableRawPointer?,
-    _ digitsPointer: UnsafePointer<CChar>?
+    _ bindingsPointer: UnsafePointer<CChar>?
 ) {
-    guard let surfacePointer, let digitsPointer else {
+    guard let surfacePointer, let bindingsPointer else {
         return
     }
 
     let pointer = SendablePointer(value: surfacePointer)
-    let digits = String(cString: digitsPointer)
+    let bindings = String(cString: bindingsPointer)
     mainActorSync {
         guard let surface = liveSurface(from: pointer) else { return }
-        surface.setShortcutDigits(digits)
+        surface.setKeybindings(bindings)
     }
 }
 

--- a/native/ghostty-parent/ghostty_native_parent.cc
+++ b/native/ghostty-parent/ghostty_native_parent.cc
@@ -16,7 +16,7 @@ using InputCallback = void (*)(void *, const unsigned char *, int);
 using ResizeCallback = void (*)(void *, int, int);
 using FocusCallback = void (*)(void *);
 using ShortcutCallback = void (*)(void *, const char *, const char *, bool,
-                                  bool, bool, bool, bool);
+                                  bool, bool, bool, bool, bool);
 using RenamePaneCallback = void (*)(void *);
 using CreateFn = void *(*)(void *, InputCallback, ResizeCallback,
                            FocusCallback, ShortcutCallback,
@@ -26,7 +26,7 @@ using CreateFn = void *(*)(void *, InputCallback, ResizeCallback,
 // plus styling and same-snapshot parent height for Swift's AppKit y-flip.
 using SetFrameFn = void (*)(
     void *, double, double, double, double, double, double);
-using SetShortcutDigitsFn = void (*)(void *, const char *);
+using SetKeybindingsFn = void (*)(void *, const char *);
 using SetBackgroundColorFn = void (*)(void *, const char *);
 using SetForegroundColorFn = void (*)(void *, const char *);
 using SetFontFamilyFn = void (*)(void *, const char *);
@@ -45,7 +45,7 @@ struct BridgeApi {
   std::string loaded_path;
   CreateFn create = nullptr;
   SetFrameFn set_frame = nullptr;
-  SetShortcutDigitsFn set_shortcut_digits = nullptr;
+  SetKeybindingsFn set_keybindings = nullptr;
   SetBackgroundColorFn set_background_color = nullptr;
   SetForegroundColorFn set_foreground_color = nullptr;
   SetFontFamilyFn set_font_family = nullptr;
@@ -92,6 +92,7 @@ struct ShortcutPayload {
   bool alt = false;
   bool shift = false;
   bool repeat = false;
+  bool from_secondary = false;
 };
 
 BridgeApi bridge;
@@ -209,8 +210,8 @@ bool EnsureBridge(napi_env env, const std::string &path) {
                  reinterpret_cast<void **>(&bridge.create)) &&
       LoadSymbol(env, "vimeflow_ghostty_set_frame",
                  reinterpret_cast<void **>(&bridge.set_frame)) &&
-      LoadSymbol(env, "vimeflow_ghostty_set_shortcut_digits",
-                 reinterpret_cast<void **>(&bridge.set_shortcut_digits)) &&
+      LoadSymbol(env, "vimeflow_ghostty_set_keybindings",
+                 reinterpret_cast<void **>(&bridge.set_keybindings)) &&
       LoadSymbol(env, "vimeflow_ghostty_set_background_color",
                  reinterpret_cast<void **>(&bridge.set_background_color)) &&
       LoadSymbol(env, "vimeflow_ghostty_set_foreground_color",
@@ -432,7 +433,8 @@ void OnFocus(void *context) {
 }
 
 void OnShortcut(void *context, const char *key, const char *code, bool control,
-                bool meta, bool alt, bool shift, bool repeat) {
+                bool meta, bool alt, bool shift, bool repeat,
+                bool from_secondary) {
   if (context == nullptr || key == nullptr || code == nullptr) {
     return;
   }
@@ -452,6 +454,7 @@ void OnShortcut(void *context, const char *key, const char *code, bool control,
   payload->alt = alt;
   payload->shift = shift;
   payload->repeat = repeat;
+  payload->from_secondary = from_secondary;
   if (napi_call_threadsafe_function(tsfn, payload.get(),
                                     napi_tsfn_nonblocking) == napi_ok) {
     payload.release();
@@ -526,7 +529,7 @@ void CallJsShortcut(napi_env env, napi_value callback, void *, void *data) {
   }
 
   napi_value global;
-  napi_value argv[7];
+  napi_value argv[8];
   if (napi_get_global(env, &global) == napi_ok &&
       napi_create_string_utf8(env, payload->key.data(), payload->key.size(),
                               &argv[0]) == napi_ok &&
@@ -536,9 +539,10 @@ void CallJsShortcut(napi_env env, napi_value callback, void *, void *data) {
       napi_get_boolean(env, payload->meta, &argv[3]) == napi_ok &&
       napi_get_boolean(env, payload->alt, &argv[4]) == napi_ok &&
       napi_get_boolean(env, payload->shift, &argv[5]) == napi_ok &&
-      napi_get_boolean(env, payload->repeat, &argv[6]) == napi_ok) {
+      napi_get_boolean(env, payload->repeat, &argv[6]) == napi_ok &&
+      napi_get_boolean(env, payload->from_secondary, &argv[7]) == napi_ok) {
     napi_value ignored;
-    napi_call_function(env, global, callback, 7, argv, &ignored);
+    napi_call_function(env, global, callback, 8, argv, &ignored);
   }
 }
 
@@ -764,12 +768,12 @@ napi_value SetFrame(napi_env env, napi_callback_info info) {
   return nullptr;
 }
 
-napi_value SetShortcutDigits(napi_env env, napi_callback_info info) {
+napi_value SetKeybindings(napi_env env, napi_callback_info info) {
   size_t argc = 2;
   napi_value args[2];
   napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
   if (argc < 2) {
-    return Throw(env, "setShortcutDigits(surface, digits) expected");
+    return Throw(env, "setKeybindings(surface, bindings) expected");
   }
 
   SurfaceHandle *surface = GetSurface(env, args[0]);
@@ -777,12 +781,12 @@ napi_value SetShortcutDigits(napi_env env, napi_callback_info info) {
     return nullptr;
   }
 
-  std::string digits;
-  if (!GetString(env, args[1], &digits)) {
+  std::string bindings;
+  if (!GetString(env, args[1], &bindings)) {
     return nullptr;
   }
 
-  bridge.set_shortcut_digits(surface->swift_surface, digits.c_str());
+  bridge.set_keybindings(surface->swift_surface, bindings.c_str());
 
   return nullptr;
 }
@@ -1077,8 +1081,8 @@ napi_value Init(napi_env env, napi_value exports) {
        nullptr},
       {"setFrame", nullptr, SetFrame, nullptr, nullptr, nullptr, napi_default,
        nullptr},
-      {"setShortcutDigits", nullptr, SetShortcutDigits, nullptr, nullptr,
-       nullptr, napi_default, nullptr},
+      {"setKeybindings", nullptr, SetKeybindings, nullptr, nullptr, nullptr,
+       napi_default, nullptr},
       {"setBackgroundColor", nullptr, SetBackgroundColor, nullptr, nullptr,
        nullptr, napi_default, nullptr},
       {"setForegroundColor", nullptr, SetForegroundColor, nullptr, nullptr,

--- a/scripts/smoke-ghostty-native-parent.js
+++ b/scripts/smoke-ghostty-native-parent.js
@@ -14,6 +14,7 @@ const bridgePath = join(nativeDir, 'libGhosttyElectronBridge.dylib')
 const expectedExports = [
   'create',
   'setFrame',
+  'setKeybindings',
   'write',
   'focus',
   'addSecondary',

--- a/src/features/browser/components/BrowserAddressBar.test.tsx
+++ b/src/features/browser/components/BrowserAddressBar.test.tsx
@@ -1,9 +1,28 @@
 import { test, expect, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render as rtlRender, screen, fireEvent } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { SettingsContext } from '../../settings/SettingsProvider'
+import { DEFAULT_SETTINGS } from '../../settings/store/settingsDefaults'
 import {
   BrowserAddressBar,
   type BrowserAddressBarProps,
 } from './BrowserAddressBar'
+
+const render = (
+  ui: ReactElement,
+  customKeybindings: Record<string, string> = {}
+): ReturnType<typeof rtlRender> =>
+  rtlRender(
+    <SettingsContext.Provider
+      value={{
+        settings: { ...DEFAULT_SETTINGS, customKeybindings },
+        saveError: null,
+        update: vi.fn(),
+      }}
+    >
+      {ui}
+    </SettingsContext.Provider>
+  )
 
 const baseProps: BrowserAddressBarProps = {
   committedUrl: 'https://github.com/winoooops/vimeflow',
@@ -90,4 +109,15 @@ test('the decorative lock icon is aria-hidden', () => {
   render(<BrowserAddressBar {...baseProps} />)
 
   expect(screen.getByText('lock')).toHaveAttribute('aria-hidden', 'true')
+})
+
+test('renders the resolved browser-location shortcut and ARIA binding', () => {
+  render(<BrowserAddressBar {...baseProps} />, {
+    'browser-location': 'Mod+Shift+KeyK',
+  })
+
+  expect(screen.getByText('Ctrl+Shift+K')).toBeInTheDocument()
+  expect(
+    screen.getByRole('button', { name: /Ctrl\+Shift\+K/ })
+  ).toHaveAttribute('aria-keyshortcuts', 'Control+Shift+K')
 })

--- a/src/features/browser/components/BrowserAddressBar.tsx
+++ b/src/features/browser/components/BrowserAddressBar.tsx
@@ -5,7 +5,12 @@ import {
   type KeyboardEvent,
   type ReactElement,
 } from 'react'
-import { isMacPlatform } from '../../../lib/formatShortcut'
+import { formatShortcut } from '../../../lib/formatShortcut'
+import {
+  chordToAriaShortcut,
+  chordToShortcutInput,
+} from '../../keymap/displayKey'
+import { useKeybindings } from '../../keymap/useKeybindings'
 import { BROWSER_IDENTITY } from '../browserIdentity'
 
 export interface BrowserAddressBarProps {
@@ -38,8 +43,6 @@ const splitUrl = (url: string): UrlSegments | null => {
   }
 }
 
-const shortcutHint = (): string => (isMacPlatform() ? '⌘L' : 'Ctrl+L')
-
 const PILL_CLASS =
   'mx-auto flex h-[29px] w-[min(520px,100%)] min-w-0 items-center gap-[9px] rounded-full bg-surface-container-lowest/60 px-3'
 
@@ -52,7 +55,17 @@ export const BrowserAddressBar = ({
   onSubmit,
   onCancel,
 }: BrowserAddressBarProps): ReactElement => {
+  const { bindingFor } = useKeybindings()
   const inputRef = useRef<HTMLInputElement>(null)
+  const browserLocationBinding = bindingFor('browser-location')
+
+  const browserLocationHint = formatShortcut(
+    chordToShortcutInput(browserLocationBinding)
+  )
+
+  const browserLocationAriaShortcut = chordToAriaShortcut(
+    browserLocationBinding
+  )
 
   useEffect(() => {
     if (!isEditing) {
@@ -103,7 +116,8 @@ export const BrowserAddressBar = ({
     <button
       type="button"
       onClick={onBeginEdit}
-      aria-label={`address bar — ${committedUrl}; press Enter or ${shortcutHint()} to edit`}
+      aria-label={`address bar — ${committedUrl}; press Enter or ${browserLocationHint} to edit`}
+      aria-keyshortcuts={browserLocationAriaShortcut}
       className={PILL_CLASS}
       style={pillStyle}
     >
@@ -127,7 +141,7 @@ export const BrowserAddressBar = ({
         )}
       </span>
       <span className="shrink-0 rounded-[5px] border border-outline-variant/20 bg-wash-subtle px-[5px] py-[2px] font-mono text-[9px] text-syn-comment">
-        {shortcutHint()}
+        {browserLocationHint}
       </span>
     </button>
   )

--- a/src/features/browser/components/BrowserPane.test.tsx
+++ b/src/features/browser/components/BrowserPane.test.tsx
@@ -9,6 +9,8 @@ import { emptyActivity } from '../../sessions/constants'
 import { BrowserPane, type BrowserPaneProps } from './BrowserPane'
 import { OverlayStackProvider } from '../../workspace/overlays/OverlayStackProvider'
 import { useOverlayRegistration } from '../../workspace/overlays/useOverlayRegistration'
+import { SettingsContext } from '../../settings/SettingsProvider'
+import { DEFAULT_SETTINGS } from '../../settings/store/settingsDefaults'
 
 const bridgeMocks = vi.hoisted(() => ({
   activateBrowserPaneTab: vi.fn().mockResolvedValue(undefined),
@@ -130,16 +132,26 @@ const OverlayProbe = ({ isOpen }: OverlayProbeProps): ReactElement | null => {
 
 interface BrowserPaneHarnessProps extends BrowserPaneProps {
   overlayOpen?: boolean
+  customKeybindings?: Record<string, string>
 }
 
 const BrowserPaneHarness = ({
   overlayOpen = false,
+  customKeybindings = {},
   ...props
 }: BrowserPaneHarnessProps): ReactElement => (
-  <OverlayStackProvider>
-    <OverlayProbe isOpen={overlayOpen} />
-    <BrowserPane {...props} />
-  </OverlayStackProvider>
+  <SettingsContext.Provider
+    value={{
+      settings: { ...DEFAULT_SETTINGS, customKeybindings },
+      saveError: null,
+      update: vi.fn(),
+    }}
+  >
+    <OverlayStackProvider>
+      <OverlayProbe isOpen={overlayOpen} />
+      <BrowserPane {...props} />
+    </OverlayStackProvider>
+  </SettingsContext.Provider>
 )
 
 interface UrlEvent {
@@ -782,8 +794,18 @@ describe('BrowserPane', () => {
     ).toBeInTheDocument()
   })
 
-  test('Cmd/Ctrl+L from the chrome enters address edit', async () => {
-    render(<BrowserPaneHarness session={session} pane={browserPane} isActive />)
+  test('the resolved browser-location shortcut enters address edit from chrome', async () => {
+    render(
+      <BrowserPaneHarness
+        session={session}
+        pane={browserPane}
+        isActive
+        customKeybindings={{
+          'browser-location': 'Mod+Shift+KeyK',
+        }}
+      />
+    )
+
     await waitFor(() => {
       expect(bridgeMocks.createBrowserPane).toHaveBeenCalledOnce()
     })
@@ -791,6 +813,13 @@ describe('BrowserPane', () => {
     fireEvent.keyDown(screen.getByTestId('browser-pane'), {
       code: 'KeyL',
       ctrlKey: true,
+    })
+    expect(screen.queryByLabelText('browser address')).toBeNull()
+
+    fireEvent.keyDown(screen.getByTestId('browser-pane'), {
+      code: 'KeyK',
+      ctrlKey: true,
+      shiftKey: true,
     })
 
     expect(screen.getByLabelText('browser address')).toBeInTheDocument()

--- a/src/features/browser/components/BrowserPane.tsx
+++ b/src/features/browser/components/BrowserPane.tsx
@@ -12,7 +12,7 @@ import {
   type ReactElement,
 } from 'react'
 import type { Pane, Session } from '../../sessions/types'
-import { isMacPlatform } from '../../../lib/formatShortcut'
+import { useKeybindings } from '../../keymap/useKeybindings'
 import {
   activateBrowserPaneTab,
   closeBrowserPaneTab,
@@ -86,6 +86,7 @@ export const BrowserPane = ({
   shortcutHint = undefined,
   showFocusHighlight = true,
 }: BrowserPaneProps): ReactElement => {
+  const { matches } = useKeybindings()
   const contentRef = useRef<HTMLDivElement>(null)
   const url = pane.browserUrl ?? DEFAULT_BROWSER_URL
   const initialUrlRef = useRef(url)
@@ -656,21 +657,12 @@ export const BrowserPane = ({
 
   const handleChromeKeyDown = useCallback(
     (event: KeyboardEvent<HTMLDivElement>): void => {
-      const withModifier = isMacPlatform()
-        ? event.metaKey && !event.ctrlKey
-        : event.ctrlKey && !event.metaKey
-      if (
-        withModifier &&
-        !event.altKey &&
-        !event.shiftKey &&
-        !event.repeat &&
-        event.code === 'KeyL'
-      ) {
+      if (!event.repeat && matches(event.nativeEvent, 'browser-location')) {
         event.preventDefault()
         setIsEditing(true)
       }
     },
-    []
+    [matches]
   )
 
   const isFocusVisible = showFocusHighlight && pane.active

--- a/src/features/browser/components/BrowserToolbar.test.tsx
+++ b/src/features/browser/components/BrowserToolbar.test.tsx
@@ -1,6 +1,28 @@
 import { test, expect, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render as rtlRender, screen, fireEvent } from '@testing-library/react'
+import type { ReactElement, ReactNode } from 'react'
+import { SettingsContext } from '../../settings/SettingsProvider'
+import { DEFAULT_SETTINGS } from '../../settings/store/settingsDefaults'
 import { BrowserToolbar, type BrowserToolbarProps } from './BrowserToolbar'
+
+const SettingsWrapper = ({
+  children,
+}: {
+  children: ReactNode
+}): ReactElement => (
+  <SettingsContext.Provider
+    value={{
+      settings: DEFAULT_SETTINGS,
+      saveError: null,
+      update: vi.fn(),
+    }}
+  >
+    {children}
+  </SettingsContext.Provider>
+)
+
+const render = (ui: ReactElement): ReturnType<typeof rtlRender> =>
+  rtlRender(ui, { wrapper: SettingsWrapper })
 
 const baseProps: BrowserToolbarProps = {
   committedUrl: 'https://example.com/',

--- a/src/features/diff/Panel.test.tsx
+++ b/src/features/diff/Panel.test.tsx
@@ -40,10 +40,52 @@ import {
 } from './services/pendingReviewRequests'
 import type { DiffLineAnnotation, FileDiffOptions } from '@pierre/diffs'
 import { themeService } from '../../theme'
+import type { Keybindings } from '../keymap/useKeybindings'
+
+const codeForKey = (key: string): string => {
+  if (/^[a-z]$/i.test(key)) {
+    return `Key${key.toUpperCase()}`
+  }
+
+  return (
+    {
+      '/': 'Slash',
+      '[': 'BracketLeft',
+      ']': 'BracketRight',
+    }[key] ?? key
+  )
+}
+
+const keyDown = (
+  target: Element | Document | Window,
+  init: KeyboardEventInit & { key: string }
+): boolean =>
+  fireEvent.keyDown(target, {
+    ...init,
+    code: init.code ?? codeForKey(init.key),
+  })
 
 // Mock the hooks
 vi.mock('./hooks/useGitStatus')
 vi.mock('./hooks/useFileDiff')
+vi.mock('../keymap/useKeybindings', async () => {
+  const { getCommand } = await import('../keymap/catalog')
+  const { eventMatchesChord } = await import('../keymap/match')
+  const { resolveDefault } = await import('../keymap/resolve')
+
+  const bindingFor: Keybindings['bindingFor'] = (id) =>
+    resolveDefault(getCommand(id), false)
+
+  const matches: Keybindings['matches'] = (event, id) =>
+    eventMatchesChord(event, bindingFor(id), 'ctrl', getCommand(id).matchPolicy)
+
+  return {
+    useKeybindings: (): Pick<Keybindings, 'bindingFor' | 'matches'> => ({
+      bindingFor,
+      matches,
+    }),
+  }
+})
 
 // Stub @pierre/diffs/react: the real MultiFileDiff mounts a Pierre web
 // component and runs Shiki inside a Web Worker, neither of which jsdom
@@ -476,7 +518,7 @@ describe('Panel', () => {
       )
       await screen.findByRole('dialog', { name: 'Finish feedback' })
 
-      await user.click(screen.getByRole('button', { name: 'Copy (c)' }))
+      await user.click(screen.getByRole('button', { name: 'Copy (C)' }))
 
       await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1))
       const payload = writeText.mock.calls[0][0] as string
@@ -786,20 +828,26 @@ describe('Panel', () => {
 
     expect(screen.queryByTestId('changed-files-pane')).not.toBeInTheDocument()
 
-    fireEvent.keyDown(screen.getByTestId('diff-populated-state'), { key: 'e' })
+    keyDown(screen.getByTestId('diff-populated-state'), { key: 'e' })
 
     expect(screen.getByTestId('changed-files-pane')).toBeInTheDocument()
 
-    fireEvent.keyDown(screen.getByTestId('diff-populated-state'), { key: 'e' })
+    keyDown(screen.getByTestId('diff-populated-state'), { key: 'e' })
 
     expect(screen.queryByTestId('changed-files-pane')).not.toBeInTheDocument()
 
-    fireEvent.keyDown(screen.getByTestId('diff-populated-state'), { key: 'E' })
+    keyDown(screen.getByTestId('diff-populated-state'), {
+      key: 'E',
+      shiftKey: true,
+    })
 
     expect(window.localStorage.getItem('vf-diff-files-open')).toBe('1')
     expect(screen.getByTestId('changed-files-pane')).toHaveClass('h-full')
 
-    fireEvent.keyDown(screen.getByTestId('diff-populated-state'), { key: 'E' })
+    keyDown(screen.getByTestId('diff-populated-state'), {
+      key: 'E',
+      shiftKey: true,
+    })
 
     expect(window.localStorage.getItem('vf-diff-files-open')).toBe('0')
     expect(screen.getByTestId('changed-files-pane')).toHaveClass('absolute')
@@ -843,7 +891,7 @@ describe('Panel', () => {
 
     render(<Panel />)
 
-    fireEvent.keyDown(screen.getByTestId('diff-populated-state'), { key: 'e' })
+    keyDown(screen.getByTestId('diff-populated-state'), { key: 'e' })
 
     await user.click(
       within(screen.getByTestId('changed-files-pane')).getByRole('button', {
@@ -902,7 +950,7 @@ describe('Panel', () => {
 
     render(<Panel />)
 
-    fireEvent.keyDown(screen.getByTestId('diff-populated-state'), { key: 'e' })
+    keyDown(screen.getByTestId('diff-populated-state'), { key: 'e' })
 
     const pinButton = within(
       screen.getByTestId('changed-files-pane')
@@ -912,7 +960,7 @@ describe('Panel', () => {
     })
     expect(pinButton).toHaveFocus()
 
-    fireEvent.keyDown(pinButton, { key: 'e' })
+    keyDown(pinButton, { key: 'e' })
 
     expect(screen.queryByTestId('changed-files-pane')).not.toBeInTheDocument()
     expect(screen.getByTestId('diff-populated-state')).toHaveFocus()
@@ -1056,7 +1104,7 @@ describe('Panel', () => {
 
     render(<Panel />)
 
-    fireEvent.keyDown(screen.getByTestId('diff-populated-state'), {
+    keyDown(screen.getByTestId('diff-populated-state'), {
       key: '/',
     })
 
@@ -1171,7 +1219,7 @@ describe('Panel', () => {
 
       render(<Panel />)
 
-      fireEvent.keyDown(screen.getByTestId('diff-populated-state'), {
+      keyDown(screen.getByTestId('diff-populated-state'), {
         key: 'e',
       })
       expect(screen.getByTestId('changed-files-pane')).toBeInTheDocument()
@@ -2517,14 +2565,14 @@ describe('Panel', () => {
         />
       )
 
-      fireEvent.keyDown(screen.getByTestId('multi-file-diff'), { key: 's' })
+      keyDown(screen.getByTestId('multi-file-diff'), { key: 's' })
 
       const confirm = await screen.findByRole('dialog', {
         name: 'Stage hunk?',
       })
       expect(stageFile).not.toHaveBeenCalled()
-      const noButton = within(confirm).getByRole('button', { name: 'No (n)' })
-      const yesButton = within(confirm).getByRole('button', { name: 'Yes (y)' })
+      const noButton = within(confirm).getByRole('button', { name: 'No (N)' })
+      const yesButton = within(confirm).getByRole('button', { name: 'Yes (Y)' })
       expect(noButton).toHaveClass('focus-visible:ring-1')
       expect(noButton).toHaveClass('focus-visible:ring-primary')
       expect(noButton).not.toHaveClass('focus-visible:ring-0')
@@ -2566,14 +2614,14 @@ describe('Panel', () => {
         />
       )
 
-      fireEvent.keyDown(screen.getByTestId('multi-file-diff'), { key: 'd' })
+      keyDown(screen.getByTestId('multi-file-diff'), { key: 'd' })
 
       const confirm = await screen.findByRole('dialog', {
         name: 'Discard hunk?',
       })
       expect(discardChanges).not.toHaveBeenCalled()
 
-      await user.click(within(confirm).getByRole('button', { name: 'Yes (y)' }))
+      await user.click(within(confirm).getByRole('button', { name: 'Yes (Y)' }))
 
       await waitFor(() => expect(discardChanges).toHaveBeenCalledTimes(1))
     })
@@ -2607,14 +2655,17 @@ describe('Panel', () => {
         />
       )
 
-      fireEvent.keyDown(screen.getByTestId('multi-file-diff'), { key: 'D' })
+      keyDown(screen.getByTestId('multi-file-diff'), {
+        key: 'D',
+        shiftKey: true,
+      })
 
       const confirm = await screen.findByRole('dialog', {
         name: 'Discard file?',
       })
       expect(discardChanges).not.toHaveBeenCalled()
 
-      await user.click(within(confirm).getByRole('button', { name: 'Yes (y)' }))
+      await user.click(within(confirm).getByRole('button', { name: 'Yes (Y)' }))
 
       await waitFor(() => expect(discardChanges).toHaveBeenCalledTimes(1))
       expect(discardChanges.mock.calls[0][1]).toBeUndefined()
@@ -2649,12 +2700,12 @@ describe('Panel', () => {
       )
 
       const diff = screen.getByTestId('multi-file-diff')
-      fireEvent.keyDown(diff, { key: 's' })
+      keyDown(diff, { key: 's' })
       expect(
         await screen.findByRole('dialog', { name: 'Stage hunk?' })
       ).toBeInTheDocument()
 
-      fireEvent.keyDown(document, { key: 'n' })
+      keyDown(document, { key: 'n' })
       expect(stageFile).not.toHaveBeenCalled()
       await waitFor(() =>
         expect(
@@ -2662,12 +2713,12 @@ describe('Panel', () => {
         ).not.toBeInTheDocument()
       )
 
-      fireEvent.keyDown(document, { key: 's' })
+      keyDown(document, { key: 's' })
       expect(
         await screen.findByRole('dialog', { name: 'Stage hunk?' })
       ).toBeInTheDocument()
 
-      fireEvent.keyDown(document, { key: 'y' })
+      keyDown(document, { key: 'y' })
 
       await waitFor(() => expect(stageFile).toHaveBeenCalledTimes(1))
     })
@@ -3178,7 +3229,7 @@ describe('Panel', () => {
       shadowRoot.append(additions)
       scrollBody.append(host)
 
-      fireEvent.keyDown(diff, { key: ']' })
+      keyDown(diff, { key: ']' })
       expect(
         screen.getByRole('group', { name: /hunk 2\/3/i })
       ).toBeInTheDocument()
@@ -3198,14 +3249,14 @@ describe('Panel', () => {
       scrollFirstHunkLineIntoView.mockClear()
       scrollLastHunkLineIntoView.mockClear()
 
-      fireEvent.keyDown(diff, { key: ']' })
+      keyDown(diff, { key: ']' })
       expect(
         screen.getByRole('group', { name: /hunk 3\/3/i })
       ).toBeInTheDocument()
       expect(diff.getAttribute('data-selected-lines-start')).toBe('50')
       expect(diff.getAttribute('data-selected-lines-side')).toBe('deletions')
 
-      fireEvent.keyDown(diff, { key: '[' })
+      keyDown(diff, { key: '[' })
       expect(
         screen.getByRole('group', { name: /hunk 2\/3/i })
       ).toBeInTheDocument()
@@ -3217,7 +3268,7 @@ describe('Panel', () => {
       })
       expect(scrollLastHunkLineIntoView).not.toHaveBeenCalled()
 
-      fireEvent.keyDown(diff, { key: 'i' })
+      keyDown(diff, { key: 'i' })
       expect(
         screen.getByRole('dialog', { name: /Comment on line R20/ })
       ).toBeInTheDocument()
@@ -3244,7 +3295,7 @@ describe('Panel', () => {
       expect(diff).toHaveAttribute('data-selected-lines-start', '20')
       expect(diff).toHaveAttribute('data-selected-lines-side', 'additions')
 
-      fireEvent.keyDown(diff, { key: ']' })
+      keyDown(diff, { key: ']' })
 
       expect(
         screen.getByRole('group', { name: /hunk 3\/3/i })
@@ -3271,7 +3322,7 @@ describe('Panel', () => {
         screen.getByRole('group', { name: /hunk 2\/3/i })
       ).toBeInTheDocument()
 
-      fireEvent.keyDown(diff, { key: ']' })
+      keyDown(diff, { key: ']' })
 
       expect(
         screen.getByRole('group', { name: /hunk 3\/3/i })
@@ -3689,7 +3740,7 @@ describe('Panel', () => {
         />
       )
 
-      fireEvent.keyDown(screen.getByTestId('multi-file-diff'), {
+      keyDown(screen.getByTestId('multi-file-diff'), {
         key: 'I',
         shiftKey: true,
       })
@@ -3734,7 +3785,7 @@ describe('Panel', () => {
         />
       )
 
-      fireEvent.keyDown(screen.getByTestId('multi-file-diff'), {
+      keyDown(screen.getByTestId('multi-file-diff'), {
         key: 'I',
         shiftKey: true,
       })
@@ -3788,7 +3839,7 @@ describe('Panel', () => {
         />
       )
 
-      fireEvent.keyDown(screen.getByTestId('multi-file-diff'), {
+      keyDown(screen.getByTestId('multi-file-diff'), {
         key: 'I',
         shiftKey: true,
       })
@@ -3803,7 +3854,7 @@ describe('Panel', () => {
       )
       await user.keyboard('{Enter}')
 
-      fireEvent.keyDown(screen.getByTestId('multi-file-diff'), {
+      keyDown(screen.getByTestId('multi-file-diff'), {
         key: 'U',
         shiftKey: true,
       })
@@ -3871,7 +3922,7 @@ describe('Panel', () => {
 
       setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
 
-      fireEvent.keyDown(screen.getByTestId('multi-file-diff'), {
+      keyDown(screen.getByTestId('multi-file-diff'), {
         key: 'U',
         shiftKey: true,
       })
@@ -3908,7 +3959,7 @@ describe('Panel', () => {
 
       const { rerender } = render(<Panel {...props} />)
 
-      fireEvent.keyDown(screen.getByTestId('multi-file-diff'), {
+      keyDown(screen.getByTestId('multi-file-diff'), {
         key: 'I',
         shiftKey: true,
       })
@@ -3992,11 +4043,11 @@ describe('Panel', () => {
 
       const diff = screen.getByTestId('multi-file-diff')
 
-      fireEvent.keyDown(diff, { key: 'j' })
+      keyDown(diff, { key: 'j' })
       expect(diff).toHaveAttribute('data-selected-lines-start', '2')
       expect(diff).toHaveAttribute('data-selected-lines-side', 'additions')
 
-      fireEvent.keyDown(diff, { key: 'k' })
+      keyDown(diff, { key: 'k' })
       expect(diff).toHaveAttribute('data-selected-lines-start', '1')
       expect(diff).toHaveAttribute('data-selected-lines-side', 'additions')
     })
@@ -4014,16 +4065,16 @@ describe('Panel', () => {
 
       const diff = screen.getByTestId('multi-file-diff')
 
-      fireEvent.keyDown(diff, { key: 'v' })
+      keyDown(diff, { key: 'v' })
       expect(diff).toHaveAttribute('data-selected-lines-start', '1')
       expect(diff).toHaveAttribute('data-selected-lines-end', '1')
 
-      fireEvent.keyDown(diff, { key: 'j' })
+      keyDown(diff, { key: 'j' })
       expect(diff).toHaveAttribute('data-selected-lines-start', '1')
       expect(diff).toHaveAttribute('data-selected-lines-end', '2')
       expect(diff).toHaveAttribute('data-selected-lines-side', 'additions')
 
-      fireEvent.keyDown(diff, { key: 'k' })
+      keyDown(diff, { key: 'k' })
       expect(diff).toHaveAttribute('data-selected-lines-start', '1')
       expect(diff).toHaveAttribute('data-selected-lines-end', '1')
     })
@@ -4139,7 +4190,7 @@ describe('Panel', () => {
 
       const diff = screen.getByTestId('multi-file-diff')
 
-      fireEvent.keyDown(diff, { key: 'j' })
+      keyDown(diff, { key: 'j' })
       expect(scrollSecondIntoView).toHaveBeenCalledWith({
         block: 'nearest',
         inline: 'nearest',
@@ -4147,7 +4198,7 @@ describe('Panel', () => {
 
       scrollBody.scrollTop = 100
 
-      fireEvent.keyDown(diff, { key: 'k' })
+      keyDown(diff, { key: 'k' })
       expect(scrollFirstIntoView).toHaveBeenCalledWith({
         block: 'start',
         inline: 'nearest',
@@ -4228,16 +4279,16 @@ describe('Panel', () => {
       scrollBody.append(host)
 
       const diff = screen.getByTestId('multi-file-diff')
-      fireEvent.keyDown(diff, { key: 'l' })
+      keyDown(diff, { key: 'l' })
       expect(scrollAdditionIntoView).toHaveBeenCalledWith({
         block: 'nearest',
         inline: 'nearest',
       })
 
-      fireEvent.keyDown(diff, { key: 'h' })
+      keyDown(diff, { key: 'h' })
       scrollDeletionIntoView.mockClear()
 
-      fireEvent.keyDown(diff, { key: 'j' })
+      keyDown(diff, { key: 'j' })
 
       expect(diff).toHaveAttribute('data-selected-lines-start', '1')
       expect(diff).toHaveAttribute('data-selected-lines-side', 'deletions')
@@ -4256,8 +4307,8 @@ describe('Panel', () => {
       setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
 
       const diff = screen.getByTestId('multi-file-diff')
-      fireEvent.keyDown(diff, { key: 'j' })
-      fireEvent.keyDown(diff, { key: 'i' })
+      keyDown(diff, { key: 'j' })
+      keyDown(diff, { key: 'i' })
 
       expect(
         screen.getByRole('dialog', { name: /Comment on line R2/ })
@@ -4294,9 +4345,9 @@ describe('Panel', () => {
       setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
 
       const diff = screen.getByTestId('multi-file-diff')
-      fireEvent.keyDown(diff, { key: 'v' })
-      fireEvent.keyDown(diff, { key: 'j' })
-      fireEvent.keyDown(diff, { key: 'i' })
+      keyDown(diff, { key: 'v' })
+      keyDown(diff, { key: 'j' })
+      keyDown(diff, { key: 'i' })
 
       const dialog = screen.getByRole('dialog', {
         name: /Comment on lines R1-R2/,
@@ -4344,9 +4395,9 @@ describe('Panel', () => {
       setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
 
       const diff = screen.getByTestId('multi-file-diff')
-      fireEvent.keyDown(diff, { key: 'j' })
-      fireEvent.keyDown(diff, { key: 'v' })
-      fireEvent.keyDown(diff, { key: 'j' })
+      keyDown(diff, { key: 'j' })
+      keyDown(diff, { key: 'v' })
+      keyDown(diff, { key: 'j' })
 
       expect(diff).toHaveAttribute('data-selected-lines-start', '2')
       expect(diff).toHaveAttribute('data-selected-lines-end', '3')
@@ -4473,8 +4524,8 @@ describe('Panel', () => {
       setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
 
       const diff = screen.getByTestId('multi-file-diff')
-      fireEvent.keyDown(diff, { key: 'v' })
-      fireEvent.keyDown(diff, { key: 'j' })
+      keyDown(diff, { key: 'v' })
+      keyDown(diff, { key: 'j' })
 
       expect(diff).toHaveAttribute('data-selected-lines-start', '1')
       expect(diff).toHaveAttribute('data-selected-lines-end', '2')
@@ -4495,7 +4546,7 @@ describe('Panel', () => {
         'comment-1',
         { text: 'Updated comment', category: 'change' }
       )
-      fireEvent.keyDown(diff, { key: 'i' })
+      keyDown(diff, { key: 'i' })
 
       expect(
         screen.getByRole('dialog', { name: /Comment on line R2/ })
@@ -4592,9 +4643,9 @@ describe('Panel', () => {
         setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
 
         const diff = screen.getByTestId('multi-file-diff')
-        fireEvent.keyDown(diff, { key: 'v' })
-        fireEvent.keyDown(diff, { key: 'j' })
-        fireEvent.keyDown(diff, { key: 'y' })
+        keyDown(diff, { key: 'v' })
+        keyDown(diff, { key: 'j' })
+        keyDown(diff, { key: 'y' })
         await waitFor(() =>
           expect(writeText).toHaveBeenCalledWith('alpha\nbeta')
         )
@@ -4618,7 +4669,7 @@ describe('Panel', () => {
 
       setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
 
-      fireEvent.keyDown(screen.getByTestId('multi-file-diff'), {
+      keyDown(screen.getByTestId('multi-file-diff'), {
         key: 'I',
         shiftKey: true,
       })
@@ -4654,7 +4705,7 @@ describe('Panel', () => {
       await user.keyboard('{Enter}')
 
       const diff = screen.getByTestId('multi-file-diff')
-      fireEvent.keyDown(diff, { key: 'u' })
+      keyDown(diff, { key: 'u' })
 
       const editTextarea = within(
         screen.getByRole('dialog', { name: /Comment on line R1/ })
@@ -4667,7 +4718,7 @@ describe('Panel', () => {
 
       expect(screen.getByText('Updated comment')).toBeInTheDocument()
 
-      fireEvent.keyDown(diff, { key: 'x' })
+      keyDown(diff, { key: 'x' })
 
       expect(screen.queryByText('Updated comment')).not.toBeInTheDocument()
     })
@@ -4714,8 +4765,8 @@ describe('Panel', () => {
       setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
 
       const diff = screen.getByTestId('multi-file-diff')
-      fireEvent.keyDown(diff, { key: 'u' })
-      fireEvent.keyDown(diff, { key: 'x' })
+      keyDown(diff, { key: 'u' })
+      keyDown(diff, { key: 'x' })
 
       expect(
         screen.queryByRole('dialog', { name: /Comment on line R1/ })
@@ -4737,7 +4788,7 @@ describe('Panel', () => {
       )
 
       const diff = screen.getByTestId('multi-file-diff')
-      fireEvent.keyDown(diff, { key: 'i' })
+      keyDown(diff, { key: 'i' })
 
       const textarea = within(
         screen.getByRole('dialog', { name: /Comment on line R1/ })
@@ -4776,10 +4827,10 @@ describe('Panel', () => {
       setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
 
       const diff = screen.getByTestId('multi-file-diff')
-      fireEvent.keyDown(diff, { key: 'j' })
+      keyDown(diff, { key: 'j' })
       expect(diff).toHaveAttribute('data-selected-lines-start', '2')
 
-      fireEvent.keyDown(diff, { key: 'i' })
+      keyDown(diff, { key: 'i' })
 
       const textarea = within(
         screen.getByRole('dialog', { name: /Comment on line R2/ })
@@ -4815,10 +4866,10 @@ describe('Panel', () => {
       )
 
       const diff = screen.getByTestId('multi-file-diff')
-      fireEvent.keyDown(diff, { key: 'n' })
+      keyDown(diff, { key: 'n' })
       expect(screen.getByTestId('diff-populated-state')).toHaveFocus()
 
-      fireEvent.keyDown(document, { key: 'p' })
+      keyDown(document, { key: 'p' })
 
       expect(onSelectedFileChange).toHaveBeenNthCalledWith(1, {
         path: 'src/bar.ts',
@@ -4876,7 +4927,7 @@ describe('Panel', () => {
         )
       ).toHaveFocus()
 
-      fireEvent.keyDown(document, { key: 'n' })
+      keyDown(document, { key: 'n' })
 
       expect(onSelectedFileChange).toHaveBeenCalledWith({
         path: 'src/bar.ts',
@@ -4931,7 +4982,7 @@ describe('Panel', () => {
         scrollBody.append(element)
       }
 
-      fireEvent.keyDown(screen.getByTestId('multi-file-diff'), {
+      keyDown(screen.getByTestId('multi-file-diff'), {
         key: 'd',
         ctrlKey: true,
       })
@@ -4940,7 +4991,7 @@ describe('Panel', () => {
       expect(diff).toHaveAttribute('data-selected-lines-start', '3')
       expect(screen.getByTestId('diff-populated-state')).toHaveFocus()
 
-      fireEvent.keyDown(document, { key: 'u', ctrlKey: true })
+      keyDown(document, { key: 'u', ctrlKey: true })
       expect(scrollBody.scrollTop).toBe(0)
       expect(diff).toHaveAttribute('data-selected-lines-start', '1')
     })
@@ -4959,7 +5010,7 @@ describe('Panel', () => {
       const diff = screen.getByTestId('multi-file-diff')
       expect(diff).toHaveAttribute('data-diff-style', 'split')
 
-      fireEvent.keyDown(diff, { key: 't' })
+      keyDown(diff, { key: 't' })
 
       expect(diff).toHaveAttribute('data-diff-style', 'unified')
     })
@@ -5014,27 +5065,27 @@ describe('Panel', () => {
 
       const diff = screen.getByTestId('multi-file-diff')
 
-      fireEvent.keyDown(diff, { key: 'j' })
+      keyDown(diff, { key: 'j' })
       expect(diff).toHaveAttribute('data-selected-lines-start', '2')
       expect(diff).toHaveAttribute('data-selected-lines-side', 'additions')
 
-      fireEvent.keyDown(diff, { key: 'k' })
+      keyDown(diff, { key: 'k' })
       expect(diff).toHaveAttribute('data-selected-lines-start', '1')
       expect(diff).toHaveAttribute('data-selected-lines-side', 'additions')
 
-      fireEvent.keyDown(diff, { key: 'h' })
+      keyDown(diff, { key: 'h' })
       expect(diff).toHaveAttribute('data-selected-lines-start', '1')
       expect(diff).toHaveAttribute('data-selected-lines-side', 'deletions')
 
-      fireEvent.keyDown(diff, { key: 'l' })
+      keyDown(diff, { key: 'l' })
       expect(diff).toHaveAttribute('data-selected-lines-start', '1')
       expect(diff).toHaveAttribute('data-selected-lines-side', 'additions')
 
-      fireEvent.keyDown(diff, { key: 'h' })
+      keyDown(diff, { key: 'h' })
       expect(diff).toHaveAttribute('data-selected-lines-start', '1')
       expect(diff).toHaveAttribute('data-selected-lines-side', 'deletions')
 
-      fireEvent.keyDown(diff, { key: 'i' })
+      keyDown(diff, { key: 'i' })
       expect(
         screen.getByRole('dialog', { name: /Comment on line L1/ })
       ).toBeInTheDocument()
@@ -5089,18 +5140,18 @@ describe('Panel', () => {
       setPaneWidth(SPLIT_MIN_WIDTH_PX + 100)
 
       const diff = screen.getByTestId('multi-file-diff')
-      fireEvent.keyDown(diff, { key: 't' })
+      keyDown(diff, { key: 't' })
       expect(diff).toHaveAttribute('data-diff-style', 'unified')
 
-      fireEvent.keyDown(diff, { key: 'j' })
+      keyDown(diff, { key: 'j' })
       expect(diff).toHaveAttribute('data-selected-lines-start', '1')
       expect(diff).toHaveAttribute('data-selected-lines-side', 'additions')
 
-      fireEvent.keyDown(diff, { key: 'j' })
+      keyDown(diff, { key: 'j' })
       expect(diff).toHaveAttribute('data-selected-lines-start', '2')
       expect(diff).toHaveAttribute('data-selected-lines-side', 'additions')
 
-      fireEvent.keyDown(diff, { key: 'k' })
+      keyDown(diff, { key: 'k' })
       expect(diff).toHaveAttribute('data-selected-lines-start', '1')
       expect(diff).toHaveAttribute('data-selected-lines-side', 'additions')
     })
@@ -5357,7 +5408,7 @@ describe('Panel', () => {
         />
       )
 
-      fireEvent.keyDown(screen.getByTestId('multi-file-diff'), { key: 'r' })
+      keyDown(screen.getByTestId('multi-file-diff'), { key: 'r' })
 
       expect(acceptLatestDiff).toHaveBeenCalledOnce()
     })
@@ -5386,7 +5437,7 @@ describe('Panel', () => {
         />
       )
 
-      fireEvent.keyDown(screen.getByTestId('multi-file-diff'), { key: 'r' })
+      keyDown(screen.getByTestId('multi-file-diff'), { key: 'r' })
 
       expect(acceptLatestDiff).not.toHaveBeenCalled()
     })
@@ -5480,7 +5531,7 @@ describe('Panel', () => {
         )
       })
 
-      fireEvent.keyDown(document, { key: 'n' })
+      keyDown(document, { key: 'n' })
 
       expect(onSelectedFileChange).toHaveBeenCalledWith({
         path: 'src/bar.ts',
@@ -5578,7 +5629,7 @@ describe('Panel', () => {
       // eslint-disable-next-line testing-library/no-node-access -- asserting the browser body-focus handoff was not reclaimed
       expect(document.activeElement).toBe(document.body)
 
-      fireEvent.keyDown(document, { key: 'n' })
+      keyDown(document, { key: 'n' })
 
       expect(onSelectedFileChange).not.toHaveBeenCalled()
     })
@@ -5681,7 +5732,7 @@ describe('Panel', () => {
 
         expect(screen.getByTestId('diff-populated-state')).toHaveFocus()
 
-        fireEvent.keyDown(document, { key: 'n' })
+        keyDown(document, { key: 'n' })
 
         expect(onSelectedFileChange).toHaveBeenCalledWith({
           path: 'src/bar.ts',
@@ -5957,7 +6008,7 @@ describe('Panel', () => {
         await screen.findByRole('button', { name: /finish feedback \(1\)/i })
       ).toBeInTheDocument()
 
-      await user.keyboard('Y')
+      await user.keyboard('{Shift>}y{/Shift}')
 
       const popover = await screen.findByRole('dialog', {
         name: 'Finish feedback',
@@ -5965,10 +6016,10 @@ describe('Panel', () => {
       expect(popover).toHaveTextContent(/Send 1 comment/)
 
       expect(
-        within(popover).getByRole('button', { name: 'Confirm (Y)' })
-      ).toHaveAttribute('aria-keyshortcuts', 'Y')
+        within(popover).getByRole('button', { name: 'Confirm (Shift+Y)' })
+      ).toHaveAttribute('aria-keyshortcuts', 'Shift+Y')
 
-      await user.keyboard('Y')
+      await user.keyboard('{Shift>}y{/Shift}')
 
       await waitFor(() => expect(writePty).toHaveBeenCalledTimes(1))
       await waitFor(() => expect(focusTerminal).toHaveBeenCalledOnce())
@@ -6079,7 +6130,7 @@ describe('Panel', () => {
       })
       expect(popover).toHaveTextContent(/Send 1 comment/)
 
-      await user.keyboard('Y')
+      await user.keyboard('{Shift>}y{/Shift}')
 
       await waitFor(() => expect(writePty).toHaveBeenCalledTimes(1))
       const [, payload] = writePty.mock.calls[0]
@@ -6274,7 +6325,7 @@ describe('Panel', () => {
         'Reply to the agent…'
       )
       await user.type(replyTextarea, 'How does that interact with resize?')
-      fireEvent.keyDown(replyTextarea, { key: 'Enter' })
+      keyDown(replyTextarea, { key: 'Enter' })
 
       // Confirm popover should open scoped to 1 comment.
       const popover = await screen.findByRole('dialog', {
@@ -6287,7 +6338,7 @@ describe('Panel', () => {
         within(popover).queryByRole('button', { name: /copy/i })
       ).not.toBeInTheDocument()
 
-      await user.keyboard('Y')
+      await user.keyboard('{Shift>}y{/Shift}')
 
       await waitFor(() => expect(writePty).toHaveBeenCalledTimes(1))
 
@@ -6488,10 +6539,10 @@ describe('Panel', () => {
         'Reply to the agent…'
       )
       await user.type(replyTextarea, 'Follow-up question')
-      fireEvent.keyDown(replyTextarea, { key: 'Enter' })
+      keyDown(replyTextarea, { key: 'Enter' })
 
       await screen.findByRole('dialog', { name: 'Finish feedback' })
-      await user.keyboard('Y')
+      await user.keyboard('{Shift>}y{/Shift}')
 
       // Write rejected — no comment inserted.
       await waitFor(() => expect(writePty).toHaveBeenCalledOnce())
@@ -6588,7 +6639,7 @@ describe('Panel', () => {
         'Reply to the agent…'
       )
       await user.type(replyTextarea, 'Typed draft text')
-      fireEvent.keyDown(replyTextarea, { key: 'Enter' })
+      keyDown(replyTextarea, { key: 'Enter' })
 
       const popover = await screen.findByRole('dialog', {
         name: 'Finish feedback',
@@ -6729,14 +6780,14 @@ describe('Panel', () => {
         'Reply to the agent…'
       )
       await user.type(replyTextarea, 'Sub-directory follow-up')
-      fireEvent.keyDown(replyTextarea, { key: 'Enter' })
+      keyDown(replyTextarea, { key: 'Enter' })
 
       const popover = await screen.findByRole('dialog', {
         name: 'Finish feedback',
       })
       expect(popover).toHaveTextContent(/Send 1 comment/)
 
-      await user.keyboard('Y')
+      await user.keyboard('{Shift>}y{/Shift}')
 
       await waitFor(() => expect(writePty).toHaveBeenCalledOnce())
 
@@ -6844,7 +6895,7 @@ describe('Panel', () => {
 
       expect(screen.getByTestId('diff-body-region')).toHaveClass('relative')
 
-      fireEvent.keyDown(screen.getByTestId('diff-populated-state'), {
+      keyDown(screen.getByTestId('diff-populated-state'), {
         key: '/',
       })
 
@@ -6880,7 +6931,7 @@ describe('Panel', () => {
       expect(button).not.toHaveClass('right-[72px]')
       expect(button).not.toHaveClass('top-10')
 
-      fireEvent.keyDown(screen.getByTestId('diff-populated-state'), {
+      keyDown(screen.getByTestId('diff-populated-state'), {
         key: '/',
       })
 
@@ -6893,7 +6944,7 @@ describe('Panel', () => {
 
     test('popup closes when the selected file goes away', async (): Promise<void> => {
       const { clearFiles } = renderPanel()
-      fireEvent.keyDown(screen.getByTestId('diff-populated-state'), {
+      keyDown(screen.getByTestId('diff-populated-state'), {
         key: '/',
       })
       await screen.findByRole('search')
@@ -6912,7 +6963,7 @@ describe('Panel', () => {
         screen.queryByRole('button', { name: /search in diff/i })
       ).not.toBeInTheDocument()
 
-      fireEvent.keyDown(screen.getByTestId('diff-populated-state'), {
+      keyDown(screen.getByTestId('diff-populated-state'), {
         key: '/',
       })
 
@@ -7029,7 +7080,7 @@ describe('Panel', () => {
 
       // Switch to changelist scope (already forced; this verifies the SegmentedControl rendered)
       expect(
-        screen.getByRole('group', { name: 'Review scope (f/a)' })
+        screen.getByRole('group', { name: 'Review scope' })
       ).toBeInTheDocument()
 
       // 'All changes (3)' should have aria-pressed=true (forced changelist — no active diff)
@@ -7038,7 +7089,11 @@ describe('Panel', () => {
       ).toHaveAttribute('aria-pressed', 'true')
 
       // Delegate via Y
-      await user.keyboard('Y')
+      fireEvent.keyDown(document, {
+        key: 'Y',
+        code: 'KeyY',
+        shiftKey: true,
+      })
 
       // Wait for writePty to be called (async arm)
       await waitFor(() => expect(writePty).toHaveBeenCalledTimes(1))
@@ -7147,7 +7202,7 @@ describe('Panel', () => {
 
       // Scope group must be present
       expect(
-        screen.getByRole('group', { name: 'Review scope (f/a)' })
+        screen.getByRole('group', { name: 'Review scope' })
       ).toBeInTheDocument()
 
       // No active diff → 'This file' must be disabled
@@ -7222,7 +7277,7 @@ describe('Panel', () => {
 
       // Scope control must be absent in the degenerate case
       expect(
-        screen.queryByRole('group', { name: 'Review scope (f/a)' })
+        screen.queryByRole('group', { name: 'Review scope' })
       ).not.toBeInTheDocument()
     })
 
@@ -7296,7 +7351,7 @@ describe('Panel', () => {
       ).toHaveAttribute('aria-pressed', 'true')
 
       // Press 'f' to switch to file scope
-      fireEvent.keyDown(document, { key: 'f' })
+      fireEvent.keyDown(document, { key: 'f', code: 'KeyF' })
 
       // 'This file' becomes the active scope
       await waitFor(() => {
@@ -7306,7 +7361,11 @@ describe('Panel', () => {
       })
 
       // Delegate via Y and assert single-file payload
-      await user.keyboard('Y')
+      fireEvent.keyDown(document, {
+        key: 'Y',
+        code: 'KeyY',
+        shiftKey: true,
+      })
 
       await waitFor(() => expect(writePty).toHaveBeenCalledTimes(1))
 

--- a/src/features/diff/Panel.tsx
+++ b/src/features/diff/Panel.tsx
@@ -84,6 +84,8 @@ import { ReviewCommentRow } from './components/ReviewCommentRow'
 import { ReviewLevelNotes } from './components/ReviewLevelNotes'
 import { DIFF_SEARCH_UNSAFE_CSS } from './search/diffSearchDom'
 import { DIFF_RANGE_BAR_UNSAFE_CSS } from './rangeBar/diffRangeBars'
+import { useKeybindings } from '../keymap/useKeybindings'
+import { chordToAriaShortcut, chordToShortcutInput } from '../keymap/displayKey'
 
 // One stable <style> injected into pierre's shadow tree: the search highlight
 // plus the persistent range-comment gutter bar (VIM-273). A module constant so
@@ -278,6 +280,8 @@ export const Panel = ({
   feedbackDispatch = undefined,
   feedbackOwnerKey = undefined,
 }: PanelProps): ReactElement => {
+  const { bindingFor, matches } = useKeybindings()
+
   const internalGitStatus = useGitStatus(cwd, {
     watch: true,
     enabled: gitStatus === undefined,
@@ -2543,6 +2547,7 @@ export const Panel = ({
         <Notifier
           toolbarProps={{
             ...toolbarSettingsProps,
+            bindingFor,
             diffMode: 'unstaged',
             currentFileIndex: -1,
             totalFiles: 0,
@@ -2601,6 +2606,7 @@ export const Panel = ({
       <Notifier
         toolbarProps={{
           ...toolbarSettingsProps,
+          bindingFor,
           diffMode: selectedFileStaged ? 'staged' : 'unstaged',
           totalHunks: hunkCount,
           focusedHunkIndex: clampedHunkIndex,
@@ -2644,6 +2650,7 @@ export const Panel = ({
         className="relative flex min-h-0 flex-1 overflow-hidden"
       >
         <ChangedFilesListSurface
+          bindingFor={bindingFor}
           files={effectiveFiles}
           selectedFile={
             effectiveSelectedFile !== null
@@ -2666,11 +2673,14 @@ export const Panel = ({
           <>
             {!diffSearch.isOpen ? (
               <DiffSearchButton
+                bindingFor={bindingFor}
                 fileHeaderVisible={fileHeaderVisible}
                 onOpen={diffSearch.open}
               />
             ) : null}
             <DiffSearchPopup
+              bindingFor={bindingFor}
+              matches={matches}
               open={diffSearch.isOpen}
               fileHeaderVisible={fileHeaderVisible}
               query={diffSearch.query}
@@ -2783,8 +2793,14 @@ export const Panel = ({
                     <ReviewCommentRow
                       key={annotation.metadata.id}
                       comment={annotation.metadata}
-                      editShortcut="Shift+U"
+                      editShortcut={chordToShortcutInput(
+                        bindingFor('diff-file-comment-update')
+                      )}
+                      editAriaKeyshortcuts={chordToAriaShortcut(
+                        bindingFor('diff-file-comment-update')
+                      )}
                       deleteShortcut={null}
+                      deleteAriaKeyshortcuts={null}
                       onSendNow={(): void => {
                         setFinishOpen(false)
                         setReplyDispatchThreadId(null)
@@ -2820,6 +2836,7 @@ export const Panel = ({
           ) : null}
           <ReviewLevelNotes ownerKey={feedbackOwnerKey} />
           <PanelBody
+            bindingFor={bindingFor}
             scrollBodyRef={diffScrollBodyRef}
             diffError={diffError}
             diffLoading={diffLoading}

--- a/src/features/diff/components/ChangedFilesList.test.tsx
+++ b/src/features/diff/components/ChangedFilesList.test.tsx
@@ -1,8 +1,14 @@
 import { describe, test, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
+import { getCommand, type CommandId } from '@/features/keymap/catalog'
+import type { Keybindings } from '@/features/keymap/useKeybindings'
+import { resolveDefault } from '@/features/keymap/resolve'
 import type { ChangedFile } from '../types'
 import { ChangedFilesList, ChangedFilesListSurface } from './ChangedFilesList'
+
+const bindingFor: Keybindings['bindingFor'] = (id: CommandId) =>
+  resolveDefault(getCommand(id), false)
 
 describe('ChangedFilesList', () => {
   const mockFiles: ChangedFile[] = [
@@ -32,6 +38,7 @@ describe('ChangedFilesList', () => {
   test('renders CHANGED FILES header', () => {
     render(
       <ChangedFilesList
+        bindingFor={bindingFor}
         files={mockFiles}
         selectedFile={null}
         onSelectFile={vi.fn()}
@@ -47,6 +54,7 @@ describe('ChangedFilesList', () => {
   test('renders file list with status glyphs, names, and directories', () => {
     render(
       <ChangedFilesList
+        bindingFor={bindingFor}
         files={mockFiles}
         selectedFile={null}
         onSelectFile={vi.fn()}
@@ -69,6 +77,7 @@ describe('ChangedFilesList', () => {
   test('displays insertion and deletion counts', () => {
     render(
       <ChangedFilesList
+        bindingFor={bindingFor}
         files={mockFiles}
         selectedFile={null}
         onSelectFile={vi.fn()}
@@ -89,6 +98,7 @@ describe('ChangedFilesList', () => {
   test('applies active file highlighting when selected', () => {
     render(
       <ChangedFilesList
+        bindingFor={bindingFor}
         files={mockFiles}
         selectedFile={{ path: 'src/components/NavBar.tsx', staged: false }}
         onSelectFile={vi.fn()}
@@ -109,6 +119,7 @@ describe('ChangedFilesList', () => {
 
     render(
       <ChangedFilesList
+        bindingFor={bindingFor}
         files={mockFiles}
         selectedFile={null}
         onSelectFile={vi.fn()}
@@ -125,12 +136,45 @@ describe('ChangedFilesList', () => {
     expect(onTogglePinned).toHaveBeenCalledOnce()
   })
 
+  test('shows resolved pin and file-comment shortcuts', () => {
+    const remappedBindingFor: Keybindings['bindingFor'] = (id) => {
+      if (id === 'diff-files-pin') {
+        return { code: 'ArrowDown', mods: new Set(['Shift']) }
+      }
+      if (id === 'diff-comment-file') {
+        return { code: 'ArrowUp', mods: new Set(['Alt']) }
+      }
+
+      return bindingFor(id)
+    }
+
+    render(
+      <ChangedFilesList
+        bindingFor={remappedBindingFor}
+        files={mockFiles}
+        selectedFile={null}
+        onSelectFile={vi.fn()}
+        onAddFileComment={vi.fn()}
+        onTogglePinned={vi.fn()}
+      />
+    )
+
+    expect(
+      screen.getByRole('button', { name: /pin changed files/i })
+    ).toHaveAttribute('aria-keyshortcuts', 'Shift+ArrowDown')
+
+    expect(
+      screen.getByRole('button', { name: 'Comment on file NavBar.tsx' })
+    ).toHaveAttribute('aria-keyshortcuts', 'Alt+ArrowUp')
+  })
+
   test('calls onSelectFile when file is clicked', async () => {
     const handleSelect = vi.fn()
     const user = userEvent.setup()
 
     render(
       <ChangedFilesList
+        bindingFor={bindingFor}
         files={mockFiles}
         selectedFile={null}
         onSelectFile={handleSelect}
@@ -151,6 +195,7 @@ describe('ChangedFilesList', () => {
 
     render(
       <ChangedFilesList
+        bindingFor={bindingFor}
         files={mockFiles}
         selectedFile={null}
         onSelectFile={handleSelect}
@@ -198,6 +243,7 @@ describe('ChangedFilesList', () => {
 
     render(
       <ChangedFilesList
+        bindingFor={bindingFor}
         files={orderedFiles}
         selectedFile={null}
         onSelectFile={vi.fn()}
@@ -217,6 +263,7 @@ describe('ChangedFilesList', () => {
   test('applies hover state styling', () => {
     render(
       <ChangedFilesList
+        bindingFor={bindingFor}
         files={mockFiles}
         selectedFile={null}
         onSelectFile={vi.fn()}
@@ -246,6 +293,7 @@ describe('ChangedFilesList', () => {
 
     render(
       <ChangedFilesList
+        bindingFor={bindingFor}
         files={longPathFile}
         selectedFile={null}
         onSelectFile={vi.fn()}
@@ -269,6 +317,7 @@ describe('ChangedFilesList', () => {
 
     render(
       <ChangedFilesList
+        bindingFor={bindingFor}
         files={directoryLikePath}
         selectedFile={null}
         onSelectFile={vi.fn()}
@@ -280,7 +329,12 @@ describe('ChangedFilesList', () => {
 
   test('renders empty state when no files', () => {
     render(
-      <ChangedFilesList files={[]} selectedFile={null} onSelectFile={vi.fn()} />
+      <ChangedFilesList
+        bindingFor={bindingFor}
+        files={[]}
+        selectedFile={null}
+        onSelectFile={vi.fn()}
+      />
     )
 
     const header = screen.getByText(/Changed Files/i)
@@ -294,6 +348,7 @@ describe('ChangedFilesList', () => {
   test('uses correct color for insertions (green) and deletions (red)', () => {
     const { container } = render(
       <ChangedFilesList
+        bindingFor={bindingFor}
         files={mockFiles}
         selectedFile={null}
         onSelectFile={vi.fn()}
@@ -334,6 +389,7 @@ describe('ChangedFilesList', () => {
 
     render(
       <ChangedFilesList
+        bindingFor={bindingFor}
         files={mmFiles}
         selectedFile={null}
         onSelectFile={onSelect}
@@ -373,6 +429,7 @@ describe('ChangedFilesList', () => {
 
     render(
       <ChangedFilesList
+        bindingFor={bindingFor}
         files={mmFiles}
         selectedFile={null}
         onSelectFile={vi.fn()}
@@ -404,8 +461,14 @@ describe('ChangedFilesListSurface', () => {
     const unpinned = false
     const hidden = false
 
+    const remappedBindingFor: Keybindings['bindingFor'] = (id) =>
+      id === 'diff-files-toggle'
+        ? { code: 'ArrowLeft', mods: new Set(['Shift']) }
+        : bindingFor(id)
+
     render(
       <ChangedFilesListSurface
+        bindingFor={remappedBindingFor}
         files={mockFiles}
         selectedFile={null}
         pinned={unpinned}
@@ -419,9 +482,12 @@ describe('ChangedFilesListSurface', () => {
       />
     )
 
-    await user.click(
-      screen.getByRole('button', { name: /show changed files \(1\)/i })
-    )
+    const edgeHint = screen.getByRole('button', {
+      name: /show changed files \(1\)/i,
+    })
+    expect(edgeHint).toHaveAttribute('aria-keyshortcuts', 'Shift+ArrowLeft')
+
+    await user.click(edgeHint)
 
     expect(onReveal).toHaveBeenCalled()
     expect(onToggle).not.toHaveBeenCalled()
@@ -436,6 +502,7 @@ describe('ChangedFilesListSurface', () => {
     render(
       <>
         <ChangedFilesListSurface
+          bindingFor={bindingFor}
           files={mockFiles}
           selectedFile={null}
           pinned={unpinned}

--- a/src/features/diff/components/ChangedFilesList.tsx
+++ b/src/features/diff/components/ChangedFilesList.tsx
@@ -1,10 +1,17 @@
 import { useRef } from 'react'
 import type { FocusEvent, ReactElement } from 'react'
 import { IconButton } from '@/components/IconButton'
+import {
+  chordToAriaShortcut,
+  chordToShortcutInput,
+} from '@/features/keymap/displayKey'
+import type { Keybindings } from '@/features/keymap/useKeybindings'
+import type { ShortcutInput } from '@/lib/formatShortcut'
 import { sumLines } from '../utils/sumLines'
 import type { ChangedFile } from '../types'
 
 export interface ChangedFilesListProps {
+  bindingFor: Keybindings['bindingFor']
   files: ChangedFile[]
   selectedFile: { path: string; staged: boolean } | null
   onSelectFile: (file: ChangedFile) => void
@@ -14,6 +21,7 @@ export interface ChangedFilesListProps {
 }
 
 interface ChangedFilesListSurfaceProps {
+  bindingFor: Keybindings['bindingFor']
   files: ChangedFile[]
   selectedFile: { path: string; staged: boolean } | null
   pinned: boolean
@@ -27,6 +35,8 @@ interface ChangedFilesListSurfaceProps {
 }
 
 interface ChangedFileItemProps {
+  commentAriaKeyshortcuts: string
+  commentShortcut: ShortcutInput
   file: ChangedFile
   selected: boolean
   onSelectFile: (file: ChangedFile) => void
@@ -68,6 +78,8 @@ const statusTone = (
 }
 
 const ChangedFileItem = ({
+  commentAriaKeyshortcuts,
+  commentShortcut,
   file,
   selected,
   onSelectFile,
@@ -123,7 +135,8 @@ const ChangedFileItem = ({
           icon="add_comment"
           label={`Comment on file ${fileName}`}
           size="sm"
-          shortcut={['Shift', 'I']}
+          shortcut={commentShortcut}
+          aria-keyshortcuts={commentAriaKeyshortcuts}
           onClick={(event): void => onAddFileComment(file, event.currentTarget)}
         />
       ) : null}
@@ -132,6 +145,7 @@ const ChangedFileItem = ({
 }
 
 interface ChangedFilesEdgeHintProps {
+  ariaKeyshortcuts: string
   count: number
   revealed: boolean
   onReveal: () => void
@@ -140,6 +154,7 @@ interface ChangedFilesEdgeHintProps {
 }
 
 const ChangedFilesEdgeHint = ({
+  ariaKeyshortcuts,
   count,
   revealed,
   onReveal,
@@ -176,7 +191,7 @@ const ChangedFilesEdgeHint = ({
     <button
       type="button"
       aria-label={`${revealed ? 'Hide' : 'Show'} changed files (${count})`}
-      aria-keyshortcuts="e"
+      aria-keyshortcuts={ariaKeyshortcuts}
       aria-expanded={revealed}
       data-testid="changed-files-edge-hint"
       className="absolute left-0 top-1/2 z-30 flex -translate-y-1/2 flex-col items-center gap-1 rounded-r-xl border border-l-0 border-outline-variant/25 bg-surface-container-high/70 px-1.5 py-2 text-on-surface shadow-xl backdrop-blur-[14px] backdrop-saturate-150 transition-all duration-200 hover:bg-surface-container-high focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
@@ -203,6 +218,7 @@ const ChangedFilesEdgeHint = ({
  * Displays all files with git changes, sorted by status.
  */
 export const ChangedFilesList = ({
+  bindingFor,
   files,
   selectedFile,
   onSelectFile,
@@ -211,6 +227,10 @@ export const ChangedFilesList = ({
   onTogglePinned = undefined,
 }: ChangedFilesListProps): ReactElement => {
   const totals = sumLines(files)
+  const commentShortcut = bindingFor('diff-comment-file')
+  const pinShortcut = bindingFor('diff-files-pin')
+  const commentShortcutInput = chordToShortcutInput(commentShortcut)
+  const commentAriaKeyshortcuts = chordToAriaShortcut(commentShortcut)
 
   return (
     <div className="flex h-full w-full flex-col overflow-hidden">
@@ -228,8 +248,8 @@ export const ChangedFilesList = ({
             label={pinned ? 'Unpin changed files' : 'Pin changed files'}
             pressed={pinned}
             size="sm"
-            shortcut={['Shift', 'E']}
-            aria-keyshortcuts="Shift+E"
+            shortcut={chordToShortcutInput(pinShortcut)}
+            aria-keyshortcuts={chordToAriaShortcut(pinShortcut)}
             onClick={onTogglePinned}
             className="text-on-surface-variant hover:text-primary"
           />
@@ -240,6 +260,8 @@ export const ChangedFilesList = ({
         {files.map((file) => (
           <ChangedFileItem
             key={`${file.path}:${file.staged}`}
+            commentAriaKeyshortcuts={commentAriaKeyshortcuts}
+            commentShortcut={commentShortcutInput}
             file={file}
             selected={
               selectedFile?.path === file.path &&
@@ -262,6 +284,7 @@ export const ChangedFilesList = ({
 }
 
 export const ChangedFilesListSurface = ({
+  bindingFor,
   files,
   selectedFile,
   pinned,
@@ -288,6 +311,7 @@ export const ChangedFilesListSurface = ({
 
   const list = (
     <ChangedFilesList
+      bindingFor={bindingFor}
       files={files}
       selectedFile={selectedFile}
       pinned={pinned}
@@ -311,6 +335,7 @@ export const ChangedFilesListSurface = ({
   return (
     <div className="contents" onBlur={handleBlur}>
       <ChangedFilesEdgeHint
+        ariaKeyshortcuts={chordToAriaShortcut(bindingFor('diff-files-toggle'))}
         count={files.length}
         revealed={revealed}
         onReveal={onReveal}

--- a/src/features/diff/components/CommitInfoPanel.test.tsx
+++ b/src/features/diff/components/CommitInfoPanel.test.tsx
@@ -1,9 +1,30 @@
 /* eslint-disable testing-library/no-container */
 /* eslint-disable testing-library/no-node-access */
 import { describe, test, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render as rtlRender, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import type { ReactElement, ReactNode } from 'react'
+import type { AppSettings } from '../../../bindings/AppSettings'
+import { SettingsContext } from '../../settings/SettingsProvider'
+import { DEFAULT_SETTINGS } from '../../settings/store/settingsDefaults'
 import CommitInfoPanel from './CommitInfoPanel'
+
+const render = (
+  ui: ReactElement,
+  customKeybindings: Record<string, string> = {}
+): ReturnType<typeof rtlRender> => {
+  const settings: AppSettings = { ...DEFAULT_SETTINGS, customKeybindings }
+
+  return rtlRender(ui, {
+    wrapper: ({ children }: { children: ReactNode }): ReactElement => (
+      <SettingsContext.Provider
+        value={{ settings, saveError: null, update: vi.fn() }}
+      >
+        {children}
+      </SettingsContext.Provider>
+    ),
+  })
+}
 
 describe('CommitInfoPanel', () => {
   const mockProps = {
@@ -140,6 +161,32 @@ describe('CommitInfoPanel', () => {
     screen.getByRole('button', { name: /submit review/i }).focus()
     await user.keyboard('{Shift>}y{/Shift}')
 
+    expect(onSubmitReview).toHaveBeenCalledOnce()
+  })
+
+  test('uses the customized submit-review binding and hint', () => {
+    const onSubmitReview = vi.fn()
+    render(<CommitInfoPanel {...mockProps} onSubmitReview={onSubmitReview} />, {
+      'diff-commit-review-submit': 'Alt+Enter',
+    })
+
+    const button = screen.getByRole('button', {
+      name: 'Submit Review (Alt+Enter)',
+    })
+    expect(button).toHaveAttribute('aria-keyshortcuts', 'Alt+Enter')
+
+    fireEvent.keyDown(button, {
+      key: 'Y',
+      code: 'KeyY',
+      shiftKey: true,
+    })
+    expect(onSubmitReview).not.toHaveBeenCalled()
+
+    fireEvent.keyDown(button, {
+      key: 'Enter',
+      code: 'Enter',
+      altKey: true,
+    })
     expect(onSubmitReview).toHaveBeenCalledOnce()
   })
 

--- a/src/features/diff/components/CommitInfoPanel.tsx
+++ b/src/features/diff/components/CommitInfoPanel.tsx
@@ -2,7 +2,13 @@ import type { ReactElement } from 'react'
 import { Chip } from '@/components/Chip'
 import { IconButton } from '@/components/IconButton'
 import { ProgressBar } from '@/components/ProgressBar'
+import {
+  chordToAriaShortcut,
+  chordToShortcutInput,
+} from '@/features/keymap/displayKey'
+import { useKeybindings } from '@/features/keymap/useKeybindings'
 import { TOOLTIP_SUPPRESSED } from '@/lib/constants'
+import { formatShortcut } from '@/lib/formatShortcut'
 
 export interface CommitInfoPanelProps {
   commitHash: string
@@ -65,137 +71,140 @@ const CommitInfoPanel = ({
   onToggle = (): void => {
     // Default no-op handler
   },
-}: CommitInfoPanelProps): ReactElement => (
-  <>
-    {/* Floating reopen button - only visible when panel is collapsed */}
-    <IconButton
-      icon="chevron_left"
-      label="Open commit info panel"
-      size="sm"
-      onClick={onToggle}
-      showTooltip={TOOLTIP_SUPPRESSED} // aria-label already exposes intent at viewport edge
-      className={`fixed right-0 top-14 z-30 w-8 h-12 bg-surface-container hover:bg-surface-container-high text-on-surface-variant text-lg rounded-none rounded-l-lg border-l border-y border-outline-variant/10 transition-all duration-300 ${
-        isOpen
-          ? 'opacity-0 pointer-events-none translate-x-full'
-          : 'opacity-100 translate-x-0'
-      }`}
-    />
+}: CommitInfoPanelProps): ReactElement => {
+  const { bindingFor, matches } = useKeybindings()
+  const submitShortcut = bindingFor('diff-commit-review-submit')
 
-    <aside
-      role="complementary"
-      aria-label="Commit info panel"
-      onKeyDownCapture={(event): void => {
-        if (
-          (event.key === 'Y' ||
-            (event.shiftKey && event.key.toLowerCase() === 'y')) &&
-          !event.ctrlKey &&
-          !event.metaKey &&
-          !event.altKey
-        ) {
-          event.preventDefault()
-          event.stopPropagation()
-          onSubmitReview()
-        }
-      }}
-      className={`w-[320px] h-screen fixed right-0 top-0 bg-surface-container-low border-l border-outline-variant/15 z-40 overflow-y-auto transition-all duration-300 ${
-        isOpen ? '' : 'translate-x-full'
-      }`}
-    >
-      <div className="p-6 space-y-6">
-        {/* Section Header */}
-        <h2 className="text-[10px] font-bold tracking-widest text-on-surface-variant uppercase flex items-center gap-2">
-          <span
-            className="material-symbols-outlined text-xs"
-            aria-hidden="true"
-          >
-            history
-          </span>
-          Commit Info
-        </h2>
+  const submitShortcutLabel = formatShortcut(
+    chordToShortcutInput(submitShortcut)
+  )
 
-        {/* Commit Hash Badge */}
-        <div>
-          <Chip
-            tone="custom"
-            size="custom"
-            radius="chip"
-            className="rounded bg-surface-container-highest px-2 py-1 font-label text-xs text-on-surface"
-          >
-            {commitHash}
-          </Chip>
-        </div>
+  return (
+    <>
+      {/* Floating reopen button - only visible when panel is collapsed */}
+      <IconButton
+        icon="chevron_left"
+        label="Open commit info panel"
+        size="sm"
+        onClick={onToggle}
+        showTooltip={TOOLTIP_SUPPRESSED} // aria-label already exposes intent at viewport edge
+        className={`fixed right-0 top-14 z-30 w-8 h-12 bg-surface-container hover:bg-surface-container-high text-on-surface-variant text-lg rounded-none rounded-l-lg border-l border-y border-outline-variant/10 transition-all duration-300 ${
+          isOpen
+            ? 'opacity-0 pointer-events-none translate-x-full'
+            : 'opacity-100 translate-x-0'
+        }`}
+      />
 
-        {/* Commit Message */}
-        <p className="text-sm font-medium text-on-surface leading-relaxed">
-          {commitMessage}
-        </p>
-
-        {/* Author Info */}
-        <div className="flex items-center gap-3">
-          {authorAvatar && (
-            <img
-              src={authorAvatar}
-              alt={`${authorName} avatar`}
-              className="w-8 h-8 rounded-full"
-            />
-          )}
-          <div className="flex flex-col">
-            <span className="text-xs font-medium text-on-surface">
-              {authorName}
+      <aside
+        role="complementary"
+        aria-label="Commit info panel"
+        onKeyDownCapture={(event): void => {
+          if (matches(event.nativeEvent, 'diff-commit-review-submit')) {
+            event.preventDefault()
+            event.stopPropagation()
+            onSubmitReview()
+          }
+        }}
+        className={`w-[320px] h-screen fixed right-0 top-0 bg-surface-container-low border-l border-outline-variant/15 z-40 overflow-y-auto transition-all duration-300 ${
+          isOpen ? '' : 'translate-x-full'
+        }`}
+      >
+        <div className="p-6 space-y-6">
+          {/* Section Header */}
+          <h2 className="text-[10px] font-bold tracking-widest text-on-surface-variant uppercase flex items-center gap-2">
+            <span
+              className="material-symbols-outlined text-xs"
+              aria-hidden="true"
+            >
+              history
             </span>
-            <span className="text-[10px] text-on-surface-variant">
-              {formatRelativeTime(timestamp)}
-            </span>
-          </div>
-        </div>
+            Commit Info
+          </h2>
 
-        {/* Progress Bars */}
-        <div className="space-y-4">
-          {/* Context Memory Progress */}
-          <div className="space-y-2">
-            <div className="flex justify-between text-[10px] font-label text-on-surface-variant">
-              <span>Context Memory</span>
-              <span>{contextMemoryPercent}%</span>
+          {/* Commit Hash Badge */}
+          <div>
+            <Chip
+              tone="custom"
+              size="custom"
+              radius="chip"
+              className="rounded bg-surface-container-highest px-2 py-1 font-label text-xs text-on-surface"
+            >
+              {commitHash}
+            </Chip>
+          </div>
+
+          {/* Commit Message */}
+          <p className="text-sm font-medium text-on-surface leading-relaxed">
+            {commitMessage}
+          </p>
+
+          {/* Author Info */}
+          <div className="flex items-center gap-3">
+            {authorAvatar && (
+              <img
+                src={authorAvatar}
+                alt={`${authorName} avatar`}
+                className="w-8 h-8 rounded-full"
+              />
+            )}
+            <div className="flex flex-col">
+              <span className="text-xs font-medium text-on-surface">
+                {authorName}
+              </span>
+              <span className="text-[10px] text-on-surface-variant">
+                {formatRelativeTime(timestamp)}
+              </span>
             </div>
-            <ProgressBar
-              label="Context Memory"
-              value={contextMemoryPercent}
-              height="sm"
-              tone="secondary"
-              gradient
-              className="bg-surface-container-highest"
-            />
           </div>
 
-          {/* Tokens Processed Progress */}
-          <div className="space-y-2">
-            <div className="flex justify-between text-[10px] font-label text-on-surface-variant">
-              <span>Tokens Processed</span>
-              <span>{tokensProcessedPercent}%</span>
+          {/* Progress Bars */}
+          <div className="space-y-4">
+            {/* Context Memory Progress */}
+            <div className="space-y-2">
+              <div className="flex justify-between text-[10px] font-label text-on-surface-variant">
+                <span>Context Memory</span>
+                <span>{contextMemoryPercent}%</span>
+              </div>
+              <ProgressBar
+                label="Context Memory"
+                value={contextMemoryPercent}
+                height="sm"
+                tone="secondary"
+                gradient
+                className="bg-surface-container-highest"
+              />
             </div>
-            <ProgressBar
-              label="Tokens Processed"
-              value={tokensProcessedPercent}
-              height="sm"
-              tone="primary"
-              gradient
-              className="bg-surface-container-highest"
-            />
-          </div>
-        </div>
 
-        {/* Submit Review CTA */}
-        <button
-          type="button"
-          aria-keyshortcuts="Y"
-          onClick={onSubmitReview}
-          className="w-full bg-gradient-to-br from-primary to-primary-container text-on-primary text-sm font-medium py-3 px-4 rounded-lg shadow-lg shadow-primary/20 hover:shadow-xl hover:shadow-primary/30 transition-shadow"
-        >
-          Submit Review (Y)
-        </button>
-      </div>
-    </aside>
-  </>
-)
+            {/* Tokens Processed Progress */}
+            <div className="space-y-2">
+              <div className="flex justify-between text-[10px] font-label text-on-surface-variant">
+                <span>Tokens Processed</span>
+                <span>{tokensProcessedPercent}%</span>
+              </div>
+              <ProgressBar
+                label="Tokens Processed"
+                value={tokensProcessedPercent}
+                height="sm"
+                tone="primary"
+                gradient
+                className="bg-surface-container-highest"
+              />
+            </div>
+          </div>
+
+          {/* Submit Review CTA */}
+          <button
+            type="button"
+            aria-keyshortcuts={chordToAriaShortcut(submitShortcut)}
+            onClick={onSubmitReview}
+            className="w-full bg-gradient-to-br from-primary to-primary-container text-on-primary text-sm font-medium py-3 px-4 rounded-lg shadow-lg shadow-primary/20 hover:shadow-xl hover:shadow-primary/30 transition-shadow"
+          >
+            Submit Review ({submitShortcutLabel})
+          </button>
+        </div>
+      </aside>
+    </>
+  )
+}
 
 export default CommitInfoPanel

--- a/src/features/diff/components/DiffSearchButton.test.tsx
+++ b/src/features/diff/components/DiffSearchButton.test.tsx
@@ -1,16 +1,29 @@
 import { describe, test, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { getCommand, type CommandId } from '@/features/keymap/catalog'
+import { resolveDefault } from '@/features/keymap/resolve'
+import type { Keybindings } from '@/features/keymap/useKeybindings'
 import { DiffSearchButton } from './DiffSearchButton'
 
 const fileHeaderHidden = false
 
+const bindingFor: Keybindings['bindingFor'] = (id: CommandId) =>
+  resolveDefault(getCommand(id), false)
+
 describe('DiffSearchButton', () => {
   test('renders an accessible search button and fires onOpen', async () => {
     const onOpen = vi.fn()
-    render(<DiffSearchButton fileHeaderVisible onOpen={onOpen} />)
+    render(
+      <DiffSearchButton
+        bindingFor={bindingFor}
+        fileHeaderVisible
+        onOpen={onOpen}
+      />
+    )
 
     const button = screen.getByRole('button', { name: /search in diff/i })
+    expect(button).toHaveAttribute('aria-keyshortcuts', '/')
     await userEvent.click(button)
 
     expect(onOpen).toHaveBeenCalledTimes(1)
@@ -18,7 +31,11 @@ describe('DiffSearchButton', () => {
 
   test('moves down while the pierre file header is visible', () => {
     const { rerender } = render(
-      <DiffSearchButton fileHeaderVisible onOpen={vi.fn()} />
+      <DiffSearchButton
+        bindingFor={bindingFor}
+        fileHeaderVisible
+        onOpen={vi.fn()}
+      />
     )
 
     const button = screen.getByRole('button', { name: /search in diff/i })
@@ -28,7 +45,11 @@ describe('DiffSearchButton', () => {
     expect(button).not.toHaveClass('top-1')
 
     rerender(
-      <DiffSearchButton fileHeaderVisible={fileHeaderHidden} onOpen={vi.fn()} />
+      <DiffSearchButton
+        bindingFor={bindingFor}
+        fileHeaderVisible={fileHeaderHidden}
+        onOpen={vi.fn()}
+      />
     )
 
     expect(button).toHaveClass('right-[22px]')

--- a/src/features/diff/components/DiffSearchButton.tsx
+++ b/src/features/diff/components/DiffSearchButton.tsx
@@ -1,7 +1,13 @@
 import type { ReactElement } from 'react'
 import { IconButton } from '@/components/IconButton'
+import {
+  chordToAriaShortcut,
+  chordToShortcutInput,
+} from '@/features/keymap/displayKey'
+import type { Keybindings } from '@/features/keymap/useKeybindings'
 
 interface DiffSearchButtonProps {
+  bindingFor: Keybindings['bindingFor']
   fileHeaderVisible: boolean
   onOpen: () => void
 }
@@ -11,16 +17,19 @@ interface DiffSearchButtonProps {
  * or below Pierre's file header when visible. Hover tints the icon only.
  */
 export const DiffSearchButton = ({
+  bindingFor,
   fileHeaderVisible,
   onOpen,
 }: DiffSearchButtonProps): ReactElement => {
   const topOffsetClass = fileHeaderVisible ? 'top-10' : 'top-1'
+  const shortcut = bindingFor('diff-search-open')
 
   return (
     <IconButton
       icon="search"
       label="Search in diff"
-      shortcut="/"
+      shortcut={chordToShortcutInput(shortcut)}
+      aria-keyshortcuts={chordToAriaShortcut(shortcut)}
       size="md"
       className={`absolute right-[22px] ${topOffsetClass} z-30 h-[34px] w-[34px] rounded-xl border border-outline-variant/25 bg-surface-container-high/30 text-on-surface-muted shadow-md backdrop-blur-[14px] backdrop-saturate-150 hover:bg-surface-container-high/30 hover:text-primary`}
       onClick={onOpen}

--- a/src/features/diff/components/DiffSearchPopup.test.tsx
+++ b/src/features/diff/components/DiffSearchPopup.test.tsx
@@ -1,12 +1,24 @@
 import { describe, test, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { createRef } from 'react'
+import { getCommand } from '@/features/keymap/catalog'
+import { eventMatchesChord } from '@/features/keymap/match'
+import { resolveDefault } from '@/features/keymap/resolve'
+import type { Keybindings } from '@/features/keymap/useKeybindings'
 import { DiffSearchPopup } from './DiffSearchPopup'
 
 const fileHeaderHidden = false
 
+const bindingFor: Keybindings['bindingFor'] = (id) =>
+  resolveDefault(getCommand(id), false)
+
+const matches: Keybindings['matches'] = (event, id) =>
+  eventMatchesChord(event, bindingFor(id), 'ctrl', getCommand(id).matchPolicy)
+
 const baseProps = {
+  bindingFor,
+  matches,
   open: true,
   fileHeaderVisible: true,
   query: '',
@@ -31,15 +43,16 @@ describe('DiffSearchPopup', () => {
 
     expect(
       screen.getByRole('button', { name: /previous match/i })
-    ).toBeInTheDocument()
+    ).toHaveAttribute('aria-keyshortcuts', 'p')
 
-    expect(
-      screen.getByRole('button', { name: /next match/i })
-    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /next match/i })).toHaveAttribute(
+      'aria-keyshortcuts',
+      'n'
+    )
 
     expect(
       screen.getByRole('button', { name: /close search/i })
-    ).toBeInTheDocument()
+    ).toHaveAttribute('aria-keyshortcuts', 'Escape')
   })
 
   test('counter states: empty query → blank; matches → k/N; none → 0/0', () => {
@@ -90,6 +103,62 @@ describe('DiffSearchPopup', () => {
     expect(onClose).toHaveBeenCalled()
   })
 
+  test('uses resolved search commit bindings and exposes them to assistive tech', () => {
+    const onCommit = vi.fn()
+
+    const remappedBindingFor: Keybindings['bindingFor'] = (id) => {
+      if (id === 'diff-search-commit-next') {
+        return { code: 'Enter', mods: new Set(['Alt']) }
+      }
+      if (id === 'diff-search-commit-previous') {
+        return { code: 'Enter', mods: new Set(['Alt', 'Shift']) }
+      }
+
+      return bindingFor(id)
+    }
+
+    const remappedMatches: Keybindings['matches'] = (event, id) =>
+      eventMatchesChord(
+        event,
+        remappedBindingFor(id),
+        'ctrl',
+        getCommand(id).matchPolicy
+      )
+
+    render(
+      <DiffSearchPopup
+        {...baseProps}
+        bindingFor={remappedBindingFor}
+        matches={remappedMatches}
+        onCommit={onCommit}
+      />
+    )
+
+    const input = screen.getByRole('textbox', { name: /search in diff/i })
+    expect(input).toHaveAttribute(
+      'aria-keyshortcuts',
+      'Alt+Enter Alt+Shift+Enter Escape'
+    )
+
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' })
+    expect(onCommit).not.toHaveBeenCalled()
+
+    fireEvent.keyDown(input, {
+      key: 'Enter',
+      code: 'Enter',
+      altKey: true,
+    })
+
+    fireEvent.keyDown(input, {
+      key: 'Enter',
+      code: 'Enter',
+      altKey: true,
+      shiftKey: true,
+    })
+    expect(onCommit).toHaveBeenNthCalledWith(1, 1)
+    expect(onCommit).toHaveBeenNthCalledWith(2, -1)
+  })
+
   test('Esc is inert while confirming (spec §3)', async () => {
     const onClose = vi.fn()
     render(<DiffSearchPopup {...baseProps} confirming onClose={onClose} />)
@@ -99,6 +168,83 @@ describe('DiffSearchPopup', () => {
       '{Escape}'
     )
     expect(onClose).not.toHaveBeenCalled()
+  })
+
+  test('uses the resolved close-search binding while the input is focused', () => {
+    const onClose = vi.fn()
+
+    const remappedBindingFor: Keybindings['bindingFor'] = (id) =>
+      id === 'diff-search-or-visual-cancel'
+        ? { code: 'ArrowDown', mods: new Set(['Shift']) }
+        : bindingFor(id)
+
+    const remappedMatches: Keybindings['matches'] = (event, id) =>
+      eventMatchesChord(
+        event,
+        remappedBindingFor(id),
+        'ctrl',
+        getCommand(id).matchPolicy
+      )
+
+    render(
+      <DiffSearchPopup
+        {...baseProps}
+        bindingFor={remappedBindingFor}
+        matches={remappedMatches}
+        onClose={onClose}
+      />
+    )
+
+    const input = screen.getByRole('textbox', { name: /search in diff/i })
+    const close = screen.getByRole('button', { name: /close search/i })
+
+    expect(close).toHaveAttribute('aria-keyshortcuts', 'Shift+ArrowDown')
+
+    fireEvent.keyDown(input, { key: 'Escape', code: 'Escape' })
+    expect(onClose).not.toHaveBeenCalled()
+
+    fireEvent.keyDown(input, {
+      key: 'ArrowDown',
+      code: 'ArrowDown',
+      shiftKey: true,
+    })
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  test('a remapped Enter closes without also committing the search', () => {
+    const onClose = vi.fn()
+    const onCommit = vi.fn()
+
+    const remappedBindingFor: Keybindings['bindingFor'] = (id) =>
+      id === 'diff-search-or-visual-cancel'
+        ? { code: 'Enter', mods: new Set() }
+        : bindingFor(id)
+
+    const remappedMatches: Keybindings['matches'] = (event, id) =>
+      eventMatchesChord(
+        event,
+        remappedBindingFor(id),
+        'ctrl',
+        getCommand(id).matchPolicy
+      )
+
+    render(
+      <DiffSearchPopup
+        {...baseProps}
+        bindingFor={remappedBindingFor}
+        matches={remappedMatches}
+        onClose={onClose}
+        onCommit={onCommit}
+      />
+    )
+
+    fireEvent.keyDown(
+      screen.getByRole('textbox', { name: /search in diff/i }),
+      { key: 'Enter', code: 'Enter' }
+    )
+
+    expect(onClose).toHaveBeenCalledOnce()
+    expect(onCommit).not.toHaveBeenCalled()
   })
 
   test('typing forwards to onQueryChange', async () => {

--- a/src/features/diff/components/DiffSearchPopup.tsx
+++ b/src/features/diff/components/DiffSearchPopup.tsx
@@ -1,7 +1,14 @@
 import type { KeyboardEvent, ReactElement, RefObject } from 'react'
 import { IconButton } from '@/components/IconButton'
+import {
+  chordToAriaShortcut,
+  chordToShortcutInput,
+} from '@/features/keymap/displayKey'
+import type { Keybindings } from '@/features/keymap/useKeybindings'
 
 interface DiffSearchPopupProps {
+  bindingFor: Keybindings['bindingFor']
+  matches: Keybindings['matches']
   open: boolean
   fileHeaderVisible: boolean
   query: string
@@ -10,7 +17,7 @@ interface DiffSearchPopupProps {
   confirming: boolean
   inputRef: RefObject<HTMLInputElement | null>
   onQueryChange: (query: string) => void
-  /** Enter (1) / Shift+Enter (-1) from the input. Distinct from onStep: the
+  /** Forward (1) / backward (-1) commit binding from the input. Distinct from onStep: the
    * first commit after typing jumps to the already-active match without
    * advancing and hands focus back to the diff so n/p take over; later
    * commits step in the given direction (vim search flow, spec §3). */
@@ -24,6 +31,8 @@ interface DiffSearchPopupProps {
  * NOT the shared Popover (spec §2 primitive-choice + UNIFIED.md exception).
  */
 export const DiffSearchPopup = ({
+  bindingFor,
+  matches,
   open,
   fileHeaderVisible,
   query,
@@ -37,20 +46,37 @@ export const DiffSearchPopup = ({
   onClose,
 }: DiffSearchPopupProps): ReactElement => {
   const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>): void => {
-    if (event.key === 'Enter') {
+    if (matches(event.nativeEvent, 'diff-search-or-visual-cancel')) {
       event.preventDefault()
-      onCommit(event.shiftKey ? -1 : 1)
-    }
-
-    if (event.key === 'Escape') {
       event.stopPropagation()
       if (!confirming) {
         onClose()
       }
+
+      return
+    }
+
+    const commitDirection = matches(
+      event.nativeEvent,
+      'diff-search-commit-previous'
+    )
+      ? -1
+      : matches(event.nativeEvent, 'diff-search-commit-next')
+        ? 1
+        : null
+
+    if (commitDirection !== null) {
+      event.preventDefault()
+      onCommit(commitDirection)
     }
   }
 
   const topOffsetClass = fileHeaderVisible ? 'top-10' : 'top-1'
+  const previousShortcut = bindingFor('diff-file-previous')
+  const nextShortcut = bindingFor('diff-file-next')
+  const closeShortcut = bindingFor('diff-search-or-visual-cancel')
+  const commitNextShortcut = bindingFor('diff-search-commit-next')
+  const commitPreviousShortcut = bindingFor('diff-search-commit-previous')
 
   return (
     <div
@@ -66,6 +92,13 @@ export const DiffSearchPopup = ({
         ref={inputRef}
         type="text"
         aria-label="Search in diff"
+        aria-keyshortcuts={[
+          commitNextShortcut,
+          commitPreviousShortcut,
+          closeShortcut,
+        ]
+          .map((shortcut) => chordToAriaShortcut(shortcut))
+          .join(' ')}
         placeholder="Search in diff…"
         // eslint-disable-next-line react/jsx-boolean-value -- false is a meaningful DOM attribute value here, not a prop to omit
         spellCheck={false}
@@ -86,18 +119,24 @@ export const DiffSearchPopup = ({
         icon="keyboard_arrow_up"
         label="Previous match"
         size="sm"
+        shortcut={chordToShortcutInput(previousShortcut)}
+        aria-keyshortcuts={chordToAriaShortcut(previousShortcut)}
         onClick={(): void => onStep(-1)}
       />
       <IconButton
         icon="keyboard_arrow_down"
         label="Next match"
         size="sm"
+        shortcut={chordToShortcutInput(nextShortcut)}
+        aria-keyshortcuts={chordToAriaShortcut(nextShortcut)}
         onClick={(): void => onStep(1)}
       />
       <IconButton
         icon="close"
         label="Close search"
         size="sm"
+        shortcut={chordToShortcutInput(closeShortcut)}
+        aria-keyshortcuts={chordToAriaShortcut(closeShortcut)}
         onClick={onClose}
       />
     </div>

--- a/src/features/diff/components/FinishFeedbackPopover.test.tsx
+++ b/src/features/diff/components/FinishFeedbackPopover.test.tsx
@@ -1,8 +1,29 @@
 import { test, expect, vi } from 'vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render as rtlRender, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { FinishFeedbackPopover } from './FinishFeedbackPopover'
 import type { PaneCandidate, ResolveResult } from '../services/activePanePicker'
+import type { ReactElement, ReactNode } from 'react'
+import type { AppSettings } from '../../../bindings/AppSettings'
+import { SettingsContext } from '../../settings/SettingsProvider'
+import { DEFAULT_SETTINGS } from '../../settings/store/settingsDefaults'
+
+const render = (
+  ui: ReactElement,
+  customKeybindings: Record<string, string> = {}
+): ReturnType<typeof rtlRender> => {
+  const settings: AppSettings = { ...DEFAULT_SETTINGS, customKeybindings }
+
+  return rtlRender(ui, {
+    wrapper: ({ children }: { children: ReactNode }): ReactElement => (
+      <SettingsContext.Provider
+        value={{ settings, saveError: null, update: vi.fn() }}
+      >
+        {children}
+      </SettingsContext.Provider>
+    ),
+  })
+}
 
 const createAnchor = (): HTMLDivElement => {
   const el = document.createElement('div')
@@ -48,10 +69,10 @@ test('kind none shows no-agent message and Dismiss button calls onCancel', async
   ).toBeInTheDocument()
 
   expect(
-    screen.getByRole('button', { name: 'Dismiss (n)' })
+    screen.getByRole('button', { name: 'Dismiss (N)' })
   ).toBeInTheDocument()
 
-  await user.click(screen.getByRole('button', { name: 'Dismiss (n)' }))
+  await user.click(screen.getByRole('button', { name: 'Dismiss (N)' }))
   expect(onCancel).toHaveBeenCalledTimes(1)
   expect(onSend).not.toHaveBeenCalled()
 
@@ -82,12 +103,12 @@ test('kind one shows pane info, correct copy, and buttons work', async () => {
     )
   ).toBeInTheDocument()
 
-  await user.click(screen.getByRole('button', { name: 'Confirm (Y)' }))
+  await user.click(screen.getByRole('button', { name: 'Confirm (Shift+Y)' }))
   expect(onSend).toHaveBeenCalledTimes(1)
   expect(onSend).toHaveBeenCalledWith(pane)
 
   onSend.mockClear()
-  await user.click(screen.getByRole('button', { name: 'Cancel (n)' }))
+  await user.click(screen.getByRole('button', { name: 'Cancel (N)' }))
   expect(onCancel).toHaveBeenCalledTimes(1)
   expect(onSend).not.toHaveBeenCalled()
 
@@ -109,14 +130,14 @@ test('kind one confirmation buttons render visible keyboard focus styles', () =>
     />
   )
 
-  expect(screen.getByRole('button', { name: 'Cancel (n)' })).toHaveClass(
+  expect(screen.getByRole('button', { name: 'Cancel (N)' })).toHaveClass(
     'focus:outline-none',
     'focus-visible:bg-surface-container-high',
     'focus-visible:outline-none',
     'focus-visible:ring-0'
   )
 
-  expect(screen.getByRole('button', { name: 'Confirm (Y)' })).toHaveClass(
+  expect(screen.getByRole('button', { name: 'Confirm (Shift+Y)' })).toHaveClass(
     'focus:outline-none',
     'focus-visible:outline-none',
     'focus-visible:ring-2',
@@ -125,10 +146,9 @@ test('kind one confirmation buttons render visible keyboard focus styles', () =>
     'focus-visible:ring-offset-surface-container'
   )
 
-  expect(screen.getByRole('button', { name: 'Confirm (Y)' })).not.toHaveClass(
-    'focus-visible:brightness-110',
-    'focus-visible:ring-0'
-  )
+  expect(
+    screen.getByRole('button', { name: 'Confirm (Shift+Y)' })
+  ).not.toHaveClass('focus-visible:brightness-110', 'focus-visible:ring-0')
 
   anchor.remove()
 })
@@ -215,7 +235,7 @@ test('kind many renders row per candidate and sends to correct pane', async () =
   expect(onSend).toHaveBeenCalledTimes(1)
   expect(onSend).toHaveBeenCalledWith(paneB)
 
-  await user.click(screen.getByRole('button', { name: 'Cancel (n)' }))
+  await user.click(screen.getByRole('button', { name: 'Cancel (N)' }))
   expect(onCancel).toHaveBeenCalledTimes(1)
 
   anchor.remove()
@@ -278,7 +298,7 @@ test('shows a Copy button that calls onCopy on click and via the c key', async (
     />
   )
 
-  await user.click(screen.getByRole('button', { name: 'Copy (c)' }))
+  await user.click(screen.getByRole('button', { name: 'Copy (C)' }))
   expect(onCopy).toHaveBeenCalledTimes(1)
 
   await user.keyboard('c')
@@ -302,8 +322,55 @@ test('omits the Copy button when onCopy is not provided', () => {
   )
 
   expect(
-    screen.queryByRole('button', { name: 'Copy (c)' })
+    screen.queryByRole('button', { name: 'Copy (C)' })
   ).not.toBeInTheDocument()
+
+  anchor.remove()
+})
+
+test('uses customized finish-feedback actions and hints', () => {
+  const anchor = createAnchor()
+  const pane = makePane()
+  const onCopy = vi.fn()
+  const onCancel = vi.fn()
+  const onSend = vi.fn()
+
+  render(
+    <FinishFeedbackPopover
+      anchor={anchor}
+      result={{ kind: 'one', pane } as ResolveResult}
+      commentCount={1}
+      fileCount={1}
+      onSend={onSend}
+      onCancel={onCancel}
+      onCopy={onCopy}
+    />,
+    {
+      'diff-review-copy': 'Alt+KeyC',
+      'diff-confirm-cancel': 'Alt+Escape',
+      'diff-feedback-send': 'Alt+Enter',
+    }
+  )
+
+  expect(screen.getByRole('button', { name: 'Copy (Alt+C)' })).toHaveAttribute(
+    'aria-keyshortcuts',
+    'Alt+c'
+  )
+
+  expect(
+    screen.getByRole('button', { name: 'Cancel (Alt+Escape)' })
+  ).toHaveAttribute('aria-keyshortcuts', 'Alt+Escape')
+
+  expect(
+    screen.getByRole('button', { name: 'Confirm (Alt+Enter)' })
+  ).toHaveAttribute('aria-keyshortcuts', 'Alt+Enter')
+
+  fireEvent.keyDown(document, { key: 'c', code: 'KeyC', altKey: true })
+  fireEvent.keyDown(document, { key: 'Enter', code: 'Enter', altKey: true })
+  fireEvent.keyDown(document, { key: 'Escape', code: 'Escape', altKey: true })
+  expect(onCopy).toHaveBeenCalledOnce()
+  expect(onSend).toHaveBeenCalledWith(pane)
+  expect(onCancel).toHaveBeenCalledOnce()
 
   anchor.remove()
 })

--- a/src/features/diff/components/FinishFeedbackPopover.tsx
+++ b/src/features/diff/components/FinishFeedbackPopover.tsx
@@ -1,5 +1,11 @@
 import { useEffect, type ReactElement } from 'react'
 import { Popover } from '@/components/Popover'
+import {
+  chordToAriaShortcut,
+  chordToShortcutInput,
+} from '@/features/keymap/displayKey'
+import { useKeybindings } from '@/features/keymap/useKeybindings'
+import { formatShortcut } from '@/lib/formatShortcut'
 import type { PaneCandidate, ResolveResult } from '../services/activePanePicker'
 
 const popoverGhostActionFocusClass =
@@ -20,10 +26,6 @@ interface FinishFeedbackPopoverProps {
   onCopy?: () => void
 }
 
-const isCapitalY = (event: KeyboardEvent): boolean =>
-  event.key === 'Y' ||
-  (event.shiftKey && (event.key.toLowerCase() === 'y' || event.code === 'KeyY'))
-
 export const FinishFeedbackPopover = ({
   anchor,
   result,
@@ -33,27 +35,30 @@ export const FinishFeedbackPopover = ({
   onCancel,
   onCopy = undefined,
 }: FinishFeedbackPopoverProps): ReactElement => {
+  const { bindingFor, matches } = useKeybindings()
   const commentWord = commentCount === 1 ? 'comment' : 'comments'
   const fileWord = fileCount === 1 ? 'file' : 'files'
+  const copyShortcut = bindingFor('diff-review-copy')
+  const cancelShortcut = bindingFor('diff-confirm-cancel')
+  const sendShortcut = bindingFor('diff-feedback-send')
+  const copyLabel = formatShortcut(chordToShortcutInput(copyShortcut))
+  const cancelLabel = formatShortcut(chordToShortcutInput(cancelShortcut))
+  const sendLabel = formatShortcut(chordToShortcutInput(sendShortcut))
 
   const copyButton = onCopy ? (
     <button
       type="button"
-      aria-keyshortcuts="c"
+      aria-keyshortcuts={chordToAriaShortcut(copyShortcut)}
       onClick={(): void => onCopy()}
       className={`rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface ${popoverGhostActionFocusClass}`}
     >
-      Copy (c)
+      Copy ({copyLabel})
     </button>
   ) : null
 
   useEffect((): (() => void) => {
     const handleKeyDown = (event: KeyboardEvent): void => {
-      if (event.ctrlKey || event.metaKey || event.altKey) {
-        return
-      }
-
-      if (event.key === 'n') {
+      if (matches(event, 'diff-confirm-cancel')) {
         event.preventDefault()
         event.stopPropagation()
         onCancel()
@@ -61,7 +66,7 @@ export const FinishFeedbackPopover = ({
         return
       }
 
-      if (onCopy && event.key === 'c') {
+      if (onCopy && matches(event, 'diff-review-copy')) {
         event.preventDefault()
         event.stopPropagation()
         onCopy()
@@ -69,7 +74,7 @@ export const FinishFeedbackPopover = ({
         return
       }
 
-      if (isCapitalY(event) && result.kind === 'one') {
+      if (matches(event, 'diff-feedback-send') && result.kind === 'one') {
         event.preventDefault()
         event.stopPropagation()
         onSend(result.pane)
@@ -81,7 +86,7 @@ export const FinishFeedbackPopover = ({
     return (): void => {
       document.removeEventListener('keydown', handleKeyDown, { capture: true })
     }
-  }, [onCancel, onCopy, onSend, result])
+  }, [matches, onCancel, onCopy, onSend, result])
 
   return (
     <Popover
@@ -112,11 +117,11 @@ export const FinishFeedbackPopover = ({
             {copyButton}
             <button
               type="button"
-              aria-keyshortcuts="n"
+              aria-keyshortcuts={chordToAriaShortcut(cancelShortcut)}
               onClick={(): void => onCancel()}
               className={`rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface ${popoverGhostActionFocusClass}`}
             >
-              Dismiss (n)
+              Dismiss ({cancelLabel})
             </button>
           </div>
         </div>
@@ -132,19 +137,19 @@ export const FinishFeedbackPopover = ({
             {copyButton}
             <button
               type="button"
-              aria-keyshortcuts="n"
+              aria-keyshortcuts={chordToAriaShortcut(cancelShortcut)}
               onClick={(): void => onCancel()}
               className={`rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface ${popoverGhostActionFocusClass}`}
             >
-              Cancel (n)
+              Cancel ({cancelLabel})
             </button>
             <button
               type="button"
-              aria-keyshortcuts="Y"
+              aria-keyshortcuts={chordToAriaShortcut(sendShortcut)}
               onClick={(): void => onSend(result.pane)}
               className={`rounded-md bg-primary px-3 py-1 text-xs text-on-primary hover:bg-primary/80 ${popoverPrimaryActionFocusClass}`}
             >
-              Confirm (Y)
+              Confirm ({sendLabel})
             </button>
           </div>
         </div>
@@ -178,11 +183,11 @@ export const FinishFeedbackPopover = ({
             {copyButton}
             <button
               type="button"
-              aria-keyshortcuts="n"
+              aria-keyshortcuts={chordToAriaShortcut(cancelShortcut)}
               onClick={(): void => onCancel()}
               className={`rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface ${popoverGhostActionFocusClass}`}
             >
-              Cancel (n)
+              Cancel ({cancelLabel})
             </button>
           </div>
         </div>

--- a/src/features/diff/components/Notifier.test.tsx
+++ b/src/features/diff/components/Notifier.test.tsx
@@ -1,9 +1,14 @@
-import type { ReactNode } from 'react'
-import { render, screen } from '@testing-library/react'
+import type { ReactElement, ReactNode } from 'react'
+import { render as rtlRender, screen } from '@testing-library/react'
 import { describe, expect, test, vi } from 'vitest'
+import type { AppSettings } from '../../../bindings/AppSettings'
+import { SettingsContext } from '../../settings/SettingsProvider'
+import { DEFAULT_SETTINGS } from '../../settings/store/settingsDefaults'
 import type { DiffChipToolbarProps } from './toolbar'
 import { Notifier } from './Notifier'
 import type { RequestReviewScopeControl } from './RequestReviewPopover'
+import { getCommand } from '../../keymap/catalog'
+import { resolveDefault } from '../../keymap/resolve'
 
 vi.mock('@/components/Popover', () => ({
   Popover: ({
@@ -30,6 +35,7 @@ vi.mock('./FinishFeedbackPopover', () => ({
 }))
 
 const toolbarProps: DiffChipToolbarProps = {
+  bindingFor: (id) => resolveDefault(getCommand(id), false),
   diffMode: 'unstaged',
   diffStyle: 'split',
   onDiffStyleChange: vi.fn(),
@@ -54,9 +60,12 @@ const toolbarProps: DiffChipToolbarProps = {
 }
 
 const renderNotifier = (
-  overrides: Partial<Parameters<typeof Notifier>[0]> = {}
-): ReturnType<typeof render> =>
-  render(
+  overrides: Partial<Parameters<typeof Notifier>[0]> = {},
+  customKeybindings: Record<string, string> = {}
+): ReturnType<typeof rtlRender> => {
+  const settings: AppSettings = { ...DEFAULT_SETTINGS, customKeybindings }
+
+  return rtlRender(
     <Notifier
       toolbarProps={toolbarProps}
       finishFeedback={{
@@ -72,8 +81,18 @@ const renderNotifier = (
       onCancelKeyboardConfirm={vi.fn()}
       onConfirmKeyboardAction={vi.fn()}
       {...overrides}
-    />
+    />,
+    {
+      wrapper: ({ children }: { children: ReactNode }): ReactElement => (
+        <SettingsContext.Provider
+          value={{ settings, saveError: null, update: vi.fn() }}
+        >
+          {children}
+        </SettingsContext.Provider>
+      ),
+    }
   )
+}
 
 describe('Notifier', () => {
   test('renders toolbar status messages and preserved draft copy', () => {
@@ -126,7 +145,46 @@ describe('Notifier', () => {
     )
 
     expect(screen.getByTestId('popover')).toHaveTextContent('Discard hunk?')
-    expect(screen.getByRole('button', { name: 'Yes (y)' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Yes (Y)' })).toBeInTheDocument()
+  })
+
+  test('renders customized confirmation hints', () => {
+    const { rerender } = renderNotifier(
+      {},
+      {
+        'diff-confirm-accept': 'Alt+Enter',
+        'diff-confirm-cancel': 'Alt+Escape',
+      }
+    )
+
+    rerender(
+      <Notifier
+        toolbarProps={toolbarProps}
+        finishFeedback={{
+          open: false,
+          result: { kind: 'none' },
+          commentCount: 0,
+          fileCount: 0,
+          onCancel: vi.fn(),
+          onSend: vi.fn(),
+        }}
+        keyboardConfirm={{
+          title: 'Discard hunk?',
+          body: 'This cannot be undone.',
+          variant: 'danger',
+        }}
+        onCancelKeyboardConfirm={vi.fn()}
+        onConfirmKeyboardAction={vi.fn()}
+      />
+    )
+
+    expect(
+      screen.getByRole('button', { name: 'No (Alt+Escape)' })
+    ).toHaveAttribute('aria-keyshortcuts', 'Alt+Escape')
+
+    expect(
+      screen.getByRole('button', { name: 'Yes (Alt+Enter)' })
+    ).toHaveAttribute('aria-keyshortcuts', 'Alt+Enter')
   })
 
   test('scopeControl on requestReview reaches RequestReviewPopover', () => {
@@ -174,7 +232,7 @@ describe('Notifier', () => {
 
     // The SegmentedControl group from RequestReviewPopover must be in the DOM
     expect(
-      screen.getByRole('group', { name: 'Review scope (f/a)' })
+      screen.getByRole('group', { name: 'Review scope' })
     ).toBeInTheDocument()
 
     expect(screen.getByRole('button', { name: 'All changes' })).toHaveAttribute(

--- a/src/features/diff/components/Notifier.tsx
+++ b/src/features/diff/components/Notifier.tsx
@@ -1,6 +1,12 @@
 import { useRef, type ReactElement } from 'react'
 import { Button } from '@/components/Button'
 import { Popover } from '@/components/Popover'
+import {
+  chordToAriaShortcut,
+  chordToShortcutInput,
+} from '@/features/keymap/displayKey'
+import { useKeybindings } from '@/features/keymap/useKeybindings'
+import { formatShortcut } from '@/lib/formatShortcut'
 import { DiffChipToolbar, type DiffChipToolbarProps } from './toolbar'
 import { FinishFeedbackPopover } from './FinishFeedbackPopover'
 import {
@@ -68,6 +74,11 @@ export const Notifier = ({
   onConfirmKeyboardAction,
 }: NotifierProps): ReactElement => {
   const toolbarShellRef = useRef<HTMLDivElement>(null)
+  const { bindingFor } = useKeybindings()
+  const confirmShortcut = bindingFor('diff-confirm-accept')
+  const cancelShortcut = bindingFor('diff-confirm-cancel')
+  const confirmLabel = formatShortcut(chordToShortcutInput(confirmShortcut))
+  const cancelLabel = formatShortcut(chordToShortcutInput(cancelShortcut))
 
   return (
     <div
@@ -161,18 +172,18 @@ export const Notifier = ({
               <Button
                 size="sm"
                 variant="ghost"
-                aria-keyshortcuts="n"
+                aria-keyshortcuts={chordToAriaShortcut(cancelShortcut)}
                 onClick={onCancelKeyboardConfirm}
               >
-                No (n)
+                No ({cancelLabel})
               </Button>
               <Button
                 size="sm"
                 variant={keyboardConfirm.variant}
-                aria-keyshortcuts="y"
+                aria-keyshortcuts={chordToAriaShortcut(confirmShortcut)}
                 onClick={onConfirmKeyboardAction}
               >
-                Yes (y)
+                Yes ({confirmLabel})
               </Button>
             </div>
           </div>

--- a/src/features/diff/components/PanelBody.test.tsx
+++ b/src/features/diff/components/PanelBody.test.tsx
@@ -2,6 +2,11 @@ import { createRef, type ReactElement, type ReactNode } from 'react'
 import { act, render, screen, waitFor } from '@testing-library/react'
 import type { DiffLineAnnotation, FileDiffOptions } from '@pierre/diffs'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { getCommand, type CommandId } from '@/features/keymap/catalog'
+import { resolveDefault } from '@/features/keymap/resolve'
+import type { Keybindings } from '@/features/keymap/useKeybindings'
+import { SettingsContext } from '@/features/settings/SettingsProvider'
+import { DEFAULT_SETTINGS } from '@/features/settings/store/settingsDefaults'
 import { PanelBody } from './PanelBody'
 import type { ReviewComment } from '../hooks/useFeedbackBatch'
 import type { PierreFileInputs } from '../services/pierreAdapter'
@@ -73,9 +78,25 @@ const options: FileDiffOptions<ReviewComment> = {
   theme: 'pierre-dark',
 }
 
+const bindingFor: Keybindings['bindingFor'] = (id: CommandId) =>
+  resolveDefault(getCommand(id), false)
+
+const SettingsFixture = ({
+  children,
+}: {
+  children: ReactNode
+}): ReactElement => (
+  <SettingsContext.Provider
+    value={{ settings: DEFAULT_SETTINGS, saveError: null, update: vi.fn() }}
+  >
+    {children}
+  </SettingsContext.Provider>
+)
+
 const createBodyProps = (
   overrides: Partial<Parameters<typeof PanelBody>[0]> = {}
 ): Parameters<typeof PanelBody>[0] => ({
+  bindingFor,
   scrollBodyRef: createRef<HTMLDivElement>(),
   diffError: null,
   diffLoading: false,
@@ -102,7 +123,9 @@ const createBodyProps = (
 const renderBody = (
   overrides: Partial<Parameters<typeof PanelBody>[0]> = {}
 ): ReturnType<typeof render> =>
-  render(<PanelBody {...createBodyProps(overrides)} />)
+  render(<PanelBody {...createBodyProps(overrides)} />, {
+    wrapper: SettingsFixture,
+  })
 
 describe('PanelBody', () => {
   beforeEach(() => {
@@ -146,6 +169,43 @@ describe('PanelBody', () => {
     expect(renderer).toHaveAttribute('data-old-file', 'src/foo.ts')
     expect(renderer).toHaveAttribute('data-new-file', 'src/foo.ts')
     expect(renderer).toHaveAttribute('data-diff-style', 'split')
+  })
+
+  test('shows resolved comment action shortcuts', () => {
+    const remappedBindingFor: Keybindings['bindingFor'] = (id) => {
+      if (id === 'diff-comment-update') {
+        return { code: 'ArrowDown', mods: new Set(['Shift']) }
+      }
+      if (id === 'diff-comment-delete') {
+        return { code: 'ArrowUp', mods: new Set(['Alt']) }
+      }
+
+      return bindingFor(id)
+    }
+
+    const annotation: DiffLineAnnotation<ReviewComment> = {
+      side: 'additions',
+      lineNumber: 2,
+      metadata: {
+        id: 'pending',
+        text: 'Pending comment',
+        author: 'self',
+        createdAt: 1,
+      },
+    }
+
+    renderBody({
+      bindingFor: remappedBindingFor,
+      lineAnnotations: [annotation],
+    })
+
+    expect(
+      screen.getByRole('button', { name: 'Edit comment' })
+    ).toHaveAttribute('aria-keyshortcuts', 'Shift+ArrowDown')
+
+    expect(
+      screen.getByRole('button', { name: 'Delete comment' })
+    ).toHaveAttribute('aria-keyshortcuts', 'Alt+ArrowUp')
   })
 
   test('rerenders Pierre when the active diff highlight cache becomes available', async () => {

--- a/src/features/diff/components/PanelBody.tsx
+++ b/src/features/diff/components/PanelBody.tsx
@@ -15,6 +15,11 @@ import type {
 } from '@pierre/diffs'
 import { IconButton } from '@/components/IconButton'
 import {
+  chordToAriaShortcut,
+  chordToShortcutInput,
+} from '@/features/keymap/displayKey'
+import type { Keybindings } from '@/features/keymap/useKeybindings'
+import {
   DRAFT_ID,
   type ReviewComment,
   type ReviewCommentCategory,
@@ -181,6 +186,7 @@ export const bindThreadCardActions = (
 })
 
 interface PanelBodyProps {
+  bindingFor: Keybindings['bindingFor']
   scrollBodyRef: RefObject<HTMLDivElement | null>
   diffError: Error | null
   diffLoading: boolean
@@ -211,6 +217,7 @@ interface PanelBodyProps {
 }
 
 export const PanelBody = ({
+  bindingFor,
   scrollBodyRef,
   diffError,
   diffLoading,
@@ -241,6 +248,9 @@ export const PanelBody = ({
     pierreInputs?.diffCacheKey ?? null
   )
   const effectiveRenderKey = `${renderKey}:${highlightCacheRevision}`
+  const commentShortcut = bindingFor('diff-comment-line')
+  const editShortcut = bindingFor('diff-comment-update')
+  const deleteShortcut = bindingFor('diff-comment-delete')
 
   return (
     <div
@@ -270,7 +280,8 @@ export const PanelBody = ({
                 icon="add"
                 label="Add comment on this line"
                 size="sm"
-                shortcut="i"
+                shortcut={chordToShortcutInput(commentShortcut)}
+                aria-keyshortcuts={chordToAriaShortcut(commentShortcut)}
                 className="h-5 w-5 translate-x-3/4 rounded-full bg-primary text-on-primary shadow-md hover:bg-primary/90"
                 onClick={(): void => {
                   const hovered = getHoveredLine()
@@ -336,6 +347,10 @@ export const PanelBody = ({
               return (
                 <ReviewCommentRow
                   comment={annotation.metadata}
+                  editShortcut={chordToShortcutInput(editShortcut)}
+                  editAriaKeyshortcuts={chordToAriaShortcut(editShortcut)}
+                  deleteShortcut={chordToShortcutInput(deleteShortcut)}
+                  deleteAriaKeyshortcuts={chordToAriaShortcut(deleteShortcut)}
                   targetLabel={annotationTargetLabel(annotation)}
                   onSendNow={
                     onSendComment === undefined

--- a/src/features/diff/components/RequestReviewPopover.test.tsx
+++ b/src/features/diff/components/RequestReviewPopover.test.tsx
@@ -1,9 +1,30 @@
 import { test, expect, vi } from 'vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render as rtlRender, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { RequestReviewPopover } from './RequestReviewPopover'
 import type { PaneCandidate, ResolveResult } from '../services/activePanePicker'
 import type { RequestReviewScopeControl } from './RequestReviewPopover'
+import type { ReactElement, ReactNode } from 'react'
+import type { AppSettings } from '../../../bindings/AppSettings'
+import { SettingsContext } from '../../settings/SettingsProvider'
+import { DEFAULT_SETTINGS } from '../../settings/store/settingsDefaults'
+
+const render = (
+  ui: ReactElement,
+  customKeybindings: Record<string, string> = {}
+): ReturnType<typeof rtlRender> => {
+  const settings: AppSettings = { ...DEFAULT_SETTINGS, customKeybindings }
+
+  return rtlRender(ui, {
+    wrapper: ({ children }: { children: ReactNode }): ReactElement => (
+      <SettingsContext.Provider
+        value={{ settings, saveError: null, update: vi.fn() }}
+      >
+        {children}
+      </SettingsContext.Provider>
+    ),
+  })
+}
 
 const createAnchor = (): HTMLDivElement => {
   const el = document.createElement('div')
@@ -45,10 +66,10 @@ test('kind none shows no-agent copy; Copy and Dismiss fire their handlers', asyn
     screen.getByRole('dialog', { name: 'Request review' })
   ).toBeInTheDocument()
 
-  await user.click(screen.getByRole('button', { name: 'Copy (c)' }))
+  await user.click(screen.getByRole('button', { name: 'Copy (C)' }))
   expect(onCopy).toHaveBeenCalledTimes(1)
 
-  await user.click(screen.getByRole('button', { name: 'Dismiss (n)' }))
+  await user.click(screen.getByRole('button', { name: 'Dismiss (N)' }))
   expect(onCancel).toHaveBeenCalledTimes(1)
   expect(onSubmit).not.toHaveBeenCalled()
 
@@ -79,11 +100,11 @@ test('kind one shows the scope label + pane, and Delegate submits the pane', asy
     )
   ).toBeInTheDocument()
 
-  await user.click(screen.getByRole('button', { name: 'Delegate (Y)' }))
+  await user.click(screen.getByRole('button', { name: 'Delegate (Shift+Y)' }))
   expect(onSubmit).toHaveBeenCalledTimes(1)
   expect(onSubmit).toHaveBeenCalledWith(pane)
 
-  await user.click(screen.getByRole('button', { name: 'Cancel (n)' }))
+  await user.click(screen.getByRole('button', { name: 'Cancel (N)' }))
   expect(onCancel).toHaveBeenCalledTimes(1)
 
   anchor.remove()
@@ -139,7 +160,7 @@ test('kind many shows copy-only (no picker) — review targets one bound agent',
   // No per-pane picker: multiple agents fall back to copy, not a chooser.
   expect(screen.queryByRole('button', { name: 'Delegate' })).toBeNull()
 
-  await user.click(screen.getByRole('button', { name: 'Copy (c)' }))
+  await user.click(screen.getByRole('button', { name: 'Copy (C)' }))
   expect(onCopy).toHaveBeenCalledTimes(1)
   expect(onSubmit).not.toHaveBeenCalled()
 
@@ -192,7 +213,7 @@ test('renders the scope control with both options when provided', () => {
     />
   )
 
-  const group = screen.getByRole('group', { name: 'Review scope (f/a)' })
+  const group = screen.getByRole('group', { name: 'Review scope' })
   expect(group).toBeInTheDocument()
 
   const fileBtn = screen.getByRole('button', { name: 'This file' })
@@ -206,7 +227,7 @@ test('renders the scope control with both options when provided', () => {
   anchor.remove()
 })
 
-test('f and a hotkeys switch scope', () => {
+test('custom scope hotkeys replace the defaults', () => {
   const onScopeChange = vi.fn()
 
   const scopeControl: RequestReviewScopeControl = {
@@ -227,14 +248,22 @@ test('f and a hotkeys switch scope', () => {
       onSubmit={vi.fn()}
       onCopy={vi.fn()}
       onCancel={vi.fn()}
-    />
+    />,
+    {
+      'diff-request-review-scope-file': 'Alt+KeyF',
+      'diff-request-review-scope-changelist': 'Alt+KeyA',
+    }
   )
 
-  fireEvent.keyDown(document, { key: 'f' })
+  fireEvent.keyDown(document, { key: 'f', code: 'KeyF' })
+  fireEvent.keyDown(document, { key: 'a', code: 'KeyA' })
+  expect(onScopeChange).not.toHaveBeenCalled()
+
+  fireEvent.keyDown(document, { key: 'f', code: 'KeyF', altKey: true })
   expect(onScopeChange).toHaveBeenCalledWith('file')
   onScopeChange.mockClear()
 
-  fireEvent.keyDown(document, { key: 'a' })
+  fireEvent.keyDown(document, { key: 'a', code: 'KeyA', altKey: true })
   expect(onScopeChange).toHaveBeenCalledWith('changelist')
 
   anchor.remove()
@@ -254,7 +283,7 @@ test('scope control absent when scopeControl is undefined', () => {
     />
   )
 
-  expect(screen.queryByRole('group', { name: 'Review scope (f/a)' })).toBeNull()
+  expect(screen.queryByRole('group', { name: 'Review scope' })).toBeNull()
 
   anchor.remove()
 })
@@ -287,7 +316,7 @@ test('This file option is disabled without an active diff', () => {
   expect(fileBtn).toHaveAttribute('aria-disabled', 'true')
 
   // pressing f must NOT call onScopeChange when fileDisabled is true
-  fireEvent.keyDown(document, { key: 'f' })
+  fireEvent.keyDown(document, { key: 'f', code: 'KeyF' })
   expect(onScopeChange).not.toHaveBeenCalled()
 
   anchor.remove()
@@ -321,8 +350,61 @@ test('All changes option is disabled on an empty strip', () => {
   expect(changelistBtn).toHaveAttribute('aria-disabled', 'true')
 
   // pressing a must NOT call onScopeChange when changelistDisabled is true
-  fireEvent.keyDown(document, { key: 'a' })
+  fireEvent.keyDown(document, { key: 'a', code: 'KeyA' })
   expect(onScopeChange).not.toHaveBeenCalled()
+
+  anchor.remove()
+})
+
+test('uses customized request-review actions and hints', () => {
+  const anchor = createAnchor()
+  const pane = makePane()
+  const onCopy = vi.fn()
+  const onCancel = vi.fn()
+  const onSubmit = vi.fn()
+
+  render(
+    <RequestReviewPopover
+      anchor={anchor}
+      result={{ kind: 'one', pane } as ResolveResult}
+      scopeLabel="this file"
+      onSubmit={onSubmit}
+      onCopy={onCopy}
+      onCancel={onCancel}
+    />,
+    {
+      'diff-review-copy': 'Alt+KeyC',
+      'diff-confirm-cancel': 'Alt+Escape',
+      'diff-request-review-submit': 'Alt+Enter',
+    }
+  )
+
+  expect(screen.getByRole('button', { name: 'Copy (Alt+C)' })).toHaveAttribute(
+    'aria-keyshortcuts',
+    'Alt+c'
+  )
+
+  expect(
+    screen.getByRole('button', { name: 'Cancel (Alt+Escape)' })
+  ).toHaveAttribute('aria-keyshortcuts', 'Alt+Escape')
+
+  expect(
+    screen.getByRole('button', { name: 'Delegate (Alt+Enter)' })
+  ).toHaveAttribute('aria-keyshortcuts', 'Alt+Enter')
+
+  fireEvent.keyDown(document, { key: 'c', code: 'KeyC' })
+  fireEvent.keyDown(document, { key: 'n', code: 'KeyN' })
+  fireEvent.keyDown(document, { key: 'Y', code: 'KeyY', shiftKey: true })
+  expect(onCopy).not.toHaveBeenCalled()
+  expect(onCancel).not.toHaveBeenCalled()
+  expect(onSubmit).not.toHaveBeenCalled()
+
+  fireEvent.keyDown(document, { key: 'c', code: 'KeyC', altKey: true })
+  fireEvent.keyDown(document, { key: 'Enter', code: 'Enter', altKey: true })
+  fireEvent.keyDown(document, { key: 'Escape', code: 'Escape', altKey: true })
+  expect(onCopy).toHaveBeenCalledOnce()
+  expect(onSubmit).toHaveBeenCalledWith(pane)
+  expect(onCancel).toHaveBeenCalledOnce()
 
   anchor.remove()
 })

--- a/src/features/diff/components/RequestReviewPopover.tsx
+++ b/src/features/diff/components/RequestReviewPopover.tsx
@@ -1,6 +1,12 @@
 import { useEffect, type ReactElement } from 'react'
 import { Popover } from '@/components/Popover'
 import { SegmentedControl } from '@/components/SegmentedControl'
+import {
+  chordToAriaShortcut,
+  chordToShortcutInput,
+} from '@/features/keymap/displayKey'
+import { useKeybindings } from '@/features/keymap/useKeybindings'
+import { formatShortcut } from '@/lib/formatShortcut'
 import type { PaneCandidate, ResolveResult } from '../services/activePanePicker'
 import type { ReviewScope } from '../hooks/useRequestReview'
 
@@ -34,10 +40,6 @@ interface RequestReviewPopoverProps {
   onCancel: () => void
 }
 
-const isCapitalY = (event: KeyboardEvent): boolean =>
-  event.key === 'Y' ||
-  (event.shiftKey && (event.key.toLowerCase() === 'y' || event.code === 'KeyY'))
-
 /**
  * The popover that opens from the diff toolbar's "Request review" button. It
  * asks how to hand the current file's diff to a coding agent:
@@ -59,24 +61,28 @@ export const RequestReviewPopover = ({
   onCopy,
   onCancel,
 }: RequestReviewPopoverProps): ReactElement => {
+  const { bindingFor, matches } = useKeybindings()
+  const copyShortcut = bindingFor('diff-review-copy')
+  const cancelShortcut = bindingFor('diff-confirm-cancel')
+  const submitShortcut = bindingFor('diff-request-review-submit')
+  const copyLabel = formatShortcut(chordToShortcutInput(copyShortcut))
+  const cancelLabel = formatShortcut(chordToShortcutInput(cancelShortcut))
+  const submitLabel = formatShortcut(chordToShortcutInput(submitShortcut))
+
   const copyButton = (
     <button
       type="button"
-      aria-keyshortcuts="c"
+      aria-keyshortcuts={chordToAriaShortcut(copyShortcut)}
       onClick={(): void => onCopy()}
       className={`rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface ${popoverGhostActionFocusClass}`}
     >
-      Copy (c)
+      Copy ({copyLabel})
     </button>
   )
 
   useEffect((): (() => void) => {
     const handleKeyDown = (event: KeyboardEvent): void => {
-      if (event.ctrlKey || event.metaKey || event.altKey) {
-        return
-      }
-
-      if (event.key === 'n') {
+      if (matches(event, 'diff-confirm-cancel')) {
         event.preventDefault()
         event.stopPropagation()
         onCancel()
@@ -84,7 +90,7 @@ export const RequestReviewPopover = ({
         return
       }
 
-      if (event.key === 'c') {
+      if (matches(event, 'diff-review-copy')) {
         event.preventDefault()
         event.stopPropagation()
         onCopy()
@@ -93,7 +99,7 @@ export const RequestReviewPopover = ({
       }
 
       if (
-        event.key === 'f' &&
+        matches(event, 'diff-request-review-scope-file') &&
         scopeControl !== undefined &&
         !scopeControl.fileDisabled
       ) {
@@ -105,7 +111,7 @@ export const RequestReviewPopover = ({
       }
 
       if (
-        event.key === 'a' &&
+        matches(event, 'diff-request-review-scope-changelist') &&
         scopeControl !== undefined &&
         !scopeControl.changelistDisabled
       ) {
@@ -116,7 +122,10 @@ export const RequestReviewPopover = ({
         return
       }
 
-      if (isCapitalY(event) && result.kind === 'one') {
+      if (
+        matches(event, 'diff-request-review-submit') &&
+        result.kind === 'one'
+      ) {
         event.preventDefault()
         event.stopPropagation()
         onSubmit(result.pane)
@@ -128,7 +137,7 @@ export const RequestReviewPopover = ({
     return (): void => {
       document.removeEventListener('keydown', handleKeyDown, { capture: true })
     }
-  }, [onCancel, onCopy, onSubmit, result, scopeControl])
+  }, [matches, onCancel, onCopy, onSubmit, result, scopeControl])
 
   return (
     <Popover
@@ -146,7 +155,7 @@ export const RequestReviewPopover = ({
         <div className="flex items-center gap-2 px-4 pt-3">
           <span className="text-xs text-on-surface-variant">Scope</span>
           <SegmentedControl<ReviewScope>
-            aria-label="Review scope (f/a)"
+            aria-label="Review scope"
             value={scopeControl.scope}
             onChange={scopeControl.onScopeChange}
             options={[
@@ -182,11 +191,11 @@ export const RequestReviewPopover = ({
             {copyButton}
             <button
               type="button"
-              aria-keyshortcuts="n"
+              aria-keyshortcuts={chordToAriaShortcut(cancelShortcut)}
               onClick={(): void => onCancel()}
               className={`rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface ${popoverGhostActionFocusClass}`}
             >
-              Dismiss (n)
+              Dismiss ({cancelLabel})
             </button>
           </div>
         </div>
@@ -202,19 +211,19 @@ export const RequestReviewPopover = ({
             {copyButton}
             <button
               type="button"
-              aria-keyshortcuts="n"
+              aria-keyshortcuts={chordToAriaShortcut(cancelShortcut)}
               onClick={(): void => onCancel()}
               className={`rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface ${popoverGhostActionFocusClass}`}
             >
-              Cancel (n)
+              Cancel ({cancelLabel})
             </button>
             <button
               type="button"
-              aria-keyshortcuts="Y"
+              aria-keyshortcuts={chordToAriaShortcut(submitShortcut)}
               onClick={(): void => onSubmit(result.pane)}
               className={`rounded-md bg-primary px-3 py-1 text-xs text-on-primary hover:bg-primary/80 ${popoverPrimaryActionFocusClass}`}
             >
-              Delegate (Y)
+              Delegate ({submitLabel})
             </button>
           </div>
         </div>

--- a/src/features/diff/components/ReviewCommentEditor.test.tsx
+++ b/src/features/diff/components/ReviewCommentEditor.test.tsx
@@ -572,8 +572,13 @@ describe('ReviewCommentEditor', () => {
     )
 
     const textarea = screen.getByPlaceholderText('Reply to the agent…')
-    fireEvent.keyDown(textarea, { key: 'l', code: 'KeyL', ctrlKey: true })
-    fireEvent.keyDown(textarea, { key: 'h', code: 'KeyH', ctrlKey: true })
+    expect(
+      fireEvent.keyDown(textarea, { key: 'l', code: 'KeyL', ctrlKey: true })
+    ).toBe(false)
+
+    expect(
+      fireEvent.keyDown(textarea, { key: 'h', code: 'KeyH', ctrlKey: true })
+    ).toBe(false)
     fireEvent.change(textarea, { target: { value: 'follow-up' } })
     fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter' })
 

--- a/src/features/diff/components/ReviewCommentEditor.test.tsx
+++ b/src/features/diff/components/ReviewCommentEditor.test.tsx
@@ -1,10 +1,31 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render as rtlRender, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, test, vi } from 'vitest'
+import type { ReactElement, ReactNode } from 'react'
+import type { AppSettings } from '../../../bindings/AppSettings'
+import { SettingsContext } from '../../settings/SettingsProvider'
+import { DEFAULT_SETTINGS } from '../../settings/store/settingsDefaults'
 import {
   ReviewCommentEditor,
   moveTextareaCursorVertically,
 } from './ReviewCommentEditor'
+
+const render = (
+  ui: ReactElement,
+  customKeybindings: Record<string, string> = {}
+): ReturnType<typeof rtlRender> => {
+  const settings: AppSettings = { ...DEFAULT_SETTINGS, customKeybindings }
+
+  const wrapper = ({ children }: { children: ReactNode }): ReactElement => (
+    <SettingsContext.Provider
+      value={{ settings, saveError: null, update: vi.fn() }}
+    >
+      {children}
+    </SettingsContext.Provider>
+  )
+
+  return rtlRender(ui, { wrapper })
+}
 
 describe('ReviewCommentEditor', () => {
   test('renders the "Local comment" header and the R-side line reference', () => {
@@ -208,6 +229,47 @@ describe('ReviewCommentEditor', () => {
     expect(textarea.selectionStart).toBe(0)
   })
 
+  test('uses customized comment editing bindings', () => {
+    render(
+      <ReviewCommentEditor
+        lineNumber={1}
+        side="additions"
+        initialText={'one\ntwo'}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+      {
+        'diff-comment-insert-newline': 'Alt+Enter',
+        'diff-comment-cursor-up': 'Alt+ArrowUp',
+      }
+    )
+
+    const textarea = screen.getByRole('textbox')
+    if (!(textarea instanceof HTMLTextAreaElement)) {
+      throw new Error('Expected textarea')
+    }
+
+    expect(textarea).toHaveAttribute(
+      'aria-keyshortcuts',
+      expect.stringContaining('Alt+Enter')
+    )
+
+    textarea.setSelectionRange(5, 5)
+    fireEvent.keyDown(textarea, {
+      key: 'Enter',
+      code: 'Enter',
+      altKey: true,
+    })
+    expect(textarea).toHaveValue('one\nt\nwo')
+
+    fireEvent.keyDown(textarea, {
+      key: 'ArrowUp',
+      code: 'ArrowUp',
+      altKey: true,
+    })
+    expect(textarea.selectionStart).toBe(4)
+  })
+
   test('Escape calls onCancel', async () => {
     const user = userEvent.setup()
     const handleCancel = vi.fn()
@@ -226,6 +288,45 @@ describe('ReviewCommentEditor', () => {
     await user.keyboard('{Escape}')
 
     expect(handleCancel).toHaveBeenCalledTimes(1)
+  })
+
+  test('uses customized submit and cancel bindings', () => {
+    const handleConfirm = vi.fn()
+    const handleCancel = vi.fn()
+
+    render(
+      <ReviewCommentEditor
+        lineNumber={1}
+        side="additions"
+        initialText="comment"
+        onConfirm={handleConfirm}
+        onCancel={handleCancel}
+      />,
+      {
+        'diff-comment-submit': 'Alt+Enter',
+        'diff-comment-cancel': 'Alt+Escape',
+      }
+    )
+
+    const textarea = screen.getByRole('textbox')
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter' })
+    fireEvent.keyDown(textarea, { key: 'Escape', code: 'Escape' })
+    expect(handleConfirm).not.toHaveBeenCalled()
+    expect(handleCancel).not.toHaveBeenCalled()
+
+    fireEvent.keyDown(textarea, {
+      key: 'Enter',
+      code: 'Enter',
+      altKey: true,
+    })
+
+    fireEvent.keyDown(textarea, {
+      key: 'Escape',
+      code: 'Escape',
+      altKey: true,
+    })
+    expect(handleConfirm).toHaveBeenCalledWith('comment', 'change')
+    expect(handleCancel).toHaveBeenCalledOnce()
   })
 
   test('Cancel button calls onCancel', async () => {
@@ -356,6 +457,43 @@ describe('ReviewCommentEditor', () => {
     expect(handleConfirm).toHaveBeenLastCalledWith('cycled', 'bug')
   })
 
+  test('uses customized category bindings and displays their shortcuts', () => {
+    const handleConfirm = vi.fn()
+
+    render(
+      <ReviewCommentEditor
+        lineNumber={1}
+        side="additions"
+        initialText="custom binding"
+        onConfirm={handleConfirm}
+        onCancel={vi.fn()}
+      />,
+      {
+        'diff-comment-category-previous': 'Alt+KeyP',
+        'diff-comment-category-next': 'Shift+KeyN',
+      }
+    )
+
+    const textarea = screen.getByRole('textbox')
+
+    fireEvent.keyDown(textarea, {
+      key: 'l',
+      code: 'KeyL',
+      ctrlKey: true,
+    })
+
+    fireEvent.keyDown(textarea, {
+      key: 'N',
+      code: 'KeyN',
+      shiftKey: true,
+    })
+
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter' })
+
+    expect(handleConfirm).toHaveBeenCalledWith('custom binding', 'bug')
+    expect(screen.getByText('Alt+P / Shift+N')).toBeInTheDocument()
+  })
+
   test('initialCategory seeds the picker (used when editing)', async () => {
     const user = userEvent.setup()
     const handleConfirm = vi.fn()
@@ -434,10 +572,10 @@ describe('ReviewCommentEditor', () => {
     )
 
     const textarea = screen.getByPlaceholderText('Reply to the agent…')
-    fireEvent.keyDown(textarea, { key: 'l', ctrlKey: true })
-    fireEvent.keyDown(textarea, { key: 'h', ctrlKey: true })
+    fireEvent.keyDown(textarea, { key: 'l', code: 'KeyL', ctrlKey: true })
+    fireEvent.keyDown(textarea, { key: 'h', code: 'KeyH', ctrlKey: true })
     fireEvent.change(textarea, { target: { value: 'follow-up' } })
-    fireEvent.keyDown(textarea, { key: 'Enter' })
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter' })
 
     expect(onConfirm).toHaveBeenCalledWith('follow-up', 'change')
   })

--- a/src/features/diff/components/ReviewCommentEditor.tsx
+++ b/src/features/diff/components/ReviewCommentEditor.tsx
@@ -5,6 +5,12 @@ import {
   type ReviewCommentCategory,
 } from '../hooks/useFeedbackBatch'
 import { REVIEW_CATEGORY_META } from '../reviewCategoryMeta'
+import { formatShortcut } from '../../../lib/formatShortcut'
+import {
+  chordToAriaShortcut,
+  chordToShortcutInput,
+} from '../../keymap/displayKey'
+import { useKeybindings } from '../../keymap/useKeybindings'
 
 type CommentSide = 'deletions' | 'additions'
 
@@ -71,22 +77,6 @@ export const moveTextareaCursorVertically = (
   textarea.setSelectionRange(next, next)
 }
 
-const isCtrlTextNavigation = (
-  event: Pick<
-    KeyboardEvent,
-    'altKey' | 'code' | 'ctrlKey' | 'key' | 'keyCode' | 'metaKey'
-  >,
-  key: 'j' | 'k'
-): boolean =>
-  event.ctrlKey &&
-  !event.metaKey &&
-  !event.altKey &&
-  (event.key.toLowerCase() === key ||
-    (key === 'j' && event.key === 'Enter') ||
-    event.code === `Key${key.toUpperCase()}` ||
-    event.keyCode === (key === 'j' ? 10 : 11) ||
-    event.keyCode === key.toUpperCase().charCodeAt(0))
-
 const insertTextareaNewline = (
   textarea: HTMLTextAreaElement,
   updateText: (next: string) => void
@@ -102,8 +92,8 @@ const insertTextareaNewline = (
 
 // Codex-style inline comment editor. Rendered in Pierre's annotation slot
 // (full-width, below the target line) rather than as a floating popover, so it
-// sits in the diff flow and never chases the cursor. Enter submits, Shift+Enter
-// inserts a newline, Escape cancels.
+// sits in the diff flow and never chases the cursor. App actions resolve through
+// the keymap registry; Shift+Enter remains native textarea newline editing.
 export const ReviewCommentEditor = ({
   lineNumber = undefined,
   side = undefined,
@@ -120,6 +110,7 @@ export const ReviewCommentEditor = ({
   onCancel,
   mode = 'comment',
 }: ReviewCommentEditorProps): ReactElement => {
+  const { bindingFor, matches } = useKeybindings()
   const [uncontrolledText, setUncontrolledText] = useState(initialText)
 
   const [uncontrolledCategory, setUncontrolledCategory] =
@@ -136,7 +127,6 @@ export const ReviewCommentEditor = ({
     onCategoryChange?.(next)
   }
 
-  // Ctrl+H / Ctrl+L cycle the category (vim h/l).
   const cycleCategory = (direction: 1 | -1): void => {
     if (mode === 'reply') {
       return
@@ -176,6 +166,18 @@ export const ReviewCommentEditor = ({
 
   const targetDescription =
     targetLabel ?? `line ${side === 'deletions' ? 'L' : 'R'}${lineNumber ?? ''}`
+
+  const previousCategoryShortcut = formatShortcut(
+    chordToShortcutInput(bindingFor('diff-comment-category-previous'))
+  )
+
+  const nextCategoryShortcut = formatShortcut(
+    chordToShortcutInput(bindingFor('diff-comment-category-next'))
+  )
+  const insertNewlineShortcut = bindingFor('diff-comment-insert-newline')
+  const cursorUpShortcut = bindingFor('diff-comment-cursor-up')
+  const submitShortcut = bindingFor('diff-comment-submit')
+  const cancelShortcut = bindingFor('diff-comment-cancel')
 
   const className =
     chrome === 'card'
@@ -226,16 +228,44 @@ export const ReviewCommentEditor = ({
             )
           })}
           <span className="ml-auto text-[10px] text-on-surface-variant/70">
-            ⌃H / ⌃L
+            {previousCategoryShortcut} / {nextCategoryShortcut}
           </span>
         </div>
       )}
       <textarea
         ref={textareaRef}
         value={text}
+        aria-keyshortcuts={[
+          insertNewlineShortcut,
+          cursorUpShortcut,
+          submitShortcut,
+          cancelShortcut,
+        ]
+          .map((shortcut) => chordToAriaShortcut(shortcut))
+          .join(' ')}
         onChange={(e): void => updateText(e.target.value)}
         onKeyDownCapture={(e): void => {
-          if (isCtrlTextNavigation(e, 'j')) {
+          if (mode !== 'reply') {
+            let direction: 1 | -1 | null = null
+
+            if (matches(e.nativeEvent, 'diff-comment-category-next')) {
+              direction = 1
+            } else if (
+              matches(e.nativeEvent, 'diff-comment-category-previous')
+            ) {
+              direction = -1
+            }
+
+            if (direction !== null) {
+              e.preventDefault()
+              e.stopPropagation()
+              cycleCategory(direction)
+
+              return
+            }
+          }
+
+          if (matches(e.nativeEvent, 'diff-comment-insert-newline')) {
             e.preventDefault()
             e.stopPropagation()
             insertTextareaNewline(e.currentTarget, updateText)
@@ -243,7 +273,7 @@ export const ReviewCommentEditor = ({
             return
           }
 
-          if (isCtrlTextNavigation(e, 'k')) {
+          if (matches(e.nativeEvent, 'diff-comment-cursor-up')) {
             e.preventDefault()
             e.stopPropagation()
             moveTextareaCursorVertically(e.currentTarget, -1)
@@ -251,32 +281,10 @@ export const ReviewCommentEditor = ({
             return
           }
 
-          // Ctrl+H / Ctrl+L cycle the category (vim h/l). Capturing Ctrl+H
-          // overrides textarea backspace — deletion uses the Backspace key.
-          if (e.ctrlKey && !e.metaKey && !e.altKey) {
-            const lowered = e.key.toLowerCase()
-
-            if (lowered === 'l') {
-              e.preventDefault()
-              e.stopPropagation()
-              cycleCategory(1)
-
-              return
-            }
-
-            if (lowered === 'h') {
-              e.preventDefault()
-              e.stopPropagation()
-              cycleCategory(-1)
-
-              return
-            }
-          }
-
-          if (e.key === 'Enter' && !e.shiftKey && !e.ctrlKey) {
+          if (matches(e.nativeEvent, 'diff-comment-submit')) {
             e.preventDefault()
             submit()
-          } else if (e.key === 'Escape') {
+          } else if (matches(e.nativeEvent, 'diff-comment-cancel')) {
             e.preventDefault()
             onCancel()
           }
@@ -290,6 +298,7 @@ export const ReviewCommentEditor = ({
       <div className="flex justify-end gap-2">
         <button
           type="button"
+          aria-keyshortcuts={chordToAriaShortcut(cancelShortcut)}
           onClick={(): void => onCancel()}
           className="rounded-md px-3 py-1 text-xs text-on-surface-variant hover:text-on-surface"
         >
@@ -297,6 +306,7 @@ export const ReviewCommentEditor = ({
         </button>
         <button
           type="button"
+          aria-keyshortcuts={chordToAriaShortcut(submitShortcut)}
           onClick={(): void => submit()}
           disabled={text.trim().length === 0}
           className="rounded-md bg-primary px-3 py-1 text-xs text-on-primary hover:bg-primary/80 disabled:opacity-50"

--- a/src/features/diff/components/ReviewCommentEditor.tsx
+++ b/src/features/diff/components/ReviewCommentEditor.tsx
@@ -245,24 +245,23 @@ export const ReviewCommentEditor = ({
           .join(' ')}
         onChange={(e): void => updateText(e.target.value)}
         onKeyDownCapture={(e): void => {
-          if (mode !== 'reply') {
-            let direction: 1 | -1 | null = null
+          let direction: 1 | -1 | null = null
 
-            if (matches(e.nativeEvent, 'diff-comment-category-next')) {
-              direction = 1
-            } else if (
-              matches(e.nativeEvent, 'diff-comment-category-previous')
-            ) {
-              direction = -1
-            }
+          if (matches(e.nativeEvent, 'diff-comment-category-next')) {
+            direction = 1
+          } else if (matches(e.nativeEvent, 'diff-comment-category-previous')) {
+            direction = -1
+          }
 
-            if (direction !== null) {
-              e.preventDefault()
-              e.stopPropagation()
+          if (direction !== null) {
+            e.preventDefault()
+            e.stopPropagation()
+
+            if (mode !== 'reply') {
               cycleCategory(direction)
-
-              return
             }
+
+            return
           }
 
           if (matches(e.nativeEvent, 'diff-comment-insert-newline')) {

--- a/src/features/diff/components/ReviewCommentRow.test.tsx
+++ b/src/features/diff/components/ReviewCommentRow.test.tsx
@@ -90,8 +90,10 @@ describe('ReviewCommentRow', () => {
           author: 'self',
           createdAt: 2000,
         }}
-        editShortcut="Shift+U"
+        editShortcut={['Shift', 'U']}
+        editAriaKeyshortcuts="Shift+U"
         deleteShortcut={null}
+        deleteAriaKeyshortcuts={null}
         onEdit={vi.fn()}
         onDelete={vi.fn()}
       />

--- a/src/features/diff/components/ReviewCommentRow.tsx
+++ b/src/features/diff/components/ReviewCommentRow.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from 'react'
 import { IconButton } from '@/components/IconButton'
+import type { ShortcutInput } from '@/lib/formatShortcut'
 import {
   reviewCommentCategory,
   type ReviewComment,
@@ -8,8 +9,10 @@ import { AGENT_OUTCOME_META, REVIEW_CATEGORY_META } from '../reviewCategoryMeta'
 
 interface ReviewCommentRowProps {
   comment: ReviewComment
-  editShortcut?: 'u' | 'Shift+U'
-  deleteShortcut?: 'x' | null
+  editShortcut?: ShortcutInput
+  editAriaKeyshortcuts?: string | null
+  deleteShortcut?: ShortcutInput | null
+  deleteAriaKeyshortcuts?: string | null
   /** Dispatch just this comment to the agent now (VIM-297). Omitted → hidden;
    * read-only rows (dispatched anchors, agent/reviewer output) never show it. */
   onSendNow?: () => void
@@ -51,7 +54,9 @@ export const formatSentAgo = (dispatchedAt: number, now: number): string => {
 export const ReviewCommentRow = ({
   comment,
   editShortcut = 'u',
+  editAriaKeyshortcuts = 'u',
   deleteShortcut = 'x',
+  deleteAriaKeyshortcuts = 'x',
   targetLabel = undefined,
   onSendNow = undefined,
   onEdit,
@@ -141,8 +146,8 @@ export const ReviewCommentRow = ({
             icon="edit"
             label="Edit comment"
             size="sm"
-            shortcut={editShortcut === 'Shift+U' ? ['Shift', 'U'] : 'u'}
-            aria-keyshortcuts={editShortcut}
+            shortcut={editShortcut}
+            aria-keyshortcuts={editAriaKeyshortcuts ?? undefined}
             onClick={(): void => onEdit()}
           />
           <IconButton
@@ -151,7 +156,7 @@ export const ReviewCommentRow = ({
             variant="danger"
             size="sm"
             shortcut={deleteShortcut ?? undefined}
-            aria-keyshortcuts={deleteShortcut ?? undefined}
+            aria-keyshortcuts={deleteAriaKeyshortcuts ?? undefined}
             onClick={(): void => onDelete()}
           />
         </div>

--- a/src/features/diff/components/ReviewThreadCard.test.tsx
+++ b/src/features/diff/components/ReviewThreadCard.test.tsx
@@ -1,8 +1,23 @@
 import { describe, expect, test, vi } from 'vitest'
 import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import type { ReactElement, ReactNode } from 'react'
+import { SettingsContext } from '@/features/settings/SettingsProvider'
+import { DEFAULT_SETTINGS } from '@/features/settings/store/settingsDefaults'
 import type { ThreadGroup } from '../services/threadGroups'
 import { ReviewThreadCard } from './ReviewThreadCard'
+
+const SettingsFixture = ({
+  children,
+}: {
+  children: ReactNode
+}): ReactElement => (
+  <SettingsContext.Provider
+    value={{ settings: DEFAULT_SETTINGS, saveError: null, update: vi.fn() }}
+  >
+    {children}
+  </SettingsContext.Provider>
+)
 
 const group = (overrides: Partial<ThreadGroup> = {}): ThreadGroup => ({
   threadId: 'c1',
@@ -102,11 +117,13 @@ describe('ReviewThreadCard', () => {
   test('reply expands the editor; confirm submits the draft', () => {
     const a = actions({ replying: true, replyDraft: 'follow-up text' })
     render(
-      <ReviewThreadCard group={group()} anchorLabel="line R40" actions={a} />
+      <ReviewThreadCard group={group()} anchorLabel="line R40" actions={a} />,
+      { wrapper: SettingsFixture }
     )
 
     fireEvent.keyDown(screen.getByPlaceholderText('Reply to the agent…'), {
       key: 'Enter',
+      code: 'Enter',
     })
     expect(a.onSubmitReply).toHaveBeenCalledWith('follow-up text')
   })

--- a/src/features/diff/components/toolbar/ChangeStepper.test.tsx
+++ b/src/features/diff/components/toolbar/ChangeStepper.test.tsx
@@ -11,6 +11,10 @@ const renderStepper = (
     navEnabled: true,
     onPrev: vi.fn<() => void>(),
     onNext: vi.fn<() => void>(),
+    previousShortcut: '[',
+    previousAriaKeyshortcuts: '[',
+    nextShortcut: ']',
+    nextAriaKeyshortcuts: ']',
   }
 
   return render(<ChangeStepper {...baseProps} {...overrides} />)

--- a/src/features/diff/components/toolbar/ChangeStepper.tsx
+++ b/src/features/diff/components/toolbar/ChangeStepper.tsx
@@ -3,6 +3,7 @@ import { Chip } from '@/components/Chip'
 import { Tooltip } from '@/components/Tooltip'
 import { IconButton } from '@/components/IconButton'
 import { TOOLTIP_SUPPRESSED } from '@/lib/constants'
+import type { ShortcutInput } from '@/lib/formatShortcut'
 
 export interface ChangeStepperProps {
   // 1-based `N/N` hunk position string (or `0/0` when there are no hunks),
@@ -14,6 +15,10 @@ export interface ChangeStepperProps {
   navEnabled: boolean
   onPrev: (() => void) | undefined
   onNext: (() => void) | undefined
+  previousShortcut: ShortcutInput
+  previousAriaKeyshortcuts: string
+  nextShortcut: ShortcutInput
+  nextAriaKeyshortcuts: string
 }
 
 // Azure (secondary) change-navigation group: a leading `data_object` glyph, the
@@ -36,6 +41,10 @@ export const ChangeStepper = ({
   navEnabled,
   onPrev,
   onNext,
+  previousShortcut,
+  previousAriaKeyshortcuts,
+  nextShortcut,
+  nextAriaKeyshortcuts,
 }: ChangeStepperProps): ReactElement => (
   // role="group" makes the aria-label a valid author name — ARIA 1.2 forbids
   // names on the implicit `generic` role of a bare <span>, so the hunk
@@ -63,25 +72,25 @@ export const ChangeStepper = ({
       </span>
     </Tooltip>
     <span className="flex flex-col">
-      <Tooltip content="Previous change" shortcut="[">
+      <Tooltip content="Previous change" shortcut={previousShortcut}>
         <IconButton
           icon="keyboard_arrow_up"
           label="prev hunk"
           size="sm"
           disabled={!navEnabled}
-          aria-keyshortcuts="["
+          aria-keyshortcuts={previousAriaKeyshortcuts}
           onClick={onPrev}
           showTooltip={TOOLTIP_SUPPRESSED} // explicit outer Tooltip owns the label
           className={VERTICAL_STEP_ARROW_CLASSES}
         />
       </Tooltip>
-      <Tooltip content="Next change" shortcut="]">
+      <Tooltip content="Next change" shortcut={nextShortcut}>
         <IconButton
           icon="keyboard_arrow_down"
           label="next hunk"
           size="sm"
           disabled={!navEnabled}
-          aria-keyshortcuts="]"
+          aria-keyshortcuts={nextAriaKeyshortcuts}
           onClick={onNext}
           showTooltip={TOOLTIP_SUPPRESSED} // explicit outer Tooltip owns the label
           className={VERTICAL_STEP_ARROW_CLASSES}

--- a/src/features/diff/components/toolbar/DiffChipToolbar.test.tsx
+++ b/src/features/diff/components/toolbar/DiffChipToolbar.test.tsx
@@ -2,6 +2,9 @@ import { act, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import type { BaseDiffOptions, DiffsThemeNames } from '@pierre/diffs'
+import { getCommand } from '@/features/keymap/catalog'
+import { resolveDefault } from '@/features/keymap/resolve'
+import type { Keybindings } from '@/features/keymap/useKeybindings'
 import { DiffChipToolbar, type DiffChipToolbarProps } from './DiffChipToolbar'
 
 // Capture the ResizeObserver callback so the test can flush PriorityPlus
@@ -107,10 +110,14 @@ type LineDiffType = NonNullable<BaseDiffOptions['lineDiffType']>
 type DiffIndicators = NonNullable<BaseDiffOptions['diffIndicators']>
 type Overflow = NonNullable<BaseDiffOptions['overflow']>
 
+const defaultBindingFor: Keybindings['bindingFor'] = (id) =>
+  resolveDefault(getCommand(id), false)
+
 const renderToolbar = (
   overrides: Partial<DiffChipToolbarProps> = {}
 ): ReturnType<typeof render> => {
   const baseProps: DiffChipToolbarProps = {
+    bindingFor: defaultBindingFor,
     diffMode: 'unstaged',
     diffStyle: 'split',
     onDiffStyleChange: vi.fn<(next: DiffStyle) => void>(),
@@ -789,7 +796,8 @@ describe('DiffChipToolbar', () => {
       name: /finish feedback \(3\)/i,
     })
     expect(finish).toBeInTheDocument()
-    expect(finish).toHaveAttribute('aria-keyshortcuts', 'Y')
+    expect(finish).toHaveAttribute('aria-keyshortcuts', 'Shift+Y')
+    expect(finish).toHaveTextContent('Finish (Shift+Y)')
     // The count pill surfaces the number on the button text.
     expect(finish).toHaveTextContent('3')
 
@@ -829,7 +837,7 @@ describe('DiffChipToolbar', () => {
 
     const button = screen.getByRole('button', { name: /request review/i })
     expect(button).toBeInTheDocument()
-    expect(button).toHaveAttribute('aria-keyshortcuts', '@')
+    expect(button).toHaveAttribute('aria-keyshortcuts', 'Shift+2')
   })
 
   test('omits the Request review button when onRequestReview is undefined', () => {
@@ -873,13 +881,38 @@ describe('DiffChipToolbar', () => {
     const refresh = screen.getByRole('button', { name: 'refresh diff' })
     expect(refresh).toHaveTextContent('Refresh diff')
     expect(refresh).toHaveAttribute('aria-keyshortcuts', 'r')
-    expect(within(refresh).getByText('r')).toHaveAttribute(
+    expect(within(refresh).getByText('R')).toHaveAttribute(
       'aria-hidden',
       'true'
     )
 
     await user.click(refresh)
     expect(onRefresh).toHaveBeenCalledTimes(1)
+  })
+
+  test('renders a live keybinding override in its tooltip, label, and ARIA shortcut', async () => {
+    setNavigatorPlatform('Win32')
+
+    const user = userEvent.setup()
+
+    const bindingFor: Keybindings['bindingFor'] = (id) =>
+      id === 'diff-refresh'
+        ? { code: 'ArrowDown', mods: new Set(['Shift']) }
+        : defaultBindingFor(id)
+
+    renderToolbar({
+      bindingFor,
+      onRefreshActiveFile: vi.fn<() => void>(),
+    })
+
+    const refresh = screen.getByRole('button', { name: 'refresh diff' })
+    expect(refresh).toHaveAttribute('aria-keyshortcuts', 'Shift+ArrowDown')
+    expect(within(refresh).getByText('Shift+↓')).toBeInTheDocument()
+
+    await user.hover(refresh)
+    expect(await screen.findByTestId('tooltip-shortcut')).toHaveTextContent(
+      'Shift+↓'
+    )
   })
 
   test('the pinned feedback actions render outside PriorityPlus (never overflow)', () => {

--- a/src/features/diff/components/toolbar/DiffChipToolbar.tsx
+++ b/src/features/diff/components/toolbar/DiffChipToolbar.tsx
@@ -5,6 +5,13 @@ import { Tooltip } from '@/components/Tooltip'
 import { IconButton } from '@/components/IconButton'
 import { Popover } from '@/components/Popover'
 import { TOOLTIP_SUPPRESSED } from '@/lib/constants'
+import { formatShortcut, type ShortcutInput } from '@/lib/formatShortcut'
+import type { CommandId } from '@/features/keymap/catalog'
+import {
+  chordToAriaShortcut,
+  chordToShortcutInput,
+} from '@/features/keymap/displayKey'
+import type { Keybindings } from '@/features/keymap/useKeybindings'
 import { Dropdown, type DropdownOption } from '@/components/Dropdown'
 import { Menu } from '@/components/Menu'
 import { PriorityPlus } from './PriorityPlus'
@@ -128,6 +135,7 @@ const DIFF_STYLE_OPTIONS: readonly {
 ]
 
 export interface DiffChipToolbarProps {
+  bindingFor: Keybindings['bindingFor']
   // Which side of the diff this toolbar is bound to. Drives whether the
   // `unstage` chip renders (staged view only).
   diffMode: DiffMode
@@ -217,6 +225,7 @@ export interface DiffChipToolbarProps {
 // are provided and there is more than one hunk. The pinned feedback actions
 // render when feedbackCount > 0 (PR4 inline review).
 export const DiffChipToolbar = ({
+  bindingFor,
   diffMode,
   diffStyle,
   onDiffStyleChange,
@@ -256,6 +265,15 @@ export const DiffChipToolbar = ({
   onRefreshActiveFile = undefined,
   onRequestReview = undefined,
 }: DiffChipToolbarProps): ReactElement => {
+  const shortcutFor = (id: CommandId): ShortcutInput =>
+    chordToShortcutInput(bindingFor(id))
+
+  const ariaShortcutFor = (id: CommandId): string =>
+    chordToAriaShortcut(bindingFor(id))
+
+  const shortcutLabelFor = (id: CommandId): string =>
+    formatShortcut(shortcutFor(id))
+
   // Discard All confirmation popover state. The trigger is the discard-all
   // button inside the tool-well; the confirm card renders on the shared Popover
   // anchored to that button.
@@ -322,7 +340,7 @@ export const DiffChipToolbar = ({
     onDiscardAll !== undefined ? (
       <Tooltip
         content="Discard all changes"
-        shortcut="D"
+        shortcut={shortcutFor('diff-file-discard')}
         disabled={discardAllOpen}
       >
         <span>
@@ -333,6 +351,7 @@ export const DiffChipToolbar = ({
             variant="danger"
             size="md"
             disabled={staging}
+            aria-keyshortcuts={ariaShortcutFor('diff-file-discard')}
             aria-haspopup="dialog"
             aria-expanded={discardAllOpen}
             showTooltip={TOOLTIP_SUPPRESSED} // outer Tooltip already wraps the discard-all span
@@ -390,7 +409,10 @@ export const DiffChipToolbar = ({
       options={['split', 'unified'] as const}
       onChange={onDiffStyleChange}
       icons={{ split: 'vertical_split', unified: 'view_headline' }}
-      shortcuts={{ split: 't', unified: 't' }}
+      shortcuts={{
+        split: shortcutFor('diff-view-toggle'),
+        unified: shortcutFor('diff-view-toggle'),
+      }}
     />,
     // hairline between the view-mode control and the navigation cluster.
     <ToolbarSeparator key="sep-nav" />,
@@ -404,6 +426,10 @@ export const DiffChipToolbar = ({
       navEnabled={fileNavEnabled}
       onPrev={onPrevFile}
       onNext={onNextFile}
+      previousShortcut={shortcutFor('diff-file-previous')}
+      previousAriaKeyshortcuts={ariaShortcutFor('diff-file-previous')}
+      nextShortcut={shortcutFor('diff-file-next')}
+      nextAriaKeyshortcuts={ariaShortcutFor('diff-file-next')}
     />,
     // 3. tool-well — staging group (stage / unstage / discard / discard-all) as
     // a flat ghost-icon group (one unit).
@@ -414,6 +440,10 @@ export const DiffChipToolbar = ({
       onStage={onStage}
       onUnstage={onUnstage}
       onDiscard={onDiscard}
+      stageShortcut={shortcutFor('diff-hunk-stage')}
+      stageAriaKeyshortcuts={ariaShortcutFor('diff-hunk-stage')}
+      discardShortcut={shortcutFor('diff-hunk-discard')}
+      discardAriaKeyshortcuts={ariaShortcutFor('diff-hunk-discard')}
       discardAllSlot={discardAllSlot}
     />,
     // 4. change stepper — azure (secondary) hunk-nav group (data_object glyph
@@ -424,6 +454,10 @@ export const DiffChipToolbar = ({
       navEnabled={hunkNavEnabled}
       onPrev={onPrevHunk}
       onNext={onNextHunk}
+      previousShortcut={shortcutFor('diff-hunk-previous')}
+      previousAriaKeyshortcuts={ariaShortcutFor('diff-hunk-previous')}
+      nextShortcut={shortcutFor('diff-hunk-next')}
+      nextAriaKeyshortcuts={ariaShortcutFor('diff-hunk-next')}
     />,
     // hairline between the navigation cluster and the config chips.
     <ToolbarSeparator key="sep-config" />,
@@ -538,7 +572,7 @@ export const DiffChipToolbar = ({
             onSelect={onPrevFile}
           >
             <span>Previous file</span>
-            <kbd>p</kbd>
+            <kbd>{shortcutLabelFor('diff-file-previous')}</kbd>
           </Menu.Row>
           <Menu.Row
             label="Next file"
@@ -547,7 +581,7 @@ export const DiffChipToolbar = ({
             onSelect={onNextFile}
           >
             <span>Next file</span>
-            <kbd>n</kbd>
+            <kbd>{shortcutLabelFor('diff-file-next')}</kbd>
           </Menu.Row>
         </Menu.Section>
       )
@@ -563,7 +597,7 @@ export const DiffChipToolbar = ({
             onSelect={(): Promise<void> | undefined => onStage?.()}
           >
             <span>Stage hunk</span>
-            <kbd>s</kbd>
+            <kbd>{shortcutLabelFor('diff-hunk-stage')}</kbd>
           </Menu.Row>
           {diffMode === 'staged' ? (
             <Menu.Row
@@ -573,7 +607,7 @@ export const DiffChipToolbar = ({
               onSelect={(): Promise<void> | undefined => onUnstage?.()}
             >
               <span>Unstage</span>
-              <kbd>s</kbd>
+              <kbd>{shortcutLabelFor('diff-hunk-stage')}</kbd>
             </Menu.Row>
           ) : null}
           <Menu.Row
@@ -583,7 +617,7 @@ export const DiffChipToolbar = ({
             onSelect={(): Promise<void> | undefined => onDiscard?.()}
           >
             <span>Discard hunk</span>
-            <kbd>d</kbd>
+            <kbd>{shortcutLabelFor('diff-hunk-discard')}</kbd>
           </Menu.Row>
           {onDiscardAll !== undefined ? (
             <Menu.Row
@@ -594,6 +628,7 @@ export const DiffChipToolbar = ({
               onSelect={openDiscardAllConfirmation}
             >
               <span>Discard all changes</span>
+              <kbd>{shortcutLabelFor('diff-file-discard')}</kbd>
             </Menu.Row>
           ) : null}
         </Menu.Section>
@@ -610,7 +645,7 @@ export const DiffChipToolbar = ({
             onSelect={onPrevHunk}
           >
             <span>Previous change</span>
-            <kbd>[</kbd>
+            <kbd>{shortcutLabelFor('diff-hunk-previous')}</kbd>
           </Menu.Row>
           <Menu.Row
             label="Next change"
@@ -619,7 +654,7 @@ export const DiffChipToolbar = ({
             onSelect={onNextHunk}
           >
             <span>Next change</span>
-            <kbd>]</kbd>
+            <kbd>{shortcutLabelFor('diff-hunk-next')}</kbd>
           </Menu.Row>
         </Menu.Section>
       )
@@ -739,12 +774,15 @@ export const DiffChipToolbar = ({
         {showPinnedActions ? (
           <div className="ml-auto flex shrink-0 items-center gap-2 pl-3">
             {onRefreshActiveFile !== undefined ? (
-              <Tooltip content="Refresh diff" shortcut="r">
+              <Tooltip
+                content="Refresh diff"
+                shortcut={shortcutFor('diff-refresh')}
+              >
                 <button
                   type="button"
                   data-testid="diff-active-file-refresh"
                   aria-label="refresh diff"
-                  aria-keyshortcuts="r"
+                  aria-keyshortcuts={ariaShortcutFor('diff-refresh')}
                   onClick={onRefreshActiveFile}
                   className="inline-flex h-7 items-center gap-1.5 rounded-md border border-outline-variant/60 bg-transparent px-3 font-mono text-[0.6875rem] font-medium text-on-surface transition-colors hover:border-primary/50 hover:bg-surface-container hover:text-primary disabled:cursor-default disabled:opacity-70 disabled:hover:border-outline-variant/60 disabled:hover:bg-transparent disabled:hover:text-on-surface"
                 >
@@ -759,18 +797,21 @@ export const DiffChipToolbar = ({
                     aria-hidden="true"
                     className="rounded border border-outline-variant/40 px-1 text-[0.625rem] leading-none text-on-surface-muted"
                   >
-                    r
+                    {shortcutLabelFor('diff-refresh')}
                   </span>
                 </button>
               </Tooltip>
             ) : null}
             {canRequestReview ? (
-              <Tooltip content="Request agent review" shortcut="@">
+              <Tooltip
+                content="Request agent review"
+                shortcut={shortcutFor('diff-review-request')}
+              >
                 <button
                   type="button"
                   data-testid="diff-request-review"
                   aria-label="request review"
-                  aria-keyshortcuts="@"
+                  aria-keyshortcuts={ariaShortcutFor('diff-review-request')}
                   onClick={onRequestReview}
                   className="inline-flex h-7 items-center gap-1.5 rounded-md border border-outline-variant/60 bg-transparent px-3 font-mono text-[0.6875rem] font-medium text-on-surface transition-colors hover:border-primary/50 hover:bg-surface-container hover:text-primary"
                 >
@@ -785,7 +826,7 @@ export const DiffChipToolbar = ({
                     aria-hidden="true"
                     className="rounded border border-outline-variant/40 px-1 text-[0.625rem] leading-none text-on-surface-muted"
                   >
-                    @
+                    {shortcutLabelFor('diff-review-request')}
                   </span>
                 </button>
               </Tooltip>
@@ -805,7 +846,7 @@ export const DiffChipToolbar = ({
               <button
                 type="button"
                 aria-label={`finish feedback (${feedbackCount})`}
-                aria-keyshortcuts="Y"
+                aria-keyshortcuts={ariaShortcutFor('diff-review-finish')}
                 disabled={!canFinishFeedback}
                 onClick={onFinishFeedback}
                 className="inline-flex items-center gap-[7px] h-7 pl-[11px] pr-2 rounded-md font-mono text-[0.6875rem] font-bold text-on-primary bg-primary hover:bg-primary-container shadow-[0_1px_5px_color-mix(in_srgb,var(--color-primary)_40%,transparent)] transition-colors disabled:cursor-not-allowed disabled:opacity-50"
@@ -816,7 +857,7 @@ export const DiffChipToolbar = ({
                 >
                   check
                 </span>
-                Finish (Y)
+                Finish ({shortcutLabelFor('diff-review-finish')})
                 <Chip
                   tone="custom"
                   radius="pill"

--- a/src/features/diff/components/toolbar/FilePill.test.tsx
+++ b/src/features/diff/components/toolbar/FilePill.test.tsx
@@ -12,6 +12,10 @@ const renderPill = (
     navEnabled: true,
     onPrev: vi.fn<() => void>(),
     onNext: vi.fn<() => void>(),
+    previousShortcut: 'p',
+    previousAriaKeyshortcuts: 'p',
+    nextShortcut: 'n',
+    nextAriaKeyshortcuts: 'n',
   }
 
   return render(<FilePill {...baseProps} {...overrides} />)
@@ -74,6 +78,10 @@ describe('FilePill', () => {
 
     expect(await screen.findByText('Next file')).toBeInTheDocument()
     expect(screen.getByTestId('tooltip-shortcut')).toHaveTextContent('n')
+    expect(screen.getByRole('button', { name: /next file/i })).toHaveAttribute(
+      'aria-keyshortcuts',
+      'n'
+    )
   })
 
   test('arrows are disabled and inert when navEnabled is false', () => {

--- a/src/features/diff/components/toolbar/FilePill.tsx
+++ b/src/features/diff/components/toolbar/FilePill.tsx
@@ -3,6 +3,7 @@ import { Chip } from '@/components/Chip'
 import { Tooltip } from '@/components/Tooltip'
 import { IconButton } from '@/components/IconButton'
 import { TOOLTIP_SUPPRESSED } from '@/lib/constants'
+import type { ShortcutInput } from '@/lib/formatShortcut'
 
 export interface FilePillProps {
   // Basename + count are rendered on the lavender pill body. `fileName` is the
@@ -18,6 +19,10 @@ export interface FilePillProps {
   navEnabled: boolean
   onPrev: (() => void) | undefined
   onNext: (() => void) | undefined
+  previousShortcut: ShortcutInput
+  previousAriaKeyshortcuts: string
+  nextShortcut: ShortcutInput
+  nextAriaKeyshortcuts: string
 }
 
 // Lavender (primary) file-navigation group: a previous-file ghost arrow, the
@@ -39,6 +44,10 @@ export const FilePill = ({
   navEnabled,
   onPrev,
   onNext,
+  previousShortcut,
+  previousAriaKeyshortcuts,
+  nextShortcut,
+  nextAriaKeyshortcuts,
 }: FilePillProps): ReactElement => {
   // Show only the trailing path segment on the pill; keep the full path on the
   // accessible name + tooltip so users can disambiguate same-named files.
@@ -46,12 +55,13 @@ export const FilePill = ({
 
   return (
     <span className="inline-flex items-center gap-0.5">
-      <Tooltip content="Previous file" shortcut="p">
+      <Tooltip content="Previous file" shortcut={previousShortcut}>
         <IconButton
           icon="chevron_left"
           label="previous file"
           size="sm"
           disabled={!navEnabled}
+          aria-keyshortcuts={previousAriaKeyshortcuts}
           onClick={onPrev}
           showTooltip={TOOLTIP_SUPPRESSED} // explicit outer Tooltip owns the label
           className={GHOST_ARROW_CLASSES}
@@ -82,12 +92,13 @@ export const FilePill = ({
           className="h-7 gap-2 rounded-md bg-primary/10 px-3 ring-1 ring-inset ring-primary/20"
         />
       </Tooltip>
-      <Tooltip content="Next file" shortcut="n">
+      <Tooltip content="Next file" shortcut={nextShortcut}>
         <IconButton
           icon="chevron_right"
           label="next file"
           size="sm"
           disabled={!navEnabled}
+          aria-keyshortcuts={nextAriaKeyshortcuts}
           onClick={onNext}
           showTooltip={TOOLTIP_SUPPRESSED} // explicit outer Tooltip owns the label
           className={GHOST_ARROW_CLASSES}

--- a/src/features/diff/components/toolbar/ToolWell.test.tsx
+++ b/src/features/diff/components/toolbar/ToolWell.test.tsx
@@ -12,6 +12,10 @@ const renderWell = (
     onStage: undefined,
     onUnstage: undefined,
     onDiscard: undefined,
+    stageShortcut: 's',
+    stageAriaKeyshortcuts: 's',
+    discardShortcut: 'd',
+    discardAriaKeyshortcuts: 'd',
     discardAllSlot: (
       <button type="button" aria-label="discard all">
         slot
@@ -61,6 +65,10 @@ describe('ToolWell', () => {
 
     expect(await screen.findByText('Stage hunk')).toBeInTheDocument()
     expect(screen.getByTestId('tooltip-shortcut')).toHaveTextContent('s')
+    expect(screen.getByRole('button', { name: /^stage$/i })).toHaveAttribute(
+      'aria-keyshortcuts',
+      's'
+    )
   })
 
   test('staging buttons render as placeholders when no handlers provided', () => {

--- a/src/features/diff/components/toolbar/ToolWell.tsx
+++ b/src/features/diff/components/toolbar/ToolWell.tsx
@@ -78,14 +78,16 @@ const WellButton = ({
   icon,
   label,
   tooltip,
-  shortcut = undefined,
+  shortcut,
+  ariaKeyshortcuts,
   onClick,
   disabled,
 }: {
   icon: string
   label: string
   tooltip: string
-  shortcut?: ShortcutInput
+  shortcut: ShortcutInput
+  ariaKeyshortcuts: string
   onClick: () => void
   disabled: boolean
 }): ReactElement => (
@@ -95,6 +97,7 @@ const WellButton = ({
       label={label}
       size="md"
       disabled={disabled}
+      aria-keyshortcuts={ariaKeyshortcuts}
       onClick={onClick}
       showTooltip={TOOLTIP_SUPPRESSED} // explicit outer Tooltip owns the label
       className={disabled ? WELL_DISABLED_BUTTON_CLASSES : WELL_BUTTON_CLASSES}
@@ -114,6 +117,10 @@ export interface ToolWellProps {
   onStage: (() => Promise<void>) | undefined
   onUnstage: (() => Promise<void>) | undefined
   onDiscard: (() => Promise<void>) | undefined
+  stageShortcut: ShortcutInput
+  stageAriaKeyshortcuts: string
+  discardShortcut: ShortcutInput
+  discardAriaKeyshortcuts: string
   // The discard-all button is rendered by the parent (it owns the confirm
   // popover + floating refs) and slotted in here so it sits inside the same
   // tonal well, after the felt divider.
@@ -135,6 +142,10 @@ export const ToolWell = ({
   onStage,
   onUnstage,
   onDiscard,
+  stageShortcut,
+  stageAriaKeyshortcuts,
+  discardShortcut,
+  discardAriaKeyshortcuts,
   discardAllSlot,
 }: ToolWellProps): ReactElement => (
   <span className="inline-flex items-center gap-px">
@@ -144,7 +155,8 @@ export const ToolWell = ({
         icon="add_box"
         label="stage"
         tooltip="Stage hunk"
-        shortcut="s"
+        shortcut={stageShortcut}
+        ariaKeyshortcuts={stageAriaKeyshortcuts}
         onClick={(): void => {
           void onStage()
         }}
@@ -161,7 +173,8 @@ export const ToolWell = ({
           icon="indeterminate_check_box"
           label="unstage"
           tooltip="Unstage"
-          shortcut="s"
+          shortcut={stageShortcut}
+          ariaKeyshortcuts={stageAriaKeyshortcuts}
           onClick={(): void => {
             void onUnstage()
           }}
@@ -178,7 +191,8 @@ export const ToolWell = ({
         icon="backspace"
         label="discard"
         tooltip="Discard hunk"
-        shortcut="d"
+        shortcut={discardShortcut}
+        ariaKeyshortcuts={discardAriaKeyshortcuts}
         onClick={(): void => {
           void onDiscard()
         }}

--- a/src/features/diff/hooks/useFeedbackBatch.ts
+++ b/src/features/diff/hooks/useFeedbackBatch.ts
@@ -22,7 +22,7 @@ import type { AgentReplyStatus } from '@/bindings'
  */
 export type ReviewCommentCategory = 'question' | 'change' | 'bug' | 'suggestion'
 
-/** Ordered for the editor's Ctrl+H / Ctrl+L cycling and the category chips. */
+/** Ordered for the editor's registered previous/next cycling and category chips. */
 export const REVIEW_COMMENT_CATEGORIES: readonly ReviewCommentCategory[] = [
   'question',
   'change',

--- a/src/features/diff/hooks/useKeyboard.test.ts
+++ b/src/features/diff/hooks/useKeyboard.test.ts
@@ -1,7 +1,25 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook } from '@testing-library/react'
-import { createRef, type RefObject } from 'react'
+import { createElement, createRef, type ReactNode, type RefObject } from 'react'
+import type { AppSettings } from '../../../bindings/AppSettings'
+import { SettingsContext } from '../../settings/SettingsProvider'
+import { DEFAULT_SETTINGS } from '../../settings/store/settingsDefaults'
 import { useKeyboard, type UseKeyboardOptions } from './useKeyboard'
+
+const codeForKey = (key: string): string => {
+  if (/^[a-z]$/i.test(key)) {
+    return `Key${key.toUpperCase()}`
+  }
+
+  return (
+    {
+      '/': 'Slash',
+      '@': 'Digit2',
+      '[': 'BracketLeft',
+      ']': 'BracketRight',
+    }[key] ?? key
+  )
+}
 
 const dispatch = (
   key: string,
@@ -13,6 +31,7 @@ const dispatch = (
 } => {
   const event = new KeyboardEvent('keydown', {
     key,
+    code: codeForKey(key),
     bubbles: true,
     cancelable: true,
     ...init,
@@ -51,7 +70,8 @@ const appendDiffRoot = (): {
 }
 
 const renderKeyboard = (
-  overrides: Partial<UseKeyboardOptions> = {}
+  overrides: Partial<UseKeyboardOptions> = {},
+  customKeybindings: Record<string, string> = {}
 ): {
   root: HTMLDivElement
   props: UseKeyboardOptions
@@ -97,7 +117,15 @@ const renderKeyboard = (
     onCancelConfirm: vi.fn(),
     ...overrides,
   }
-  const { unmount } = renderHook(() => useKeyboard(props))
+  const settings: AppSettings = { ...DEFAULT_SETTINGS, customKeybindings }
+
+  const wrapper = ({ children }: { children: ReactNode }): ReactNode =>
+    createElement(
+      SettingsContext.Provider,
+      { value: { settings, saveError: null, update: vi.fn() } },
+      children
+    )
+  const { unmount } = renderHook(() => useKeyboard(props), { wrapper })
 
   return { root, props, unmount }
 }
@@ -120,6 +148,36 @@ describe('useKeyboard', () => {
 
     expect(props.onMoveLine).toHaveBeenNthCalledWith(1, 1)
     expect(props.onMoveLine).toHaveBeenNthCalledWith(2, -1)
+  })
+
+  test('uses a persisted Shift-only override instead of the default', () => {
+    const { props } = renderKeyboard(
+      {},
+      { 'diff-line-next': 'Shift+ArrowDown' }
+    )
+
+    dispatch('j')
+    expect(props.onMoveLine).not.toHaveBeenCalled()
+
+    dispatch('ArrowDown', undefined, {
+      code: 'ArrowDown',
+      shiftKey: true,
+    })
+
+    expect(props.onMoveLine).toHaveBeenCalledOnce()
+    expect(props.onMoveLine).toHaveBeenCalledWith(1)
+  })
+
+  test('uses a persisted Alt-only override', () => {
+    const { props } = renderKeyboard({}, { 'diff-line-next': 'Alt+ArrowDown' })
+
+    dispatch('ArrowDown', undefined, {
+      code: 'ArrowDown',
+      altKey: true,
+    })
+
+    expect(props.onMoveLine).toHaveBeenCalledOnce()
+    expect(props.onMoveLine).toHaveBeenCalledWith(1)
   })
 
   test('n and p navigate files', () => {
@@ -153,7 +211,7 @@ describe('useKeyboard', () => {
   test('Shift+E toggles the sticky changed-files list', () => {
     const { props } = renderKeyboard()
 
-    dispatch('E')
+    dispatch('E', undefined, { shiftKey: true })
 
     expect(props.onToggleFilesListPinned).toHaveBeenCalledOnce()
     expect(props.onToggleFilesList).not.toHaveBeenCalled()
@@ -178,7 +236,7 @@ describe('useKeyboard', () => {
   test('Shift+I opens comment editor for the selected file', () => {
     const { props } = renderKeyboard()
 
-    dispatch('I')
+    dispatch('I', undefined, { shiftKey: true })
 
     expect(props.onFileComment).toHaveBeenCalledOnce()
     expect(props.onComment).not.toHaveBeenCalled()
@@ -197,7 +255,7 @@ describe('useKeyboard', () => {
   test('Shift+U updates the selected file comment', () => {
     const { props } = renderKeyboard()
 
-    dispatch('U')
+    dispatch('U', undefined, { shiftKey: true })
 
     expect(props.onUpdateFileComment).toHaveBeenCalledOnce()
     expect(props.onUpdateComment).not.toHaveBeenCalled()
@@ -206,7 +264,7 @@ describe('useKeyboard', () => {
   test('Y opens finish review', () => {
     const { props } = renderKeyboard()
 
-    dispatch('Y')
+    dispatch('Y', undefined, { shiftKey: true })
 
     expect(props.onFinishReview).toHaveBeenCalledOnce()
   })
@@ -214,7 +272,7 @@ describe('useKeyboard', () => {
   test('@ opens request review', () => {
     const { props } = renderKeyboard()
 
-    dispatch('@')
+    dispatch('@', undefined, { shiftKey: true })
 
     expect(props.onRequestReview).toHaveBeenCalledOnce()
   })
@@ -224,7 +282,7 @@ describe('useKeyboard', () => {
 
     dispatch('s')
     dispatch('d')
-    dispatch('D')
+    dispatch('D', undefined, { shiftKey: true })
 
     expect(props.onStageHunk).toHaveBeenCalledOnce()
     expect(props.onDiscardHunk).toHaveBeenCalledOnce()
@@ -284,6 +342,15 @@ describe('useKeyboard', () => {
     expect(props.onScrollPage).toHaveBeenNthCalledWith(2, -1)
   })
 
+  test('Ctrl+D and Ctrl+U reject extra modifiers', () => {
+    const { props } = renderKeyboard()
+
+    dispatch('d', undefined, { ctrlKey: true, shiftKey: true })
+    dispatch('u', undefined, { altKey: true, ctrlKey: true })
+
+    expect(props.onScrollPage).not.toHaveBeenCalled()
+  })
+
   test('y and n confirm or cancel while a keyboard confirmation is open', () => {
     const { props } = renderKeyboard({ confirming: true })
 
@@ -293,6 +360,26 @@ describe('useKeyboard', () => {
     expect(props.onConfirm).toHaveBeenCalledOnce()
     expect(props.onCancelConfirm).toHaveBeenCalledOnce()
     expect(props.onNextFile).not.toHaveBeenCalled()
+  })
+
+  test('uses persisted confirmation bindings instead of y and n', () => {
+    const { props } = renderKeyboard(
+      { confirming: true },
+      {
+        'diff-confirm-accept': 'Alt+Enter',
+        'diff-confirm-cancel': 'Alt+Escape',
+      }
+    )
+
+    dispatch('y')
+    dispatch('n')
+    expect(props.onConfirm).not.toHaveBeenCalled()
+    expect(props.onCancelConfirm).not.toHaveBeenCalled()
+
+    dispatch('Enter', undefined, { altKey: true })
+    dispatch('Escape', undefined, { altKey: true })
+    expect(props.onConfirm).toHaveBeenCalledOnce()
+    expect(props.onCancelConfirm).toHaveBeenCalledOnce()
   })
 
   test('r is inert while a keyboard confirmation is open', () => {
@@ -442,7 +529,19 @@ describe('useKeyboard', () => {
       onCancelConfirm: vi.fn(),
     }
 
-    renderHook(() => useKeyboard(props))
+    const settings: AppSettings = {
+      ...DEFAULT_SETTINGS,
+      customKeybindings: {},
+    }
+
+    const wrapper = ({ children }: { children: ReactNode }): ReactNode =>
+      createElement(
+        SettingsContext.Provider,
+        { value: { settings, saveError: null, update: vi.fn() } },
+        children
+      )
+
+    renderHook(() => useKeyboard(props), { wrapper })
     dispatch('j')
 
     expect(props.onMoveLine).not.toHaveBeenCalled()

--- a/src/features/diff/hooks/useKeyboard.ts
+++ b/src/features/diff/hooks/useKeyboard.ts
@@ -3,6 +3,8 @@ import {
   DIALOG_SELECTOR,
   TERMINAL_CONTAINER_ID,
 } from '../../workspace/containerIds'
+import { DIFF_COMMANDS, type DiffCommandId } from '../../keymap/catalog'
+import { useKeybindings } from '../../keymap/useKeybindings'
 
 export interface UseKeyboardOptions {
   enabled: boolean
@@ -61,6 +63,8 @@ const isDiffScopeActive = (
 
 /** Focus-scoped keyboard shortcuts for the git diff viewer. */
 export const useKeyboard = (options: UseKeyboardOptions): void => {
+  const { matches } = useKeybindings()
+
   const {
     enabled,
     rootRef,
@@ -123,17 +127,13 @@ export const useKeyboard = (options: UseKeyboardOptions): void => {
           : target
 
       if (confirming) {
-        const key = event.key.toLowerCase()
+        const handler = matches(event, 'diff-confirm-accept')
+          ? onConfirm
+          : matches(event, 'diff-confirm-cancel')
+            ? onCancelConfirm
+            : null
 
-        const handler =
-          key === 'y' ? onConfirm : key === 'n' ? onCancelConfirm : null
-
-        if (
-          handler !== null &&
-          !event.ctrlKey &&
-          !event.metaKey &&
-          !event.altKey
-        ) {
+        if (handler !== null) {
           event.preventDefault()
           event.stopPropagation()
           handler()
@@ -156,70 +156,46 @@ export const useKeyboard = (options: UseKeyboardOptions): void => {
         return
       }
 
-      if (event.ctrlKey && !event.metaKey && !event.altKey) {
-        const key = event.key.toLowerCase()
-        const direction = key === 'd' ? 1 : key === 'u' ? -1 : 0
-
-        if (direction !== 0) {
-          event.preventDefault()
-          event.stopPropagation()
-          onScrollPage(direction)
-        }
-
-        return
+      const handlers: Partial<Record<DiffCommandId, () => void>> = {
+        'diff-line-next': () => onMoveLine(1),
+        'diff-line-previous': () => onMoveLine(-1),
+        'diff-scroll-page-down': () => onScrollPage(1),
+        'diff-scroll-page-up': () => onScrollPage(-1),
+        'diff-file-next': searchOpen ? onNextMatch : onNextFile,
+        'diff-file-previous': searchOpen ? onPreviousMatch : onPreviousFile,
+        'diff-search-open': onOpenSearch,
+        'diff-search-or-visual-cancel': searchOpen
+          ? onCloseSearch
+          : visualMode
+            ? onCancelVisualSelection
+            : undefined,
+        'diff-files-toggle': onToggleFilesList,
+        'diff-files-pin': onToggleFilesListPinned,
+        'diff-refresh': onRefreshDiff,
+        'diff-hunk-previous': onPreviousHunk,
+        'diff-hunk-next': onNextHunk,
+        'diff-comment-line': onComment,
+        'diff-comment-file': onFileComment,
+        'diff-comment-update': onUpdateComment,
+        'diff-file-comment-update': onUpdateFileComment,
+        'diff-comment-delete': onDeleteComment,
+        'diff-review-finish': onFinishReview,
+        'diff-review-request': onRequestReview,
+        'diff-hunk-stage': onStageHunk,
+        'diff-hunk-discard': onDiscardHunk,
+        'diff-file-discard': onDiscardFile,
+        'diff-view-toggle': onToggleView,
+        'diff-side-deletions': () => onMoveLineSide('deletions'),
+        'diff-side-additions': () => onMoveLineSide('additions'),
+        'diff-visual-start': onStartVisualSelection,
+        'diff-visual-yank': onYankSelection,
       }
 
-      if (event.metaKey || event.altKey || event.ctrlKey) {
-        return
-      }
+      const command = DIFF_COMMANDS.find(
+        ({ id }) => handlers[id] !== undefined && matches(event, id)
+      )
+      const handler = command === undefined ? undefined : handlers[command.id]
 
-      if (event.key === 'Escape') {
-        if (searchOpen) {
-          event.preventDefault()
-          event.stopPropagation()
-          onCloseSearch()
-
-          return
-        }
-
-        if (visualMode) {
-          event.preventDefault()
-          event.stopPropagation()
-          onCancelVisualSelection()
-
-          return
-        }
-      }
-
-      const handlers: Partial<Record<string, () => void>> = {
-        j: () => onMoveLine(1),
-        k: () => onMoveLine(-1),
-        n: searchOpen ? onNextMatch : onNextFile,
-        p: searchOpen ? onPreviousMatch : onPreviousFile,
-        '/': onOpenSearch,
-        e: onToggleFilesList,
-        E: onToggleFilesListPinned,
-        r: onRefreshDiff,
-        '[': onPreviousHunk,
-        ']': onNextHunk,
-        i: onComment,
-        I: onFileComment,
-        u: onUpdateComment,
-        U: onUpdateFileComment,
-        x: onDeleteComment,
-        Y: onFinishReview,
-        '@': onRequestReview,
-        s: onStageHunk,
-        d: onDiscardHunk,
-        D: onDiscardFile,
-        t: onToggleView,
-        h: () => onMoveLineSide('deletions'),
-        l: () => onMoveLineSide('additions'),
-        v: onStartVisualSelection,
-        y: onYankSelection,
-      }
-
-      const handler = handlers[event.key]
       if (handler) {
         event.preventDefault()
         event.stopPropagation()
@@ -268,5 +244,6 @@ export const useKeyboard = (options: UseKeyboardOptions): void => {
     onCancelVisualSelection,
     onConfirm,
     onCancelConfirm,
+    matches,
   ])
 }

--- a/src/features/keymap/acceptance.test.tsx
+++ b/src/features/keymap/acceptance.test.tsx
@@ -46,12 +46,12 @@ const sessions: Session[] = [
 // End-to-end: a persisted override flows settings → useKeybindings → the migrated
 // hook, so it dispatches on the new combo and not the old default. jsdom is
 // non-mac, so useKeybindings resolves `Mod` to `ctrl`.
-test('persisted override changes the live shortcut (focus-pane-2 -> Mod+KeyK)', () => {
+test('persisted override changes the live shortcut (focus-pane-2 -> Mod+KeyM)', () => {
   const setSessionActivePane = vi.fn()
 
   const settings: AppSettings = {
     ...DEFAULT_SETTINGS,
-    customKeybindings: { 'focus-pane-2': 'Mod+KeyK' },
+    customKeybindings: { 'focus-pane-2': 'Mod+KeyM' },
   }
 
   const wrapper = ({ children }: { children: ReactNode }): ReactNode =>
@@ -77,7 +77,7 @@ test('persisted override changes the live shortcut (focus-pane-2 -> Mod+KeyK)', 
   )
 
   document.dispatchEvent(
-    new KeyboardEvent('keydown', { code: 'KeyK', ctrlKey: true })
+    new KeyboardEvent('keydown', { code: 'KeyM', ctrlKey: true })
   )
   expect(setSessionActivePane).toHaveBeenCalledWith('s1', 'p1') // rebound combo focuses pane 2
 

--- a/src/features/keymap/capture.test.ts
+++ b/src/features/keymap/capture.test.ts
@@ -39,11 +39,8 @@ describe('eventToChord', () => {
     })
   })
 
-  test('ignores non-mac meta because the runtime matcher uses Control for Mod', () => {
-    expect(eventToChord(keydown('KeyK', { metaKey: true }), false)).toEqual({
-      code: 'KeyK',
-      mods: new Set(),
-    })
+  test('rejects non-mac meta instead of capturing it as a bare chord', () => {
+    expect(eventToChord(keydown('KeyK', { metaKey: true }), false)).toBeNull()
   })
 
   test('returns null when the browser event does not expose a physical code', () => {

--- a/src/features/keymap/capture.ts
+++ b/src/features/keymap/capture.ts
@@ -26,7 +26,11 @@ export const eventToChord = (
   event: KeyboardEvent,
   isMac: boolean
 ): Chord | null => {
-  if (event.code === '' || MODIFIER_CODES.has(event.code)) {
+  if (
+    event.code === '' ||
+    MODIFIER_CODES.has(event.code) ||
+    (!isMac && event.metaKey)
+  ) {
     return null
   }
 

--- a/src/features/keymap/catalog.test.ts
+++ b/src/features/keymap/catalog.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest'
-import { CATALOG, getCommand, type CommandId } from './catalog'
-import { exactlyOneSuper } from './chord'
-import { resolveDefault } from './resolve'
+import { CATALOG, DIFF_COMMANDS, getCommand, type CommandId } from './catalog'
+import { formatChord } from './chord'
+import { isValidBinding, resolveDefault } from './resolve'
 
 describe('CATALOG', () => {
   test('ids are unique', () => {
@@ -9,7 +9,7 @@ describe('CATALOG', () => {
     expect(new Set(ids).size).toBe(ids.length)
   })
 
-  test('PR1 + PR2 + PR3 migrated commands are rebindable; the rest are display-only', () => {
+  test('workspace, browser, and Diff commands are rebindable', () => {
     const rebindable = CATALOG.filter((cmd) => cmd.rebindable)
       .map((cmd) => cmd.id)
       .sort()
@@ -31,6 +31,7 @@ describe('CATALOG', () => {
         'cycle-layout',
         'single-pane-focus',
         'dock-toggle',
+        'activity-panel-toggle',
         'palette',
         'palette-leader',
         'new-session',
@@ -42,18 +43,83 @@ describe('CATALOG', () => {
         'focus-editor',
         'focus-diff',
         'burner-toggle',
+        'browser-location',
+        ...DIFF_COMMANDS.map((cmd) => cmd.id),
       ].sort()
     )
   })
 
-  test('every rebindable default has exactly one super (terminal-safety)', () => {
+  test('every rebindable default is valid for its context', () => {
     for (const cmd of CATALOG.filter((c) => c.rebindable)) {
-      expect(exactlyOneSuper(resolveDefault(cmd, true))).toBe(true)
+      expect(isValidBinding(cmd, resolveDefault(cmd, true))).toBe(true)
     }
   })
 
   test('getCommand resolves a known id and is typed', () => {
     const id: CommandId = 'dock-toggle'
     expect(getCommand(id).label).toBe('Show / hide editor & diff dock')
+  })
+
+  test('registers every focus-scoped Diff command as rebindable', () => {
+    expect(
+      DIFF_COMMANDS.map((cmd) => [
+        cmd.id,
+        formatChord(resolveDefault(cmd, true)),
+      ])
+    ).toEqual([
+      ['diff-line-next', 'KeyJ'],
+      ['diff-line-previous', 'KeyK'],
+      ['diff-scroll-page-down', 'Ctrl+KeyD'],
+      ['diff-scroll-page-up', 'Ctrl+KeyU'],
+      ['diff-file-next', 'KeyN'],
+      ['diff-file-previous', 'KeyP'],
+      ['diff-search-open', 'Slash'],
+      ['diff-search-or-visual-cancel', 'Escape'],
+      ['diff-search-commit-next', 'Enter'],
+      ['diff-search-commit-previous', 'Shift+Enter'],
+      ['diff-files-toggle', 'KeyE'],
+      ['diff-files-pin', 'Shift+KeyE'],
+      ['diff-refresh', 'KeyR'],
+      ['diff-hunk-previous', 'BracketLeft'],
+      ['diff-hunk-next', 'BracketRight'],
+      ['diff-side-deletions', 'KeyH'],
+      ['diff-side-additions', 'KeyL'],
+      ['diff-view-toggle', 'KeyT'],
+      ['diff-comment-line', 'KeyI'],
+      ['diff-comment-file', 'Shift+KeyI'],
+      ['diff-comment-update', 'KeyU'],
+      ['diff-file-comment-update', 'Shift+KeyU'],
+      ['diff-comment-delete', 'KeyX'],
+      ['diff-comment-category-previous', 'Ctrl+KeyH'],
+      ['diff-comment-category-next', 'Ctrl+KeyL'],
+      ['diff-comment-insert-newline', 'Ctrl+KeyJ'],
+      ['diff-comment-cursor-up', 'Ctrl+KeyK'],
+      ['diff-comment-submit', 'Enter'],
+      ['diff-comment-cancel', 'Escape'],
+      ['diff-visual-start', 'KeyV'],
+      ['diff-visual-yank', 'KeyY'],
+      ['diff-review-finish', 'Shift+KeyY'],
+      ['diff-review-request', 'Shift+Digit2'],
+      ['diff-request-review-scope-file', 'KeyF'],
+      ['diff-request-review-scope-changelist', 'KeyA'],
+      ['diff-review-copy', 'KeyC'],
+      ['diff-request-review-submit', 'Shift+KeyY'],
+      ['diff-feedback-send', 'Shift+KeyY'],
+      ['diff-commit-review-submit', 'Shift+KeyY'],
+      ['diff-confirm-accept', 'KeyY'],
+      ['diff-confirm-cancel', 'KeyN'],
+      ['diff-hunk-stage', 'KeyS'],
+      ['diff-hunk-discard', 'KeyD'],
+      ['diff-file-discard', 'Shift+KeyD'],
+    ])
+
+    expect(
+      DIFF_COMMANDS.every(
+        (cmd) =>
+          cmd.context === 'diff' &&
+          cmd.group === 'Diff (when focused)' &&
+          cmd.rebindable
+      )
+    ).toBe(true)
   })
 })

--- a/src/features/keymap/catalog.ts
+++ b/src/features/keymap/catalog.ts
@@ -1,4 +1,4 @@
-import type { Chord } from './chord'
+import type { Chord, Mod } from './chord'
 
 export type BindingContext =
   | 'global'
@@ -8,16 +8,189 @@ export type BindingContext =
   | 'dock'
   | 'browser'
 
-const c = (
+const c = (code: string, ...mods: Mod[]): Chord => ({
+  code,
+  mods: new Set(mods),
+})
+
+const DIFF_GROUP = 'Diff (when focused)'
+type DiffMod = Exclude<Mod, 'Mod'>
+
+interface DiffCommandLiteral<Id extends string> {
+  readonly id: Id
+  readonly label: string
+  readonly group: typeof DIFF_GROUP
+  readonly context: 'diff'
+  readonly matchPolicy: 'exact'
+  readonly rebindable: true
+  readonly defaultCombo: Chord
+}
+
+const diffCommand = <Id extends string>(
+  id: Id,
+  label: string,
   code: string,
-  ...mods: ('Mod' | 'Ctrl' | 'Shift' | 'Alt')[]
-): Chord => ({ code, mods: new Set(mods) })
+  ...mods: DiffMod[]
+): DiffCommandLiteral<Id> => ({
+  id,
+  label,
+  group: DIFF_GROUP,
+  context: 'diff' as const,
+  matchPolicy: 'exact' as const,
+  rebindable: true as const,
+  defaultCombo: c(code, ...mods),
+})
+
+const DIFF_CATALOG_LITERAL = [
+  diffCommand('diff-line-next', 'Move to next line', 'KeyJ'),
+  diffCommand('diff-line-previous', 'Move to previous line', 'KeyK'),
+  diffCommand('diff-scroll-page-down', 'Scroll down half page', 'KeyD', 'Ctrl'),
+  diffCommand('diff-scroll-page-up', 'Scroll up half page', 'KeyU', 'Ctrl'),
+  diffCommand('diff-file-next', 'Next file / search match', 'KeyN'),
+  diffCommand('diff-file-previous', 'Previous file / search match', 'KeyP'),
+  diffCommand('diff-search-open', 'Open diff search', 'Slash'),
+  diffCommand(
+    'diff-search-or-visual-cancel',
+    'Close search / cancel visual selection',
+    'Escape'
+  ),
+  {
+    ...diffCommand('diff-search-commit-next', 'Commit search forward', 'Enter'),
+    intentionalShadowWith: ['diff-comment-submit'],
+  },
+  diffCommand(
+    'diff-search-commit-previous',
+    'Commit search backward',
+    'Enter',
+    'Shift'
+  ),
+  diffCommand('diff-files-toggle', 'Show / hide changed files', 'KeyE'),
+  diffCommand('diff-files-pin', 'Pin / unpin changed files', 'KeyE', 'Shift'),
+  diffCommand('diff-refresh', 'Refresh diff', 'KeyR'),
+  diffCommand('diff-hunk-previous', 'Previous hunk', 'BracketLeft'),
+  diffCommand('diff-hunk-next', 'Next hunk', 'BracketRight'),
+  diffCommand('diff-side-deletions', 'Move to deletions side', 'KeyH'),
+  diffCommand('diff-side-additions', 'Move to additions side', 'KeyL'),
+  diffCommand('diff-view-toggle', 'Toggle split / unified view', 'KeyT'),
+  diffCommand('diff-comment-line', 'Comment on selected line / range', 'KeyI'),
+  diffCommand('diff-comment-file', 'Comment on selected file', 'KeyI', 'Shift'),
+  diffCommand('diff-comment-update', 'Edit selected line comment', 'KeyU'),
+  diffCommand(
+    'diff-file-comment-update',
+    'Edit selected file comment',
+    'KeyU',
+    'Shift'
+  ),
+  diffCommand('diff-comment-delete', 'Delete selected line comment', 'KeyX'),
+  diffCommand(
+    'diff-comment-category-previous',
+    'Previous comment category',
+    'KeyH',
+    'Ctrl'
+  ),
+  diffCommand(
+    'diff-comment-category-next',
+    'Next comment category',
+    'KeyL',
+    'Ctrl'
+  ),
+  diffCommand(
+    'diff-comment-insert-newline',
+    'Insert comment newline',
+    'KeyJ',
+    'Ctrl'
+  ),
+  diffCommand(
+    'diff-comment-cursor-up',
+    'Move comment cursor up',
+    'KeyK',
+    'Ctrl'
+  ),
+  {
+    ...diffCommand('diff-comment-submit', 'Submit comment', 'Enter'),
+    intentionalShadowWith: ['diff-search-commit-next'],
+  },
+  {
+    ...diffCommand('diff-comment-cancel', 'Cancel comment', 'Escape'),
+    intentionalShadowWith: ['diff-search-or-visual-cancel'],
+  },
+  diffCommand('diff-visual-start', 'Start visual selection', 'KeyV'),
+  diffCommand('diff-visual-yank', 'Copy visual selection', 'KeyY'),
+  diffCommand('diff-review-finish', 'Finish feedback', 'KeyY', 'Shift'),
+  diffCommand('diff-review-request', 'Request agent review', 'Digit2', 'Shift'),
+  diffCommand('diff-request-review-scope-file', 'Review this file', 'KeyF'),
+  diffCommand(
+    'diff-request-review-scope-changelist',
+    'Review all changes',
+    'KeyA'
+  ),
+  diffCommand('diff-review-copy', 'Copy review payload', 'KeyC'),
+  {
+    ...diffCommand(
+      'diff-request-review-submit',
+      'Delegate review request',
+      'KeyY',
+      'Shift'
+    ),
+    intentionalShadowWith: [
+      'diff-review-finish',
+      'diff-feedback-send',
+      'diff-commit-review-submit',
+    ],
+  },
+  {
+    ...diffCommand(
+      'diff-feedback-send',
+      'Send finished feedback',
+      'KeyY',
+      'Shift'
+    ),
+    intentionalShadowWith: [
+      'diff-review-finish',
+      'diff-request-review-submit',
+      'diff-commit-review-submit',
+    ],
+  },
+  {
+    ...diffCommand(
+      'diff-commit-review-submit',
+      'Submit commit review',
+      'KeyY',
+      'Shift'
+    ),
+    intentionalShadowWith: [
+      'diff-review-finish',
+      'diff-request-review-submit',
+      'diff-feedback-send',
+    ],
+  },
+  {
+    ...diffCommand('diff-confirm-accept', 'Accept confirmation', 'KeyY'),
+    intentionalShadowWith: [
+      'diff-visual-yank',
+      'diff-search-commit-next',
+      'diff-comment-submit',
+    ],
+  },
+  {
+    ...diffCommand('diff-confirm-cancel', 'Cancel confirmation', 'KeyN'),
+    intentionalShadowWith: [
+      'diff-file-next',
+      'diff-search-or-visual-cancel',
+      'diff-comment-cancel',
+    ],
+  },
+  diffCommand('diff-hunk-stage', 'Stage / unstage hunk', 'KeyS'),
+  diffCommand('diff-hunk-discard', 'Discard hunk', 'KeyD'),
+  diffCommand('diff-file-discard', 'Discard file', 'KeyD', 'Shift'),
+] as const
 
 // PR1 migrated usePaneShortcuts (the focus-pane / cycle-layout commands) and
 // useDockToggleShortcut. PR2 migrates the remaining workspace hooks. PR3
 // migrates the command-palette direct toggle and leader prefix. Their
 // defaultCombo MUST equal today's hardcoded combos (resolve.test asserts this).
-// Terminal-owned rows remain display-only.
+// Terminal-owned rows remain display-only. Diff bindings are focus-scoped;
+// normal-mode handlers ignore text entry, while editor commands opt in.
 const CATALOG_LITERAL = [
   // ── Panes & Layout (MIGRATED — rebindable) ──
   {
@@ -165,6 +338,16 @@ const CATALOG_LITERAL = [
     matchPolicy: 'tolerant',
     rebindable: true,
     defaultCombo: c('Digit0', 'Mod'),
+  },
+  {
+    id: 'activity-panel-toggle',
+    label: 'Show / hide agent activity panel',
+    group: 'Global',
+    context: 'global',
+    matchPolicy: 'exact',
+    rebindable: true,
+    defaultCombo: (isMac: boolean): Chord =>
+      isMac ? c('KeyR', 'Mod') : c('KeyR', 'Mod', 'Shift'),
   },
   {
     id: 'palette',
@@ -323,20 +506,22 @@ const CATALOG_LITERAL = [
     defaultCombo: c('KeyC', 'Ctrl'),
   },
 
-  // ── Browser (display-only; browser chrome owns address-bar focus) ──
+  // ── Browser (focus-scoped) ──
   {
     id: 'browser-location',
     label: 'Focus browser address bar',
     group: 'Browser',
     context: 'browser',
     matchPolicy: 'exact',
-    rebindable: false,
-    preserveStoredOverrides: true,
+    rebindable: true,
     defaultCombo: c('KeyL', 'Mod'),
   },
+  ...DIFF_CATALOG_LITERAL,
 ] as const
 
 export type CommandId = (typeof CATALOG_LITERAL)[number]['id']
+
+export type DiffCommandId = (typeof DIFF_CATALOG_LITERAL)[number]['id']
 
 export interface CommandDescriptor {
   readonly id: CommandId
@@ -351,11 +536,21 @@ export interface CommandDescriptor {
   readonly intentionalShadowWith?: readonly CommandId[]
 }
 
+export interface DiffCommandDescriptor extends CommandDescriptor {
+  readonly id: DiffCommandId
+  readonly context: 'diff'
+  readonly defaultCombo: Chord
+  readonly rebindable: true
+}
+
 // Exported catalog is widened to CommandDescriptor so consumers see a uniform
 // array type, while CommandId is derived from the literal catalog above. This
 // breaks the circular dependency and lets intentionalShadowWith reject typos
 // at compile time.
 export const CATALOG: readonly CommandDescriptor[] = CATALOG_LITERAL
+
+export const DIFF_COMMANDS: readonly DiffCommandDescriptor[] =
+  DIFF_CATALOG_LITERAL
 
 const BY_ID = new Map<CommandId, CommandDescriptor>(
   CATALOG.map((cmd) => [cmd.id, cmd])

--- a/src/features/keymap/chord.test.ts
+++ b/src/features/keymap/chord.test.ts
@@ -29,6 +29,9 @@ describe('parseChord', () => {
       'Mod+Shift+ArrowLeft',
       'Ctrl+Backquote',
       'Mod+Digit1',
+      'Mod+KanaMode',
+      'Mod+Hiragana',
+      'Mod+Eject',
     ]) {
       expect(formatChord(parseChord(token)!)).toBe(token)
     }
@@ -39,6 +42,9 @@ describe('parseChord', () => {
     expect(parseChord('Mod+')).toBeNull()
     expect(parseChord('+KeyC')).toBeNull()
     expect(parseChord('Hyper+KeyC')).toBeNull()
+    expect(parseChord('garbage')).toBeNull()
+    expect(parseChord('Mod+NotAKey')).toBeNull()
+    expect(parseChord('ShiftLeft')).toBeNull()
     expect(parseChord('Mod+Mod+KeyC')).toBeNull() // duplicate
     expect(parseChord('Mod+Ctrl+KeyC')).toBeNull() // both supers — unsatisfiable
   })

--- a/src/features/keymap/chord.ts
+++ b/src/features/keymap/chord.ts
@@ -11,6 +11,62 @@ export interface Chord {
 const MOD_ORDER: readonly Mod[] = ['Mod', 'Ctrl', 'Alt', 'Shift']
 const MOD_SET: ReadonlySet<string> = new Set(MOD_ORDER)
 
+const NAMED_CODE_SET: ReadonlySet<string> = new Set([
+  'Abort',
+  'Backquote',
+  'Backslash',
+  'BracketLeft',
+  'BracketRight',
+  'Comma',
+  'Equal',
+  'Minus',
+  'Period',
+  'Quote',
+  'Semicolon',
+  'Slash',
+  'Backspace',
+  'ContextMenu',
+  'Enter',
+  'Space',
+  'Tab',
+  'Delete',
+  'End',
+  'Help',
+  'Hiragana',
+  'Home',
+  'Insert',
+  'PageDown',
+  'PageUp',
+  'Convert',
+  'Escape',
+  'Eject',
+  'KanaMode',
+  'Katakana',
+  'NonConvert',
+  'PrintScreen',
+  'Pause',
+  'Power',
+  'Resume',
+  'Sleep',
+  'Suspend',
+  'WakeUp',
+  'Again',
+  'Copy',
+  'Cut',
+  'Find',
+  'Open',
+  'Paste',
+  'Props',
+  'Select',
+  'Undo',
+])
+
+const CODE_PATTERN =
+  /^(?:Key[A-Z]|Digit[0-9]|F(?:[1-9]|1[0-9]|2[0-4])|Lang[1-5]|Arrow(?:Down|Left|Right|Up)|Volume(?:Down|Mute|Up)|Numpad(?:[0-9]|[A-Z][A-Za-z0-9]*)|(?:AudioVolume|Browser|Intl|Launch|Media)[A-Z][A-Za-z0-9]*)$/
+
+const isUsableCode = (code: string): boolean =>
+  NAMED_CODE_SET.has(code) || CODE_PATTERN.test(code)
+
 // Canonical token: mods in fixed order then code, joined by '+'. e.g. 'Mod+Shift+ArrowLeft'.
 export const formatChord = (chord: Chord): string =>
   [...MOD_ORDER.filter((mod) => chord.mods.has(mod)), chord.code].join('+')
@@ -21,7 +77,7 @@ export const formatChord = (chord: Chord): string =>
 export const parseChord = (token: string): Chord | null => {
   const parts = token.split('+')
   const code = parts.pop()
-  if (code === undefined || code === '') {
+  if (code === undefined || !isUsableCode(code)) {
     return null
   }
   const mods = new Set<Mod>()
@@ -39,6 +95,7 @@ export const parseChord = (token: string): Chord | null => {
 }
 
 // Exactly one super present (Mod xor literal Ctrl) — the terminal-safety
-// invariant for a rebindable binding (§5.1, §6.2).
+// invariant for global rebindable bindings (§5.1, §6.2). Focus-scoped Diff
+// bindings may omit both; resolve.ts owns that context exception.
 export const exactlyOneSuper = (chord: Chord): boolean =>
   chord.mods.has('Mod') !== chord.mods.has('Ctrl')

--- a/src/features/keymap/conflicts.test.ts
+++ b/src/features/keymap/conflicts.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from 'vitest'
 import { chordsOverlap, contextsOverlap, detectConflicts } from './conflicts'
 import type { Chord } from './chord'
-import type { CommandId } from './catalog'
+import { CATALOG, type CommandId } from './catalog'
+import { resolveDefault } from './resolve'
 
 const c = (
   code: string,
@@ -67,6 +68,19 @@ describe('contextsOverlap', () => {
 })
 
 describe('detectConflicts', () => {
+  test('catalog defaults contain only declared modal overlaps', () => {
+    for (const [isMac, superKey] of [
+      [true, 'meta'],
+      [false, 'ctrl'],
+    ] as const) {
+      const resolved = new Map<CommandId, Chord>(
+        CATALOG.map((command) => [command.id, resolveDefault(command, isMac)])
+      )
+
+      expect(detectConflicts(resolved, superKey)).toHaveLength(0)
+    }
+  })
+
   test('reports two commands sharing a resolved key + overlapping context', () => {
     const resolved = new Map<CommandId, Chord>([
       ['focus-pane-1', c('Digit1', 'Mod')],

--- a/src/features/keymap/displayKey.test.ts
+++ b/src/features/keymap/displayKey.test.ts
@@ -3,6 +3,7 @@ import {
   chordToAriaShortcut,
   chordToKeycapShortcut,
   chordToShortcutInput,
+  chordToVisibleShortcutInput,
 } from './displayKey'
 import { formatShortcut } from '../../lib/formatShortcut'
 import type { Chord, Mod } from './chord'
@@ -51,6 +52,20 @@ describe('chordToAriaShortcut', () => {
       'Shift+ArrowDown'
     )
     expect(chordToAriaShortcut(c('Slash'), false)).toBe('/')
+  })
+})
+
+describe('chordToVisibleShortcutInput', () => {
+  test('renders bare letter chords in typed case', () => {
+    expect(chordToVisibleShortcutInput(c('KeyJ'))).toEqual(['j'])
+    expect(chordToVisibleShortcutInput(c('KeyJ', 'Shift'))).toEqual([
+      'Shift',
+      'J',
+    ])
+  })
+
+  test('keeps modifier shortcut labels conventional', () => {
+    expect(chordToVisibleShortcutInput(c('KeyC', 'Mod'))).toEqual(['Mod', 'C'])
   })
 })
 

--- a/src/features/keymap/displayKey.test.ts
+++ b/src/features/keymap/displayKey.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'vitest'
-import { chordToShortcutInput } from './displayKey'
+import {
+  chordToAriaShortcut,
+  chordToKeycapShortcut,
+  chordToShortcutInput,
+} from './displayKey'
 import { formatShortcut } from '../../lib/formatShortcut'
 import type { Chord, Mod } from './chord'
 
@@ -19,6 +23,7 @@ describe('chordToShortcutInput', () => {
       '←',
     ])
     expect(chordToShortcutInput(c('Backquote', 'Ctrl'))).toEqual(['Ctrl', '`'])
+    expect(chordToShortcutInput(c('Slash'))).toEqual(['/'])
   })
 
   test('round-trips through formatShortcut to the right glyphs', () => {
@@ -31,5 +36,37 @@ describe('chordToShortcutInput', () => {
         isMac: false,
       })
     ).toBe('Ctrl+Shift+B')
+  })
+})
+
+describe('chordToAriaShortcut', () => {
+  test('uses platform-specific primary modifier names', () => {
+    expect(chordToAriaShortcut(c('KeyC', 'Mod'), true)).toBe('Meta+c')
+    expect(chordToAriaShortcut(c('KeyC', 'Mod'), false)).toBe('Control+c')
+  })
+
+  test('preserves secondary modifiers and logical key values', () => {
+    expect(chordToAriaShortcut(c('KeyI', 'Shift'), true)).toBe('Shift+I')
+    expect(chordToAriaShortcut(c('ArrowDown', 'Shift'), false)).toBe(
+      'Shift+ArrowDown'
+    )
+    expect(chordToAriaShortcut(c('Slash'), false)).toBe('/')
+  })
+})
+
+describe('chordToKeycapShortcut', () => {
+  test('renders platform modifiers as individual keycaps', () => {
+    expect(
+      chordToKeycapShortcut(c('KeyK', 'Mod', 'Alt', 'Shift'), true)
+    ).toEqual(['⌘', '⌥', '⇧', 'K'])
+
+    expect(
+      chordToKeycapShortcut(c('KeyK', 'Mod', 'Alt', 'Shift'), false)
+    ).toEqual(['Ctrl', 'Alt', '⇧', 'K'])
+
+    expect(chordToKeycapShortcut(c('Backquote', 'Ctrl'), true)).toEqual([
+      '⌃',
+      '`',
+    ])
   })
 })

--- a/src/features/keymap/displayKey.ts
+++ b/src/features/keymap/displayKey.ts
@@ -45,6 +45,22 @@ export const chordToShortcutInput = (chord: Chord): readonly string[] => [
   codeToDisplay(chord.code),
 ]
 
+const codeToVisibleShortcutKey = (chord: Chord): string => {
+  const letter = /^Key([A-Z])$/.exec(chord.code)
+  if (letter !== null && chord.mods.size === 0) {
+    return letter[1].toLowerCase()
+  }
+
+  return codeToDisplay(chord.code)
+}
+
+export const chordToVisibleShortcutInput = (
+  chord: Chord
+): readonly string[] => [
+  ...MOD_DISPLAY_ORDER.filter((mod) => chord.mods.has(mod)),
+  codeToVisibleShortcutKey(chord),
+]
+
 export const chordToKeycapShortcut = (
   chord: Chord,
   isMac = isMacPlatform()

--- a/src/features/keymap/displayKey.ts
+++ b/src/features/keymap/displayKey.ts
@@ -1,5 +1,5 @@
 import type { Chord, Mod } from './chord'
-import type { ShortcutInput } from '../../lib/formatShortcut'
+import { isMacPlatform } from '../../lib/formatShortcut'
 
 // event.code → the friendly key token formatShortcut understands. Letters and
 // digits are derived; symbols/arrows are mapped. Named keys (Enter, Space,
@@ -8,6 +8,11 @@ const CODE_DISPLAY: ReadonlyMap<string, string> = new Map([
   ['Backslash', '\\'],
   ['Semicolon', ';'],
   ['Backquote', '`'],
+  ['Slash', '/'],
+  ['Comma', ','],
+  ['Period', '.'],
+  ['Minus', '-'],
+  ['Equal', '='],
   ['BracketLeft', '['],
   ['BracketRight', ']'],
   ['ArrowLeft', '←'],
@@ -35,7 +40,64 @@ const codeToDisplay = (code: string): string => {
   return code
 }
 
-export const chordToShortcutInput = (chord: Chord): ShortcutInput => [
+export const chordToShortcutInput = (chord: Chord): readonly string[] => [
   ...MOD_DISPLAY_ORDER.filter((mod) => chord.mods.has(mod)),
   codeToDisplay(chord.code),
 ]
+
+export const chordToKeycapShortcut = (
+  chord: Chord,
+  isMac = isMacPlatform()
+): string[] =>
+  chordToShortcutInput(chord).map((key) => {
+    if (key === 'Mod') {
+      return isMac ? '⌘' : 'Ctrl'
+    }
+    if (key === 'Ctrl') {
+      return isMac ? '⌃' : 'Ctrl'
+    }
+    if (key === 'Alt') {
+      return isMac ? '⌥' : 'Alt'
+    }
+    if (key === 'Shift') {
+      return '⇧'
+    }
+
+    return key
+  })
+
+const codeToAriaKey = (code: string, shifted: boolean): string => {
+  const letter = /^Key([A-Z])$/.exec(code)
+  if (letter !== null) {
+    return shifted ? letter[1] : letter[1].toLowerCase()
+  }
+
+  if (code.startsWith('Arrow')) {
+    return code
+  }
+
+  return codeToDisplay(code)
+}
+
+export const chordToAriaShortcut = (
+  chord: Chord,
+  isMac = isMacPlatform()
+): string => {
+  const modifiers = MOD_DISPLAY_ORDER.filter((mod) => chord.mods.has(mod)).map(
+    (mod) => {
+      if (mod === 'Mod') {
+        return isMac ? 'Meta' : 'Control'
+      }
+      if (mod === 'Ctrl') {
+        return 'Control'
+      }
+
+      return mod
+    }
+  )
+
+  return [
+    ...modifiers,
+    codeToAriaKey(chord.code, chord.mods.has('Shift')),
+  ].join('+')
+}

--- a/src/features/keymap/match.ts
+++ b/src/features/keymap/match.ts
@@ -3,11 +3,19 @@ import type { Chord } from './chord'
 // The resolved 'Mod' — WorkspaceView already derives this as `preferModifier`.
 export type PlatformSuper = 'meta' | 'ctrl'
 
+export interface KeyChordInput {
+  code: string
+  metaKey: boolean
+  ctrlKey: boolean
+  shiftKey: boolean
+  altKey: boolean
+}
+
 // Pure matcher (spec §6.1). Super modifiers are EXACT (required down, all others
 // up); Shift/Alt follow `policy`: a listed one must be down; an unlisted one is
 // forbidden-if-down under 'exact' and ignored under 'tolerant'.
 export const eventMatchesChord = (
-  event: KeyboardEvent,
+  event: KeyChordInput,
   chord: Chord,
   superKey: PlatformSuper,
   policy: 'exact' | 'tolerant' = 'exact'

--- a/src/features/keymap/resolve.test.ts
+++ b/src/features/keymap/resolve.test.ts
@@ -45,6 +45,10 @@ describe('behavior preservation — migrated defaults equal today’s hardcoded 
 
 describe('behavior preservation — platform-specific PR2 defaults equal today’s hardcoded combos', () => {
   const expectedByPlatform: Record<string, { mac: string; other: string }> = {
+    'activity-panel-toggle': {
+      mac: 'Mod+KeyR',
+      other: 'Mod+Shift+KeyR',
+    },
     'new-session': { mac: 'Mod+KeyN', other: 'Mod+Shift+KeyN' },
     'session-prev': {
       mac: 'Mod+BracketLeft',
@@ -74,7 +78,35 @@ describe('resolveBindings', () => {
     )
   })
 
-  test('stored overrides colliding with fixed browser shortcuts are reverted', () => {
+  test('a Shift-only Diff override wins', () => {
+    expect(
+      tokenOf({ 'diff-line-next': 'Shift+ArrowDown' }, 'diff-line-next')
+    ).toBe('Shift+ArrowDown')
+  })
+
+  test('confirmation commands may reuse state-exclusive submit and cancel bindings', () => {
+    const overrides: CustomKeybindings = {
+      'diff-confirm-accept': 'Enter',
+      'diff-confirm-cancel': 'Escape',
+    }
+
+    expect(tokenOf(overrides, 'diff-confirm-accept')).toBe('Enter')
+    expect(tokenOf(overrides, 'diff-confirm-cancel')).toBe('Escape')
+  })
+
+  test('an unusable hand-edited Diff code falls back to its default', () => {
+    expect(tokenOf({ 'diff-line-next': 'garbage' }, 'diff-line-next')).toBe(
+      'KeyJ'
+    )
+  })
+
+  test('a browser-location override wins', () => {
+    expect(
+      tokenOf({ 'browser-location': 'Mod+KeyK' }, 'browser-location')
+    ).toBe('Mod+KeyK')
+  })
+
+  test('stored overrides colliding with browser shortcuts are reverted', () => {
     expect(tokenOf({ 'focus-pane-2': 'Mod+KeyL' }, 'focus-pane-2')).toBe(
       'Mod+Digit2'
     )

--- a/src/features/keymap/resolve.ts
+++ b/src/features/keymap/resolve.ts
@@ -5,6 +5,14 @@ import type { PlatformSuper } from './match'
 
 export type CustomKeybindings = Partial<Record<CommandId, string>>
 
+export const isValidBinding = (
+  command: Pick<CommandDescriptor, 'context'>,
+  chord: Chord
+): boolean =>
+  command.context === 'diff'
+    ? !(chord.mods.has('Mod') && chord.mods.has('Ctrl'))
+    : exactlyOneSuper(chord)
+
 export const resolveDefault = (
   cmd: Pick<CommandDescriptor, 'defaultCombo'>,
   isMac: boolean
@@ -39,7 +47,7 @@ export const resolveBindings = (
       continue
     }
     const chord = parseChord(token)
-    if (chord !== null && exactlyOneSuper(chord)) {
+    if (chord !== null && isValidBinding(cmd, chord)) {
       resolved.set(cmd.id, chord)
     }
   }

--- a/src/features/keymap/snapshot.test.ts
+++ b/src/features/keymap/snapshot.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from 'vitest'
+import { CATALOG } from './catalog'
+import {
+  createWorkspaceKeybindingSnapshot,
+  matchingWorkspaceKeybindings,
+} from './snapshot'
+
+const input = (
+  code: string,
+  modifiers: Partial<{
+    control: boolean
+    meta: boolean
+    alt: boolean
+    shift: boolean
+  }> = {}
+): {
+  code: string
+  control: boolean
+  meta: boolean
+  alt: boolean
+  shift: boolean
+} => ({
+  code,
+  control: modifiers.control ?? false,
+  meta: modifiers.meta ?? false,
+  alt: modifiers.alt ?? false,
+  shift: modifiers.shift ?? false,
+})
+
+describe('createWorkspaceKeybindingSnapshot', () => {
+  test('includes the full catalog in source order', () => {
+    const snapshot = createWorkspaceKeybindingSnapshot({}, 'darwin')
+
+    expect(snapshot.version).toBe(1)
+    expect(snapshot.bindings.map((entry) => entry.id)).toEqual(
+      CATALOG.map((command) => command.id)
+    )
+  })
+
+  test('expands Mod for the target platform and preserves literal Ctrl', () => {
+    const mac = createWorkspaceKeybindingSnapshot({}, 'darwin')
+    const linux = createWorkspaceKeybindingSnapshot({}, 'linux')
+
+    expect(
+      mac.bindings.find((entry) => entry.id === 'activity-panel-toggle')
+    ).toEqual(
+      expect.objectContaining({
+        token: 'Mod+KeyR',
+        control: false,
+        meta: true,
+        alt: false,
+        shift: false,
+      })
+    )
+
+    expect(
+      linux.bindings.find((entry) => entry.id === 'activity-panel-toggle')
+    ).toEqual(
+      expect.objectContaining({
+        token: 'Mod+Shift+KeyR',
+        control: true,
+        meta: false,
+        shift: true,
+      })
+    )
+
+    expect(
+      mac.bindings.find((entry) => entry.id === 'diff-scroll-page-down')
+    ).toEqual(expect.objectContaining({ control: true, meta: false }))
+  })
+
+  test('uses resolved custom bindings', () => {
+    const snapshot = createWorkspaceKeybindingSnapshot(
+      { 'activity-panel-toggle': 'Mod+Shift+KeyK' },
+      'darwin'
+    )
+
+    expect(
+      snapshot.bindings.find((entry) => entry.id === 'activity-panel-toggle')
+    ).toEqual(
+      expect.objectContaining({
+        code: 'KeyK',
+        token: 'Mod+Shift+KeyK',
+        meta: true,
+        shift: true,
+      })
+    )
+  })
+})
+
+describe('matchingWorkspaceKeybindings', () => {
+  const snapshot = createWorkspaceKeybindingSnapshot({}, 'darwin')
+
+  test('matches exact bindings and rejects unlisted secondary modifiers', () => {
+    expect(
+      matchingWorkspaceKeybindings(snapshot, input('KeyR', { meta: true })).map(
+        (entry) => entry.id
+      )
+    ).toContain('activity-panel-toggle')
+
+    expect(
+      matchingWorkspaceKeybindings(
+        snapshot,
+        input('KeyR', { meta: true, shift: true })
+      ).map((entry) => entry.id)
+    ).not.toContain('activity-panel-toggle')
+  })
+
+  test('allows unlisted secondary modifiers for tolerant bindings', () => {
+    expect(
+      matchingWorkspaceKeybindings(
+        snapshot,
+        input('Digit1', { meta: true, alt: true, shift: true })
+      ).map((entry) => entry.id)
+    ).toContain('focus-pane-1')
+  })
+
+  test('filters matches to requested contexts', () => {
+    const bareJ = input('KeyJ')
+
+    expect(
+      matchingWorkspaceKeybindings(snapshot, bareJ, ['diff']).map(
+        (entry) => entry.id
+      )
+    ).toContain('diff-line-next')
+
+    expect(matchingWorkspaceKeybindings(snapshot, bareJ, ['global'])).toEqual(
+      []
+    )
+  })
+})

--- a/src/features/keymap/snapshot.ts
+++ b/src/features/keymap/snapshot.ts
@@ -1,0 +1,80 @@
+import { CATALOG, type BindingContext, type CommandId } from './catalog'
+import { formatChord } from './chord'
+import { resolveBindings, type CustomKeybindings } from './resolve'
+
+export type WorkspaceKeybindingOverrides = CustomKeybindings
+
+export interface WorkspaceKeybindingSnapshotEntry {
+  id: CommandId
+  context: BindingContext
+  matchPolicy: 'exact' | 'tolerant'
+  code: string
+  token: string
+  control: boolean
+  meta: boolean
+  alt: boolean
+  shift: boolean
+}
+
+export interface WorkspaceKeybindingSnapshot {
+  version: 1
+  bindings: readonly WorkspaceKeybindingSnapshotEntry[]
+}
+
+export interface WorkspaceKeybindingInput {
+  code: string
+  control: boolean
+  meta: boolean
+  alt: boolean
+  shift?: boolean
+}
+
+export const createWorkspaceKeybindingSnapshot = (
+  overrides: WorkspaceKeybindingOverrides,
+  platform: string
+): WorkspaceKeybindingSnapshot => {
+  const isMac = platform === 'darwin'
+  const superKey = isMac ? 'meta' : 'ctrl'
+  const resolved = resolveBindings(overrides, isMac, superKey)
+
+  return {
+    version: 1,
+    bindings: CATALOG.map((command): WorkspaceKeybindingSnapshotEntry => {
+      const chord = resolved.get(command.id)!
+      const hasMod = chord.mods.has('Mod')
+
+      return {
+        id: command.id,
+        context: command.context,
+        matchPolicy: command.matchPolicy,
+        code: chord.code,
+        token: formatChord(chord),
+        control: chord.mods.has('Ctrl') || (hasMod && !isMac),
+        meta: hasMod && isMac,
+        alt: chord.mods.has('Alt'),
+        shift: chord.mods.has('Shift'),
+      }
+    }),
+  }
+}
+
+const secondaryMatches = (
+  down: boolean,
+  required: boolean,
+  policy: WorkspaceKeybindingSnapshotEntry['matchPolicy']
+): boolean => (required ? down : policy === 'tolerant' || !down)
+
+export const matchingWorkspaceKeybindings = (
+  snapshot: WorkspaceKeybindingSnapshot,
+  input: WorkspaceKeybindingInput,
+  contexts?: readonly BindingContext[]
+): WorkspaceKeybindingSnapshotEntry[] =>
+  snapshot.bindings.filter(
+    (entry) =>
+      (contexts === undefined || contexts.includes(entry.context)) &&
+      entry.code === input.code &&
+      entry.control === input.control &&
+      entry.meta === input.meta &&
+      secondaryMatches(input.alt, entry.alt, entry.matchPolicy) &&
+      secondaryMatches(input.shift === true, entry.shift, entry.matchPolicy)
+  )

--- a/src/features/keymap/useKeybindings.test.tsx
+++ b/src/features/keymap/useKeybindings.test.tsx
@@ -28,9 +28,9 @@ const renderKeybindings = (
 
 describe('useKeybindings', () => {
   test('bindingFor reflects a stored override', () => {
-    const { result } = renderKeybindings({ 'dock-toggle': 'Mod+KeyK' })
+    const { result } = renderKeybindings({ 'dock-toggle': 'Mod+KeyO' })
     expect(result.current.bindingFor('dock-toggle')).toEqual({
-      code: 'KeyK',
+      code: 'KeyO',
       mods: new Set(['Mod']),
     })
   })
@@ -108,14 +108,14 @@ describe('useKeybindings', () => {
     }
   })
 
-  test("setUserBinding rejects shadowing the browser address shortcut as 'reserved'", () => {
+  test("setUserBinding rejects shadowing the browser address shortcut as 'conflict'", () => {
     const { result, update } = renderKeybindings()
     expect(
       result.current.setUserBinding('dock-toggle', {
         code: 'KeyL',
         mods: new Set(['Mod']),
       })
-    ).toEqual({ ok: false, reason: 'reserved' })
+    ).toEqual({ ok: false, reason: 'conflict' })
     expect(update).not.toHaveBeenCalled()
   })
 
@@ -145,18 +145,58 @@ describe('useKeybindings', () => {
     const { result, update } = renderKeybindings()
     expect(
       result.current.setUserBinding('dock-toggle', {
-        code: 'KeyK',
+        code: 'KeyO',
         mods: new Set(['Mod']),
       })
     ).toEqual({ ok: true })
 
     expect(update).toHaveBeenCalledWith({
-      customKeybindings: { 'dock-toggle': 'Mod+KeyK' },
+      customKeybindings: { 'dock-toggle': 'Mod+KeyO' },
     })
   })
 
+  test('setUserBinding persists a Shift-only Diff override', () => {
+    const { result, update } = renderKeybindings()
+    expect(
+      result.current.setUserBinding('diff-line-next', {
+        code: 'ArrowDown',
+        mods: new Set(['Shift']),
+      })
+    ).toEqual({ ok: true })
+
+    expect(update).toHaveBeenCalledWith({
+      customKeybindings: { 'diff-line-next': 'Shift+ArrowDown' },
+    })
+  })
+
+  test('setUserBinding persists an Alt-only Diff override', () => {
+    const { result, update } = renderKeybindings()
+
+    expect(
+      result.current.setUserBinding('diff-line-next', {
+        code: 'ArrowDown',
+        mods: new Set(['Alt']),
+      })
+    ).toEqual({ ok: true })
+
+    expect(update).toHaveBeenCalledWith({
+      customKeybindings: { 'diff-line-next': 'Alt+ArrowDown' },
+    })
+  })
+
+  test('setUserBinding rejects both primary modifiers for Diff', () => {
+    const { result, update } = renderKeybindings()
+    expect(
+      result.current.setUserBinding('diff-line-next', {
+        code: 'ArrowDown',
+        mods: new Set(['Mod', 'Ctrl']),
+      })
+    ).toEqual({ ok: false, reason: 'invalid-super' })
+    expect(update).not.toHaveBeenCalled()
+  })
+
   test('resetBinding removes the override', () => {
-    const { result, update } = renderKeybindings({ 'dock-toggle': 'Mod+KeyK' })
+    const { result, update } = renderKeybindings({ 'dock-toggle': 'Mod+KeyO' })
     result.current.resetBinding('dock-toggle')
     expect(update).toHaveBeenCalledWith({ customKeybindings: {} })
   })

--- a/src/features/keymap/useKeybindings.ts
+++ b/src/features/keymap/useKeybindings.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from 'react'
 import { useSettings } from '../settings/hooks/useSettings'
 import { isMacPlatform } from '../../lib/formatShortcut'
 import { getCommand, type CommandId } from './catalog'
-import { exactlyOneSuper, formatChord, type Chord } from './chord'
+import { formatChord, type Chord } from './chord'
 import {
   chordsOverlap,
   contextsOverlap,
@@ -11,7 +11,11 @@ import {
   type Conflict,
 } from './conflicts'
 import { eventMatchesChord, type PlatformSuper } from './match'
-import { resolveBindings, type CustomKeybindings } from './resolve'
+import {
+  isValidBinding,
+  resolveBindings,
+  type CustomKeybindings,
+} from './resolve'
 
 export type SetBindingResult =
   | { ok: true }
@@ -54,10 +58,10 @@ export const useKeybindings = (): Keybindings => {
 
   const setUserBinding = useCallback(
     (id: CommandId, chord: Chord): SetBindingResult => {
-      if (!exactlyOneSuper(chord)) {
+      const me = getCommand(id)
+      if (!isValidBinding(me, chord)) {
         return { ok: false, reason: 'invalid-super' }
       }
-      const me = getCommand(id)
       if (!me.rebindable) {
         return { ok: false, reason: 'reserved' }
       }

--- a/src/features/sessions/components/NewSessionDialog/NewSessionDialog.test.tsx
+++ b/src/features/sessions/components/NewSessionDialog/NewSessionDialog.test.tsx
@@ -2,9 +2,22 @@ import { act, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import type { AgentAlias } from '@/bindings'
+import type { Keybindings } from '@/features/keymap/useKeybindings'
 import { DEFAULT_SETTINGS } from '@/features/settings/store/settingsDefaults'
 import { BUILTIN_PANE_LAYOUT_REGISTRY } from '../../../terminal/layout-registry'
 import { NewSessionDialog } from './NewSessionDialog'
+
+vi.mock('@/features/keymap/useKeybindings', async () => {
+  const { getCommand } = await import('@/features/keymap/catalog')
+  const { resolveDefault } = await import('@/features/keymap/resolve')
+
+  const bindingFor: Keybindings['bindingFor'] = (id) =>
+    resolveDefault(getCommand(id), false)
+
+  return {
+    useKeybindings: (): Pick<Keybindings, 'bindingFor'> => ({ bindingFor }),
+  }
+})
 
 interface CapturedNativeOverlayRequest {
   surfaceId: string

--- a/src/features/settings/SettingsProvider.test.tsx
+++ b/src/features/settings/SettingsProvider.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, test, vi, afterEach } from 'vitest'
 import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import type { ReactElement } from 'react'
+import { StrictMode, type ReactElement } from 'react'
 import type { AppSettings } from '../../bindings/AppSettings'
 import { SettingsProvider } from './SettingsProvider'
 import { useSettings } from './hooks/useSettings'
@@ -189,7 +189,7 @@ describe('SettingsProvider', () => {
     })
   })
 
-  test('syncs an in-memory snapshot to the main process only on update', async () => {
+  test('syncs the loaded snapshot and subsequent updates to the main process', async () => {
     const loaded = createLoadedSettings()
     const load = vi.fn().mockResolvedValue(loaded)
     const save = vi.fn().mockResolvedValue(undefined)
@@ -209,7 +209,11 @@ describe('SettingsProvider', () => {
       expect(screen.getByTestId('closeWithNoTabs').textContent).toBe('close')
     })
 
-    expect(syncSnapshot).not.toHaveBeenCalled()
+    await waitFor(() => {
+      expect(syncSnapshot).toHaveBeenCalledWith(loaded)
+    })
+
+    syncSnapshot.mockClear()
 
     const user = userEvent.setup()
     await user.click(screen.getByRole('button', { name: 'Update' }))
@@ -223,6 +227,67 @@ describe('SettingsProvider', () => {
         expect.objectContaining({ closeWithNoTabs: 'nothing' })
       )
     })
+  })
+
+  test('ignores a stale StrictMode load completion', async () => {
+    const older = createLoadedSettings()
+
+    const newer = {
+      ...older,
+      closeWithNoTabs: 'nothing' as const,
+      customKeybindings: {
+        'activity-panel-toggle': 'Mod+KeyK',
+      },
+    }
+
+    const loadResolvers: ((settings: AppSettings) => void)[] = []
+
+    const load = vi.fn(
+      () =>
+        new Promise<AppSettings>((resolve) => {
+          loadResolvers.push(resolve)
+        })
+    )
+    const syncSnapshot = vi.fn().mockResolvedValue(undefined)
+
+    window.vimeflow = {
+      settings: {
+        load,
+        save: vi.fn().mockResolvedValue(undefined),
+        openFile: vi.fn(),
+        syncSnapshot,
+      },
+    } as unknown as Window['vimeflow']
+
+    render(
+      <StrictMode>
+        <SettingsProvider>
+          <TestConsumer />
+        </SettingsProvider>
+      </StrictMode>
+    )
+
+    await waitFor(() => {
+      expect(loadResolvers).toHaveLength(2)
+    })
+
+    await act(async () => {
+      loadResolvers[1]?.(newer)
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('closeWithNoTabs').textContent).toBe('nothing')
+      expect(syncSnapshot).toHaveBeenCalledWith(newer)
+    })
+
+    await act(async () => {
+      loadResolvers[0]?.(older)
+      await Promise.resolve()
+    })
+
+    expect(screen.getByTestId('closeWithNoTabs').textContent).toBe('nothing')
+    expect(syncSnapshot).not.toHaveBeenCalledWith(older)
   })
 
   test('applies settings broadcasts from another renderer', async () => {

--- a/src/features/settings/SettingsProvider.tsx
+++ b/src/features/settings/SettingsProvider.tsx
@@ -98,18 +98,26 @@ export const SettingsProvider = ({
   )
 
   useEffect(() => {
+    let cancelled = false
+
     const load = async (): Promise<void> => {
       const bridge =
         typeof window !== 'undefined' ? window.vimeflow?.settings : undefined
 
       if (!bridge) {
-        hasLoadedRef.current = true
+        if (!cancelled) {
+          hasLoadedRef.current = true
+        }
 
         return
       }
 
       try {
         const loaded = await bridge.load()
+        if (cancelled) {
+          return
+        }
+
         const base = latestBroadcastBeforeLoadRef.current ?? loaded
         latestBroadcastBeforeLoadRef.current = null
         hasLoadedRef.current = true
@@ -118,7 +126,12 @@ export const SettingsProvider = ({
         }
         setSettings(base)
         settingsRef.current = base
+        void syncSnapshotToMain(base)
       } catch {
+        if (cancelled) {
+          return
+        }
+
         const base = latestBroadcastBeforeLoadRef.current ?? DEFAULT_SETTINGS
         latestBroadcastBeforeLoadRef.current = null
         hasLoadedRef.current = true
@@ -128,7 +141,11 @@ export const SettingsProvider = ({
     }
 
     void load()
-  }, [applyPendingLoadPatch])
+
+    return (): void => {
+      cancelled = true
+    }
+  }, [applyPendingLoadPatch, syncSnapshotToMain])
 
   useEffect(() => {
     const bridge =

--- a/src/features/settings/components/panes/KeymapPane.test.tsx
+++ b/src/features/settings/components/panes/KeymapPane.test.tsx
@@ -4,6 +4,7 @@ import {
   fireEvent,
   render as rtlRender,
   screen,
+  within,
 } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { createElement, type ReactElement } from 'react'
@@ -64,7 +65,7 @@ describe('KeymapPane', () => {
     expect(screen.getByLabelText('Keymap preset')).toHaveValue('vimeflow')
   })
 
-  test('renders granular catalog rows + the Diff zone', () => {
+  test('renders granular catalog rows including the current Diff keymap', () => {
     render(<KeymapPane />)
 
     // Granular catalog labels (one per command — replacing the old grouped rows).
@@ -73,12 +74,30 @@ describe('KeymapPane', () => {
     expect(
       screen.getByText('Show / hide editor & diff dock')
     ).toBeInTheDocument()
+
+    expect(
+      screen.getByText('Show / hide agent activity panel')
+    ).toBeInTheDocument()
     expect(screen.getByText('Open settings')).toBeInTheDocument()
     expect(screen.getByText('Open command palette')).toBeInTheDocument()
     expect(screen.getByText('Command palette leader')).toBeInTheDocument()
     expect(screen.getByText('Focus browser address bar')).toBeInTheDocument()
-    // The bare-key Diff zone still renders from KEYMAP_GROUPS.
-    expect(screen.getByText('Next / previous file')).toBeInTheDocument()
+    expect(screen.getByText('Move to next line')).toBeInTheDocument()
+    expect(screen.getByText('Next file / search match')).toBeInTheDocument()
+    expect(screen.getByText('Previous hunk')).toBeInTheDocument()
+    expect(screen.getByText('Stage / unstage hunk')).toBeInTheDocument()
+    expect(screen.getByText('Request agent review')).toBeInTheDocument()
+    expect(
+      within(
+        screen.getByTestId('settings-target-keymap-command-diff-review-request')
+      ).getByText('Shift+2')
+    ).toBeInTheDocument()
+
+    expect(
+      screen.getByText('Close search / cancel visual selection')
+    ).toBeInTheDocument()
+    expect(screen.queryByText('Open file')).not.toBeInTheDocument()
+    expect(screen.queryByText('Back to file list')).not.toBeInTheDocument()
   })
 
   test('switching the preset to vim reveals the Vim ex-command rows', async () => {
@@ -124,16 +143,37 @@ describe('KeymapPane', () => {
     vi.unstubAllGlobals()
   })
 
+  test('uses the resolved palette binding in the footer', () => {
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      platform: 'Linux x86_64',
+    })
+
+    renderWithSettings({ palette: 'Mod+Shift+KeyP' })
+
+    expect(
+      screen.getByText(
+        'More actions are available in the Ctrl+Shift+P command palette.'
+      )
+    ).toBeInTheDocument()
+
+    vi.unstubAllGlobals()
+  })
+
   test('reflects a persisted override on a rebindable row', () => {
     vi.stubGlobal('navigator', {
       ...navigator,
       platform: 'MacIntel',
     })
 
-    // dock-toggle default is ⌘0; the override re-renders the row as ⌘K.
-    renderWithSettings({ 'dock-toggle': 'Mod+KeyK' })
+    // dock-toggle default is ⌘0; the override re-renders the row as ⌘O.
+    renderWithSettings({
+      'dock-toggle': 'Mod+KeyO',
+      'diff-line-next': 'Shift+ArrowDown',
+    })
 
-    expect(screen.getByText('⌘K')).toBeInTheDocument()
+    expect(screen.getByText('⌘O')).toBeInTheDocument()
+    expect(screen.getByText('⇧↓')).toBeInTheDocument()
 
     vi.unstubAllGlobals()
   })
@@ -155,8 +195,8 @@ describe('KeymapPane', () => {
       name: 'Capture Show / hide editor & diff dock binding',
     })
     expect(capture).toHaveAttribute(KEYMAP_CAPTURE_TARGET_ATTRIBUTE, 'true')
-    fireEvent.keyDown(capture, { key: 'k', code: 'KeyK', ctrlKey: true })
-    expect(screen.getByText('Ctrl+K')).toBeInTheDocument()
+    fireEvent.keyDown(capture, { key: 'o', code: 'KeyO', ctrlKey: true })
+    expect(screen.getByText('Ctrl+O')).toBeInTheDocument()
 
     fireEvent.click(
       screen.getByRole('button', {
@@ -165,9 +205,87 @@ describe('KeymapPane', () => {
     )
 
     expect(update).toHaveBeenCalledWith({
-      customKeybindings: { 'dock-toggle': 'Mod+KeyK' },
+      customKeybindings: { 'dock-toggle': 'Mod+KeyO' },
     })
-    expect(screen.getByRole('status')).toHaveTextContent('Saved.')
+
+    const row = screen.getByTestId('settings-target-keymap-command-dock-toggle')
+    const status = within(row).getByRole('status')
+    const shortcut = within(row).getByText('Ctrl+0')
+
+    expect(status).toHaveTextContent('Saved.')
+    expect(within(row).getAllByText(/^(Saved\.|Ctrl\+0)$/)).toEqual([
+      status,
+      shortcut,
+    ])
+
+    vi.unstubAllGlobals()
+  })
+
+  test('saves and displays a Shift-only Diff binding', () => {
+    const { update } = renderWithSettings()
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Edit Move to next line binding',
+      })
+    )
+
+    const capture = screen.getByRole('button', {
+      name: 'Capture Move to next line binding',
+    })
+    fireEvent.keyDown(capture, {
+      key: 'ArrowDown',
+      code: 'ArrowDown',
+      shiftKey: true,
+    })
+    expect(screen.getByText('Shift+↓')).toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Save Move to next line binding',
+      })
+    )
+
+    expect(update).toHaveBeenCalledWith({
+      customKeybindings: { 'diff-line-next': 'Shift+ArrowDown' },
+    })
+  })
+
+  test('explains that a Diff binding can omit the primary modifier', () => {
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      platform: 'MacIntel',
+    })
+    const { update } = renderWithSettings()
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Edit Move to next line binding',
+      })
+    )
+
+    fireEvent.keyDown(
+      screen.getByRole('button', {
+        name: 'Capture Move to next line binding',
+      }),
+      {
+        key: 'ArrowDown',
+        code: 'ArrowDown',
+        metaKey: true,
+        ctrlKey: true,
+      }
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Save Move to next line binding',
+      })
+    )
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Use at most one primary modifier.'
+    )
+    expect(update).not.toHaveBeenCalled()
 
     vi.unstubAllGlobals()
   })
@@ -188,14 +306,14 @@ describe('KeymapPane', () => {
     const capture = screen.getByRole('button', {
       name: 'Capture Show / hide editor & diff dock binding',
     })
-    fireEvent.keyDown(capture, { key: 'k', code: 'KeyK', ctrlKey: true })
+    fireEvent.keyDown(capture, { key: 'o', code: 'KeyO', ctrlKey: true })
     fireEvent.keyDown(capture, {
       key: 'Shift',
       code: 'ShiftLeft',
       shiftKey: true,
     })
 
-    expect(screen.getByText('Ctrl+K')).toBeInTheDocument()
+    expect(screen.getByText('Ctrl+O')).toBeInTheDocument()
     expect(screen.queryByText('ShiftLeft')).not.toBeInTheDocument()
 
     vi.unstubAllGlobals()
@@ -289,7 +407,7 @@ describe('KeymapPane', () => {
     const capture = screen.getByRole('button', {
       name: 'Capture Show / hide editor & diff dock binding',
     })
-    fireEvent.keyDown(capture, { key: 'k', code: 'KeyK', ctrlKey: true })
+    fireEvent.keyDown(capture, { key: 'o', code: 'KeyO', ctrlKey: true })
 
     fireEvent.click(
       screen.getByRole('button', {
@@ -452,7 +570,7 @@ describe('KeymapPane', () => {
     const capture = screen.getByRole('button', {
       name: 'Capture Show / hide editor & diff dock binding',
     })
-    fireEvent.keyDown(capture, { key: 'k', code: 'KeyK', ctrlKey: true })
+    fireEvent.keyDown(capture, { key: 'o', code: 'KeyO', ctrlKey: true })
 
     const save = screen.getByRole('button', {
       name: 'Save Show / hide editor & diff dock binding',
@@ -461,7 +579,7 @@ describe('KeymapPane', () => {
     fireEvent.click(save)
 
     expect(update).toHaveBeenCalledWith({
-      customKeybindings: { 'dock-toggle': 'Mod+KeyK' },
+      customKeybindings: { 'dock-toggle': 'Mod+KeyO' },
     })
 
     vi.unstubAllGlobals()
@@ -471,7 +589,7 @@ describe('KeymapPane', () => {
     vi.useFakeTimers()
 
     const { update } = renderWithSettings({
-      'dock-toggle': 'Mod+KeyK',
+      'dock-toggle': 'Mod+KeyO',
       'focus-pane-1': 'Mod+KeyJ',
     })
 
@@ -550,7 +668,7 @@ describe('KeymapPane', () => {
       screen.getByRole('button', {
         name: 'Capture Show / hide editor & diff dock binding',
       }),
-      { key: 'k', code: 'KeyK', ctrlKey: true }
+      { key: 'o', code: 'KeyO', ctrlKey: true }
     )
 
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()

--- a/src/features/settings/components/panes/KeymapPane.test.tsx
+++ b/src/features/settings/components/panes/KeymapPane.test.tsx
@@ -83,6 +83,11 @@ describe('KeymapPane', () => {
     expect(screen.getByText('Command palette leader')).toBeInTheDocument()
     expect(screen.getByText('Focus browser address bar')).toBeInTheDocument()
     expect(screen.getByText('Move to next line')).toBeInTheDocument()
+    expect(
+      within(
+        screen.getByTestId('settings-target-keymap-command-diff-line-next')
+      ).getByText('j')
+    ).toBeInTheDocument()
     expect(screen.getByText('Next file / search match')).toBeInTheDocument()
     expect(screen.getByText('Previous hunk')).toBeInTheDocument()
     expect(screen.getByText('Stage / unstage hunk')).toBeInTheDocument()

--- a/src/features/settings/components/panes/KeymapPane.tsx
+++ b/src/features/settings/components/panes/KeymapPane.tsx
@@ -26,7 +26,7 @@ import {
   KEYMAP_CAPTURE_TARGET_ATTRIBUTE,
 } from '../../../keymap/capture'
 import type { Chord } from '../../../keymap/chord'
-import { chordToShortcutInput } from '../../../keymap/displayKey'
+import { chordToVisibleShortcutInput } from '../../../keymap/displayKey'
 import {
   useKeybindings,
   type SetBindingResult,
@@ -131,7 +131,7 @@ const labelCell = (text: string): ReactElement => (
 )
 
 const shortcutLabel = (chord: Chord): string =>
-  formatShortcut(chordToShortcutInput(chord))
+  formatShortcut(chordToVisibleShortcutInput(chord))
 
 const iconButtonClass = (disabled = false): string =>
   `inline-flex h-7 w-7 items-center justify-center rounded-md border border-outline-variant/35 bg-surface-container-low/70 text-on-surface-muted transition-colors ${

--- a/src/features/settings/components/panes/KeymapPane.tsx
+++ b/src/features/settings/components/panes/KeymapPane.tsx
@@ -15,13 +15,12 @@ import {
 } from '../../../../lib/formatShortcut'
 import { useSettings } from '../../hooks/useSettings'
 import {
-  KEYMAP_GROUPS,
   SETTINGS_TARGET_IDS,
   VIM_KEYMAP_GROUPS,
   keymapCommandTargetId,
   keymapStaticTargetId,
 } from '../../sections'
-import { CATALOG, type CommandId } from '../../../keymap/catalog'
+import { CATALOG, getCommand, type CommandId } from '../../../keymap/catalog'
 import {
   eventToChord,
   KEYMAP_CAPTURE_TARGET_ATTRIBUTE,
@@ -41,10 +40,15 @@ import type {
 import { Kbd } from '../Kbd'
 import { PaneTitle, Row, Select } from '../controls'
 
-// The catalog owns the modifier-based rows (Global / Panes & Layout / Terminal / Browser).
-// The bare-key Diff zone keeps rendering from KEYMAP_GROUPS (no platform-modifier
-// drift; vim-style lowercase display), as do the Vim ex-command rows. (§6.4)
-const GROUP_ORDER = ['Global', 'Panes & Layout', 'Terminal', 'Browser'] as const
+// Vim ex-commands are palette text commands, not keybindings, so they retain
+// their own static rows. Every keyboard binding renders from the catalog.
+const GROUP_ORDER = [
+  'Global',
+  'Panes & Layout',
+  'Terminal',
+  'Browser',
+  'Diff (when focused)',
+] as const
 type CatalogCommand = (typeof CATALOG)[number]
 type FeedbackTone = 'info' | 'danger'
 type TabDirection = 'forward' | 'backward'
@@ -137,10 +141,13 @@ const iconButtonClass = (disabled = false): string =>
   }`
 
 const resultMessage = (
-  reason: Exclude<SetBindingResult, { ok: true }>['reason']
+  reason: Exclude<SetBindingResult, { ok: true }>['reason'],
+  id: CommandId
 ): string => {
   if (reason === 'invalid-super') {
-    return 'Use exactly one primary modifier.'
+    return getCommand(id).context === 'diff'
+      ? 'Use at most one primary modifier.'
+      : 'Use exactly one primary modifier.'
   }
   if (reason === 'reserved') {
     return 'Shortcut is reserved.'
@@ -304,7 +311,11 @@ export const KeymapPane = ({
       return
     }
 
-    setFeedback({ id, tone: 'danger', text: resultMessage(result.reason) })
+    setFeedback({
+      id,
+      tone: 'danger',
+      text: resultMessage(result.reason, id),
+    })
   }
 
   const resetCommand = (id: CommandId): void => {
@@ -362,6 +373,19 @@ export const KeymapPane = ({
       >
         {labelCell(cmd.label)}
         <div className="flex shrink-0 items-center gap-2">
+          {rowFeedback && (
+            <span
+              role={rowFeedback.tone === 'danger' ? 'alert' : 'status'}
+              className={`min-w-[148px] text-right font-body text-xs ${
+                rowFeedback.tone === 'danger'
+                  ? 'text-error'
+                  : 'text-on-surface-muted'
+              }`}
+            >
+              {rowFeedback.text}
+            </span>
+          )}
+
           <span className="flex min-w-[72px] justify-end gap-1">
             <Kbd>{shortcutLabel(bindingFor(cmd.id))}</Kbd>
           </span>
@@ -416,19 +440,6 @@ export const KeymapPane = ({
                 </div>
               )}
             </>
-          )}
-
-          {rowFeedback && (
-            <span
-              role={rowFeedback.tone === 'danger' ? 'alert' : 'status'}
-              className={`min-w-[148px] text-right font-body text-xs ${
-                rowFeedback.tone === 'danger'
-                  ? 'text-error'
-                  : 'text-on-surface-muted'
-              }`}
-            >
-              {rowFeedback.text}
-            </span>
           )}
         </div>
       </div>
@@ -494,15 +505,11 @@ export const KeymapPane = ({
         )
       })}
 
-      {KEYMAP_GROUPS.filter(
-        (group) => group.zone === 'Diff (when focused)'
-      ).map(staticGroup)}
-
       {showVim && VIM_KEYMAP_GROUPS.map(staticGroup)}
 
       <p className="font-body text-xs text-on-surface-muted">
-        More actions are available in the {formatShortcut(['Mod', ';'])} command
-        palette.
+        More actions are available in the {shortcutLabel(bindingFor('palette'))}{' '}
+        command palette.
       </p>
     </>
   )

--- a/src/features/settings/hooks/useSettingsDialog.test.ts
+++ b/src/features/settings/hooks/useSettingsDialog.test.ts
@@ -78,6 +78,23 @@ describe('useSettingsDialog', () => {
     expect(result.current.isOpen).toBe(true)
   })
 
+  test('literal Ctrl+, toggles the dialog open on macOS', () => {
+    vi.stubGlobal('navigator', { userAgent: 'test-mac', platform: 'MacIntel' })
+    const { result } = renderHook(() => useSettingsDialog())
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          ctrlKey: true,
+          key: ',',
+          bubbles: true,
+        })
+      )
+    })
+
+    expect(result.current.isOpen).toBe(true)
+  })
+
   test('Ctrl+, toggles the dialog open on non-macOS', () => {
     vi.stubGlobal('navigator', {
       userAgent: 'test-linux',

--- a/src/features/settings/hooks/useSettingsDialog.ts
+++ b/src/features/settings/hooks/useSettingsDialog.ts
@@ -67,11 +67,16 @@ export const useSettingsDialog = (): UseSettingsDialogReturn => {
 
       const isMac = isMacPlatform()
 
-      const isSuper = isMac
-        ? event.metaKey && !event.ctrlKey
+      const isSettingsModifier = isMac
+        ? event.metaKey !== event.ctrlKey
         : event.ctrlKey && !event.metaKey
 
-      if (isSuper && event.key === ',' && !event.altKey && !event.shiftKey) {
+      if (
+        isSettingsModifier &&
+        event.key === ',' &&
+        !event.altKey &&
+        !event.shiftKey
+      ) {
         event.preventDefault()
         handlersRef.current.toggle()
 

--- a/src/features/settings/index.test.ts
+++ b/src/features/settings/index.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import {
   DEFAULT_ALIASES,
-  KEYMAP_GROUPS,
   SETTINGS_SECTIONS,
   SETTINGS_SUBSECTIONS,
   SettingsContent,
@@ -26,7 +25,6 @@ describe('settings feature barrel', () => {
   test('exports section constants', () => {
     expect(SETTINGS_SECTIONS.length).toBeGreaterThan(0)
     expect(SETTINGS_SUBSECTIONS.length).toBeGreaterThan(0)
-    expect(KEYMAP_GROUPS.length).toBeGreaterThan(0)
     expect(VIM_KEYMAP_GROUPS.length).toBeGreaterThan(0)
     expect(DEFAULT_ALIASES.length).toBeGreaterThan(0)
   })

--- a/src/features/settings/index.ts
+++ b/src/features/settings/index.ts
@@ -6,7 +6,6 @@ export { useSettingsDialog } from './hooks/useSettingsDialog'
 
 export {
   DEFAULT_ALIASES,
-  KEYMAP_GROUPS,
   SETTINGS_TARGET_IDS,
   SETTINGS_SUBSECTIONS,
   SETTINGS_TARGETS,

--- a/src/features/settings/sections.test.ts
+++ b/src/features/settings/sections.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest'
+import { DIFF_COMMANDS } from '../keymap/catalog'
 import {
   DEFAULT_ALIASES,
-  KEYMAP_GROUPS,
   SETTINGS_TARGET_IDS,
   SETTINGS_SUBSECTIONS,
   SETTINGS_TARGETS,
@@ -74,6 +74,16 @@ describe('SETTINGS_TARGETS', () => {
       ])
     )
   })
+
+  test('indexes every registered Diff command', () => {
+    const diffTargets = SETTINGS_TARGETS.filter(
+      (target) => target.subsection === 'Diff (when focused)'
+    )
+
+    expect(diffTargets.map((target) => target.label)).toEqual(
+      DIFF_COMMANDS.map((command) => command.label)
+    )
+  })
 })
 
 describe('SETTINGS_SUBSECTIONS', () => {
@@ -108,31 +118,6 @@ describe('SETTINGS_SUBSECTIONS', () => {
         }),
       ])
     )
-  })
-})
-
-describe('KEYMAP_GROUPS', () => {
-  test('contains the expected base bindings', () => {
-    const ids = KEYMAP_GROUPS.flatMap((g) => g.bindings).map((b) => b.id)
-
-    expect(ids).toContain('palette')
-    expect(ids).toContain('cycle-layout')
-  })
-
-  test('each group has a zone and at least one binding', () => {
-    KEYMAP_GROUPS.forEach((g) => {
-      expect(g.zone).toBeDefined()
-      expect(g.bindings.length).toBeGreaterThan(0)
-    })
-  })
-
-  test('each binding has id, label, and keys', () => {
-    KEYMAP_GROUPS.flatMap((g) => g.bindings).forEach((b) => {
-      expect(b.id).toBeDefined()
-      expect(b.label).toBeDefined()
-      const resolved = typeof b.keys === 'function' ? b.keys(false) : b.keys
-      expect(resolved.length).toBeGreaterThan(0)
-    })
   })
 })
 

--- a/src/features/settings/sections.ts
+++ b/src/features/settings/sections.ts
@@ -61,111 +61,6 @@ export const settingsSubsectionId = (
   label: string
 ): SettingsSubsectionId => `${section}-${slugifySubsection(label)}`
 
-export const KEYMAP_GROUPS: KeymapGroup[] = [
-  {
-    zone: 'Global',
-    bindings: [
-      { id: 'palette', label: 'Open command palette', keys: [['Mod', ';']] },
-      {
-        id: 'new-session',
-        label: 'New terminal session',
-        keys: (isMac) => (isMac ? [['Mod', 'N']] : [['Mod', 'Shift', 'N']]),
-      },
-      {
-        id: 'session-nav',
-        label: 'Previous / next session',
-        keys: (isMac) =>
-          isMac
-            ? [
-                ['Mod', '['],
-                ['Mod', ']'],
-              ]
-            : [
-                ['Mod', 'Shift', '['],
-                ['Mod', 'Shift', ']'],
-              ],
-      },
-      {
-        id: 'sidebar',
-        label: 'Toggle sidebar',
-        keys: (isMac) => (isMac ? [['Mod', 'B']] : [['Mod', 'Shift', 'B']]),
-      },
-      {
-        id: 'sidebar-switch',
-        label: 'Sidebar: show sessions / files',
-        keys: [
-          ['Mod', 'Shift', 'S'],
-          ['Mod', 'Shift', 'F'],
-        ],
-      },
-      { id: 'editor', label: 'Focus editor', keys: [['Mod', 'E']] },
-      { id: 'diff', label: 'Focus diff', keys: [['Mod', 'G']] },
-      {
-        id: 'dock',
-        label: 'Show / hide editor & diff dock',
-        keys: [['Mod', '0']],
-      },
-      {
-        id: 'burner',
-        label: 'Toggle burner terminal',
-        keys: [['Ctrl', '`']],
-      },
-    ],
-  },
-  {
-    zone: 'Panes & Layout',
-    bindings: [
-      {
-        id: 'focus-number',
-        label: 'Focus pane by number',
-        keys: [
-          ['Mod', '1'],
-          ['Mod', '2'],
-          ['Mod', '3'],
-          ['Mod', '4'],
-        ],
-      },
-      {
-        id: 'focus-direction',
-        label: 'Focus pane left / down / up / right',
-        keys: [
-          ['Mod', 'Shift', '←'],
-          ['Mod', 'Shift', '↓'],
-          ['Mod', 'Shift', '↑'],
-          ['Mod', 'Shift', '→'],
-        ],
-      },
-      { id: 'cycle-layout', label: 'Cycle layout', keys: [['Mod', '\\']] },
-    ],
-  },
-  {
-    zone: 'Terminal',
-    bindings: [
-      {
-        id: 'copy',
-        label: 'Copy selection',
-        keys: (isMac) => (isMac ? [['Mod', 'C']] : [['Mod', 'Shift', 'C']]),
-      },
-      { id: 'paste', label: 'Paste', keys: [['Mod', 'Shift', 'V']] },
-      {
-        id: 'interrupt',
-        label: 'Interrupt (sent to the agent)',
-        keys: [['Ctrl', 'C']],
-      },
-    ],
-  },
-  {
-    zone: 'Diff (when focused)',
-    bindings: [
-      { id: 'diff-nav', label: 'Next / previous file', keys: ['j', 'k'] },
-      { id: 'diff-open', label: 'Open file', keys: ['Enter'] },
-      { id: 'diff-stage', label: 'Stage / discard', keys: ['Space', 'd'] },
-      { id: 'diff-hunk', label: 'Next / previous hunk', keys: ['→', '←'] },
-      { id: 'diff-back', label: 'Back to file list', keys: ['Esc'] },
-    ],
-  },
-]
-
 // cspell:disable
 export const VIM_KEYMAP_GROUPS: KeymapGroup[] = [
   {
@@ -196,6 +91,7 @@ const KEYMAP_TARGET_GROUPS = new Set([
   'Panes & Layout',
   'Terminal',
   'Browser',
+  'Diff (when focused)',
 ])
 
 export const SETTINGS_TARGETS: SettingsTarget[] = [
@@ -284,19 +180,6 @@ export const SETTINGS_TARGETS: SettingsTarget[] = [
       hint: `${cmd.group} shortcut`,
       subsection: cmd.group,
     })
-  ),
-  ...KEYMAP_GROUPS.filter(
-    (group) => group.zone === 'Diff (when focused)'
-  ).flatMap((group) =>
-    group.bindings.map(
-      (binding): SettingsTarget => ({
-        id: keymapStaticTargetId(binding.id),
-        section: 'keymap',
-        label: binding.label,
-        hint: `${group.zone} shortcut`,
-        subsection: group.zone,
-      })
-    )
   ),
   {
     id: SETTINGS_TARGET_IDS.agentsManageAliases,

--- a/src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.test.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.test.tsx
@@ -1,8 +1,38 @@
-import { render, screen, waitFor, within } from '@testing-library/react'
+import {
+  render as rtlRender,
+  screen,
+  waitFor,
+  within,
+  type RenderResult,
+} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import type { ReactElement } from 'react'
 import { afterEach, describe, expect, test, vi } from 'vitest'
+import type { AppSettings } from '@/bindings/AppSettings'
+import { SettingsContext } from '@/features/settings/SettingsProvider'
+import { DEFAULT_SETTINGS } from '@/features/settings/store/settingsDefaults'
 import { SINGLE_PANE_FOCUS_LABEL } from '../../layout-registry'
 import { LayoutSwitcher } from './LayoutSwitcher'
+
+const renderWithKeybindings = (
+  ui: ReactElement,
+  customKeybindings: AppSettings['customKeybindings'] = {}
+): RenderResult =>
+  rtlRender(ui, {
+    wrapper: ({ children }) => (
+      <SettingsContext.Provider
+        value={{
+          settings: { ...DEFAULT_SETTINGS, customKeybindings },
+          saveError: null,
+          update: vi.fn(),
+        }}
+      >
+        {children}
+      </SettingsContext.Provider>
+    ),
+  })
+
+const render = (ui: ReactElement): RenderResult => renderWithKeybindings(ui)
 
 let restorePlatform: (() => void) | null = null
 
@@ -273,14 +303,15 @@ describe('LayoutSwitcher', () => {
     expect(within(quadTip).queryByTestId('tooltip-shortcut')).toBeNull()
   })
 
-  test('workspace focus mode labels single layout as an active-pane action', async () => {
+  test('workspace focus mode shows the resolved single-pane shortcut', async () => {
     const user = userEvent.setup()
-    render(
+    renderWithKeybindings(
       <LayoutSwitcher
         activeLayoutId="single"
         onPick={vi.fn()}
         labelSingleAsFocusAction
-      />
+      />,
+      { 'single-pane-focus': 'Mod+KeyO' }
     )
 
     const focusButton = screen.getByRole('button', {
@@ -290,7 +321,7 @@ describe('LayoutSwitcher', () => {
     const focusTip = await screen.findByRole('tooltip')
     expect(focusTip).toHaveTextContent(SINGLE_PANE_FOCUS_LABEL)
     expect(within(focusTip).getByTestId('tooltip-shortcut')).toHaveTextContent(
-      'Z'
+      'O'
     )
   })
 

--- a/src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.tsx
+++ b/src/features/terminal/components/LayoutSwitcher/LayoutSwitcher.tsx
@@ -8,6 +8,8 @@ import {
 } from '../../layout-registry'
 import { LayoutGlyph } from './LayoutGlyph'
 import { SegmentedControl } from '@/components/SegmentedControl'
+import { chordToShortcutInput } from '@/features/keymap/displayKey'
+import { useKeybindings } from '@/features/keymap/useKeybindings'
 
 export interface LayoutSwitcherProps {
   activeLayoutId: PaneLayoutId
@@ -55,7 +57,12 @@ export const LayoutSwitcher = ({
   labelSingleAsFocusAction = false,
   nativeOverlayTooltips = false,
 }: LayoutSwitcherProps): ReactElement => {
+  const { bindingFor } = useKeybindings()
   const layoutIds = useMemo(() => layouts.map((layout) => layout.id), [layouts])
+
+  const singlePaneFocusShortcut = chordToShortcutInput(
+    bindingFor('single-pane-focus')
+  )
 
   const layoutById = useMemo(
     () => new Map(layouts.map((layout) => [layout.id, layout])),
@@ -119,7 +126,7 @@ export const LayoutSwitcher = ({
             tooltip: label,
             shortcut:
               isSingleFocus && labelSingleAsFocusAction
-                ? ['Mod', 'Z']
+                ? singlePaneFocusShortcut
                 : undefined,
             disabled,
           }

--- a/src/features/terminal/components/SplitView/SplitView.test.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.test.tsx
@@ -1,8 +1,17 @@
 // cspell:ignore vsplit hsplit vdiv hdiv
-import { render, screen, within, fireEvent } from '@testing-library/react'
+import {
+  render as rtlRender,
+  screen,
+  within,
+  fireEvent,
+  type RenderResult,
+} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { createRef } from 'react'
+import { createRef, type ReactElement } from 'react'
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { AppSettings } from '@/bindings/AppSettings'
+import { SettingsContext } from '@/features/settings/SettingsProvider'
+import { DEFAULT_SETTINGS } from '@/features/settings/store/settingsDefaults'
 import type { UseGitBranchReturn } from '../../../diff/hooks/useGitBranch'
 import type { UseGitStatusReturn } from '../../../diff/hooks/useGitStatus'
 import type { BodyHandle, BodyProps } from '../TerminalPane/Body'
@@ -26,6 +35,26 @@ import {
   type PaneLayoutDefinition,
 } from '../../layout-registry'
 import { resolvePanePlacement } from '../../../sessions/utils/panePlacements'
+
+const renderWithKeybindings = (
+  ui: ReactElement,
+  customKeybindings: AppSettings['customKeybindings'] = {}
+): RenderResult =>
+  rtlRender(ui, {
+    wrapper: ({ children }) => (
+      <SettingsContext.Provider
+        value={{
+          settings: { ...DEFAULT_SETTINGS, customKeybindings },
+          saveError: null,
+          update: vi.fn(),
+        }}
+      >
+        {children}
+      </SettingsContext.Provider>
+    ),
+  })
+
+const render = (ui: ReactElement): RenderResult => renderWithKeybindings(ui)
 
 class MockResizeObserver {
   observe = vi.fn()
@@ -860,13 +889,14 @@ describe('SplitView - click-to-focus', () => {
     expect(screen.getAllByTestId('split-view-slot')).toHaveLength(2)
   })
 
-  test('renders visible pane shortcut hints instead of focus tooltips', async () => {
-    render(
+  test('renders resolved pane shortcut hints instead of focus tooltips', async () => {
+    renderWithKeybindings(
       <SplitView
         session={makeSession('vsplit', 2)}
         service={makeMockService()}
         isSessionVisible
-      />
+      />,
+      { 'focus-pane-2': 'Mod+KeyO' }
     )
 
     expect(screen.getAllByTestId('pane-shortcut-hint')).toHaveLength(2)
@@ -875,7 +905,7 @@ describe('SplitView - click-to-focus', () => {
     )
 
     expect(screen.getAllByTestId('pane-shortcut-hint')[1]).toHaveTextContent(
-      '2'
+      'O'
     )
 
     const user = userEvent.setup()
@@ -889,7 +919,7 @@ describe('SplitView - click-to-focus', () => {
     expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
   })
 
-  test('passes visible pane shortcut hints to browser panes', () => {
+  test('passes resolved pane shortcut hints to browser panes', () => {
     const session = {
       ...makeSession('vsplit', 2),
       panes: [
@@ -903,17 +933,18 @@ describe('SplitView - click-to-focus', () => {
       ],
     } satisfies Session
 
-    render(
+    renderWithKeybindings(
       <SplitView
         session={session}
         service={makeMockService()}
         isSessionVisible
-      />
+      />,
+      { 'focus-pane-2': 'Mod+KeyO' }
     )
 
     expect(screen.getByTestId('browser-pane-mock')).toBeInTheDocument()
     expect(screen.getAllByTestId('pane-shortcut-hint')[1]).toHaveTextContent(
-      '2'
+      'O'
     )
   })
 

--- a/src/features/terminal/components/SplitView/SplitView.tsx
+++ b/src/features/terminal/components/SplitView/SplitView.tsx
@@ -42,6 +42,9 @@ import {
 } from '@/features/terminal/components/TerminalPane'
 import { EmptySlot } from '@/features/terminal/components/SplitView/EmptySlot'
 import { Tooltip } from '@/components/Tooltip'
+import type { CommandId } from '@/features/keymap/catalog'
+import { chordToShortcutInput } from '@/features/keymap/displayKey'
+import { useKeybindings } from '@/features/keymap/useKeybindings'
 import { formatShortcut } from '@/lib/formatShortcut'
 import { SplitDividers } from '@/features/terminal/components/SplitView/SplitDividers'
 import { resolveGrid } from '@/features/terminal/components/SplitView/resolveGrid'
@@ -212,6 +215,7 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
     }: SplitViewProps,
     ref
   ): ReactElement {
+    const { bindingFor } = useKeybindings()
     const layout = layoutRegistry.getFallbackLayout(session.layout)
     const outerDivRef = useRef<HTMLDivElement>(null)
 
@@ -561,6 +565,15 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
               const isBrowserPane = !isShellPane(pane)
               const mode = isBrowserPane ? 'browser' : paneMode(pane)
               const slotIndex = layout.definition.addOrder.indexOf(slotId)
+
+              const shortcutHint =
+                slotIndex >= 0 && slotIndex < 9
+                  ? formatShortcut(
+                      chordToShortcutInput(
+                        bindingFor(`focus-pane-${slotIndex + 1}` as CommandId)
+                      )
+                    )
+                  : undefined
               // Only the visible session's selected pane is globally active.
               const isActive = isSessionVisible && pane.active
 
@@ -665,11 +678,7 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
                           onRequestActive={onSetActivePane}
                           onRequestFocus={onRequestFocus}
                           onUrlChange={onBrowserPaneUrlChange}
-                          shortcutHint={
-                            slotIndex < 9
-                              ? formatShortcut(['Mod', String(slotIndex + 1)])
-                              : undefined
-                          }
+                          shortcutHint={shortcutHint}
                         />
                       </>
                     ) : (
@@ -700,11 +709,7 @@ export const SplitView = forwardRef<SplitViewHandle, SplitViewProps>(
                         isActive={isActive}
                         isSessionVisible={isSessionVisible}
                         shortcutContext={nativeShortcutContext}
-                        shortcutHint={
-                          slotIndex < 9
-                            ? formatShortcut(['Mod', String(slotIndex + 1)])
-                            : undefined
-                        }
+                        shortcutHint={shortcutHint}
                         deferFit={deferTerminalFit}
                         showFocusHighlight={showPaneFocusHighlight}
                         terminalFontFamily={terminalFontFamily}

--- a/src/features/terminal/nativeGhosttyClient.test.ts
+++ b/src/features/terminal/nativeGhosttyClient.test.ts
@@ -108,7 +108,7 @@ describe('nativeGhosttyClient', () => {
     ).resolves.toBe(false)
   })
 
-  test('keeps native secondary burners disabled for the legacy helper bridge', () => {
+  test('keeps native secondary burners disabled for an incomplete native bridge', () => {
     const api: NativeGhosttyApi = {
       update: vi.fn(() => Promise.resolve({})),
       data: vi.fn(() => Promise.resolve({})),

--- a/src/features/workspace/WorkspaceView.command-palette.test.tsx
+++ b/src/features/workspace/WorkspaceView.command-palette.test.tsx
@@ -491,39 +491,6 @@ describe('WorkspaceView - Command Palette Integration', () => {
     return call[0]
   }
 
-  test('syncs separate palette and leader bindings to Electron', async () => {
-    const setCommandPaletteBindings = vi.fn()
-    const setCommandPaletteBinding = vi.fn()
-    window.vimeflow = {
-      setCommandPaletteBindings,
-      setCommandPaletteBinding,
-    } as unknown as Window['vimeflow']
-
-    const settings: AppSettings = {
-      ...DEFAULT_SETTINGS,
-      customKeybindings: {
-        palette: 'Mod+KeyP',
-        'palette-leader': 'Mod+KeyK',
-      },
-    }
-
-    rtlRender(
-      <SettingsContext.Provider
-        value={{ settings, saveError: null, update: vi.fn() }}
-      >
-        <WorkspaceView />
-      </SettingsContext.Provider>
-    )
-
-    await waitFor(() => {
-      expect(setCommandPaletteBindings).toHaveBeenCalledWith({
-        palette: 'Mod+KeyP',
-        leader: 'Mod+KeyK',
-      })
-    })
-    expect(setCommandPaletteBinding).not.toHaveBeenCalled()
-  })
-
   test(':new command creates a new session', async () => {
     const user = userEvent.setup()
     render(<WorkspaceView />)

--- a/src/features/workspace/WorkspaceView.integration.test.tsx
+++ b/src/features/workspace/WorkspaceView.integration.test.tsx
@@ -397,6 +397,58 @@ describe('WorkspaceView Integration Tests', () => {
       ).toBeInTheDocument()
       expect(screen.queryByTestId('agent-status-rail')).not.toBeInTheDocument()
     })
+
+    test('Meta+R toggles the activity panel without reloading the app', async () => {
+      const originalPlatform = navigator.platform
+      Object.defineProperty(navigator, 'platform', {
+        value: 'MacIntel',
+        configurable: true,
+      })
+
+      try {
+        render(<WorkspaceView />)
+
+        await screen.findByRole('button', { name: 'session 1' })
+
+        const collapseEvent = new KeyboardEvent('keydown', {
+          key: 'r',
+          code: 'KeyR',
+          metaKey: true,
+          bubbles: true,
+          cancelable: true,
+        })
+
+        act(() => {
+          document.dispatchEvent(collapseEvent)
+        })
+
+        expect(collapseEvent.defaultPrevented).toBe(true)
+        expect(
+          await screen.findByTestId('agent-status-rail')
+        ).toBeInTheDocument()
+
+        act(() => {
+          document.dispatchEvent(
+            new KeyboardEvent('keydown', {
+              key: 'r',
+              code: 'KeyR',
+              metaKey: true,
+              bubbles: true,
+              cancelable: true,
+            })
+          )
+        })
+
+        expect(
+          await screen.findByTestId('agent-status-panel-header')
+        ).toBeInTheDocument()
+      } finally {
+        Object.defineProperty(navigator, 'platform', {
+          value: originalPlatform,
+          configurable: true,
+        })
+      }
+    })
   })
 
   describe('File open flow integration', () => {

--- a/src/features/workspace/WorkspaceView.tsx
+++ b/src/features/workspace/WorkspaceView.tsx
@@ -66,6 +66,7 @@ import {
 } from '@/features/command-palette/hooks/usePaneRenameChord'
 import { listen, renameAgentSession } from '@/lib/backend'
 import { registerCommandPaletteShortcutOpenerForE2e } from '@/lib/e2e-bridge'
+import { formatShortcut } from '@/lib/formatShortcut'
 import { useSessionManager } from '@/features/sessions/hooks/useSessionManager'
 import { cycleSession } from '@/features/sessions/utils/cycleSession'
 import { NewSessionDialog } from '@/features/sessions/components/NewSessionDialog'
@@ -87,8 +88,11 @@ import {
 import { useDockShortcuts } from './hooks/useDockShortcuts'
 import { useDockToggleShortcut } from './hooks/useDockToggleShortcut'
 import { useKeybindings } from '@/features/keymap/useKeybindings'
-import { formatChord } from '@/features/keymap/chord'
-import { chordToShortcutInput } from '@/features/keymap/displayKey'
+import {
+  chordToAriaShortcut,
+  chordToKeycapShortcut,
+  chordToShortcutInput,
+} from '@/features/keymap/displayKey'
 import { useSidebarShortcut } from './hooks/useSidebarShortcut'
 import { useNewSessionShortcut } from './hooks/useNewSessionShortcut'
 import { useSidebarTabShortcut } from './hooks/useSidebarTabShortcut'
@@ -424,11 +428,23 @@ const WorkspaceViewContent = (): ReactElement => {
     return detected.startsWith('mac') ? 'meta' : 'ctrl'
   }, [])
 
-  const sidebarShortcutHint = preferModifier === 'meta' ? '⌘B' : 'Ctrl+⇧B'
-  const newSessionShortcutHint = preferModifier === 'meta' ? '⌘N' : 'Ctrl+⇧N'
+  // One resolved registry read drives renderer behavior and visible hints;
+  // SettingsProvider publishes the same overrides to Electron/native surfaces.
+  const { bindingFor, matches } = useKeybindings()
+  const paletteBinding = bindingFor('palette')
+  const dockToggleBinding = bindingFor('dock-toggle')
+  const activityPanelToggleBinding = bindingFor('activity-panel-toggle')
+  const sidebarToggleBinding = bindingFor('sidebar-toggle')
+  const newSessionBinding = bindingFor('new-session')
+  const sidebarSessionsBinding = bindingFor('sidebar-sessions')
+  const sidebarFilesBinding = bindingFor('sidebar-files')
 
-  const newSessionAriaKeyshortcuts =
-    preferModifier === 'meta' ? 'Meta+N' : 'Control+Shift+N'
+  const sidebarShortcutHint = chordToShortcutInput(sidebarToggleBinding)
+
+  const newSessionShortcutHint = formatShortcut(
+    chordToShortcutInput(newSessionBinding)
+  )
+  const newSessionAriaKeyshortcuts = chordToAriaShortcut(newSessionBinding)
   const reserveWindowControls = preferModifier === 'meta'
 
   const windowControlsInset = reserveWindowControls
@@ -897,6 +913,10 @@ const WorkspaceViewContent = (): ReactElement => {
     },
     [activeSessionId, setSessionActivityPanelCollapsed]
   )
+
+  const handleToggleActivityPanel = useCallback((): void => {
+    handleActivityPanelCollapsed(!activityPanelCollapsed)
+  }, [activityPanelCollapsed, handleActivityPanelCollapsed])
 
   // Bridge: keep pane chrome in sync with agent detection for the active
   // pane. Live detections stamp the agent identity; an explicit
@@ -1978,8 +1998,7 @@ const WorkspaceViewContent = (): ReactElement => {
         })),
         setDockPosition,
         dockPosition,
-        toggleActivityPanel: (): void =>
-          handleActivityPanelCollapsed(!activityPanelCollapsed),
+        toggleActivityPanel: handleToggleActivityPanel,
         showSidebarTab: (tab: SidebarTab): void => {
           setActiveTab(tab)
           // Compact viewports gate sidebar visibility on the drawer flag.
@@ -1994,6 +2013,8 @@ const WorkspaceViewContent = (): ReactElement => {
           setTimeout(() => claimTerminal(), 0)
         },
         openFile: requestOpenFile,
+        keybindingShortcut: (id) =>
+          chordToKeycapShortcut(bindingFor(id), preferModifier === 'meta'),
       }),
     // sessionsSignature captures every field the closures read; activity-only
     // changes keep the signature stable so the memo (and downstream
@@ -2029,25 +2050,17 @@ const WorkspaceViewContent = (): ReactElement => {
       layoutRegistry,
       setDockPosition,
       dockPosition,
-      handleActivityPanelCollapsed,
-      activityPanelCollapsed,
+      handleToggleActivityPanel,
       setActiveTab,
       setSidebarCollapsed,
       isCompactViewport,
       setCompactSidebarOpen,
       claimTerminal,
       requestOpenFile,
+      bindingFor,
+      preferModifier,
     ]
   )
-
-  // Keybinding registry matcher — keeps the palette and migrated workspace
-  // shortcuts aligned with persisted overrides.
-  const { bindingFor, matches } = useKeybindings()
-  const paletteBinding = bindingFor('palette')
-  const paletteLeaderBinding = bindingFor('palette-leader')
-  const dockToggleBinding = bindingFor('dock-toggle')
-  const sidebarSessionsBinding = bindingFor('sidebar-sessions')
-  const sidebarFilesBinding = bindingFor('sidebar-files')
 
   const paletteShortcut = useMemo(
     () => chordToShortcutInput(paletteBinding),
@@ -2057,6 +2070,11 @@ const WorkspaceViewContent = (): ReactElement => {
   const dockShortcut = useMemo(
     () => chordToShortcutInput(dockToggleBinding),
     [dockToggleBinding]
+  )
+
+  const activityPanelShortcut = useMemo(
+    () => chordToShortcutInput(activityPanelToggleBinding),
+    [activityPanelToggleBinding]
   )
 
   const sidebarTabItems = useMemo(
@@ -2077,25 +2095,6 @@ const WorkspaceViewContent = (): ReactElement => {
     (event: KeyboardEvent): boolean => matches(event, 'palette-leader'),
     [matches]
   )
-
-  const paletteToken = formatChord(paletteBinding)
-  const leaderToken = formatChord(paletteLeaderBinding)
-
-  useEffect(() => {
-    const bindings = {
-      palette: paletteToken,
-      leader: leaderToken,
-    }
-    const bridge = window.vimeflow
-
-    if (bridge?.setCommandPaletteBindings) {
-      bridge.setCommandPaletteBindings(bindings)
-
-      return
-    }
-
-    bridge?.setCommandPaletteBinding?.(bindings.leader)
-  }, [paletteToken, leaderToken])
 
   const settingsDialog = useSettingsDialog()
 
@@ -2168,6 +2167,7 @@ const WorkspaceViewContent = (): ReactElement => {
 
   useSidebarShortcut({
     onToggle: handleToggleSidebar,
+    onToggleActivityPanel: handleToggleActivityPanel,
     matches,
     activeContainerId,
   })
@@ -3104,6 +3104,7 @@ const WorkspaceViewContent = (): ReactElement => {
           variant="inset"
           data-testid="sidebar-toggle-fixed"
           shortcutHint={sidebarShortcutHint}
+          ariaKeyshortcuts={chordToAriaShortcut(sidebarToggleBinding)}
         />
       </div>
 
@@ -3451,10 +3452,10 @@ const WorkspaceViewContent = (): ReactElement => {
           <SidebarToggle
             collapsed={activityPanelCollapsed}
             mirrored
-            onClick={() => {
-              handleActivityPanelCollapsed(!activityPanelCollapsed)
-            }}
+            onClick={handleToggleActivityPanel}
             size={SIDEBAR_TOGGLE_SIZE}
+            shortcutHint={activityPanelShortcut}
+            ariaKeyshortcuts={chordToAriaShortcut(activityPanelToggleBinding)}
             label={
               activityPanelCollapsed
                 ? 'Expand activity panel'

--- a/src/features/workspace/commands/buildWorkspaceCommands.test.ts
+++ b/src/features/workspace/commands/buildWorkspaceCommands.test.ts
@@ -2145,6 +2145,9 @@ describe('buildWorkspaceCommands - shortcut chips', () => {
     expect(chip(commands, 'open-editor')).toEqual(['⌘', 'E'])
     expect(chip(commands, 'open-diff')).toEqual(['⌘', 'G'])
     expect(chip(commands, 'toggle-dock')).toEqual(['⌘', '0'])
+    expect(chip(commands, 'next')).toEqual(['⌘', ']'])
+    expect(chip(commands, 'previous')).toEqual(['⌘', '['])
+    expect(chip(commands, 'burner')).toEqual(['⌃', '`'])
   })
 
   test('Linux chips match the wired accelerators', () => {
@@ -2154,9 +2157,12 @@ describe('buildWorkspaceCommands - shortcut chips', () => {
     expect(chip(commands, 'open-editor')).toEqual(['Ctrl', 'E'])
     expect(chip(commands, 'open-diff')).toEqual(['Ctrl', 'G'])
     expect(chip(commands, 'toggle-dock')).toEqual(['Ctrl', '0'])
+    expect(chip(commands, 'next')).toEqual(['Ctrl', '⇧', ']'])
+    expect(chip(commands, 'previous')).toEqual(['Ctrl', '⇧', '['])
+    expect(chip(commands, 'burner')).toEqual(['Ctrl', '`'])
   })
 
-  test('only the five accelerator commands carry chips', () => {
+  test('only commands with registered accelerators carry chips', () => {
     vi.mocked(isMacPlatform).mockReturnValue(true)
 
     const commands = buildWorkspaceCommands({
@@ -2174,11 +2180,39 @@ describe('buildWorkspaceCommands - shortcut chips', () => {
     expect(withChips).toEqual(
       [
         'new',
+        'next',
         'open-diff',
         'open-editor',
+        'previous',
+        'burner',
         'toggle-dock',
         'toggle-sidebar',
       ].sort()
     )
+  })
+
+  test('uses resolved registry chips when supplied', () => {
+    const commands = buildWorkspaceCommands({
+      ...chipDeps(),
+      toggleActivityPanel: vi.fn(),
+      showSidebarTab: vi.fn(),
+      keybindingShortcut: (id) => ['custom', id],
+    })
+
+    expect(chip(commands, 'new')).toEqual(['custom', 'new-session'])
+    expect(chip(commands, 'toggle-sidebar')).toEqual([
+      'custom',
+      'sidebar-toggle',
+    ])
+
+    expect(chip(commands, 'toggle-activity')).toEqual([
+      'custom',
+      'activity-panel-toggle',
+    ])
+
+    expect(chip(commands, 'show-sessions')).toEqual([
+      'custom',
+      'sidebar-sessions',
+    ])
   })
 })

--- a/src/features/workspace/commands/buildWorkspaceCommands.ts
+++ b/src/features/workspace/commands/buildWorkspaceCommands.ts
@@ -15,6 +15,7 @@ import {
   SINGLE_PANE_FOCUS_LAYOUT_ID,
 } from '../../terminal/layout-registry'
 import { themeService } from '../../../theme'
+import type { CommandId } from '../../keymap/catalog'
 
 export type DockPositionCommandArg = 'bottom' | 'top' | 'left' | 'right'
 
@@ -83,7 +84,7 @@ export interface WorkspaceCommandDeps {
   toggleSidebar?: () => void
   /**
    * Toggle the focused pane's burner terminal (VIM-72). Resolves the focused
-   * pane and hides-if-shown, same as the `Mod+;` then backtick chord. Optional
+   * pane and hides-if-shown, same as the registered burner shortcut. Optional
    * so the builder's unit tests need not thread it; WorkspaceView always wires it.
    */
   toggleBurner?: () => void
@@ -132,6 +133,8 @@ export interface WorkspaceCommandDeps {
   focusTerminal?: () => void
   // Open a file in the dock editor by absolute path.
   openFile?: (path: string) => void
+  // Resolved registry display tokens for commands with a live accelerator.
+  keybindingShortcut?: (id: CommandId) => string[]
 }
 
 interface FallbackPaneRenameRequestState {
@@ -208,9 +211,13 @@ export const buildWorkspaceCommands = (
     showSidebarTab,
     focusTerminal,
     openFile,
+    keybindingShortcut,
   } = deps
 
   const isMac = isMacPlatform()
+
+  const shortcutFor = (id: CommandId, fallback: string[]): string[] =>
+    keybindingShortcut?.(id) ?? fallback
 
   const fallbackPaneRenameRequestState =
     fallbackPaneRenameRequestStateFor(renameAgentSession)
@@ -302,8 +309,10 @@ export const buildWorkspaceCommands = (
         description: 'Open editor',
         hint: 'edit files in the dock',
         icon: 'code',
-        // ⌘E / Ctrl+E — useDockShortcuts.
-        shortcut: isMac ? ['⌘', 'E'] : ['Ctrl', 'E'],
+        shortcut: shortcutFor(
+          'focus-editor',
+          isMac ? ['⌘', 'E'] : ['Ctrl', 'E']
+        ),
         execute: (): void => {
           openEditor()
         },
@@ -317,8 +326,7 @@ export const buildWorkspaceCommands = (
         description: 'Open diff',
         hint: 'review changes vs HEAD',
         icon: 'difference',
-        // ⌘G / Ctrl+G — useDockShortcuts.
-        shortcut: isMac ? ['⌘', 'G'] : ['Ctrl', 'G'],
+        shortcut: shortcutFor('focus-diff', isMac ? ['⌘', 'G'] : ['Ctrl', 'G']),
         execute: (): void => {
           openDiff()
         },
@@ -332,8 +340,10 @@ export const buildWorkspaceCommands = (
         description: 'Toggle dock',
         hint: 'show or hide the panel',
         icon: 'horizontal_split',
-        // ⌘0 / Ctrl+0 — useDockToggleShortcut.
-        shortcut: isMac ? ['⌘', '0'] : ['Ctrl', '0'],
+        shortcut: shortcutFor(
+          'dock-toggle',
+          isMac ? ['⌘', '0'] : ['Ctrl', '0']
+        ),
         execute: (): void => {
           toggleDock()
         },
@@ -361,9 +371,10 @@ export const buildWorkspaceCommands = (
             icon: 'grid_view',
             shortcut:
               layout.id === SINGLE_PANE_FOCUS_LAYOUT_ID
-                ? isMac
-                  ? ['⌘', 'Z']
-                  : ['Ctrl', 'Z']
+                ? shortcutFor(
+                    'single-pane-focus',
+                    isMac ? ['⌘', 'Z'] : ['Ctrl', 'Z']
+                  )
                 : undefined,
             execute: (): void => {
               // `false` means the active session has more panes than this layout holds.
@@ -404,6 +415,10 @@ export const buildWorkspaceCommands = (
         description: 'Activity panel',
         hint: 'show or hide agent activity',
         icon: 'notes',
+        shortcut: shortcutFor(
+          'activity-panel-toggle',
+          isMac ? ['⌘', 'R'] : ['Ctrl', 'R']
+        ),
         execute: (): void => {
           toggleActivityPanel()
         },
@@ -417,6 +432,10 @@ export const buildWorkspaceCommands = (
         description: 'Sessions tab',
         hint: 'open the sessions sidebar',
         icon: 'view_agenda',
+        shortcut: shortcutFor(
+          'sidebar-sessions',
+          isMac ? ['⌘', '⇧', 'S'] : ['Ctrl', '⇧', 'S']
+        ),
         execute: (): void => {
           showSidebarTab('sessions')
         },
@@ -430,6 +449,10 @@ export const buildWorkspaceCommands = (
         description: 'Files tab',
         hint: 'open the file tree',
         icon: 'folder_open',
+        shortcut: shortcutFor(
+          'sidebar-files',
+          isMac ? ['⌘', '⇧', 'F'] : ['Ctrl', '⇧', 'F']
+        ),
         execute: (): void => {
           showSidebarTab('files')
         },
@@ -507,8 +530,10 @@ export const buildWorkspaceCommands = (
       description: 'New session',
       hint: 'spawn a terminal session',
       icon: 'add',
-      // ⌘N / Ctrl+⇧N — useNewSessionShortcut.
-      shortcut: isMac ? ['⌘', 'N'] : ['Ctrl', '⇧', 'N'],
+      shortcut: shortcutFor(
+        'new-session',
+        isMac ? ['⌘', 'N'] : ['Ctrl', '⇧', 'N']
+      ),
       execute: (): void => {
         createSession()
       },
@@ -633,6 +658,10 @@ export const buildWorkspaceCommands = (
       description: 'Next session',
       hint: 'switch forward',
       icon: 'arrow_forward',
+      shortcut: shortcutFor(
+        'session-next',
+        isMac ? ['⌘', ']'] : ['Ctrl', '⇧', ']']
+      ),
       execute: (): void => {
         switchRelativeSession(1)
       },
@@ -643,6 +672,10 @@ export const buildWorkspaceCommands = (
       description: 'Previous session',
       hint: 'switch back',
       icon: 'arrow_back',
+      shortcut: shortcutFor(
+        'session-prev',
+        isMac ? ['⌘', '['] : ['Ctrl', '⇧', '[']
+      ),
       execute: (): void => {
         switchRelativeSession(-1)
       },
@@ -737,8 +770,10 @@ export const buildWorkspaceCommands = (
       description: 'Toggle sidebar',
       hint: 'show or hide the sidebar',
       icon: 'left_panel_close',
-      // ⌘B / Ctrl+⇧B — useSidebarShortcut.
-      shortcut: isMac ? ['⌘', 'B'] : ['Ctrl', '⇧', 'B'],
+      shortcut: shortcutFor(
+        'sidebar-toggle',
+        isMac ? ['⌘', 'B'] : ['Ctrl', '⇧', 'B']
+      ),
       execute: (): void => {
         toggleSidebar?.()
       },
@@ -749,7 +784,10 @@ export const buildWorkspaceCommands = (
       description: 'Burner terminal',
       hint: 'toggle for the focused pane',
       icon: 'terminal',
-      // No chip: :burner is a ⌘; then ` leader chord, not a single combo.
+      shortcut: shortcutFor(
+        'burner-toggle',
+        isMac ? ['⌃', '`'] : ['Ctrl', '`']
+      ),
       execute: (): void => {
         toggleBurner?.()
       },

--- a/src/features/workspace/components/DockPanel.test.tsx
+++ b/src/features/workspace/components/DockPanel.test.tsx
@@ -19,12 +19,31 @@ import type { UseFileDiffReturn } from '../../diff/hooks/useFileDiff'
 import type { ChangedFile, SelectedDiffFile } from '../../diff/types'
 import type { FeedbackDispatchTarget } from '../../diff/services/activePanePicker'
 import { javascript } from '@codemirror/lang-javascript'
+import type { Keybindings } from '../../keymap/useKeybindings'
 
 vi.mock('../../editor/hooks/useCodeMirror')
 vi.mock('../../editor/hooks/useVimMode')
 vi.mock('../../editor/services/languageService')
 vi.mock('../../diff/hooks/useGitStatus')
 vi.mock('../../diff/hooks/useFileDiff')
+vi.mock('../../keymap/useKeybindings', async () => {
+  const { getCommand } = await import('../../keymap/catalog')
+  const { eventMatchesChord } = await import('../../keymap/match')
+  const { resolveDefault } = await import('../../keymap/resolve')
+
+  const bindingFor: Keybindings['bindingFor'] = (id) =>
+    resolveDefault(getCommand(id), false)
+
+  const matches: Keybindings['matches'] = (event, id) =>
+    eventMatchesChord(event, bindingFor(id), 'ctrl', getCommand(id).matchPolicy)
+
+  return {
+    useKeybindings: (): Pick<Keybindings, 'bindingFor' | 'matches'> => ({
+      bindingFor,
+      matches,
+    }),
+  }
+})
 
 interface MockLineAnnotation {
   lineNumber: number
@@ -1593,7 +1612,7 @@ describe('DockPanel', () => {
       name: 'Finish feedback',
     })
     await user.click(
-      within(popover).getByRole('button', { name: 'Confirm (Y)' })
+      within(popover).getByRole('button', { name: 'Confirm (Shift+Y)' })
     )
 
     await waitFor(() => expect(writePty).toHaveBeenCalledTimes(1))

--- a/src/features/workspace/components/DockTab.test.tsx
+++ b/src/features/workspace/components/DockTab.test.tsx
@@ -1,7 +1,37 @@
-import { act, render, screen, within } from '@testing-library/react'
+import {
+  act,
+  render as rtlRender,
+  screen,
+  within,
+  type RenderResult,
+} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import type { ReactElement } from 'react'
 import { describe, test, expect, vi } from 'vitest'
+import type { AppSettings } from '@/bindings/AppSettings'
+import { SettingsContext } from '@/features/settings/SettingsProvider'
+import { DEFAULT_SETTINGS } from '@/features/settings/store/settingsDefaults'
 import { DockTab } from './DockTab'
+
+const renderWithKeybindings = (
+  ui: ReactElement,
+  customKeybindings: AppSettings['customKeybindings'] = {}
+): RenderResult =>
+  rtlRender(ui, {
+    wrapper: ({ children }) => (
+      <SettingsContext.Provider
+        value={{
+          settings: { ...DEFAULT_SETTINGS, customKeybindings },
+          saveError: null,
+          update: vi.fn(),
+        }}
+      >
+        {children}
+      </SettingsContext.Provider>
+    ),
+  })
+
+const render = (ui: ReactElement): RenderResult => renderWithKeybindings(ui)
 
 describe('DockTab', () => {
   test('renders Editor and Diff Viewer buttons', () => {
@@ -232,36 +262,43 @@ describe('DockTab', () => {
   })
 
   describe('tooltip wiring', () => {
-    test('Editor tab tooltip shows the Mod+E shortcut chip', async () => {
+    test('Editor tab tooltip shows the resolved focus-editor shortcut', async () => {
       const user = userEvent.setup()
-      render(<DockTab tab="diff" onTabChange={vi.fn()} onClose={vi.fn()} />)
+      renderWithKeybindings(
+        <DockTab tab="diff" onTabChange={vi.fn()} onClose={vi.fn()} />,
+        { 'focus-editor': 'Mod+KeyO' }
+      )
 
       await user.hover(screen.getByRole('button', { name: /editor/i }))
       const tip = await screen.findByRole('tooltip')
       expect(tip).toHaveTextContent('Editor')
-      expect(within(tip).getByTestId('tooltip-shortcut')).toHaveTextContent('E')
+      expect(within(tip).getByTestId('tooltip-shortcut')).toHaveTextContent('O')
     })
 
-    test('Diff Viewer tab tooltip shows the Mod+G shortcut chip', async () => {
+    test('Diff Viewer tab tooltip shows the resolved focus-diff shortcut', async () => {
       const user = userEvent.setup()
-      render(<DockTab tab="editor" onTabChange={vi.fn()} onClose={vi.fn()} />)
+      renderWithKeybindings(
+        <DockTab tab="editor" onTabChange={vi.fn()} onClose={vi.fn()} />,
+        { 'focus-diff': 'Mod+KeyQ' }
+      )
 
       await user.hover(screen.getByRole('button', { name: /diff viewer/i }))
       const tip = await screen.findByRole('tooltip')
       expect(tip).toHaveTextContent('Diff Viewer')
-      expect(within(tip).getByTestId('tooltip-shortcut')).toHaveTextContent('G')
+      expect(within(tip).getByTestId('tooltip-shortcut')).toHaveTextContent('Q')
     })
 
-    test('Collapse panel tooltip shows the Mod+0 shortcut chip', async () => {
+    test('Collapse panel tooltip shows the resolved dock-toggle shortcut', async () => {
       const user = userEvent.setup()
-      render(<DockTab tab="editor" onTabChange={vi.fn()} onClose={vi.fn()} />)
+      renderWithKeybindings(
+        <DockTab tab="editor" onTabChange={vi.fn()} onClose={vi.fn()} />,
+        { 'dock-toggle': 'Mod+KeyQ' }
+      )
 
       await user.hover(screen.getByRole('button', { name: /collapse panel/i }))
       const tip = await screen.findByRole('tooltip')
       expect(tip).toHaveTextContent('Collapse panel')
-      // Shares the dock-toggle keybinding (Mod+0) advertised on the
-      // bottom-bar dock button.
-      expect(within(tip).getByTestId('tooltip-shortcut')).toHaveTextContent('0')
+      expect(within(tip).getByTestId('tooltip-shortcut')).toHaveTextContent('Q')
     })
 
     // Guards the `disabled={actionsOpen}` branch on the More button's

--- a/src/features/workspace/components/DockTab.tsx
+++ b/src/features/workspace/components/DockTab.tsx
@@ -10,6 +10,8 @@ import {
 import { IconButton } from '@/components/IconButton'
 import { SegmentedControl } from '@/components/SegmentedControl'
 import { Tooltip } from '@/components/Tooltip'
+import { chordToShortcutInput } from '@/features/keymap/displayKey'
+import { useKeybindings } from '@/features/keymap/useKeybindings'
 import { TOOLTIP_SUPPRESSED } from '@/lib/constants'
 
 export type DockTabType = 'editor' | 'diff'
@@ -39,14 +41,14 @@ const DOCK_TAB_OPTIONS = [
     label: 'Diff Viewer',
     icon: 'difference',
     tooltip: 'Diff Viewer',
-    shortcut: ['Mod', 'G'] as const,
+    commandId: 'focus-diff',
   },
   {
     value: 'editor',
     label: 'Editor',
     icon: 'code',
     tooltip: 'Editor',
-    shortcut: ['Mod', 'E'] as const,
+    commandId: 'focus-editor',
   },
 ] as const
 
@@ -65,6 +67,7 @@ export const DockTab = ({
   compactMenuLeadingContent = undefined,
   hasCompactMenuBadge = false,
 }: DockTabProps): ReactElement => {
+  const { bindingFor } = useKeybindings()
   const actionsMenuId = useId()
   const [actionsOpen, setActionsOpen] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
@@ -129,6 +132,7 @@ export const DockTab = ({
   }
 
   const menuAlignClass = menuAlign === 'left' ? 'left-0' : 'right-0'
+  const dockToggleShortcut = chordToShortcutInput(bindingFor('dock-toggle'))
 
   return (
     <div
@@ -149,7 +153,10 @@ export const DockTab = ({
         aria-label="Dock tab"
         variant="dock"
         value={tab}
-        options={DOCK_TAB_OPTIONS}
+        options={DOCK_TAB_OPTIONS.map((option) => ({
+          ...option,
+          shortcut: chordToShortcutInput(bindingFor(option.commandId)),
+        }))}
         onChange={onTabChange}
         buttonClassName={compactActions ? 'w-[30px] px-0' : 'gap-1.5'}
         nativeOverlayTooltips
@@ -209,7 +216,7 @@ export const DockTab = ({
                 {children}
                 <Tooltip
                   content="Collapse panel"
-                  shortcut={['Mod', '0']}
+                  shortcut={dockToggleShortcut}
                   placement="bottom"
                   nativeOverlay
                 >
@@ -232,7 +239,7 @@ export const DockTab = ({
           <div className="ml-1 flex shrink-0 items-center">
             <Tooltip
               content="Collapse panel"
-              shortcut={['Mod', '0']}
+              shortcut={dockToggleShortcut}
               placement="bottom"
               nativeOverlay
             >

--- a/src/features/workspace/components/SidebarToggle.test.tsx
+++ b/src/features/workspace/components/SidebarToggle.test.tsx
@@ -66,6 +66,15 @@ describe('SidebarToggle', () => {
     )
   })
 
+  test('exposes a configured shortcut to assistive technology', () => {
+    renderToggle({ collapsed: false, ariaKeyshortcuts: 'Meta+r' })
+
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-keyshortcuts',
+      'Meta+r'
+    )
+  })
+
   // Open glyph = outline rect + rail-fill rect (2); collapsed glyph drops the
   // rail fill (1). The divider <path> is always drawn either way. SVG shapes
   // have no accessible role, so container.querySelectorAll is the only option.

--- a/src/features/workspace/components/SidebarToggle.tsx
+++ b/src/features/workspace/components/SidebarToggle.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/require-default-props -- forwardRef components: ESLint cannot see through forwardRef to find destructuring defaults */
 import { forwardRef, type ReactElement } from 'react'
 import { Tooltip } from '@/components/Tooltip'
+import type { ShortcutInput } from '@/lib/formatShortcut'
 
 export type SidebarToggleVariant = 'ghost' | 'inset'
 
@@ -17,8 +18,10 @@ export interface SidebarToggleProps {
    */
   variant?: SidebarToggleVariant
   'data-testid'?: string
-  /** Platform-appropriate shortcut hint shown as the tooltip chip (e.g. '⌘B' or 'Ctrl+⇧B'). Omit for controls with no shortcut (e.g. the activity panel). */
-  shortcutHint?: string
+  /** Platform-appropriate shortcut hint shown as the tooltip chip (e.g. ['Mod', 'B']). */
+  shortcutHint?: ShortcutInput
+  /** WAI-ARIA representation of the same shortcut. */
+  ariaKeyshortcuts?: string
   /** Mirror the glyph so the rail/fill sits on the RIGHT — for a right-docked panel. */
   mirrored?: boolean
   /** Override the default Show/Hide-sidebar tooltip + aria label (e.g. 'Expand activity panel'). */
@@ -50,6 +53,7 @@ export const SidebarToggle = forwardRef<HTMLButtonElement, SidebarToggleProps>(
       variant = 'ghost',
       'data-testid': testId = 'sidebar-toggle',
       shortcutHint = undefined,
+      ariaKeyshortcuts = undefined,
       mirrored = false,
       label = undefined,
     },
@@ -70,6 +74,7 @@ export const SidebarToggle = forwardRef<HTMLButtonElement, SidebarToggleProps>(
           onClick={onClick}
           aria-label={resolvedLabel}
           aria-expanded={!collapsed}
+          aria-keyshortcuts={ariaKeyshortcuts}
           style={{ width: size, height: size }}
           className={`vf-app-no-drag grid shrink-0 cursor-pointer place-items-center rounded-[7px] transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary-container ${VARIANT_CLASS[variant]}`}
         >

--- a/src/features/workspace/components/TerminalZone.test.tsx
+++ b/src/features/workspace/components/TerminalZone.test.tsx
@@ -8,6 +8,19 @@ import { mockSessions } from '../data/mockSessions'
 import type { LayoutId, Session } from '../../sessions/types'
 import type { TerminalPaneProps } from '../../terminal/components/TerminalPane'
 import type { ITerminalService } from '../../terminal/services/terminalService'
+import type { Keybindings } from '../../keymap/useKeybindings'
+
+vi.mock('../../keymap/useKeybindings', async () => {
+  const { getCommand } = await import('../../keymap/catalog')
+  const { resolveDefault } = await import('../../keymap/resolve')
+
+  const bindingFor: Keybindings['bindingFor'] = (id) =>
+    resolveDefault(getCommand(id), false)
+
+  return {
+    useKeybindings: (): Pick<Keybindings, 'bindingFor'> => ({ bindingFor }),
+  }
+})
 
 // Round 4 Finding 1: TerminalZone now requires a `service` prop so it can
 // forward it to every TerminalPane. The shared mock below is a no-op stub —

--- a/src/features/workspace/components/panels/DiffPanel.tsx
+++ b/src/features/workspace/components/panels/DiffPanel.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import type { ReactElement } from 'react'
 import { ChangedFilesList } from '../../../diff/components/ChangedFilesList'
 import type { ChangedFile } from '../../../diff/types'
+import { useKeybindings } from '../../../keymap/useKeybindings'
 
 // Mock changed files data for the diff panel
 const mockChangedFiles: ChangedFile[] = [
@@ -33,6 +34,8 @@ const mockChangedFiles: ChangedFile[] = [
  * Shows files with git status badges (M/A/D) in a scrollable list.
  */
 export const DiffPanel = (): ReactElement => {
+  const { bindingFor } = useKeybindings()
+
   const [selectedFile, setSelectedFile] = useState<{
     path: string
     staged: boolean
@@ -44,6 +47,7 @@ export const DiffPanel = (): ReactElement => {
       data-testid="diff-panel"
     >
       <ChangedFilesList
+        bindingFor={bindingFor}
         files={mockChangedFiles}
         selectedFile={selectedFile}
         onSelectFile={(file): void => {

--- a/src/features/workspace/hooks/useDockShortcuts.test.ts
+++ b/src/features/workspace/hooks/useDockShortcuts.test.ts
@@ -156,12 +156,12 @@ describe('useDockShortcuts', () => {
 
   test('focus-editor fires on a rebound combo supplied by the registry matcher', () => {
     const props = makeProps({
-      matches: matchesFor(false, { 'focus-editor': 'Mod+KeyK' }),
+      matches: matchesFor(false, { 'focus-editor': 'Mod+KeyO' }),
     })
     const dockElement = attachDockAndFocus()
     renderHook(() => useDockShortcuts(props))
 
-    const event = fire('k', { ctrlKey: true })
+    const event = fire('o', { ctrlKey: true })
 
     expect(props.openDock).toHaveBeenCalledWith('editor')
     expect(event.preventDefaultSpy).toHaveBeenCalled()

--- a/src/features/workspace/hooks/useSidebarShortcut.test.ts
+++ b/src/features/workspace/hooks/useSidebarShortcut.test.ts
@@ -69,6 +69,7 @@ const makeProps = (
   overrides: Partial<UseSidebarShortcutParams> = {}
 ): UseSidebarShortcutParams => ({
   onToggle: vi.fn(),
+  onToggleActivityPanel: vi.fn(),
   matches: matchesFor(true),
   activeContainerId: TERMINAL_CONTAINER_ID,
   ...overrides,
@@ -113,6 +114,17 @@ describe('useSidebarShortcut', () => {
 
       fireFrom(target, { metaKey: true, altKey: true })
 
+      expect(props.onToggle).not.toHaveBeenCalled()
+    })
+
+    test('⌘R toggles the right activity panel only', () => {
+      const props = makeProps({ matches: matchesFor(true) })
+      const target = append(document.createElement('div'))
+      renderHook(() => useSidebarShortcut(props))
+
+      fireFrom(target, { key: 'r', code: 'KeyR', metaKey: true })
+
+      expect(props.onToggleActivityPanel).toHaveBeenCalledOnce()
       expect(props.onToggle).not.toHaveBeenCalled()
     })
   })
@@ -166,6 +178,21 @@ describe('useSidebarShortcut', () => {
     fireFrom(target, { ctrlKey: true, shiftKey: true })
 
     expect(props.onToggle).toHaveBeenCalledOnce()
+  })
+
+  test('does not toggle the activity panel through the compact sidebar dialog', () => {
+    const props = makeProps({ matches: matchesFor(true) })
+    const sidebarDialog = document.createElement('div')
+    sidebarDialog.setAttribute('role', 'dialog')
+    sidebarDialog.setAttribute('aria-label', 'Sidebar')
+    const target = document.createElement('button')
+    sidebarDialog.appendChild(target)
+    append(sidebarDialog)
+    renderHook(() => useSidebarShortcut(props))
+
+    fireFrom(target, { key: 'r', code: 'KeyR', metaKey: true })
+
+    expect(props.onToggleActivityPanel).not.toHaveBeenCalled()
   })
 
   test('meta: bails when dock is active and target is inside the dock', () => {
@@ -227,6 +254,41 @@ describe('useSidebarShortcut', () => {
     expect(props.onToggle).toHaveBeenCalledOnce()
   })
 
+  test('fires the activity toggle on its rebound registry combo', () => {
+    const props = makeProps({
+      matches: matchesFor(true, {
+        'activity-panel-toggle': 'Mod+Shift+KeyR',
+      }),
+    })
+    const target = append(document.createElement('div'))
+    renderHook(() => useSidebarShortcut(props))
+
+    fireFrom(target, {
+      key: 'R',
+      code: 'KeyR',
+      metaKey: true,
+      shiftKey: true,
+    })
+
+    expect(props.onToggleActivityPanel).toHaveBeenCalledOnce()
+    expect(props.onToggle).not.toHaveBeenCalled()
+  })
+
+  test('ignores held activity-toggle repeats', () => {
+    const props = makeProps({ matches: matchesFor(true) })
+    const target = append(document.createElement('div'))
+    renderHook(() => useSidebarShortcut(props))
+
+    fireFrom(target, {
+      key: 'r',
+      code: 'KeyR',
+      metaKey: true,
+      repeat: true,
+    })
+
+    expect(props.onToggleActivityPanel).not.toHaveBeenCalled()
+  })
+
   test('does not defer rebound meta combos to the dock unless the key is B', () => {
     const props = makeProps({
       matches: matchesFor(true, { 'sidebar-toggle': 'Mod+KeyK' }),
@@ -236,6 +298,21 @@ describe('useSidebarShortcut', () => {
     renderHook(() => useSidebarShortcut(props))
 
     fireFrom(target, { key: 'k', code: 'KeyK', metaKey: true })
+
+    expect(props.onToggle).toHaveBeenCalledOnce()
+  })
+
+  test('does not defer a rebound modified B combo to the dock', () => {
+    const props = makeProps({
+      matches: matchesFor(true, {
+        'sidebar-toggle': 'Mod+Shift+KeyB',
+      }),
+      activeContainerId: DOCK_CONTAINER_ID,
+    })
+    const target = appendContainerWithChild(DOCK_CONTAINER_ID)
+    renderHook(() => useSidebarShortcut(props))
+
+    fireFrom(target, { key: 'B', metaKey: true, shiftKey: true })
 
     expect(props.onToggle).toHaveBeenCalledOnce()
   })

--- a/src/features/workspace/hooks/useSidebarShortcut.ts
+++ b/src/features/workspace/hooks/useSidebarShortcut.ts
@@ -8,8 +8,10 @@ import {
 } from '../containerIds'
 
 export interface UseSidebarShortcutParams {
-  /** Flip the workspace-global sidebar-collapse flag. */
+  /** Flip the workspace-global left-sidebar collapse flag. */
   onToggle: () => void
+  /** Flip the active session's right activity-panel collapse flag. */
+  onToggleActivityPanel: () => void
   /** Registry matcher — true iff the event is the resolved command chord. */
   matches: (event: KeyboardEvent, id: CommandId) => boolean
   /** Active focus container — used to defer to the dock's ⌘B when the dock is focused. */
@@ -28,14 +30,17 @@ export interface UseSidebarShortcutParams {
 // match comes from the keybinding registry so persisted overrides take effect.
 export const useSidebarShortcut = ({
   onToggle,
+  onToggleActivityPanel,
   matches,
   activeContainerId,
 }: UseSidebarShortcutParams): void => {
   const onToggleRef = useRef(onToggle)
+  const onToggleActivityPanelRef = useRef(onToggleActivityPanel)
   const matchesRef = useRef(matches)
   const activeContainerIdRef = useRef(activeContainerId)
 
   onToggleRef.current = onToggle
+  onToggleActivityPanelRef.current = onToggleActivityPanel
   matchesRef.current = matches
   activeContainerIdRef.current = activeContainerId
 
@@ -45,7 +50,18 @@ export const useSidebarShortcut = ({
         return
       }
 
-      if (!matchesRef.current(event, 'sidebar-toggle')) {
+      const commandId = matchesRef.current(event, 'sidebar-toggle')
+        ? 'sidebar-toggle'
+        : matchesRef.current(event, 'activity-panel-toggle')
+          ? 'activity-panel-toggle'
+          : null
+
+      if (commandId === null) {
+        return
+      }
+
+      // A held Meta+R must not oscillate the activity panel.
+      if (commandId === 'activity-panel-toggle' && event.repeat) {
         return
       }
 
@@ -64,15 +80,21 @@ export const useSidebarShortcut = ({
       const inSidebarDialog = !!target.closest(
         '[role="dialog"][aria-label="Sidebar"]'
       )
-      if (openDialogs.length > 0 && !inSidebarDialog) {
+      if (
+        openDialogs.length > 0 &&
+        !(commandId === 'sidebar-toggle' && inSidebarDialog)
+      ) {
         return
       }
 
       // On macOS, defer to the dock's ⌘B (close dock) when the dock is focused.
       if (
+        commandId === 'sidebar-toggle' &&
         event.key.toLowerCase() === 'b' &&
         event.metaKey &&
         !event.ctrlKey &&
+        !event.shiftKey &&
+        !event.altKey &&
         activeContainerIdRef.current === DOCK_CONTAINER_ID &&
         target.closest(`[data-container-id="${DOCK_CONTAINER_ID}"]`)
       ) {
@@ -96,7 +118,11 @@ export const useSidebarShortcut = ({
 
       event.preventDefault()
       event.stopPropagation()
-      onToggleRef.current()
+      if (commandId === 'sidebar-toggle') {
+        onToggleRef.current()
+      } else {
+        onToggleActivityPanelRef.current()
+      }
     }
 
     document.addEventListener('keydown', handleKeyDown, { capture: true })

--- a/src/lib/backend.ts
+++ b/src/lib/backend.ts
@@ -18,11 +18,6 @@ export type UnlistenFn = () => void
 
 export type CommandPaletteShortcutSource = 'palette' | 'leader'
 
-export interface CommandPaletteBindingSync {
-  palette: string
-  leader: string
-}
-
 export interface SettingsBridge {
   load: () => Promise<AppSettings>
   save: (settings: AppSettings) => Promise<void>
@@ -50,8 +45,6 @@ export interface BackendApi {
     callback: (source?: CommandPaletteShortcutSource) => void
   ) => UnlistenFn
   setKeymapCaptureActive?: (active: boolean) => void
-  setCommandPaletteBinding?: (binding: string) => void
-  setCommandPaletteBindings?: (bindings: CommandPaletteBindingSync) => void
   e2e?: {
     dispatchCommandPaletteShortcut: () => Promise<boolean>
   }

--- a/tests/e2e/terminal/specs/agent-resume-lifecycle.spec.ts
+++ b/tests/e2e/terminal/specs/agent-resume-lifecycle.spec.ts
@@ -18,7 +18,7 @@ type ElectronModule = typeof import('electron')
 
 // macos-26 GitHub runners can vary by several seconds after Electron reload
 // while still preserving the intended lazy-hydration bound for 384 panes.
-const RENDERER_STRESS_RESUME_BUDGET_MS = 22_500
+const RENDERER_STRESS_RESUME_BUDGET_MS = 24_000
 
 const fixtureLogPath = (): string => {
   const configured = process.env.VIMEFLOW_E2E_AGENT_LOG


### PR DESCRIPTION
## Summary

- Centralize workspace, browser, and Diff/hunk shortcuts in one settings-backed keymap catalog.
- Publish resolved shortcuts to Electron browser panes and native Ghostty/AppKit surfaces.
- Keep shortcut hints and settings rows stable while validating persisted bindings and IPC payload bounds.

## Why

Shortcut ownership had drifted across React, Electron, and AppKit. Diff actions were not configurable, and custom bindings could be ignored when native Ghostty or embedded browser content held focus.

## Validation

- `npx vitest run` — 446 files passed; 5,630 tests passed, 3 skipped
- `npm run lint`
- `npm run type-check:generated`
- `npm run format:check`
- pre-commit and pre-push hooks

Refs VIM-349