### PR TITLE
fix(terminal): restore agent image paste shortcut

### DIFF
--- a/src/features/terminal/components/TerminalContextMenu.test.tsx
+++ b/src/features/terminal/components/TerminalContextMenu.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { expect, test, vi } from 'vitest'
 import { TerminalContextMenu } from './TerminalContextMenu'
@@ -7,10 +7,7 @@ const baseProps = {
   onClose: vi.fn(),
   onCopy: vi.fn(),
   onPaste: vi.fn(),
-  onPasteImage: vi.fn(),
   canCopy: true,
-  canPasteImage: false,
-  showPasteImage: true,
 }
 
 const closed = false
@@ -24,21 +21,6 @@ test('renders null when isOpen is false', () => {
   expect(container).toBeEmptyDOMElement()
 })
 
-test('hides Paste Image outside coding agent sessions', () => {
-  render(
-    <TerminalContextMenu
-      {...baseProps}
-      {...{ showPasteImage: false }}
-      isOpen
-      position={{ x: 50, y: 60 }}
-    />
-  )
-
-  expect(
-    screen.queryByRole('menuitem', { name: 'Paste Image' })
-  ).not.toBeInTheDocument()
-})
-
 test('renders a menu with Copy and Paste items when isOpen and canCopy', () => {
   render(
     <TerminalContextMenu {...baseProps} isOpen position={{ x: 50, y: 60 }} />
@@ -49,10 +31,9 @@ test('renders a menu with Copy and Paste items when isOpen and canCopy', () => {
   ).toBeInTheDocument()
   expect(screen.getByRole('menuitem', { name: 'Copy' })).toBeInTheDocument()
   expect(screen.getByRole('menuitem', { name: 'Paste' })).toBeInTheDocument()
-
   expect(
-    screen.getByRole('menuitem', { name: 'Paste Image' })
-  ).toBeInTheDocument()
+    screen.queryByRole('menuitem', { name: 'Paste Image' })
+  ).not.toBeInTheDocument()
 
   expect(
     screen.queryByRole('menuitem', { name: 'Select All' })
@@ -63,45 +44,6 @@ test('renders a menu with Copy and Paste items when isOpen and canCopy', () => {
   ).not.toBeInTheDocument()
 })
 
-test('Paste Image item is disabled when the top clipboard item is not an image', () => {
-  render(
-    <TerminalContextMenu {...baseProps} isOpen position={{ x: 50, y: 60 }} />
-  )
-
-  expect(screen.getByRole('menuitem', { name: 'Paste Image' })).toHaveAttribute(
-    'aria-disabled',
-    'true'
-  )
-})
-
-test('clicking Paste Image when enabled fires onPasteImage then onClose', async () => {
-  const user = userEvent.setup()
-  const order: string[] = []
-
-  const onPasteImage = vi.fn(() => {
-    order.push('paste-image')
-  })
-
-  const onClose = vi.fn(() => {
-    order.push('close')
-  })
-
-  render(
-    <TerminalContextMenu
-      {...baseProps}
-      onPasteImage={onPasteImage}
-      onClose={onClose}
-      canPasteImage
-      isOpen
-      position={{ x: 0, y: 0 }}
-    />
-  )
-
-  await user.click(screen.getByRole('menuitem', { name: 'Paste Image' }))
-
-  expect(order).toEqual(['paste-image', 'close'])
-})
-
 test('renders shortcut chips beside Copy and Paste', () => {
   render(
     <TerminalContextMenu {...baseProps} isOpen position={{ x: 50, y: 60 }} />
@@ -109,47 +51,6 @@ test('renders shortcut chips beside Copy and Paste', () => {
 
   expect(screen.getByText('Ctrl+Shift+C')).toBeInTheDocument()
   expect(screen.getByText('Ctrl+Shift+V')).toBeInTheDocument()
-  expect(screen.getByText('Ctrl+V')).toBeInTheDocument()
-})
-
-test('omits duplicate Paste Image shortcut chip on macOS', async () => {
-  const originalPlatform = Object.getOwnPropertyDescriptor(
-    window.navigator,
-    'platform'
-  )
-
-  Object.defineProperty(window.navigator, 'platform', {
-    configurable: true,
-    value: 'MacIntel',
-  })
-  vi.resetModules()
-
-  try {
-    const { TerminalContextMenu: MacTerminalContextMenu } =
-      await import('./TerminalContextMenu')
-
-    render(
-      <MacTerminalContextMenu
-        {...baseProps}
-        canPasteImage
-        isOpen
-        position={{ x: 50, y: 60 }}
-      />
-    )
-
-    const pasteRow = screen.getByRole('menuitem', { name: 'Paste' })
-    const pasteImageRow = screen.getByRole('menuitem', { name: 'Paste Image' })
-
-    expect(within(pasteRow).getByText(/V$/)).toBeInTheDocument()
-    expect(within(pasteImageRow).queryByText(/V$/)).not.toBeInTheDocument()
-  } finally {
-    if (originalPlatform === undefined) {
-      delete (window.navigator as unknown as { platform?: string }).platform
-    } else {
-      Object.defineProperty(window.navigator, 'platform', originalPlatform)
-    }
-    vi.resetModules()
-  }
 })
 
 test('Copy item has aria-disabled="true" when canCopy is false', () => {

--- a/src/features/terminal/components/TerminalContextMenu.tsx
+++ b/src/features/terminal/components/TerminalContextMenu.tsx
@@ -12,10 +12,7 @@ export interface TerminalContextMenuProps {
   onClose: () => void
   onCopy: () => void
   onPaste: () => void
-  onPasteImage: () => void
   canCopy: boolean
-  canPasteImage: boolean
-  showPasteImage: boolean
 }
 
 // Chips reflect the active platform's handled terminal clipboard shortcuts:
@@ -31,8 +28,6 @@ const COPY_SHORTCUT: ShortcutInput = IS_MAC
 const PASTE_SHORTCUT: ShortcutInput = IS_MAC
   ? ['Mod', 'V']
   : ['Ctrl', 'Shift', 'V']
-
-const PASTE_IMAGE_SHORTCUT: ShortcutInput | null = IS_MAC ? null : ['Ctrl', 'V']
 
 const TERMINAL_MENU_ROW_CLASSES =
   'flex min-h-7 w-40 items-center justify-between gap-6 px-2.5 py-1 ' +
@@ -52,10 +47,7 @@ export const TerminalContextMenu = ({
   onClose,
   onCopy,
   onPaste,
-  onPasteImage,
   canCopy,
-  canPasteImage,
-  showPasteImage,
 }: TerminalContextMenuProps): ReactElement | null => {
   if (position === null) {
     return null
@@ -99,24 +91,6 @@ export const TerminalContextMenu = ({
           {formatShortcut(PASTE_SHORTCUT)}
         </kbd>
       </Menu.Row>
-      {showPasteImage ? (
-        <Menu.Row
-          label="Paste Image"
-          disabled={!canPasteImage}
-          className={`${TERMINAL_MENU_ROW_CLASSES} ${TERMINAL_MENU_DISABLED_ROW_CLASSES}`}
-          onSelect={(): void => {
-            onPasteImage()
-            onClose()
-          }}
-        >
-          <span>Paste Image</span>
-          {PASTE_IMAGE_SHORTCUT === null ? null : (
-            <kbd className={TERMINAL_MENU_SHORTCUT_CLASSES} aria-hidden="true">
-              {formatShortcut(PASTE_IMAGE_SHORTCUT)}
-            </kbd>
-          )}
-        </Menu.Row>
-      ) : null}
     </Menu.Context>
   )
 }

--- a/src/features/terminal/components/TerminalPane/Body.tsx
+++ b/src/features/terminal/components/TerminalPane/Body.tsx
@@ -220,11 +220,6 @@ export interface BodyProps {
    * bundled and platform fallbacks so stale settings keep rendering.
    */
   terminalFontFamily?: string
-
-  /**
-   * Enables coding-agent-only clipboard image paste controls.
-   */
-  enableImagePaste?: boolean
 }
 
 export interface BodyHandle {
@@ -246,7 +241,6 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
     onFocusChange = undefined,
     deferFit = false,
     terminalFontFamily = '',
-    enableImagePaste = false,
   },
   ref
 ): ReactElement {
@@ -1070,7 +1064,6 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
 
   const clipboard = useTerminalClipboard({
     terminal,
-    enableImagePaste,
     // TODO: surface clipboard failures via a visible status/error channel.
     onCopyError: (): void => undefined,
     onPasteError: (): void => undefined,
@@ -1098,12 +1091,7 @@ export const Body = forwardRef<BodyHandle, BodyProps>(function Body(
         onPaste={(): void => {
           void clipboard.paste()
         }}
-        onPasteImage={(): void => {
-          void clipboard.pasteImage()
-        }}
         canCopy={clipboard.hasSelection}
-        canPasteImage={clipboard.canPasteImage}
-        showPasteImage={enableImagePaste}
       />
     </div>
   )

--- a/src/features/terminal/components/TerminalPane/TerminalBody.test.tsx
+++ b/src/features/terminal/components/TerminalPane/TerminalBody.test.tsx
@@ -78,7 +78,6 @@ vi.mock('./Body', () => {
 
 const createService = (): ITerminalService => ({}) as ITerminalService
 const deferFit = false
-const enableImagePaste = false
 
 describe('TerminalBody', () => {
   beforeEach(() => {
@@ -97,7 +96,6 @@ describe('TerminalBody', () => {
         service={createService()}
         mode="attach"
         deferFit={deferFit}
-        enableImagePaste={enableImagePaste}
       />
     )
 
@@ -127,7 +125,6 @@ describe('TerminalBody', () => {
         shortcutContext={shortcutContext}
         mode="attach"
         deferFit={deferFit}
-        enableImagePaste={enableImagePaste}
       />
     )
 
@@ -146,7 +143,6 @@ describe('TerminalBody', () => {
         bottomCornerRadius={10}
         mode="attach"
         deferFit={deferFit}
-        enableImagePaste={enableImagePaste}
       />
     )
 
@@ -164,7 +160,6 @@ describe('TerminalBody', () => {
         terminalFontFamily="Iosevka"
         mode="attach"
         deferFit={deferFit}
-        enableImagePaste={enableImagePaste}
       />
     )
 
@@ -187,7 +182,6 @@ describe('TerminalBody', () => {
         service={createService()}
         mode="attach"
         deferFit={deferFit}
-        enableImagePaste={enableImagePaste}
       />
     )
 
@@ -214,7 +208,6 @@ describe('TerminalBody', () => {
         service={createService()}
         mode="attach"
         deferFit={deferFit}
-        enableImagePaste={enableImagePaste}
       />
     )
 

--- a/src/features/terminal/components/TerminalPane/TerminalBody.tsx
+++ b/src/features/terminal/components/TerminalPane/TerminalBody.tsx
@@ -36,7 +36,6 @@ interface TerminalBodyProps {
   mode: BodyMode
   deferFit: boolean
   terminalFontFamily?: string
-  enableImagePaste: boolean
 }
 
 export interface TerminalBodyHandle {
@@ -64,7 +63,6 @@ export const TerminalBody = forwardRef<TerminalBodyHandle, TerminalBodyProps>(
       mode,
       deferFit,
       terminalFontFamily = undefined,
-      enableImagePaste,
     },
     ref
   ): ReactElement {
@@ -147,7 +145,6 @@ export const TerminalBody = forwardRef<TerminalBodyHandle, TerminalBodyProps>(
         mode={mode}
         deferFit={deferFit}
         terminalFontFamily={terminalFontFamily}
-        enableImagePaste={enableImagePaste}
       />
     )
   }

--- a/src/features/terminal/components/TerminalPane/index.tsx
+++ b/src/features/terminal/components/TerminalPane/index.tsx
@@ -314,7 +314,6 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
 
     const isAwaitingRestart = mode === 'awaiting-restart'
     const hideCollapseToggle = isAwaitingRestart || autoCollapsed
-    const enableImagePaste = pane.agentType !== 'generic'
     const bodyMode: BodyMode = mode === 'attach' ? 'attach' : 'spawn'
 
     const terminalBodyBottomCornerRadius = isCollapsed
@@ -420,7 +419,6 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
               mode={bodyMode}
               deferFit={deferFit}
               terminalFontFamily={terminalFontFamily}
-              enableImagePaste={enableImagePaste}
             />
           </div>
         )}

--- a/src/features/terminal/hooks/useTerminalClipboard.test.ts
+++ b/src/features/terminal/hooks/useTerminalClipboard.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook, waitFor } from '@testing-library/react'
+import { act, renderHook } from '@testing-library/react'
 import type { IDisposable, Terminal } from '@xterm/xterm'
 import { expect, test, vi } from 'vitest'
 import { useTerminalClipboard } from './useTerminalClipboard'
@@ -62,12 +62,6 @@ const installClipboardMock = (
   overrides: {
     writeText?: () => Promise<void>
     readText?: () => Promise<string>
-    read?: () => Promise<
-      {
-        types: readonly string[]
-        getType: (type: string) => Promise<Blob>
-      }[]
-    >
   } = {}
 ): ClipboardMockControls => {
   const writeTextMock = vi.fn(
@@ -78,17 +72,10 @@ const installClipboardMock = (
     overrides.readText ?? ((): Promise<string> => Promise.resolve(''))
   )
 
-  const readMock =
-    overrides.read === undefined ? undefined : vi.fn(overrides.read)
-
   const original = window.navigator.clipboard
 
   Object.defineProperty(window.navigator, 'clipboard', {
-    value: {
-      writeText: writeTextMock,
-      readText: readTextMock,
-      ...(readMock === undefined ? {} : { read: readMock }),
-    },
+    value: { writeText: writeTextMock, readText: readTextMock },
     configurable: true,
     writable: true,
   })
@@ -499,193 +486,6 @@ test('right-click on terminal.element sets isOpen=true, openAt={x,y}, and calls 
   expect(preventDefaultSpy).toHaveBeenCalledOnce()
 })
 
-test('right-click enables image paste only when the top clipboard item is an image', async () => {
-  const mock = createMockTerminal()
-
-  const clipboard = installClipboardMock({
-    read: () =>
-      Promise.resolve([
-        {
-          types: ['image/png'],
-          getType: (): Promise<Blob> =>
-            Promise.resolve(new Blob(['png'], { type: 'image/png' })),
-        },
-      ]),
-  })
-
-  try {
-    const { result } = renderHook(() =>
-      useTerminalClipboard({
-        terminal: mock.terminal,
-        enableImagePaste: true,
-      })
-    )
-
-    await act(async () => {
-      mock.element.dispatchEvent(
-        new MouseEvent('contextmenu', {
-          bubbles: true,
-          cancelable: true,
-          clientX: 100,
-          clientY: 200,
-        })
-      )
-      await flushMicrotasks()
-    })
-
-    await waitFor(() => {
-      expect(result.current.canPasteImage).toBe(true)
-    })
-  } finally {
-    clipboard.restore()
-  }
-})
-
-test('right-click waits for a fast image clipboard read before opening', async () => {
-  const mock = createMockTerminal()
-  let resolveRead:
-    | ((
-        items: {
-          types: readonly string[]
-          getType: (type: string) => Promise<Blob>
-        }[]
-      ) => void)
-    | null = null
-
-  const clipboard = installClipboardMock({
-    read: () =>
-      new Promise((resolve) => {
-        resolveRead = resolve
-      }),
-  })
-
-  try {
-    const { result } = renderHook(() =>
-      useTerminalClipboard({
-        terminal: mock.terminal,
-        enableImagePaste: true,
-      })
-    )
-
-    act(() => {
-      mock.element.dispatchEvent(
-        new MouseEvent('contextmenu', {
-          bubbles: true,
-          cancelable: true,
-          clientX: 100,
-          clientY: 200,
-        })
-      )
-    })
-
-    expect(result.current.isOpen).toBe(false)
-
-    await act(async () => {
-      resolveRead?.([
-        {
-          types: ['image/png'],
-          getType: (): Promise<Blob> =>
-            Promise.resolve(new Blob(['png'], { type: 'image/png' })),
-        },
-      ])
-      await flushMicrotasks()
-    })
-
-    await waitFor(() => {
-      expect(result.current.isOpen).toBe(true)
-      expect(result.current.canPasteImage).toBe(true)
-      expect(result.current.openAt).toEqual({ x: 100, y: 200 })
-    })
-  } finally {
-    clipboard.restore()
-  }
-})
-
-test('right-click does not enable image paste for copied image-path text', async () => {
-  const mock = createMockTerminal()
-
-  const clipboard = installClipboardMock({
-    read: () =>
-      Promise.resolve([
-        {
-          types: ['text/plain'],
-          getType: (): Promise<Blob> =>
-            Promise.resolve(
-              new Blob(['/tmp/codex-clipboard-image.png'], {
-                type: 'text/plain',
-              })
-            ),
-        },
-      ]),
-  })
-
-  try {
-    const { result } = renderHook(() =>
-      useTerminalClipboard({
-        terminal: mock.terminal,
-        enableImagePaste: true,
-      })
-    )
-
-    await act(async () => {
-      mock.element.dispatchEvent(
-        new MouseEvent('contextmenu', {
-          bubbles: true,
-          cancelable: true,
-          clientX: 100,
-          clientY: 200,
-        })
-      )
-      await flushMicrotasks()
-    })
-
-    expect(result.current.canPasteImage).toBe(false)
-  } finally {
-    clipboard.restore()
-  }
-})
-
-test('pasteImage() rejects clipboard images above the paste size cap', async () => {
-  const mock = createMockTerminal()
-  const pasteSpy = vi.spyOn(mock.terminal, 'paste')
-  const onPasteError = vi.fn()
-
-  const clipboard = installClipboardMock({
-    read: () =>
-      Promise.resolve([
-        {
-          types: ['image/png'],
-          getType: (): Promise<Blob> =>
-            Promise.resolve(
-              new Blob([new Uint8Array(512 * 1024 + 1)], {
-                type: 'image/png',
-              })
-            ),
-        },
-      ]),
-  })
-
-  try {
-    const { result } = renderHook(() =>
-      useTerminalClipboard({
-        terminal: mock.terminal,
-        enableImagePaste: true,
-        onPasteError,
-      })
-    )
-
-    await result.current.pasteImage()
-
-    expect(pasteSpy).not.toHaveBeenCalled()
-    expect(onPasteError).toHaveBeenCalledOnce()
-    expect((onPasteError.mock.calls[0][0] as Error).message).toBe(
-      'Clipboard image is too large to paste'
-    )
-  } finally {
-    clipboard.restore()
-  }
-})
-
 test('close() resets isOpen and openAt and is idempotent', () => {
   const mock = createMockTerminal()
 
@@ -951,6 +751,22 @@ test('preferModifier="ctrl" + Ctrl+Shift+V suppresses and pastes', async () => {
   }
 })
 
+test('preferModifier="ctrl" + Ctrl+V passes through for agent image handling', () => {
+  const mock = createMockTerminal()
+  const pasteSpy = vi.spyOn(mock.terminal, 'paste')
+
+  renderHook(() =>
+    useTerminalClipboard({
+      terminal: mock.terminal,
+      preferModifier: 'ctrl',
+    })
+  )
+  const handler = captureKeyHandler(mock)
+
+  expect(handler(keyboardEvent({ code: 'KeyV', ctrlKey: true }))).toBe(true)
+  expect(pasteSpy).not.toHaveBeenCalled()
+})
+
 test('preferModifier="meta" + Cmd+Shift+V suppresses and pastes', async () => {
   const mock = createMockTerminal()
   const pasteSpy = vi.spyOn(mock.terminal, 'paste')
@@ -975,45 +791,6 @@ test('preferModifier="meta" + Cmd+Shift+V suppresses and pastes', async () => {
 
     expect(result).toBe(false)
     expect(pasteSpy).toHaveBeenCalledWith('pasted')
-  } finally {
-    clipboard.restore()
-  }
-})
-
-test('preferModifier="meta" + Cmd+Shift+V still text-pastes when image paste is enabled', async () => {
-  const mock = createMockTerminal()
-  const pasteSpy = vi.spyOn(mock.terminal, 'paste')
-
-  const clipboard = installClipboardMock({
-    readText: () => Promise.resolve('pasted text'),
-    read: () =>
-      Promise.resolve([
-        {
-          types: ['image/png'],
-          getType: (): Promise<Blob> =>
-            Promise.resolve(new Blob(['png'], { type: 'image/png' })),
-        },
-      ]),
-  })
-
-  try {
-    renderHook(() =>
-      useTerminalClipboard({
-        terminal: mock.terminal,
-        preferModifier: 'meta',
-        enableImagePaste: true,
-      })
-    )
-    const handler = captureKeyHandler(mock)
-
-    const result = handler(
-      keyboardEvent({ code: 'KeyV', metaKey: true, shiftKey: true })
-    )
-    await flushMicrotasks()
-
-    expect(result).toBe(false)
-    expect(clipboard.readTextMock).toHaveBeenCalledOnce()
-    expect(pasteSpy).toHaveBeenCalledWith('pasted text')
   } finally {
     clipboard.restore()
   }

--- a/src/features/terminal/hooks/useTerminalClipboard.ts
+++ b/src/features/terminal/hooks/useTerminalClipboard.ts
@@ -6,20 +6,17 @@ export type ClipboardModifier = 'meta' | 'ctrl'
 export interface UseTerminalClipboardOptions {
   terminal: Terminal | null
   preferModifier?: ClipboardModifier
-  enableImagePaste?: boolean
   onCopyError?: (error: unknown) => void
   onPasteError?: (error: unknown) => void
 }
 
 export interface UseTerminalClipboardResult {
   hasSelection: boolean
-  canPasteImage: boolean
   isOpen: boolean
   openAt: { x: number; y: number } | null
   close: () => void
   copy: () => Promise<void>
   paste: () => Promise<void>
-  pasteImage: () => Promise<void>
   selectAll: () => void
   clear: () => void
 }
@@ -60,91 +57,15 @@ const writeViaTextarea = (text: string): boolean => {
 
 const noopAsync = (): Promise<void> => Promise.resolve()
 
-const MAX_PASTE_IMAGE_BYTES = 512 * 1024
-const IMAGE_CLIPBOARD_OPEN_DELAY_MS = 50
-
-interface ClipboardImageItem {
-  types: readonly string[]
-  getType: (type: string) => Promise<Blob>
-}
-
-const readClipboardItems = (): Promise<ClipboardImageItem[]> | null => {
-  const clipboard = window.navigator.clipboard as
-    | { read?: () => Promise<ClipboardImageItem[]> }
-    | undefined
-
-  if (clipboard?.read === undefined) {
-    return null
-  }
-
-  return clipboard.read()
-}
-
-const firstClipboardItem = (
-  items: readonly ClipboardImageItem[]
-): ClipboardImageItem | null => (items.length === 0 ? null : items[0])
-
-const imageTypeOfTopClipboardItem = (
-  items: readonly ClipboardImageItem[]
-): string | null => {
-  const topItem = firstClipboardItem(items)
-  if (topItem === null) {
-    return null
-  }
-
-  const imageType = topItem.types.find((type) => type.startsWith('image/'))
-
-  return imageType ?? null
-}
-
-const readTopClipboardImage = async (): Promise<Blob | null> => {
-  const items = await readClipboardItems()
-  if (items === null) {
-    return null
-  }
-
-  const topItem = firstClipboardItem(items)
-  if (topItem === null) {
-    return null
-  }
-
-  const imageType = imageTypeOfTopClipboardItem(items)
-
-  return imageType === null ? null : topItem.getType(imageType)
-}
-
-const blobToDataUrl = (blob: Blob): Promise<string> =>
-  new Promise((resolve, reject) => {
-    const reader = new FileReader()
-
-    reader.onload = (): void => {
-      if (typeof reader.result === 'string') {
-        resolve(reader.result)
-
-        return
-      }
-
-      reject(new Error('Clipboard image read failed'))
-    }
-
-    reader.onerror = (): void => {
-      reject(reader.error ?? new Error('Clipboard image read failed'))
-    }
-
-    reader.readAsDataURL(blob)
-  })
-
 export const useTerminalClipboard = ({
   terminal,
   preferModifier: preferredModifier = undefined,
-  enableImagePaste = false,
   onCopyError = undefined,
   onPasteError = undefined,
 }: UseTerminalClipboardOptions): UseTerminalClipboardResult => {
   const preferModifier = preferredModifier ?? detectModifier()
 
   const [hasSelection, setHasSelection] = useState(false)
-  const [canPasteImage, setCanPasteImage] = useState(false)
   const [isOpen, setIsOpen] = useState(false)
   const [openAt, setOpenAt] = useState<{ x: number; y: number } | null>(null)
 
@@ -152,10 +73,6 @@ export const useTerminalClipboard = ({
   const onPasteErrorRef = useRef(onPasteError)
   const copyRef = useRef<() => Promise<void>>(noopAsync)
   const pasteRef = useRef<() => Promise<void>>(noopAsync)
-
-  const pasteImageIfAvailableRef = useRef<() => Promise<boolean>>(() =>
-    Promise.resolve(false)
-  )
 
   onCopyErrorRef.current = onCopyError
   onPasteErrorRef.current = onPasteError
@@ -214,42 +131,6 @@ export const useTerminalClipboard = ({
     }
   }
 
-  const pasteImage = async (): Promise<void> => {
-    await pasteImageIfAvailable()
-  }
-
-  const pasteImageIfAvailable = async (): Promise<boolean> => {
-    if (!terminal || !enableImagePaste) {
-      return false
-    }
-
-    try {
-      const image = await readTopClipboardImage()
-      if (image === null) {
-        setCanPasteImage(false)
-
-        return false
-      }
-
-      if (image.size > MAX_PASTE_IMAGE_BYTES) {
-        setCanPasteImage(false)
-        onPasteErrorRef.current?.(
-          new Error('Clipboard image is too large to paste')
-        )
-
-        return false
-      }
-
-      terminal.paste(await blobToDataUrl(image))
-
-      return true
-    } catch (error: unknown) {
-      onPasteErrorRef.current?.(error)
-
-      return false
-    }
-  }
-
   const selectAll = (): void => {
     terminal?.selectAll()
   }
@@ -265,7 +146,6 @@ export const useTerminalClipboard = ({
 
   copyRef.current = copy
   pasteRef.current = paste
-  pasteImageIfAvailableRef.current = pasteImageIfAvailable
 
   useEffect(() => {
     if (!terminal) {
@@ -279,8 +159,6 @@ export const useTerminalClipboard = ({
 
     let isDragging = false
     let pendingSelection = false
-    let disposed = false
-    const pendingOpenTimers = new Set<number>()
 
     const handleMouseDown = (event: MouseEvent): void => {
       if (event.button !== 0) {
@@ -319,53 +197,8 @@ export const useTerminalClipboard = ({
     const handleContextMenu = (event: MouseEvent): void => {
       event.preventDefault()
       event.stopPropagation()
-      setCanPasteImage(false)
-
-      const openMenu = (): void => {
-        if (disposed) {
-          return
-        }
-
-        setIsOpen(true)
-        setOpenAt({ x: event.clientX, y: event.clientY })
-      }
-
-      if (!enableImagePaste) {
-        openMenu()
-
-        return
-      }
-
-      const itemsPromise = readClipboardItems()
-      if (itemsPromise === null) {
-        openMenu()
-
-        return
-      }
-
-      const fallbackOpenTimer = window.setTimeout(() => {
-        pendingOpenTimers.delete(fallbackOpenTimer)
-        openMenu()
-      }, IMAGE_CLIPBOARD_OPEN_DELAY_MS)
-
-      pendingOpenTimers.add(fallbackOpenTimer)
-
-      void (async (): Promise<void> => {
-        try {
-          setCanPasteImage(
-            imageTypeOfTopClipboardItem(await itemsPromise) !== null
-          )
-        } catch {
-          setCanPasteImage(false)
-        } finally {
-          const timerPending = pendingOpenTimers.delete(fallbackOpenTimer)
-          window.clearTimeout(fallbackOpenTimer)
-
-          if (timerPending) {
-            openMenu()
-          }
-        }
-      })()
+      setIsOpen(true)
+      setOpenAt({ x: event.clientX, y: event.clientY })
     }
 
     const isMac = preferModifier === 'meta'
@@ -406,23 +239,6 @@ export const useTerminalClipboard = ({
       }
 
       if (event.code === 'KeyV') {
-        const imagePasteShortcut = isMac
-          ? event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey
-          : event.ctrlKey && !event.shiftKey && !event.metaKey && !event.altKey
-
-        if (enableImagePaste && imagePasteShortcut) {
-          event.preventDefault()
-
-          void (async (): Promise<void> => {
-            const pasted = await pasteImageIfAvailableRef.current()
-            if (!pasted) {
-              await pasteRef.current()
-            }
-          })()
-
-          return false
-        }
-
         const matched = isMac
           ? event.metaKey && !event.ctrlKey && !event.altKey
           : event.ctrlKey && event.shiftKey && !event.metaKey && !event.altKey
@@ -451,12 +267,6 @@ export const useTerminalClipboard = ({
     })
 
     return (): void => {
-      disposed = true
-      pendingOpenTimers.forEach((timerId) => {
-        window.clearTimeout(timerId)
-      })
-      pendingOpenTimers.clear()
-
       try {
         selectionDisposable.dispose()
       } catch {
@@ -477,19 +287,16 @@ export const useTerminalClipboard = ({
       setIsOpen(false)
       setOpenAt(null)
       setHasSelection(false)
-      setCanPasteImage(false)
     }
-  }, [terminal, preferModifier, enableImagePaste])
+  }, [terminal, preferModifier])
 
   return {
     hasSelection,
-    canPasteImage,
     isOpen,
     openAt,
     close,
     copy,
     paste,
-    pasteImage,
     selectAll,
     clear,
   }


### PR DESCRIPTION
## Summary

- restore plain Linux `Ctrl+V` pass-through so coding agents can handle clipboard images
- remove the broken terminal context-menu image paste path and its component plumbing
- preserve `Ctrl+Shift+V` and macOS text paste behavior

## Root cause

PR #618 intercepted plain `Ctrl+V`, converted clipboard images to base64 data URLs, and sent them through `terminal.paste()`. PTYs accept text rather than image attachments, so the encoded image was inserted into the pane as raw content and the agent never received its image-paste shortcut.

## Validation

- full pre-push Vitest suite: 5,631 passed, 3 skipped
- focused terminal clipboard and context-menu suite: 101 passed
- TypeScript project build
- ESLint on all changed files
- generated Rust-to-TypeScript bindings: 82 export tests passed

Refs VIM-351