### PR TITLE
fix(electron): restore Linux directory picker

### DIFF
--- a/electron/dialog-ipc.test.ts
+++ b/electron/dialog-ipc.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
-import { setupDialogIpc } from './dialog-ipc'
+import { parseLinuxDirectoryReply, setupDialogIpc } from './dialog-ipc'
 import { DIALOG_PICK_DIRECTORY } from './ipc-channels'
 
 const dialog = vi.hoisted(() => ({ showOpenDialog: vi.fn() }))
@@ -12,9 +12,15 @@ const browserWindow = vi.hoisted(() => ({
 vi.mock('electron', () => ({ dialog, BrowserWindow: browserWindow }))
 
 describe('setupDialogIpc', () => {
-  beforeEach(() => vi.clearAllMocks())
+  beforeEach(() => {
+    vi.clearAllMocks()
+    dialog.showOpenDialog.mockReset()
+  })
 
-  const register = (): ((e: unknown) => Promise<string | null>) => {
+  const register = (
+    platform: NodeJS.Platform = 'darwin',
+    pickLinuxDirectory = vi.fn<() => Promise<string | null>>()
+  ): ((e: unknown) => Promise<string | null>) => {
     const handlers = new Map<string, (e: unknown) => Promise<string | null>>()
 
     const ipcMain = {
@@ -24,7 +30,7 @@ describe('setupDialogIpc', () => {
         }
       ),
     }
-    setupDialogIpc(ipcMain as never)
+    setupDialogIpc(ipcMain as never, platform, pickLinuxDirectory)
     const handler = handlers.get(DIALOG_PICK_DIRECTORY)
     if (!handler) {
       throw new Error('handler not registered')
@@ -33,7 +39,7 @@ describe('setupDialogIpc', () => {
     return handler
   }
 
-  test('returns the chosen directory path', async () => {
+  test('returns the chosen directory path from Electron', async () => {
     dialog.showOpenDialog.mockResolvedValue({
       canceled: false,
       filePaths: ['/Users/x/proj'],
@@ -47,9 +53,114 @@ describe('setupDialogIpc', () => {
     })
   })
 
+  test('uses the GTK portal backend directly on non-KDE Linux', async () => {
+    const pickLinuxDirectory = vi.fn().mockResolvedValue('/home/x/proj')
+    const handler = register('linux', pickLinuxDirectory)
+    await expect(handler({ sender: {} })).resolves.toBe('/home/x/proj')
+    expect(pickLinuxDirectory).toHaveBeenCalledOnce()
+    expect(dialog.showOpenDialog).not.toHaveBeenCalled()
+  })
+
+  test('falls back to Electron when the GTK portal backend is unavailable', async () => {
+    const pickLinuxDirectory = vi
+      .fn()
+      .mockRejectedValue(new Error('GTK backend unavailable'))
+    dialog.showOpenDialog.mockResolvedValue({
+      canceled: false,
+      filePaths: ['/home/x/proj'],
+    })
+    const handler = register('linux', pickLinuxDirectory)
+    await expect(handler({ sender: {} })).resolves.toBe('/home/x/proj')
+    expect(dialog.showOpenDialog).toHaveBeenCalledWith({
+      properties: ['openDirectory'],
+      title: 'Choose working directory',
+    })
+  })
+
   test('returns null when canceled', async () => {
     dialog.showOpenDialog.mockResolvedValue({ canceled: true, filePaths: [] })
-    const handler = register()
+    const handler = register('darwin')
     await expect(handler({ sender: {} })).resolves.toBeNull()
+  })
+
+  test('uses Electron directly on KDE Linux', async () => {
+    dialog.showOpenDialog.mockResolvedValue({
+      canceled: false,
+      filePaths: ['/home/x/proj'],
+    })
+    const pickLinuxDirectory = vi.fn().mockResolvedValue('/wrong/backend')
+    const previousDesktop = process.env.XDG_CURRENT_DESKTOP
+    process.env.XDG_CURRENT_DESKTOP = 'KDE'
+
+    try {
+      const handler = register('linux', pickLinuxDirectory)
+      await expect(handler({ sender: {} })).resolves.toBe('/home/x/proj')
+      expect(pickLinuxDirectory).not.toHaveBeenCalled()
+    } finally {
+      if (previousDesktop === undefined) {
+        delete process.env.XDG_CURRENT_DESKTOP
+      } else {
+        process.env.XDG_CURRENT_DESKTOP = previousDesktop
+      }
+    }
+  })
+})
+
+describe('parseLinuxDirectoryReply', () => {
+  test('returns the selected file URI as an absolute path', () => {
+    expect(
+      parseLinuxDirectoryReply(
+        JSON.stringify({
+          type: 'ua{sv}',
+          data: [
+            0,
+            {
+              uris: {
+                type: 'as',
+                data: ['file:///home/will/My%20Project'],
+              },
+            },
+          ],
+        })
+      )
+    ).toBe('/home/will/My Project')
+  })
+
+  test('returns null when the picker is canceled', () => {
+    expect(
+      parseLinuxDirectoryReply(
+        JSON.stringify({
+          type: 'ua{sv}',
+          data: [
+            2,
+            {
+              uris: {
+                type: 'as',
+                data: [],
+              },
+            },
+          ],
+        })
+      )
+    ).toBeNull()
+  })
+
+  test('rejects malformed portal replies', () => {
+    expect(() =>
+      parseLinuxDirectoryReply(
+        JSON.stringify({
+          type: 'ua{sv}',
+          data: [
+            0,
+            {
+              uris: {
+                type: 'as',
+                data: ['https://example.com/not-a-directory'],
+              },
+            },
+          ],
+        })
+      )
+    ).toThrow('invalid GTK portal directory response')
   })
 })

--- a/electron/dialog-ipc.ts
+++ b/electron/dialog-ipc.ts
@@ -1,3 +1,4 @@
+// cspell:ignore busctl osssa
 import {
   BrowserWindow,
   dialog,
@@ -5,19 +6,130 @@ import {
   type IpcMainInvokeEvent,
   type OpenDialogOptions,
 } from 'electron'
+import { execFile } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
 import { DIALOG_PICK_DIRECTORY } from './ipc-channels'
 
+type LinuxDirectoryPicker = () => Promise<string | null>
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const isUnknownArray = (value: unknown): value is unknown[] =>
+  Array.isArray(value)
+
+export const parseLinuxDirectoryReply = (stdout: string): string | null => {
+  const reply: unknown = JSON.parse(stdout)
+
+  if (!isRecord(reply) || !isUnknownArray(reply.data)) {
+    throw new Error('invalid GTK portal directory response')
+  }
+
+  const response: unknown = reply.data[0]
+  const results: unknown = reply.data[1]
+
+  if (response !== 0) {
+    return null
+  }
+
+  if (!isRecord(results) || !isRecord(results.uris)) {
+    throw new Error('invalid GTK portal directory response')
+  }
+
+  const uris = results.uris.data
+
+  if (
+    !isUnknownArray(uris) ||
+    uris.length === 0 ||
+    typeof uris[0] !== 'string' ||
+    !uris[0].startsWith('file:')
+  ) {
+    throw new Error('invalid GTK portal directory response')
+  }
+
+  return fileURLToPath(uris[0])
+}
+
+const runGtkPortalDirectoryPicker = (): Promise<string | null> =>
+  new Promise((resolve, reject) => {
+    const token = `vimeflow_${String(process.pid)}_${String(Date.now())}`
+    const handle = `/org/freedesktop/portal/desktop/request/vimeflow/${token}`
+
+    execFile(
+      'busctl',
+      [
+        '--user',
+        '--json=short',
+        '--timeout=0',
+        'call',
+        'org.freedesktop.impl.portal.desktop.gtk',
+        '/org/freedesktop/portal/desktop',
+        'org.freedesktop.impl.portal.FileChooser',
+        'OpenFile',
+        'osssa{sv}',
+        handle,
+        'io.vimeflow.app',
+        '',
+        'Choose working directory',
+        '2',
+        'directory',
+        'b',
+        'true',
+        'modal',
+        'b',
+        'true',
+      ],
+      { encoding: 'utf8', maxBuffer: 64 * 1024 },
+      (error, stdout) => {
+        if (error) {
+          reject(new Error(error.message, { cause: error }))
+
+          return
+        }
+
+        try {
+          resolve(parseLinuxDirectoryReply(stdout))
+        } catch (parseError) {
+          reject(
+            parseError instanceof Error
+              ? parseError
+              : new Error(String(parseError))
+          )
+        }
+      }
+    )
+  })
+
+const isKdeDesktop = (): boolean =>
+  process.env.XDG_CURRENT_DESKTOP?.toLowerCase().includes('kde') === true
+
 // Native OS directory picker. Returns the absolute path, or null on cancel.
-export const setupDialogIpc = (ipcMain: IpcMain): void => {
+export const setupDialogIpc = (
+  ipcMain: IpcMain,
+  platform: NodeJS.Platform = process.platform,
+  pickLinuxDirectory: LinuxDirectoryPicker = runGtkPortalDirectoryPicker
+): void => {
   ipcMain.handle(
     DIALOG_PICK_DIRECTORY,
     async (event: IpcMainInvokeEvent): Promise<string | null> => {
+      if (platform === 'linux' && !isKdeDesktop()) {
+        try {
+          return await pickLinuxDirectory()
+        } catch {
+          // GTK portal backend or busctl unavailable; Electron can still use
+          // the desktop's configured portal (notably KDE).
+        }
+      }
+
       const win =
         BrowserWindow.fromWebContents(event.sender) ??
         BrowserWindow.getFocusedWindow()
 
       const options: OpenDialogOptions = {
-        properties: ['openDirectory', 'createDirectory'],
+        properties:
+          platform === 'darwin'
+            ? ['openDirectory', 'createDirectory']
+            : ['openDirectory'],
         title: 'Choose working directory',
       }
 

--- a/src/features/sessions/components/NewSessionDialog/WorkingDirectoryField.test.tsx
+++ b/src/features/sessions/components/NewSessionDialog/WorkingDirectoryField.test.tsx
@@ -29,12 +29,15 @@ describe('WorkingDirectoryField', () => {
     expect(onChange).not.toHaveBeenCalled()
   })
 
-  test('a rejected pick does not call onChange', async () => {
+  test('a rejected pick shows an error and does not call onChange', async () => {
     vi.mocked(pickDirectory).mockRejectedValue(new Error('IPC unavailable'))
     const onChange = vi.fn()
     const user = userEvent.setup()
     render(<WorkingDirectoryField path="~/code/vf" onChange={onChange} />)
     await user.click(screen.getByRole('button', { name: /browse/i }))
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Could not open the folder picker.'
+    )
     expect(onChange).not.toHaveBeenCalled()
   })
 

--- a/src/features/sessions/components/NewSessionDialog/WorkingDirectoryField.tsx
+++ b/src/features/sessions/components/NewSessionDialog/WorkingDirectoryField.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement } from 'react'
+import { useState, type ReactElement } from 'react'
 import { Button } from '@/components/Button'
 import { PathCrumb } from './PathCrumb'
 import { pickDirectory } from './pickDirectory'
@@ -14,12 +14,17 @@ export const WorkingDirectoryField = ({
   onChange,
   browseDisabled = false,
 }: WorkingDirectoryFieldProps): ReactElement => {
+  const [browseFailed, setBrowseFailed] = useState(false)
+
   const handleBrowse = async (): Promise<void> => {
     let picked: string | null
+    setBrowseFailed(false)
 
     try {
       picked = await pickDirectory()
     } catch {
+      setBrowseFailed(true)
+
       return
     }
 
@@ -29,27 +34,34 @@ export const WorkingDirectoryField = ({
   }
 
   return (
-    <div className="flex items-center gap-2">
-      <div className="flex h-11 min-w-0 flex-1 items-center gap-2 rounded-[9px] bg-surface-container-lowest px-3">
-        <span
-          className="material-symbols-outlined text-base text-primary-container"
-          aria-hidden="true"
+    <div>
+      <div className="flex items-center gap-2">
+        <div className="flex h-11 min-w-0 flex-1 items-center gap-2 rounded-[9px] bg-surface-container-lowest px-3">
+          <span
+            className="material-symbols-outlined text-base text-primary-container"
+            aria-hidden="true"
+          >
+            folder_open
+          </span>
+          <PathCrumb path={path} />
+        </div>
+        <Button
+          variant="default"
+          leadingIcon="drive_folder_upload"
+          className="h-11"
+          disabled={browseDisabled}
+          onClick={() => {
+            void handleBrowse()
+          }}
         >
-          folder_open
-        </span>
-        <PathCrumb path={path} />
+          Browse…
+        </Button>
       </div>
-      <Button
-        variant="default"
-        leadingIcon="drive_folder_upload"
-        className="h-11"
-        disabled={browseDisabled}
-        onClick={() => {
-          void handleBrowse()
-        }}
-      >
-        Browse…
-      </Button>
+      {browseFailed ? (
+        <p role="alert" className="mt-1.5 font-mono text-[11px] text-error">
+          Could not open the folder picker.
+        </p>
+      ) : null}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- open the installed GTK portal file chooser directly on non-KDE Linux
- fall back to Electron's picker when the GTK portal backend or `busctl` is unavailable
- keep the native Electron picker on macOS and KDE, and surface picker failures in the session dialog

## Root cause

Electron routed the directory request through the desktop portal selected by niri. On the affected Linux setup, the GNOME portal delegated the request to Nautilus, which was not installed, so no dialog appeared. Calling the installed GTK portal backend directly restores the native Linux chooser while preserving safe fallbacks.

## Validation

- full pre-push Vitest suite: 5,639 passed, 3 skipped
- focused picker and session-dialog tests: 69 passed
- Electron TypeScript type-check
- generated Rust-to-TypeScript bindings: 82 export tests passed
- Linux x64 AppImage build and manual native-dialog verification

Refs VIM-350