### PR TITLE
fix(settings): hide unavailable sections

### DIFF
--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -95,7 +95,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Prototype Handoff Artifacts](patterns/prototype-handoff-artifacts.md)                               | review-process     | 2        | 0    | 2026-06-12   |
 | [CloudFormation Environment Prefix Coupling](patterns/cloudformation-environment-prefix-coupling.md) | infrastructure     | 1        | 0    | 2026-06-12   |
 | [CloudFormation Stale References](patterns/cloudformation-stale-references.md)                       | infrastructure     | 2        | 1    | 2026-06-12   |
-| [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 10       | 8    | 2026-07-15   |
+| [Dead Code](patterns/dead-code.md)                                                                   | code-quality       | 11       | 8    | 2026-07-17   |
 | [Unsafe Block Safety Comments](patterns/unsafe-block-safety-comments.md)                             | security           | 1        | 0    | 2026-06-14   |
 | [Type Contract Safety](patterns/type-contract-safety.md)                                             | code-quality       | 18       | 11   | 2026-07-09   |
 | [String Construction Hygiene](patterns/string-construction-hygiene.md)                               | code-quality       | 2        | 1    | 2026-06-19   |

--- a/docs/reviews/CLAUDE.md
+++ b/docs/reviews/CLAUDE.md
@@ -52,7 +52,7 @@ When appending findings to a pattern file, label the source so future readers ca
 | [Resource Cleanup](patterns/resource-cleanup.md)                                                     | react-patterns     | 32       | 25   | 2026-07-12   |
 | [Cross-Platform Paths](patterns/cross-platform-paths.md)                                             | cross-platform     | 14       | 12   | 2026-07-09   |
 | [Debug Artifacts](patterns/debug-artifacts.md)                                                       | code-quality       | 7        | 0    | 2026-06-11   |
-| [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 30       | 23   | 2026-07-11   |
+| [Derived State Consistency](patterns/derived-state-consistency.md)                                   | code-quality       | 31       | 24   | 2026-07-17   |
 | [Generated Artifacts](patterns/generated-artifacts.md)                                               | code-quality       | 9        | 6    | 2026-06-12   |
 | [Generated Shell Scripts](patterns/generated-shell-scripts.md)                                       | backend            | 8        | 2    | 2026-06-19   |
 | [Hot-Path Caching](patterns/hot-path-caching.md)                                                     | backend            | 9        | 3    | 2026-07-13   |

--- a/docs/reviews/patterns/dead-code.md
+++ b/docs/reviews/patterns/dead-code.md
@@ -2,7 +2,7 @@
 id: dead-code
 category: code-quality
 created: 2026-06-13
-last_updated: 2026-07-15
+last_updated: 2026-07-17
 ref_count: 8
 ---
 
@@ -116,3 +116,18 @@ code and should be removed.
   shortcut dispatcher, so only the exported accessor was dead surface.
 - **Fix:** Removed the unused export while keeping `setKeymapCaptureActive` and
   the existing internal capture guard intact.
+
+### 11. Settings placeholder pane branch became unreachable after availability gating
+
+- **Source:** github-claude | PR #700 round 2 | 2026-07-17
+- **Severity:** LOW
+- **File:** `src/features/settings/SettingsContent.tsx`
+- **Finding:** `hasSettingsPane(section)` and `activeSection` were derived from
+  the same available-section source, while every UI path that updates
+  `section` also selects from available sections. The fallback
+  `PlaceholderPane` render branch could no longer be reached and implied
+  unavailable settings sections were still user-selectable.
+- **Fix:** Removed the unreachable `PlaceholderPane` import, active-section
+  lookup, and fallback render branch so the pane renderer reflects the
+  availability contract directly.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/docs/reviews/patterns/derived-state-consistency.md
+++ b/docs/reviews/patterns/derived-state-consistency.md
@@ -2,8 +2,8 @@
 id: derived-state-consistency
 category: code-quality
 created: 2026-06-07
-last_updated: 2026-07-11
-ref_count: 23
+last_updated: 2026-07-17
+ref_count: 24
 ---
 
 # Derived State Consistency
@@ -400,4 +400,20 @@ base data is technically "correct."
 - **Fix:** Derived a single `isFinishPopoverOpen` value and reused it for the
   Finish popover state plus both Request-review entry gates, so the shortcut
   and toolbar share the same exclusivity contract.
+- **Commit:** same commit as this entry (see `git blame` / `git log` on this line)
+
+### 31. Settings section availability split from pane render eligibility
+
+- **Source:** github-claude | PR #700 round 1 | 2026-07-17
+- **Severity:** MEDIUM
+- **File:** `src/features/settings/sections.ts`, `src/features/settings/SettingsContent.tsx`
+- **Finding:** Settings navigation and search used `AVAILABLE_SETTINGS_SECTIONS`
+  while pane rendering maintained a separate `REAL_PANES` list with the same
+  section IDs. Future settings work could update one list without the other,
+  making a section appear navigable but render a placeholder, or hide a
+  finished pane from navigation.
+- **Fix:** Promoted available section IDs to the single exported availability
+  source, derived `SETTINGS_SECTIONS` and `AVAILABLE_SETTINGS_SECTIONS` from it,
+  and made `SettingsContent` type its pane registry against that same ID union.
+  Added focused coverage that available IDs and available sections stay aligned.
 - **Commit:** same commit as this entry (see `git blame` / `git log` on this line)

--- a/src/features/settings/SettingsContent.tsx
+++ b/src/features/settings/SettingsContent.tsx
@@ -9,7 +9,7 @@ import type {
   SettingsTargetId,
 } from './types'
 import {
-  SETTINGS_SECTIONS,
+  AVAILABLE_SETTINGS_SECTIONS,
   SETTINGS_SUBSECTIONS,
   SETTINGS_TARGETS,
 } from './sections'
@@ -90,7 +90,7 @@ export const SettingsContent = (): ReactElement => {
   const searchModel = useMemo(
     () =>
       searchSettings({
-        sections: SETTINGS_SECTIONS,
+        sections: AVAILABLE_SETTINGS_SECTIONS,
         targets: SETTINGS_TARGETS,
         query,
       }),
@@ -108,7 +108,9 @@ export const SettingsContent = (): ReactElement => {
         ? searchResults[0].key
         : null
 
-  const activeSection = SETTINGS_SECTIONS.find((s) => s.id === section)
+  const activeSection = AVAILABLE_SETTINGS_SECTIONS.find(
+    (s) => s.id === section
+  )
 
   const activeSidebarSubsection =
     activeSidebarSubsectionId === null
@@ -121,7 +123,7 @@ export const SettingsContent = (): ReactElement => {
 
   const sidebarNavigationEntries = useMemo(() => {
     const navigationSections =
-      query.trim() === '' ? SETTINGS_SECTIONS : filtered
+      query.trim() === '' ? AVAILABLE_SETTINGS_SECTIONS : filtered
 
     return navigationSections.flatMap(
       (candidate): SettingsNavigationEntry[] => {
@@ -220,7 +222,9 @@ export const SettingsContent = (): ReactElement => {
   }
 
   const handlePickTarget = (target: SettingsTarget): void => {
-    const owningSection = SETTINGS_SECTIONS.find((s) => s.id === target.section)
+    const owningSection = AVAILABLE_SETTINGS_SECTIONS.find(
+      (s) => s.id === target.section
+    )
     if (owningSection === undefined) {
       return
     }

--- a/src/features/settings/SettingsContent.tsx
+++ b/src/features/settings/SettingsContent.tsx
@@ -9,9 +9,11 @@ import type {
   SettingsTargetId,
 } from './types'
 import {
+  AVAILABLE_SETTINGS_SECTION_IDS,
   AVAILABLE_SETTINGS_SECTIONS,
   SETTINGS_SUBSECTIONS,
   SETTINGS_TARGETS,
+  type AvailableSettingsSectionId,
 } from './sections'
 import {
   searchSettings,
@@ -30,13 +32,18 @@ import { PlaceholderPane } from './components/panes/PlaceholderPane'
 import { TerminalSettingsPane } from './components/panes/TerminalSettingsPane'
 import { isKeymapCaptureTarget } from '../keymap/capture'
 
-const REAL_PANES: readonly SettingsSectionId[] = [
-  'general',
-  'appearance',
-  'keymap',
-  'agents',
-  'terminal',
-]
+const SETTINGS_PANES = {
+  general: <GeneralPane />,
+  appearance: <AppearancePane />,
+  keymap: <KeymapPane />,
+  agents: <AgentsPane />,
+  terminal: <TerminalSettingsPane />,
+} satisfies Record<AvailableSettingsSectionId, ReactElement>
+
+const hasSettingsPane = (
+  id: SettingsSectionId
+): id is AvailableSettingsSectionId =>
+  (AVAILABLE_SETTINGS_SECTION_IDS as readonly SettingsSectionId[]).includes(id)
 
 const SETTINGS_SCROLL_STEP = 96
 
@@ -554,14 +561,10 @@ export const SettingsContent = (): ReactElement => {
           data-testid="settings-dialog-content"
           className="thin-scrollbar flex-1 overflow-auto px-7 py-5"
         >
-          {section === 'general' && <GeneralPane />}
-          {section === 'appearance' && <AppearancePane />}
-          {section === 'keymap' && <KeymapPane />}
-          {section === 'agents' && <AgentsPane />}
-          {section === 'terminal' && <TerminalSettingsPane />}
-          {!REAL_PANES.includes(section) && activeSection && (
+          {hasSettingsPane(section) ? SETTINGS_PANES[section] : null}
+          {!hasSettingsPane(section) && activeSection ? (
             <PlaceholderPane section={activeSection} />
-          )}
+          ) : null}
         </div>
       </div>
     </div>

--- a/src/features/settings/SettingsContent.tsx
+++ b/src/features/settings/SettingsContent.tsx
@@ -28,7 +28,6 @@ import { AgentsPane } from './components/panes/AgentsPane'
 import { AppearancePane } from './components/panes/AppearancePane'
 import { GeneralPane } from './components/panes/GeneralPane'
 import { KeymapPane } from './components/panes/KeymapPane'
-import { PlaceholderPane } from './components/panes/PlaceholderPane'
 import { TerminalSettingsPane } from './components/panes/TerminalSettingsPane'
 import { isKeymapCaptureTarget } from '../keymap/capture'
 
@@ -114,10 +113,6 @@ export const SettingsContent = (): ReactElement => {
       : query.trim() !== '' && searchResults.length > 0
         ? searchResults[0].key
         : null
-
-  const activeSection = AVAILABLE_SETTINGS_SECTIONS.find(
-    (s) => s.id === section
-  )
 
   const activeSidebarSubsection =
     activeSidebarSubsectionId === null
@@ -562,9 +557,6 @@ export const SettingsContent = (): ReactElement => {
           className="thin-scrollbar flex-1 overflow-auto px-7 py-5"
         >
           {hasSettingsPane(section) ? SETTINGS_PANES[section] : null}
-          {!hasSettingsPane(section) && activeSection ? (
-            <PlaceholderPane section={activeSection} />
-          ) : null}
         </div>
       </div>
     </div>

--- a/src/features/settings/SettingsDialog.test.tsx
+++ b/src/features/settings/SettingsDialog.test.tsx
@@ -10,6 +10,7 @@ import userEvent from '@testing-library/user-event'
 import { useState, type ReactElement } from 'react'
 import { SettingsDialog } from './SettingsDialog'
 import {
+  AVAILABLE_SETTINGS_SECTIONS,
   SETTINGS_SECTIONS,
   SETTINGS_TARGET_IDS,
   keymapCommandTargetId,
@@ -134,9 +135,17 @@ describe('SettingsDialog', () => {
   test('renders the sidebar sections', () => {
     render(<SettingsDialog open onClose={vi.fn()} />)
 
-    SETTINGS_SECTIONS.forEach((s) => {
+    AVAILABLE_SETTINGS_SECTIONS.forEach((s) => {
       expect(screen.getByRole('option', { name: s.label })).toBeInTheDocument()
     })
+
+    SETTINGS_SECTIONS.filter((section) => section.available !== true).forEach(
+      (section) => {
+        expect(
+          screen.queryByRole('option', { name: section.label })
+        ).not.toBeInTheDocument()
+      }
+    )
   })
 
   test('defaults to the appearance pane', () => {

--- a/src/features/settings/sections.test.ts
+++ b/src/features/settings/sections.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest'
 import { DIFF_COMMANDS } from '../keymap/catalog'
 import {
+  AVAILABLE_SETTINGS_SECTIONS,
   DEFAULT_ALIASES,
   SETTINGS_TARGET_IDS,
   SETTINGS_SUBSECTIONS,
@@ -38,6 +39,16 @@ describe('SETTINGS_SECTIONS', () => {
       expect(s.label).toBeDefined()
       expect(s.icon).toBeDefined()
     })
+  })
+
+  test('only renders sections with available options', () => {
+    expect(AVAILABLE_SETTINGS_SECTIONS.map((section) => section.id)).toEqual([
+      'general',
+      'appearance',
+      'keymap',
+      'agents',
+      'terminal',
+    ])
   })
 })
 

--- a/src/features/settings/sections.test.ts
+++ b/src/features/settings/sections.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest'
 import { DIFF_COMMANDS } from '../keymap/catalog'
 import {
+  AVAILABLE_SETTINGS_SECTION_IDS,
   AVAILABLE_SETTINGS_SECTIONS,
   DEFAULT_ALIASES,
   SETTINGS_TARGET_IDS,
@@ -42,6 +43,14 @@ describe('SETTINGS_SECTIONS', () => {
   })
 
   test('only renders sections with available options', () => {
+    expect(AVAILABLE_SETTINGS_SECTION_IDS).toEqual([
+      'general',
+      'appearance',
+      'keymap',
+      'agents',
+      'terminal',
+    ])
+
     expect(AVAILABLE_SETTINGS_SECTIONS.map((section) => section.id)).toEqual([
       'general',
       'appearance',

--- a/src/features/settings/sections.ts
+++ b/src/features/settings/sections.ts
@@ -9,13 +9,31 @@ import type {
 } from './types'
 import { CATALOG, type CommandId } from '../keymap/catalog'
 
-export const SETTINGS_SECTIONS: SettingsSection[] = [
-  { id: 'general', label: 'General', icon: 'settings', available: true },
-  { id: 'appearance', label: 'Appearance', icon: 'palette', available: true },
-  { id: 'keymap', label: 'Keymap', icon: 'keyboard', available: true },
-  { id: 'agents', label: 'Coding Agents', icon: 'bolt', available: true },
+export const AVAILABLE_SETTINGS_SECTION_IDS = [
+  'general',
+  'appearance',
+  'keymap',
+  'agents',
+  'terminal',
+] as const satisfies readonly SettingsSection['id'][]
+
+export type AvailableSettingsSectionId =
+  (typeof AVAILABLE_SETTINGS_SECTION_IDS)[number]
+
+const isAvailableSettingsSectionId = (
+  id: SettingsSection['id']
+): id is AvailableSettingsSectionId =>
+  (AVAILABLE_SETTINGS_SECTION_IDS as readonly SettingsSection['id'][]).includes(
+    id
+  )
+
+const SETTINGS_SECTION_CATALOG: Omit<SettingsSection, 'available'>[] = [
+  { id: 'general', label: 'General', icon: 'settings' },
+  { id: 'appearance', label: 'Appearance', icon: 'palette' },
+  { id: 'keymap', label: 'Keymap', icon: 'keyboard' },
+  { id: 'agents', label: 'Coding Agents', icon: 'bolt' },
   { id: 'editor', label: 'Editor', icon: 'code' },
-  { id: 'terminal', label: 'Terminal', icon: 'terminal', available: true },
+  { id: 'terminal', label: 'Terminal', icon: 'terminal' },
   { id: 'languages', label: 'Languages & Tools', icon: 'data_object' },
   { id: 'search', label: 'Search & Files', icon: 'search' },
   { id: 'window', label: 'Window & Layout', icon: 'grid_view' },
@@ -26,8 +44,18 @@ export const SETTINGS_SECTIONS: SettingsSection[] = [
   { id: 'network', label: 'Network', icon: 'lan' },
 ]
 
+export const SETTINGS_SECTIONS: SettingsSection[] = SETTINGS_SECTION_CATALOG.map(
+  (section) => ({
+    ...section,
+    ...(isAvailableSettingsSectionId(section.id) ? { available: true } : {}),
+  })
+)
+
 export const AVAILABLE_SETTINGS_SECTIONS = SETTINGS_SECTIONS.filter(
-  (section) => section.available === true
+  (section): section is SettingsSection & {
+    id: AvailableSettingsSectionId
+    available: true
+  } => section.available === true
 )
 
 export const SETTINGS_TARGET_IDS = {

--- a/src/features/settings/sections.ts
+++ b/src/features/settings/sections.ts
@@ -10,12 +10,12 @@ import type {
 import { CATALOG, type CommandId } from '../keymap/catalog'
 
 export const SETTINGS_SECTIONS: SettingsSection[] = [
-  { id: 'general', label: 'General', icon: 'settings' },
-  { id: 'appearance', label: 'Appearance', icon: 'palette' },
-  { id: 'keymap', label: 'Keymap', icon: 'keyboard' },
-  { id: 'agents', label: 'Coding Agents', icon: 'bolt' },
+  { id: 'general', label: 'General', icon: 'settings', available: true },
+  { id: 'appearance', label: 'Appearance', icon: 'palette', available: true },
+  { id: 'keymap', label: 'Keymap', icon: 'keyboard', available: true },
+  { id: 'agents', label: 'Coding Agents', icon: 'bolt', available: true },
   { id: 'editor', label: 'Editor', icon: 'code' },
-  { id: 'terminal', label: 'Terminal', icon: 'terminal' },
+  { id: 'terminal', label: 'Terminal', icon: 'terminal', available: true },
   { id: 'languages', label: 'Languages & Tools', icon: 'data_object' },
   { id: 'search', label: 'Search & Files', icon: 'search' },
   { id: 'window', label: 'Window & Layout', icon: 'grid_view' },
@@ -25,6 +25,10 @@ export const SETTINGS_SECTIONS: SettingsSection[] = [
   { id: 'ai', label: 'AI', icon: 'psychology' },
   { id: 'network', label: 'Network', icon: 'lan' },
 ]
+
+export const AVAILABLE_SETTINGS_SECTIONS = SETTINGS_SECTIONS.filter(
+  (section) => section.available === true
+)
 
 export const SETTINGS_TARGET_IDS = {
   generalCloseWithNoTabs: 'general-close-with-no-tabs',

--- a/src/features/settings/sections.ts
+++ b/src/features/settings/sections.ts
@@ -44,15 +44,16 @@ const SETTINGS_SECTION_CATALOG: Omit<SettingsSection, 'available'>[] = [
   { id: 'network', label: 'Network', icon: 'lan' },
 ]
 
-export const SETTINGS_SECTIONS: SettingsSection[] = SETTINGS_SECTION_CATALOG.map(
-  (section) => ({
+export const SETTINGS_SECTIONS: SettingsSection[] =
+  SETTINGS_SECTION_CATALOG.map((section) => ({
     ...section,
     ...(isAvailableSettingsSectionId(section.id) ? { available: true } : {}),
-  })
-)
+  }))
 
 export const AVAILABLE_SETTINGS_SECTIONS = SETTINGS_SECTIONS.filter(
-  (section): section is SettingsSection & {
+  (
+    section
+  ): section is SettingsSection & {
     id: AvailableSettingsSectionId
     available: true
   } => section.available === true

--- a/src/features/settings/types.ts
+++ b/src/features/settings/types.ts
@@ -21,6 +21,7 @@ export interface SettingsSection {
   id: SettingsSectionId
   label: string
   icon: string
+  available?: boolean
 }
 
 export type SettingsTargetId = string


### PR DESCRIPTION
## Summary

- Add an availability flag to settings sections.
- Show only implemented sections in sidebar navigation, search, and keyboard navigation.
- Keep placeholder categories registered so they can be enabled when their options ship.

## Why

Planned settings categories currently open empty placeholder panes, which makes the settings surface look unfinished.

## Validation

- Focused settings suite: 78 tests passed
- Full pre-push suite: 5,634 tests passed, 3 skipped
- TypeScript type-check
- ESLint
- Prettier
- `git diff --check`

Refs VIM-352